### PR TITLE
feat: whoami command & optional --user flag

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -52,6 +52,15 @@ ZAM ist als **KI-agnostischer Kernel** konzipiert — ein CLI-Tool, das sich nah
 - **CLI-Integration** — Kompatibel mit `Claude Code`, `Copilot CLI` und `Gemini CLI`.
 - **Modularität** — Das System kann für länderspezifische oder kulturelle Eigenheiten „geforkt" werden (*Social Forking*).
 
+### Zwei Repositories, ein System
+
+ZAM ist in zwei Bereiche aufgeteilt:
+
+- **Core** ([`zam-os/zam`](https://github.com/zam-os/zam)) — Der KI-agnostische Learning-Kernel, CLI, Bridge-Protokoll und System-Beliefs. Von allen geteilt.
+- **Personal** (Fork von [`zam-os/zam-personal`](templates/personal/)) — Deine Beliefs, deine Ziele, deine Identität. Du forkst es, du besitzt es.
+
+Einstieg: `zam whoami --set <deine-id>`
+
 ---
 
 ## 🏛 Vision: Eine paradiesische Zukunft

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ ZAM is designed as an **AI-agnostic kernel** — a CLI tool that integrates seam
 - **CLI Integration** — Compatible with `Claude Code`, `Copilot CLI`, and `Gemini CLI`.
 - **Modularity** — The system can be forked for region- or culture-specific adaptations (*Social Forking*).
 
+### Two Repositories, One System
+
+ZAM is split into two concerns:
+
+- **Core** ([`zam-os/zam`](https://github.com/zam-os/zam)) — The AI-agnostic learning kernel, CLI, bridge protocol, and system beliefs. Shared by everyone.
+- **Personal** (fork of [`zam-os/zam-personal`](templates/personal/)) — Your beliefs, your goals, your identity. You fork it, you own it.
+
+Get started: `zam whoami --set <your-id>`
+
 ---
 
 ## 🏛 Vision: A Flourishing Future

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -25,6 +25,7 @@ import {
   monitorLogExists,
 } from "../../kernel/index.js";
 import type { Rating, BloomLevel, TokenPattern } from "../../kernel/index.js";
+import { resolveUser } from "./resolve-user.js";
 
 function jsonOut(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
@@ -56,14 +57,15 @@ export const bridgeCommand = new Command("bridge")
 bridgeCommand
   .command("check-due")
   .description("Check due cards for a user (JSON)")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .action((opts) => {
     withDb((db) => {
-      const dueCards = getDueCards(db, opts.user);
+      const userId = resolveUser(opts, db, { json: true });
+      const dueCards = getDueCards(db, userId);
       const domains = [...new Set(dueCards.map((c) => c.domain).filter(Boolean))].sort();
 
       jsonOut({
-        userId: opts.user,
+        userId,
         dueCount: dueCards.length,
         domains,
         cards: dueCards.map((c) => ({
@@ -85,14 +87,15 @@ bridgeCommand
 bridgeCommand
   .command("get-review")
   .description("Get next review card with prompt (JSON)")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .action((opts) => {
     withDb((db) => {
-      const queue = buildReviewQueue(db, { userId: opts.user, maxReviews: 1, maxNew: 1 });
+      const userId = resolveUser(opts, db, { json: true });
+      const queue = buildReviewQueue(db, { userId, maxReviews: 1, maxNew: 1 });
 
       if (queue.items.length === 0) {
         jsonOut({
-          userId: opts.user,
+          userId,
           hasReview: false,
           card: null,
           prompt: null,
@@ -112,10 +115,10 @@ bridgeCommand
       });
 
       // Get full queue size for context
-      const fullQueue = buildReviewQueue(db, { userId: opts.user });
+      const fullQueue = buildReviewQueue(db, { userId });
 
       jsonOut({
-        userId: opts.user,
+        userId,
         hasReview: true,
         card: item,
         prompt,
@@ -129,11 +132,12 @@ bridgeCommand
 bridgeCommand
   .command("submit")
   .description("Submit a rating for a card (JSON)")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .requiredOption("--card-id <id>", "Card ID")
   .requiredOption("--rating <n>", "Rating (1-4)")
   .action((opts) => {
     withDb((db) => {
+      const userId = resolveUser(opts, db, { json: true });
       const rating = Number(opts.rating) as Rating;
       if (rating < 1 || rating > 4) {
         jsonError("Rating must be between 1 and 4");
@@ -151,7 +155,7 @@ bridgeCommand
       const result = evaluateRating(db, {
         cardId: opts.cardId,
         tokenId: card!.token_id,
-        userId: opts.user,
+        userId,
         rating,
       });
 
@@ -164,7 +168,7 @@ bridgeCommand
         if (token) {
           const prereqs = getPrerequisites(db, card!.token_id);
           if (prereqs.length > 0) {
-            blocked = cascadeBlock(db, opts.user, token.slug);
+            blocked = cascadeBlock(db, userId, token.slug);
           }
         }
       }
@@ -297,7 +301,7 @@ bridgeCommand
 bridgeCommand
   .command("add-token")
   .description("Create a token + card from JSON stdin")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .action(async (opts) => {
     let db: Database | undefined;
     try {
@@ -332,6 +336,7 @@ bridgeCommand
       }
 
       db = openDatabase();
+      const userId = resolveUser(opts, db, { json: true });
 
       const token = createToken(db, {
         slug: data!.slug,
@@ -342,7 +347,7 @@ bridgeCommand
         symbiosis_mode: data!.symbiosis_mode as "shadowing" | "copilot" | "autonomy" | null | undefined,
       });
 
-      const card = ensureCard(db, token.id, opts.user);
+      const card = ensureCard(db, token.id, userId);
 
       jsonOut({
         success: true,

--- a/src/cli/commands/card.ts
+++ b/src/cli/commands/card.ts
@@ -15,6 +15,7 @@ import {
   getPrerequisites,
 } from "../../kernel/index.js";
 import type { Rating } from "../../kernel/index.js";
+import { resolveUser } from "./resolve-user.js";
 
 function withDb(fn: (db: Database) => void): void {
   let db: Database | undefined;
@@ -37,12 +38,13 @@ export const cardCommand = new Command("card")
 cardCommand
   .command("due")
   .description("Show due tokens for a user")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
   .option("--summary", "Show only counts per domain (no slugs or concepts)")
   .action((opts) => {
     withDb((db) => {
-      const dueCards = getDueCards(db, opts.user);
+      const userId = resolveUser(opts, db);
+      const dueCards = getDueCards(db, userId);
 
       if (opts.json) {
         console.log(JSON.stringify(dueCards, null, 2));
@@ -95,20 +97,21 @@ cardCommand
 cardCommand
   .command("update")
   .description("Apply a rating to a card")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .requiredOption("--token <slug>", "Token slug")
   .requiredOption("--rating <n>", "Rating (1=Again, 2=Hard, 3=Good, 4=Easy)")
   .option("--json", "Output as JSON")
   .option("--quiet", "Suppress output (exit code only)")
   .action((opts) => {
     withDb((db) => {
+      const userId = resolveUser(opts, db);
       const token = getTokenBySlug(db, opts.token);
       if (!token) {
         console.error(`Token not found: ${opts.token}`);
         process.exit(1);
       }
 
-      const card = ensureCard(db, token.id, opts.user);
+      const card = ensureCard(db, token.id, userId);
       const rating = Number(opts.rating) as Rating;
 
       if (rating < 1 || rating > 4) {
@@ -119,7 +122,7 @@ cardCommand
       const result = evaluateRating(db, {
         cardId: card.id,
         tokenId: token.id,
-        userId: opts.user,
+        userId,
         rating,
       });
 
@@ -127,7 +130,7 @@ cardCommand
       if (rating === 1) {
         const prereqs = getPrerequisites(db, token.id);
         if (prereqs.length > 0) {
-          const blockResult = cascadeBlock(db, opts.user, token.slug);
+          const blockResult = cascadeBlock(db, userId, token.slug);
           if (opts.quiet) return;
           if (opts.json) {
             console.log(JSON.stringify({ evaluation: result, blocked: blockResult }, null, 2));
@@ -161,12 +164,13 @@ cardCommand
 cardCommand
   .command("unblock")
   .description("Unblock cards whose prerequisites are met")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
   .option("--quiet", "Suppress output (exit code only)")
   .action((opts) => {
     withDb((db) => {
-      const result = unblockReady(db, opts.user);
+      const userId = resolveUser(opts, db);
+      const result = unblockReady(db, userId);
 
       if (opts.quiet) return;
       if (opts.json) {

--- a/src/cli/commands/resolve-user.ts
+++ b/src/cli/commands/resolve-user.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolve the active user ID from --user flag or stored whoami setting.
+ */
+
+import type { Database } from "better-sqlite3";
+import { getSetting } from "../../kernel/index.js";
+
+export interface ResolveUserOptions {
+  /** If true, output JSON error instead of console.error (for bridge commands). */
+  json?: boolean;
+}
+
+/**
+ * Returns the user ID from the explicit --user flag, or falls back to the
+ * stored `user.id` setting. Exits with an error if neither is available.
+ */
+export function resolveUser(
+  opts: { user?: string },
+  db: Database,
+  resolveOpts?: ResolveUserOptions,
+): string {
+  if (opts.user) return opts.user;
+
+  const stored = getSetting(db, "user.id");
+  if (stored) return stored;
+
+  const message = 'No user specified. Set a default with: zam whoami --set <id>';
+  if (resolveOpts?.json) {
+    console.log(JSON.stringify({ error: message }, null, 2));
+  } else {
+    console.error(message);
+  }
+  process.exit(1);
+}

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -14,19 +14,21 @@ import {
   getPrerequisites,
 } from "../../kernel/index.js";
 import type { Rating, BloomLevel } from "../../kernel/index.js";
+import { resolveUser } from "./resolve-user.js";
 
 export const reviewCommand = new Command("review")
   .description("Start an interactive review session")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .option("--max-new <n>", "Maximum new cards", "10")
   .option("--max-reviews <n>", "Maximum review cards", "50")
   .action(async (opts) => {
     let db: Database | undefined;
     try {
       db = openDatabase();
+      const userId = resolveUser(opts, db);
 
       const queue = buildReviewQueue(db, {
-        userId: opts.user,
+        userId,
         maxNew: Number(opts.maxNew),
         maxReviews: Number(opts.maxReviews),
       });
@@ -78,7 +80,7 @@ export const reviewCommand = new Command("review")
         const evalResult = evaluateRating(db, {
           cardId: item.cardId,
           tokenId: item.tokenId,
-          userId: opts.user,
+          userId,
           rating,
         });
 
@@ -86,7 +88,7 @@ export const reviewCommand = new Command("review")
         if (rating === 1) {
           const prereqs = getPrerequisites(db, item.tokenId);
           if (prereqs.length > 0) {
-            const blockResult = cascadeBlock(db, opts.user, item.slug);
+            const blockResult = cascadeBlock(db, userId, item.slug);
             console.log(`  Blocked ${blockResult.blockedSlug}. Review these prerequisites:`);
             for (const p of blockResult.prerequisites) {
               console.log(`    - ${p.slug}: ${p.concept}`);

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -13,6 +13,7 @@ import {
   getTokenBySlug,
 } from "../../kernel/index.js";
 import type { ExecutionContext } from "../../kernel/index.js";
+import { resolveUser } from "./resolve-user.js";
 
 function withDb(fn: (db: Database) => void): void {
   let db: Database | undefined;
@@ -35,7 +36,7 @@ export const sessionCommand = new Command("session")
 sessionCommand
   .command("start")
   .description("Start a new learning session")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .requiredOption("--task <description>", "Task description")
   .option("--context <level>", "Execution context: shell | ui | reallife (default: shell)", "shell")
   .option("--json", "Output as JSON")
@@ -48,8 +49,9 @@ sessionCommand
         process.exit(1);
       }
 
+      const userId = resolveUser(opts, db);
       const session = startSession(db, {
-        user_id: opts.user,
+        user_id: userId,
         task: opts.task,
         execution_context: opts.context as ExecutionContext,
       });

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -9,6 +9,7 @@ import {
   getUserStats,
   getDomainCompetence,
 } from "../../kernel/index.js";
+import { resolveUser } from "./resolve-user.js";
 
 function withDb(fn: (db: Database) => void): void {
   let db: Database | undefined;
@@ -25,12 +26,13 @@ function withDb(fn: (db: Database) => void): void {
 
 export const statsCommand = new Command("stats")
   .description("Show learning dashboard for a user")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
   .action((opts) => {
     withDb((db) => {
-      const stats = getUserStats(db, opts.user);
-      const domains = getDomainCompetence(db, opts.user);
+      const userId = resolveUser(opts, db);
+      const stats = getUserStats(db, userId);
+      const domains = getDomainCompetence(db, userId);
 
       if (opts.json) {
         console.log(JSON.stringify({ stats, domains }, null, 2));

--- a/src/cli/commands/token.ts
+++ b/src/cli/commands/token.ts
@@ -18,6 +18,7 @@ import {
   deprecateToken,
 } from "../../kernel/index.js";
 import type { BloomLevel } from "../../kernel/index.js";
+import { resolveUser } from "./resolve-user.js";
 
 function withDb(fn: (db: Database) => void): void {
   let db: Database | undefined;
@@ -192,17 +193,18 @@ tokenCommand
   .command("status")
   .description("Show full status of a token for a user")
   .requiredOption("--token <slug>", "Token slug")
-  .requiredOption("--user <id>", "User ID")
+  .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
   .action((opts) => {
     withDb((db) => {
+      const userId = resolveUser(opts, db);
       const token = getTokenBySlug(db, opts.token);
       if (!token) {
         console.error(`Token not found: ${opts.token}`);
         process.exit(1);
       }
 
-      const card = getCard(db, token.id, opts.user);
+      const card = getCard(db, token.id, userId);
       const prereqs = getPrerequisites(db, token.id);
       const dependents = getDependents(db, token.id);
 

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,0 +1,68 @@
+/**
+ * `zam whoami` — Manage default user identity.
+ */
+
+import { Command } from "commander";
+import type { Database } from "better-sqlite3";
+import {
+  openDatabase,
+  getSetting,
+  setSetting,
+  deleteSetting,
+} from "../../kernel/index.js";
+
+function withDb(fn: (db: Database) => void): void {
+  let db: Database | undefined;
+  try {
+    db = openDatabase();
+    fn(db);
+  } catch (err) {
+    console.error("Error:", (err as Error).message);
+    process.exit(1);
+  } finally {
+    db?.close();
+  }
+}
+
+export const whoamiCommand = new Command("whoami")
+  .description("Show or set the default user identity")
+  .option("--set <id>", "Set the default user ID")
+  .option("--clear", "Remove the default user ID")
+  .option("--json", "Output as JSON")
+  .action((opts) => {
+    withDb((db) => {
+      if (opts.set) {
+        setSetting(db, "user.id", opts.set);
+        if (opts.json) {
+          console.log(JSON.stringify({ userId: opts.set }));
+        } else {
+          console.log(`Default user set to: ${opts.set}`);
+        }
+        return;
+      }
+
+      if (opts.clear) {
+        const deleted = deleteSetting(db, "user.id");
+        if (opts.json) {
+          console.log(JSON.stringify({ userId: null, cleared: deleted }));
+        } else if (deleted) {
+          console.log("Default user cleared.");
+        } else {
+          console.log("No default user was set.");
+        }
+        return;
+      }
+
+      const userId = getSetting(db, "user.id");
+      if (opts.json) {
+        console.log(JSON.stringify({ userId: userId ?? null }));
+        return;
+      }
+
+      if (userId) {
+        console.log(userId);
+      } else {
+        console.log("No default user set. Use: zam whoami --set <id>");
+      }
+    });
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { bridgeCommand } from "./commands/bridge.js";
 import { skillCommand } from "./commands/skill.js";
 import { monitorCommand } from "./commands/monitor.js";
 import { settingsCommand } from "./commands/settings.js";
+import { whoamiCommand } from "./commands/whoami.js";
 
 const program = new Command();
 
@@ -29,5 +30,6 @@ program.addCommand(bridgeCommand);
 program.addCommand(skillCommand);
 program.addCommand(monitorCommand);
 program.addCommand(settingsCommand);
+program.addCommand(whoamiCommand);
 
 program.parse();

--- a/templates/personal/README.md
+++ b/templates/personal/README.md
@@ -1,0 +1,31 @@
+# Your ZAM Personal Kernel
+
+This is your personal ZAM repository. Fork it, make it yours, and start ZAM from here.
+
+## What lives here
+
+- **`beliefs/`** — Your personal worldview. What you hold to be true. The ZAM agent will propose changes through conversation; you approve them by committing.
+- **`goals/`** — Your personal objectives. High-level goals decompose into tasks and learning tokens. Maintained collaboratively with the ZAM agent.
+
+## Getting started
+
+1. Fork this repository into your own account (e.g. `YourName/zam-personal`).
+2. Install ZAM: `npm install -g zam`
+3. Initialize the database: `zam init`
+4. Set your identity: `zam whoami --set <your-id>`
+5. Start a session: `zam session start --task "my first task"`
+
+## How it works
+
+Your personal repo holds the slow-changing parts of your ZAM experience: beliefs and goals. These are markdown files tracked in git. The git history is your approval trail — every committed change represents a conscious decision.
+
+Fast-changing data (learning tokens, cards, review history, sessions) lives in the ZAM database at `~/.zam/zam.db`.
+
+The core learning kernel lives in [`zam-os/zam`](https://github.com/zam-os/zam). It provides the CLI, the FSRS scheduler, the bridge protocol, and all the learning science. This repo provides *your* context.
+
+## Beliefs vs. Goals
+
+- **Beliefs** are premises — things you hold to be true. They guide how you interpret the world and how the ZAM agent interacts with you.
+- **Goals** are intentions — things you want to achieve. They decompose into tasks, which surface learning opportunities.
+
+Both evolve through conversation with the ZAM agent. Both require your explicit approval (a git commit) to take effect.

--- a/templates/personal/beliefs/README.md
+++ b/templates/personal/beliefs/README.md
@@ -1,0 +1,19 @@
+# My Beliefs
+
+This folder captures what you hold to be true. These are not facts — they are your current understanding of the world. They will evolve as you learn and grow.
+
+The ZAM agent reads these beliefs to understand your perspective. When new evidence or insight challenges a belief, the agent will propose a change through conversation. You approve changes by committing them.
+
+## Structure
+
+Each subfolder holds a belief and decomposes it into at most 7 components (Miller's number). Follow the same pattern as the [core beliefs](https://github.com/zam-os/zam/tree/main/beliefs).
+
+## Example
+
+You might start with beliefs about your professional domain:
+
+- **Software quality** — Readable code matters more than clever code.
+- **Learning** — Spaced repetition is the most effective way to retain technical knowledge.
+- **Collaboration** — Pair programming produces better results than solo work for complex problems.
+
+Create a subfolder for each belief. Write a `README.md` that states the belief and decomposes it.

--- a/templates/personal/goals/README.md
+++ b/templates/personal/goals/README.md
@@ -1,0 +1,19 @@
+# My Goals
+
+This folder captures what you want to achieve. Goals are intentions that decompose into actionable tasks and learning opportunities.
+
+The ZAM agent reads these goals to suggest tasks and prioritize your learning queue. When you complete a goal or your priorities shift, the agent will propose updates. You approve changes by committing them.
+
+## Structure
+
+Each subfolder holds a goal and decomposes it into at most 7 sub-goals or milestones (Miller's number). The hierarchy is:
+
+**Goals** (markdown, here) -> **Tasks** (task connector) -> **Tokens** (database)
+
+## Example
+
+- **Master backend architecture** — Understand the full request lifecycle, from HTTP handler to database query, in the system I work on.
+- **Run a 10K** — Build running endurance over the next 3 months through progressive training.
+- **Learn conversational Spanish** — Reach B1 level by practicing 20 minutes daily with spaced repetition.
+
+Create a subfolder for each goal. Write a `README.md` that states the goal and breaks it down.

--- a/templates/personal/package.json
+++ b/templates/personal/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "zam-personal",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Your personal ZAM kernel — beliefs, goals, and identity.",
+  "dependencies": {
+    "zam": "^0.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `zam whoami` command to set/get/clear default user identity
- Makes `--user` optional across all 11 command occurrences — falls back to stored whoami setting
- Adds `templates/personal/` blueprint for the future `zam-os/zam-personal` repo
- Updates both READMEs with the two-repo architecture description

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test` — 47/47 pass
- [x] `zam whoami` / `--set` / `--clear` work correctly
- [x] Commands work without `--user` when whoami is set
- [x] Commands show helpful error when no user is configured
- [x] Explicit `--user` flag still overrides whoami

🤖 Generated with [Claude Code](https://claude.com/claude-code)