### PR TITLE
docs: propose current-state review and next increment

### DIFF
--- a/goals/README.md
+++ b/goals/README.md
@@ -1,0 +1,37 @@
+# Goals
+
+**Target state**: ZAM becomes a trustworthy, open, human-centered learning kernel that keeps people capable while AI and communities scale around them.
+
+## Goals
+
+1. **[Phase 1 complete](phase-1-complete/)** - one human and one agent can work together end-to-end through a reliable individual symbiosis workflow.
+2. **[Trustworthy kernel](trustworthy-kernel/)** - the kernel, schema, and bridge are stable, testable, and safe to build on.
+3. **[Human growth loop](human-growth-loop/)** - daily work, long-term goals, practice, and autonomy progression form one visible learning arc.
+4. **[Open ecosystem](open-ecosystem/)** - the same kernel works across AI vendors, interfaces, and observation contexts without contract drift.
+5. **[Community expansion](community-expansion/)** - the individual kernel can later grow into multi-repo, growth-aware community coordination.
+
+## How this folder differs from `beliefs/`
+
+- `beliefs/` captures what the project currently believes.
+- `goals/` captures what the project is trying to become.
+
+The two folders should stay linked. A belief explains the current worldview. A goal explains the intended destination.
+
+## Structure rules
+
+- Keep each file small enough to fit in working memory.
+- Prefer links over repetition.
+- Decompose each goal into no more than about 7 meaningful components.
+- Add child folders when a component needs its own definition.
+
+## How to read this folder
+
+Start at the top-level goals, then follow the linked children that matter for the current planning horizon.
+
+## Current planning horizon
+
+The next increment in `../increments/2.md` primarily advances these goals:
+
+- [Phase 1 complete](phase-1-complete/)
+- [Trustworthy kernel](trustworthy-kernel/)
+- [Open ecosystem](open-ecosystem/)

--- a/goals/community-expansion/README.md
+++ b/goals/community-expansion/README.md
@@ -1,0 +1,16 @@
+# Community expansion
+
+**Goal**: ZAM grows from one human-agent pair into a network of repos, memberships, and growth-aware community coordination.
+
+## Components
+
+1. **[Multi-repo coordination](multi-repo-coordination/)** - personal and group repositories can be loaded together for reasoning.
+2. **Levels of involvement** - goals can be owned, contributed to, or supported.
+3. **Growth-aware matching** - community needs can be matched with human learning opportunities, not only availability.
+4. **Trusted circles and memberships** - access, prioritization, and collaboration reflect real communities.
+5. **Resource stewardship** - communities can codify rules, services, and collective resource management.
+
+## Related goals
+
+- [Human growth loop](../human-growth-loop/)
+- [Open ecosystem](../open-ecosystem/)

--- a/goals/community-expansion/multi-repo-coordination/README.md
+++ b/goals/community-expansion/multi-repo-coordination/README.md
@@ -1,0 +1,16 @@
+# Multi-repo coordination
+
+**Goal**: ZAM can reason across the personal repo and the relevant group repos without losing ownership boundaries.
+
+## Components
+
+1. **Personal context** - the individual repo stores private preferences, goals, and processes.
+2. **Group context** - organization and community repos store shared rules, services, and resources.
+3. **Inherited permissions** - the agent works with the same access boundaries the human already has.
+4. **Cross-repo task reasoning** - the right context can be loaded for the goal at hand.
+5. **Lifecycle-aware archives** - repos can wind down or become read-only without losing history.
+
+## Related goals
+
+- [Community expansion](../)
+- [Goals and practice](../../human-growth-loop/goals-and-practice/)

--- a/goals/human-growth-loop/README.md
+++ b/goals/human-growth-loop/README.md
@@ -1,0 +1,16 @@
+# Human growth loop
+
+**Goal**: Daily work, long-term aspiration, practice, and autonomy progression form one visible learning arc for the human.
+
+## Components
+
+1. **[Goals and practice](goals-and-practice/)** - human goals shape tasks, practice opportunities, and learning priorities.
+2. **Operational symbiosis modes** - shadowing, copilot, and autonomy become real workflow behavior, not just analytics.
+3. **Practice against decay** - stale but important skills resurface through real work, not only flashcard prompts.
+4. **Human-readable progress** - analytics show competence growth in ways a person can trust and act on.
+5. **Inspectable agent knowledge** - agent-learned skills remain visible, reviewable, and refreshable.
+
+## Related goals
+
+- [Phase 1 complete](../phase-1-complete/)
+- [Community expansion](../community-expansion/)

--- a/goals/human-growth-loop/goals-and-practice/README.md
+++ b/goals/human-growth-loop/goals-and-practice/README.md
@@ -1,0 +1,16 @@
+# Goals and practice
+
+**Goal**: ZAM helps people move from vague aspiration to repeated real-world practice.
+
+## Components
+
+1. **Goals can be recorded** - the system can represent what a person wants to do, become, or contribute to.
+2. **Goals connect to work** - domains, tokens, and tasks can be related back to those goals.
+3. **Practice tasks are first-class** - important but stale capabilities can be refreshed through real action.
+4. **Progress is reviewable** - sessions and learning data can be read as progress toward a goal.
+5. **Involvement can vary** - a goal can be owned, contributed to, or simply supported.
+
+## Related goals
+
+- [Human growth loop](../)
+- [Multi-repo coordination](../../community-expansion/multi-repo-coordination/)

--- a/goals/open-ecosystem/README.md
+++ b/goals/open-ecosystem/README.md
@@ -1,0 +1,16 @@
+# Open ecosystem
+
+**Goal**: ZAM stays AI-agnostic in practice, not only in philosophy.
+
+## Components
+
+1. **[Single-source agent guidance](single-source-agent-guidance/)** - Claude, Copilot, Gemini, and future interfaces stay behaviorally aligned.
+2. **Portable bridge** - the integration contract remains simple enough for any language or client to consume.
+3. **Pluggable observers** - shell, UI, and real-life observation can share the same kernel abstractions.
+4. **Shared terminology** - names and concepts stay consistent across code, docs, and agent skills.
+5. **Contributor accessibility** - outsiders can integrate with ZAM without reading hidden prompts or reverse-engineering behavior.
+
+## Related goals
+
+- [Trustworthy kernel](../trustworthy-kernel/)
+- [Community expansion](../community-expansion/)

--- a/goals/open-ecosystem/single-source-agent-guidance/README.md
+++ b/goals/open-ecosystem/single-source-agent-guidance/README.md
@@ -1,0 +1,16 @@
+# Single-source agent guidance
+
+**Goal**: The repository explains the supported workflow once, then adapts it to each AI surface without behavioral drift.
+
+## Components
+
+1. **One canonical workflow description** - there is a primary source for supported agent behavior.
+2. **Derived agent-specific wrappers** - Claude, Copilot, and Gemini guidance are derived from that source instead of hand-diverging.
+3. **Synchronized updates** - behavior changes propagate across all agent surfaces together.
+4. **Intentional differences only** - when two agent surfaces differ, the reason is explicit and documented.
+5. **Code-aligned instructions** - guidance stays anchored to tested bridge and CLI behavior.
+
+## Related goals
+
+- [Open ecosystem](../)
+- [Contract and tests](../../trustworthy-kernel/contract-and-tests/)

--- a/goals/phase-1-complete/README.md
+++ b/goals/phase-1-complete/README.md
@@ -1,0 +1,16 @@
+# Phase 1 complete
+
+**Goal**: Phase 1 stops being a set of promising subsystems and becomes one reliable individual symbiosis workflow.
+
+## Components
+
+1. **[Observation-first workflow](observation-first-workflow/)** - real work is observed quietly by default, with interruption used only when needed.
+2. **[Session orchestration](session-orchestration/)** - session start, observation, rating, logging, and summary form one supported loop.
+3. **Stable onboarding** - a new user can initialize ZAM, choose a monitoring method, and start the first task without hidden assumptions.
+4. **Unified human and machine surfaces** - the CLI and the bridge support the same happy path.
+5. **Demonstrable value** - a newcomer can understand the Phase 1 promise by watching one end-to-end task flow.
+
+## Related goals
+
+- [Trustworthy kernel](../trustworthy-kernel/)
+- [Human growth loop](../human-growth-loop/)

--- a/goals/phase-1-complete/observation-first-workflow/README.md
+++ b/goals/phase-1-complete/observation-first-workflow/README.md
@@ -1,0 +1,16 @@
+# Observation-first workflow
+
+**Goal**: Observation becomes the normal way ZAM learns from work, with prompts and quizzes used only when observation is insufficient.
+
+## Components
+
+1. **Reliable shell observation** - command capture is accurate, private, and lightweight.
+2. **Remembered method choice** - inline versus terminal monitoring is an explicit user preference, not tribal knowledge.
+3. **Structured evidence** - observation produces inspectable evidence, not only hidden heuristics.
+4. **Human control over ratings** - low-confidence inferences can be confirmed or corrected before they affect learning state.
+5. **Pluggable future observers** - UI and real-life observation can extend the same model without replacing it.
+
+## Related goals
+
+- [Session orchestration](../session-orchestration/)
+- [Open ecosystem](../../open-ecosystem/)

--- a/goals/phase-1-complete/session-orchestration/README.md
+++ b/goals/phase-1-complete/session-orchestration/README.md
@@ -1,0 +1,16 @@
+# Session orchestration
+
+**Goal**: Every meaningful task can move through one session lifecycle that records what happened, who did it, and what was learned.
+
+## Components
+
+1. **Explicit session start** - a session captures user, task, context, and observation mode.
+2. **Provenance-rich steps** - touched concepts become `session_steps` with clear user-versus-agent attribution.
+3. **Connected learning state** - confirmed work updates cards and review logs without losing context.
+4. **Honest session summaries** - the ending state makes clear what the human did and what the agent did.
+5. **Shared workflow surface** - CLI commands and bridge calls expose the same lifecycle.
+
+## Related goals
+
+- [Observation-first workflow](../observation-first-workflow/)
+- [Trustworthy kernel](../../trustworthy-kernel/)

--- a/goals/trustworthy-kernel/README.md
+++ b/goals/trustworthy-kernel/README.md
@@ -1,0 +1,16 @@
+# Trustworthy kernel
+
+**Goal**: The kernel becomes a dependable substrate for learning workflows, not a set of loosely aligned internal modules.
+
+## Components
+
+1. **[Contract and tests](contract-and-tests/)** - bridge JSON, CLI behavior, and public types are exercised end-to-end.
+2. **Schema integrity** - database schema and migrations stay explicit, idempotent, and backward-safe.
+3. **Knowledge-graph invariants** - core structural rules such as acyclic prerequisites are enforced, not just documented.
+4. **Consistent lifecycles** - tokens, cards, skills, settings, and deprecation behavior are clearly defined.
+5. **Release confidence** - external integrations can depend on the kernel without reverse-engineering current behavior.
+
+## Related goals
+
+- [Phase 1 complete](../phase-1-complete/)
+- [Open ecosystem](../open-ecosystem/)

--- a/goals/trustworthy-kernel/contract-and-tests/README.md
+++ b/goals/trustworthy-kernel/contract-and-tests/README.md
@@ -1,0 +1,16 @@
+# Contract and tests
+
+**Goal**: The repository's declared public contract matches the executable behavior, and tests protect that promise.
+
+## Components
+
+1. **Exact protocol shapes** - `protocol.ts` matches emitted JSON exactly.
+2. **Complete public exports** - the bridge package exports every supported public type.
+3. **Workflow integration tests** - real CLI and bridge flows are tested across persistence boundaries.
+4. **Contract-aware documentation** - docs are updated when supported behavior changes.
+5. **Deliberate compatibility changes** - breaking contract changes are treated as explicit versioned events.
+
+## Related goals
+
+- [Phase 1 complete](../../phase-1-complete/)
+- [Single-source agent guidance](../../open-ecosystem/single-source-agent-guidance/)

--- a/increments/1 - strong kernel fragmented workflow.md
+++ b/increments/1 - strong kernel fragmented workflow.md
@@ -1,0 +1,206 @@
+# Current state - strong kernel, fragmented workflow
+
+## Executive summary
+
+ZAM is already much more than an idea repository. It contains a working local-first learning kernel, a thin CLI, a machine-facing bridge, shell observation, monitor analysis, session tracking, settings, and a carefully decomposed conceptual foundation in `beliefs/`.
+
+The strongest part of the repository is the kernel architecture and the learning-science core. The weakest part is product coherence. Phase 1 exists as a set of real subsystems, but the end-to-end workflow still depends on expert composition across commands, bridge calls, and duplicated agent instructions. The next increment should turn those parts into one stable, documented, tested loop.
+
+## Reviewed surfaces
+
+- Vision and contribution docs: `README.md`, `README.de.md`, `CONTRIBUTING.md`, `CLAUDE.md`
+- Conceptual requirements and worldview: `beliefs/`, `docs/concepts/`
+- Architecture and implementation: `src/`
+- Tests and delivery config: `tests/`, `package.json`, `tsconfig.json`, `tsup.config.ts`, `vitest.config.ts`, `biome.json`
+- Agent-facing guidance: `skills/claude-code/zam.md`, `.claude/skills/zam/SKILL.md`, `.github/copilot-instructions.md`
+
+## Current state by layer
+
+| Layer | Current state | Assessment |
+| --- | --- | --- |
+| Vision and beliefs | Strong top-level story plus a well-structured `beliefs/` hierarchy | A real strength and a good base for future planning |
+| Kernel | Clear local-first architecture with SQLite, ULIDs, FSRS, queueing, blocking, analytics, observation helpers | The most mature part of the repo |
+| CLI | Broad command coverage across tokens, cards, sessions, reviews, bridge, monitor, settings, and skills | Useful, but still orchestration-heavy |
+| Bridge | Valuable JSON integration surface for AI CLIs | Important drift between declared types and actual JSON |
+| Observation | Shell monitoring and analysis are implemented and tested | Promising differentiator, not just a concept |
+| Tests | Build and tests pass; coverage focuses on pure logic | Good start, not enough for the repo's current breadth |
+
+## What is already real
+
+### 1. A coherent conceptual foundation
+
+The repository has a serious theory of operation, not just implementation notes.
+
+- `beliefs/README.md` and its child folders decompose the project's worldview into small linked statements.
+- `docs/ARCHITECTURE.md` explains the intended system layers and review flow.
+- `docs/concepts/` expands emerging ideas like monitoring methods, multi-repo context, and user settings.
+- The bilingual README pair (`README.md`, `README.de.md`) makes the project legible to both English and German readers.
+
+This is unusually strong for an early-stage project and gives the codebase a durable center of gravity.
+
+### 2. A real local-first kernel
+
+The core architecture is clean and credible.
+
+- `src/kernel/db/connection.ts` and `src/kernel/db/schema.ts` establish the local SQLite store with WAL mode, foreign keys, and migrations.
+- The data model in `src/kernel/models/` cleanly separates tokens, cards, prerequisites, reviews, sessions, settings, and agent skills.
+- `src/kernel/scheduler/fsrs.ts` implements a pure FSRS-5 scheduler with configurable parameters.
+- `src/kernel/scheduler/queue.ts`, `interleaver.ts`, and `blocker.ts` express the core learning behavior: due/new queueing, cross-domain interleaving, and prerequisite-aware blocking.
+- `src/kernel/recall/prompter.ts` and `evaluator.ts` separate prompt generation from rating evaluation.
+
+This layer reflects the repo's stated principle that new learning logic belongs in the kernel, not in the CLI.
+
+### 3. A broad CLI surface
+
+The CLI is already more complete than the top-level README suggests.
+
+- `src/cli/index.ts` wires 10 subcommands: `init`, `token`, `card`, `session`, `stats`, `review`, `bridge`, `skill`, `monitor`, and `settings`.
+- `src/cli/commands/token.ts` covers token creation, fuzzy search, listing, prerequisites, deprecation, and per-user status.
+- `src/cli/commands/card.ts` covers due listings, rating submission, and unblocking.
+- `src/cli/commands/session.ts` covers session start, step logging, and summaries.
+- `src/cli/commands/monitor.ts` adds shell observation setup, status, and a macOS terminal opener.
+- `src/cli/commands/settings.ts` exposes persistent user preferences.
+
+This is no longer a toy CLI. It is an actual operator surface for Phase 1 experiments.
+
+### 4. Observation is implemented, not hypothetical
+
+The observation path is one of the repo's most distinctive strengths.
+
+- `src/kernel/observation/shell-hooks.ts` generates shell hooks for `zsh` and `bash`.
+- `src/kernel/observation/monitor-io.ts` persists JSONL monitor logs under `~/.zam/monitor`.
+- `src/kernel/observation/analyzer.ts` parses logs, pairs command events, and infers ratings from help-seeking, errors, self-corrections, and timing.
+- `src/cli/commands/monitor.ts` turns those pieces into a usable workflow.
+- `tests/kernel/observation/analyzer.test.ts` gives this layer dedicated test coverage.
+
+This is already a meaningful implementation of "observation over interruption".
+
+### 5. Delivery and tooling are healthy
+
+- `package.json` keeps the stack focused: Commander, Inquirer, better-sqlite3, ULID, tsup, Vitest, Biome.
+- `tsup.config.ts` builds both the CLI and library entry points.
+- `tests/kernel/fsrs.test.ts` exercises the mathematical core in detail.
+- The repository builds successfully and the test suite passes.
+
+## Strongest qualities of the repository today
+
+### Clear architectural boundary
+
+The CLI files are mostly thin wrappers around kernel logic, which keeps the domain model reusable and easier to test.
+
+### High-quality conceptual scaffolding
+
+`beliefs/` is not decorative documentation. It functions as a decomposed requirements and worldview layer that can guide future work and review.
+
+### Credible learning engine
+
+The FSRS implementation, queue building, interleaving, and blocking logic form a real learning kernel rather than a placeholder abstraction.
+
+### Distinctive product differentiation
+
+The observation pipeline is already a meaningful differentiator from generic flashcard or agent tooling.
+
+### Good extensibility direction
+
+The code already anticipates multiple contexts (`shell`, `ui`, `reallife`), multiple AI frontends, and a stable JSON bridge.
+
+## Gaps, contradictions, and risks
+
+### 1. The bridge contract is not yet the stable contract the repo claims it is
+
+This is the single highest-risk inconsistency in the current codebase.
+
+- `src/bridge/protocol.ts` declares types that do not match the JSON actually emitted by `src/cli/commands/bridge.ts` for `check-due`, `get-review`, `submit`, and `add-token`.
+- `src/bridge/index.ts` only re-exports an older subset of protocol types and omits monitor-related shapes entirely.
+- `docs/ARCHITECTURE.md` tells readers to treat `protocol.ts` as the stable contract, but the executable behavior has already drifted.
+
+Impact: any external AI integration that trusts the declared bridge types instead of the actual CLI JSON is at risk of breaking silently.
+
+### 2. Phase 1 is implemented as parts, not yet as one blessed workflow
+
+The ingredients are present, but the repo still behaves like a toolkit assembled by experts.
+
+- `session`, `monitor`, `bridge`, `settings`, `card`, and `review` commands all exist, but no single command or bridge flow defines the canonical executable-task lifecycle.
+- `src/cli/commands/review.ts` runs interactive reviews without creating sessions or writing `session_steps`.
+- The end-to-end behavior currently lives partly in code and partly in AI-facing skill instructions.
+
+Impact: the project promise is stronger than the product shape. That creates friction for new contributors and external integrations.
+
+### 3. Several core beliefs are documented more strongly than they are enforced
+
+There are important cases where the worldview is ahead of runtime guarantees.
+
+- `beliefs/knowledge-structure/dependency-graphs/README.md` says prerequisites are acyclic, but `src/kernel/models/prerequisite.ts` only rejects self-dependencies and does not detect cycles.
+- `beliefs/symbiosis/bidirectional-learning/README.md` says agent skills decay via the same scheduling logic, but the current implementation stores `agent_skills` without any skill-card or review state.
+- `beliefs/symbiosis/modes/README.md` and token metadata imply runtime mode behavior, but `symbiosis_mode` is currently stored rather than actively used to steer workflows.
+
+Impact: the codebase risks looking more complete than it is if readers assume every documented belief is already operational.
+
+### 4. Documentation and agent guidance have already started to drift
+
+The repo now has several documentation surfaces that are close, but not identical.
+
+- `docs/concepts/user-settings.md` says settings live in a local file, while the implementation stores them in SQLite via `user_config` (`src/kernel/db/schema.ts`, `src/kernel/models/settings.ts`).
+- `docs/ARCHITECTURE.md` shows an 8-command CLI/module map, but `src/cli/index.ts` wires 10 subcommands.
+- `skills/claude-code/zam.md` and `.claude/skills/zam/SKILL.md` differ on monitor shutdown behavior: one tells the user to run `zam monitor stop`, the other says closing the terminal is enough.
+
+Impact: the more AI surfaces and docs are duplicated, the easier it becomes for supported workflows to diverge.
+
+### 5. Automated coverage is too narrow for the repo's current scope
+
+The test suite is solid where it exists, but the protected area is still small.
+
+- `tests/kernel/fsrs.test.ts` covers the scheduler thoroughly.
+- `tests/kernel/observation/analyzer.test.ts` covers command log analysis.
+- Missing coverage: DB migrations, token/card/session models, bridge JSON behavior, monitor workflow, CLI command wiring, and invariant enforcement.
+
+Impact: the repo can evolve quickly right now, but the risk of accidental contract drift is growing faster than the tests.
+
+### 6. Tooling configuration has already drifted enough to break linting
+
+The repository's validation story is not fully green today.
+
+- `npm run lint` currently fails before checking source files because `biome.json` is out of sync with the installed Biome CLI.
+- The failure is configuration-level: schema version mismatch plus keys that the installed Biome no longer accepts.
+- `CLAUDE.md` and `.github/copilot-instructions.md` already hint that Biome version sensitivity is a known issue, which means this is not a random local glitch but an active maintenance concern.
+
+Impact: contributors cannot treat lint as a trustworthy safety check until the config and installed tool version are brought back into alignment.
+
+## Alignment with the stated goals in the repository
+
+### Strong alignment
+
+The implementation already matches several of the repo's core claims well.
+
+- **AI-agnostic kernel**: the learning logic is genuinely separate from any LLM dependency.
+- **Local-first ownership**: SQLite at `~/.zam/zam.db` is central to the implementation.
+- **Human-in-the-loop learning**: tokens, cards, review logs, sessions, and observation all point toward competence retention rather than pure automation.
+- **Observation over interruption**: shell monitoring is already a real subsystem, not a slide-deck idea.
+
+### Partial alignment
+
+These ideas are present, but not fully embodied as a product.
+
+- **Phase 1: individual symbiosis** is represented strongly at the subsystem level, but not yet as one obvious user journey.
+- **Competence-driven symbiosis modes** exist analytically, but are not yet the main control surface for runtime behavior.
+- **Bidirectional learning** exists in storage and narrative, but not yet as a full review/scheduling loop for agent skills.
+
+### Not yet aligned
+
+These goals remain conceptual rather than implemented.
+
+- Human goal management and the "personal repository" idea from `docs/concepts/multi-repo-context.md`
+- Community and marketplace behavior from README Phase 2
+- Cross-repo reasoning, involvement levels (`own`, `contribute`, `vote`), and community resource stewardship
+
+## Interpretation
+
+This repository is in a promising but transitional state.
+
+It has already crossed the line from manifesto to working system. The right reading is not "too early" but "structurally ahead of its narrative and integration discipline". The codebase is ready for an increment that closes the gap between a strong kernel and a coherent Phase 1 product loop.
+
+## Baseline validation
+
+- `npm run build` passes
+- `npm run test` passes (`47` tests across `2` test files)
+- `npm run lint` currently fails before linting source because `biome.json` does not match the installed Biome CLI (`@biomejs/biome` `2.4.8`)

--- a/increments/2.md
+++ b/increments/2.md
@@ -1,0 +1,123 @@
+# Next increment vision - complete the observation-first Phase 1 loop
+
+## One-sentence vision
+
+Turn ZAM's existing Phase 1 subsystems into one stable, tested, documented workflow in which a human and an AI can start a task session, observe real work, convert observation into learning signals, and finish with trustworthy logs, updated cards, and a clear summary.
+
+## Why this is the right next increment
+
+This direction builds on what is already strongest in the repository instead of opening a new frontier too early.
+
+- The kernel, observation pipeline, session model, settings, and bridge already exist.
+- The biggest current weakness is not missing raw capability, but missing coherence.
+- Completing the Phase 1 loop will make the repo easier to explain, easier to test, and safer for external AI integrations.
+- It advances the README's "individual symbiosis" focus without prematurely pulling Phase 2 community features into scope.
+
+## Scope boundary
+
+This increment should stay disciplined. It should not try to deliver screen observation, real-life observation, a full personal-goal engine, or the community marketplace. Its purpose is to make the existing Phase 1 story executable and reliable.
+
+## Significant changes
+
+### 1. Create one first-class task-session workflow
+
+Define and implement the canonical executable-task lifecycle.
+
+- Start a session with an explicit observation mode
+- Respect stored monitoring preference
+- Support inline or monitored-terminal execution
+- Finish through one supported completion path
+
+The goal is to remove the need for expert-only orchestration across multiple commands and skill documents.
+
+### 2. Make the bridge contract real and stable
+
+Bring `src/bridge/protocol.ts`, `src/bridge/index.ts`, and `src/cli/commands/bridge.ts` back into alignment.
+
+- Make the declared types match actual JSON exactly
+- Export the full public contract, including monitor-related shapes
+- Treat contract changes as versioned, deliberate events
+
+This is the foundation for trustworthy Claude/Copilot/Gemini integrations.
+
+### 3. Automatically connect observation to session provenance
+
+Right now, observation, ratings, and session logging are adjacent but not fully unified.
+
+The increment should ensure that confirmed observation results can:
+
+- write `session_steps`
+- update cards
+- append `review_logs`
+- clearly distinguish user actions from agent actions
+
+That makes Phase 1 honest, inspectable, and measurable.
+
+### 4. Enforce the most important runtime invariants
+
+The code should catch the gaps where beliefs currently exceed enforcement.
+
+- reject prerequisite cycles, not just self-links
+- clarify what is operational versus aspirational for `symbiosis_mode`
+- define the lifecycle expectations for agent skills and deprecation behavior
+
+This keeps the worldview and runtime from drifting apart further.
+
+### 5. Make onboarding and preferences part of the supported product
+
+New users and new agents should not need hidden tribal knowledge.
+
+- `zam init` should be clearly part of the supported first-run path
+- monitoring preference should be surfaced and persisted intentionally
+- docs and commands should describe the same supported choices
+
+The outcome should be that a newcomer can get from zero to first observed task without reading the whole repository.
+
+### 6. Add integration tests around the real workflow
+
+The next increment needs a broader safety net.
+
+At minimum, add end-to-end coverage for flows like:
+
+- init -> register token -> ensure card -> submit rating
+- session start -> monitor/analyze -> session end
+- bridge JSON responses matching exported protocol types
+- prerequisite blocking and unblocking behavior across persistence boundaries
+
+The repo no longer needs only math tests; it needs workflow tests.
+
+### 7. Consolidate the docs and agent guidance into one source of truth
+
+The repository currently explains itself in several nearby but diverging places.
+
+This increment should align:
+
+- `README.md` / `README.de.md`
+- `docs/ARCHITECTURE.md`
+- `docs/concepts/`
+- `skills/claude-code/zam.md`
+- `.claude/skills/zam/SKILL.md`
+- `.github/copilot-instructions.md`
+
+The goal is not more documentation. The goal is fewer conflicting stories.
+
+## Success criteria
+
+This increment is successful when all of the following are true:
+
+1. A contributor can point to one canonical Phase 1 workflow.
+2. The bridge types and executable JSON match.
+3. Session records, observation data, and review state form one connected trail.
+4. The most important conceptual invariants are enforced in code.
+5. Integration tests protect the supported workflow.
+6. The docs and agent instructions tell the same story.
+
+## Explicitly out of scope
+
+- Screen observation
+- Voice or AR observation
+- Full personal goal modeling
+- Community marketplace implementation
+- Cross-repo execution across external organizations
+
+Those belong after the Phase 1 loop is coherent and trustworthy.


### PR DESCRIPTION
## Summary
- add a current-state repository review under `increments/`
- propose the next coherent increment under `increments/2.md`
- add a `goals/` hierarchy mirroring `beliefs/` for the target state

## Why
This is a discussion PR before implementation. The aim is to gather contributor feedback on the repository review, the proposed next increment, and the target-state decomposition.

## Notes
- documentation and planning only; no implementation changes
- baseline at review time: `npm run build` passed and `npm run test` passed
- `npm run lint` currently fails because of a pre-existing Biome config/schema mismatch

## Suggested review focus
- Do the current-state findings reflect the repository accurately?
- Is the proposed next increment the right size and focus?
- Does the `goals/` hierarchy feel like the right target-state decomposition?
