### PR TITLE
feat: Azure DevOps connector & interactive session start

### DIFF
--- a/src/cli/commands/connector.ts
+++ b/src/cli/commands/connector.ts
@@ -1,0 +1,146 @@
+/**
+ * `zam connector` — Manage external service connectors.
+ */
+
+import { Command } from "commander";
+import type { Database } from "better-sqlite3";
+import { input, password } from "@inquirer/prompts";
+import {
+  openDatabase,
+  setSetting,
+  deleteSetting,
+} from "../../kernel/index.js";
+import {
+  loadADOConfig,
+  fetchActiveWorkItems,
+} from "../../kernel/connectors/azure-devops.js";
+
+function withDb(fn: (db: Database) => void): void {
+  let db: Database | undefined;
+  try {
+    db = openDatabase();
+    fn(db);
+  } catch (err) {
+    console.error("Error:", (err as Error).message);
+    process.exit(1);
+  } finally {
+    db?.close();
+  }
+}
+
+export const connectorCommand = new Command("connector")
+  .description("Manage external service connectors");
+
+// ── zam connector setup ado ─────────────────────────────────────────────────
+
+connectorCommand
+  .command("setup")
+  .description("Configure a connector")
+  .argument("<type>", "Connector type (ado)")
+  .action(async (type) => {
+    if (type !== "ado") {
+      console.error(`Unknown connector type: ${type}. Supported: ado`);
+      process.exit(1);
+    }
+
+    let db: Database | undefined;
+    try {
+      const orgUrl = await input({
+        message: "Organization URL (e.g. https://dev.azure.com/myorg):",
+      });
+      const project = await input({
+        message: "Project name:",
+      });
+      const pat = await password({
+        message: "Personal Access Token:",
+      });
+
+      if (!orgUrl || !project || !pat) {
+        console.error("All fields are required.");
+        process.exit(1);
+      }
+
+      db = openDatabase();
+      setSetting(db, "ado.org_url", orgUrl.replace(/\/+$/, ""));
+      setSetting(db, "ado.project", project);
+      setSetting(db, "ado.pat", pat);
+      db.close();
+
+      console.log(`Azure DevOps connector configured for ${orgUrl}/${project}`);
+    } catch (err) {
+      db?.close();
+      if ((err as Error).name === "ExitPromptError") {
+        console.log("\nSetup cancelled.");
+        process.exit(0);
+      }
+      console.error("Error:", (err as Error).message);
+      process.exit(1);
+    }
+  });
+
+// ── zam connector tasks ─────────────────────────────────────────────────────
+
+connectorCommand
+  .command("tasks")
+  .description("List active tasks from connected board")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    let db: Database | undefined;
+    try {
+      db = openDatabase();
+      const config = loadADOConfig(db);
+      db.close();
+
+      if (!config) {
+        console.error("No connector configured. Run: zam connector setup ado");
+        process.exit(1);
+      }
+
+      const items = await fetchActiveWorkItems(config);
+
+      if (opts.json) {
+        console.log(JSON.stringify(items, null, 2));
+        return;
+      }
+
+      if (items.length === 0) {
+        console.log("No active work items assigned to you.");
+        return;
+      }
+
+      console.log(`${items.length} active work item(s):\n`);
+      console.log(
+        "ID       Type          State       Title",
+      );
+      console.log("─".repeat(80));
+      for (const wi of items) {
+        console.log(
+          `${String(wi.id).padEnd(8)} ${wi.type.padEnd(13)} ${wi.state.padEnd(11)} ${wi.title.slice(0, 45)}`,
+        );
+      }
+    } catch (err) {
+      db?.close();
+      console.error("Error:", (err as Error).message);
+      process.exit(1);
+    }
+  });
+
+// ── zam connector clear ─────────────────────────────────────────────────────
+
+connectorCommand
+  .command("clear")
+  .description("Remove a connector configuration")
+  .argument("<type>", "Connector type (ado)")
+  .action((type) => {
+    if (type !== "ado") {
+      console.error(`Unknown connector type: ${type}. Supported: ado`);
+      process.exit(1);
+    }
+
+    withDb((db) => {
+      deleteSetting(db, "ado.org_url");
+      deleteSetting(db, "ado.project");
+      deleteSetting(db, "ado.pat");
+      console.log("Azure DevOps connector removed.");
+    });
+  });

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -4,6 +4,7 @@
 
 import { Command } from "commander";
 import type { Database } from "better-sqlite3";
+import { select, input } from "@inquirer/prompts";
 import {
   openDatabase,
   startSession,
@@ -11,6 +12,8 @@ import {
   endSession,
   getSessionSummary,
   getTokenBySlug,
+  loadADOConfig,
+  fetchActiveWorkItems,
 } from "../../kernel/index.js";
 import type { ExecutionContext } from "../../kernel/index.js";
 import { resolveUser } from "./resolve-user.js";
@@ -37,12 +40,15 @@ sessionCommand
   .command("start")
   .description("Start a new learning session")
   .option("--user <id>", "User ID (default: whoami)")
-  .requiredOption("--task <description>", "Task description")
+  .option("--task <description>", "Task description (interactive if omitted)")
   .option("--context <level>", "Execution context: shell | ui | reallife (default: shell)", "shell")
   .option("--json", "Output as JSON")
   .option("--quiet", "Output only the session ID")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    let db: Database | undefined;
+    try {
+      db = openDatabase();
+
       const validContexts = ["shell", "ui", "reallife"];
       if (!validContexts.includes(opts.context)) {
         console.error(`Invalid context: ${opts.context}. Must be one of: ${validContexts.join(", ")}`);
@@ -50,11 +56,51 @@ sessionCommand
       }
 
       const userId = resolveUser(opts, db);
+      let task: string = opts.task;
+
+      // Interactive task selection when --task is not provided
+      if (!task) {
+        const adoConfig = loadADOConfig(db);
+
+        if (adoConfig) {
+          const items = await fetchActiveWorkItems(adoConfig);
+
+          if (items.length > 0) {
+            const choices = items.map((wi) => ({
+              name: `[${wi.type}] ${wi.title} (${wi.state})`,
+              value: `[ADO-${wi.id}] ${wi.title}`,
+            }));
+            choices.push({ name: "Enter a custom task...", value: "__custom__" });
+
+            const picked = await select({
+              message: `${items.length} active work item(s) — pick one:`,
+              choices,
+            });
+
+            task = picked === "__custom__"
+              ? await input({ message: "Task description:" })
+              : picked;
+          } else {
+            console.log("No active work items found in Azure DevOps.");
+            task = await input({ message: "Task description:" });
+          }
+        } else {
+          task = await input({ message: "Task description:" });
+        }
+
+        if (!task) {
+          console.error("Task description is required.");
+          process.exit(1);
+        }
+      }
+
       const session = startSession(db, {
         user_id: userId,
-        task: opts.task,
+        task,
         execution_context: opts.context as ExecutionContext,
       });
+
+      db.close();
 
       if (opts.quiet) {
         console.log(session.id);
@@ -67,7 +113,15 @@ sessionCommand
         console.log(`  Context: ${session.execution_context}`);
         console.log(`  Started: ${session.started_at}`);
       }
-    });
+    } catch (err) {
+      db?.close();
+      if ((err as Error).name === "ExitPromptError") {
+        console.log("\nSession start cancelled.");
+        process.exit(0);
+      }
+      console.error("Error:", (err as Error).message);
+      process.exit(1);
+    }
   });
 
 // ── zam session log ───────────────────────────────────────────────────────

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { skillCommand } from "./commands/skill.js";
 import { monitorCommand } from "./commands/monitor.js";
 import { settingsCommand } from "./commands/settings.js";
 import { whoamiCommand } from "./commands/whoami.js";
+import { connectorCommand } from "./commands/connector.js";
 
 const program = new Command();
 
@@ -31,5 +32,6 @@ program.addCommand(skillCommand);
 program.addCommand(monitorCommand);
 program.addCommand(settingsCommand);
 program.addCommand(whoamiCommand);
+program.addCommand(connectorCommand);
 
 program.parse();

--- a/src/kernel/connectors/azure-devops.ts
+++ b/src/kernel/connectors/azure-devops.ts
@@ -1,0 +1,102 @@
+/**
+ * Azure DevOps connector — fetches work items from ADO boards.
+ */
+
+import type { Database } from "better-sqlite3";
+import { getSetting } from "../models/settings.js";
+
+export interface ADOConfig {
+  orgUrl: string;
+  project: string;
+  pat: string;
+}
+
+export interface WorkItem {
+  id: number;
+  title: string;
+  state: string;
+  type: string;
+  assignedTo: string;
+}
+
+/** Load ADO config from user settings. Returns null if not configured. */
+export function loadADOConfig(db: Database): ADOConfig | null {
+  const orgUrl = getSetting(db, "ado.org_url");
+  const project = getSetting(db, "ado.project");
+  const pat = getSetting(db, "ado.pat");
+
+  if (!orgUrl || !project || !pat) return null;
+
+  return { orgUrl: orgUrl.replace(/\/+$/, ""), project, pat };
+}
+
+function authHeader(pat: string): string {
+  return `Basic ${Buffer.from(`:${pat}`).toString("base64")}`;
+}
+
+/**
+ * Fetch active work items assigned to the current user.
+ * Uses WIQL to query, then batch-fetches work item details.
+ */
+export async function fetchActiveWorkItems(config: ADOConfig): Promise<WorkItem[]> {
+  const { orgUrl, project, pat } = config;
+
+  // Step 1: WIQL query for work item IDs
+  const wiqlUrl = `${orgUrl}/${project}/_apis/wit/wiql?api-version=7.1`;
+  const wiqlBody = {
+    query: `SELECT [System.Id] FROM WorkItems WHERE [System.AssignedTo] = @me AND [System.State] NOT IN ('Closed', 'Completed', 'Done', 'Removed') ORDER BY [Microsoft.VSTS.Common.Priority] ASC, [System.ChangedDate] DESC`,
+  };
+
+  const wiqlRes = await fetch(wiqlUrl, {
+    method: "POST",
+    headers: {
+      Authorization: authHeader(pat),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(wiqlBody),
+  });
+
+  if (!wiqlRes.ok) {
+    const text = await wiqlRes.text();
+    throw new Error(`ADO WIQL query failed (${wiqlRes.status}): ${text}`);
+  }
+
+  const wiqlData = (await wiqlRes.json()) as { workItems: { id: number }[] };
+  const ids = wiqlData.workItems.map((wi) => wi.id);
+
+  if (ids.length === 0) return [];
+
+  // Step 2: Batch fetch work item details (max 200 per request)
+  const batchIds = ids.slice(0, 200);
+  const fields = "System.Id,System.Title,System.State,System.WorkItemType,System.AssignedTo";
+  const detailUrl = `${orgUrl}/${project}/_apis/wit/workitems?ids=${batchIds.join(",")}&fields=${fields}&api-version=7.1`;
+
+  const detailRes = await fetch(detailUrl, {
+    headers: { Authorization: authHeader(pat) },
+  });
+
+  if (!detailRes.ok) {
+    const text = await detailRes.text();
+    throw new Error(`ADO work items fetch failed (${detailRes.status}): ${text}`);
+  }
+
+  const detailData = (await detailRes.json()) as {
+    value: Array<{
+      id: number;
+      fields: {
+        "System.Title": string;
+        "System.State": string;
+        "System.WorkItemType": string;
+        "System.AssignedTo"?: { displayName: string };
+      };
+    }>;
+  };
+
+  return detailData.value.map((wi) => ({
+    id: wi.id,
+    title: wi.fields["System.Title"],
+    state: wi.fields["System.State"],
+    type: wi.fields["System.WorkItemType"],
+    assignedTo: wi.fields["System.AssignedTo"]?.displayName ?? "",
+  }));
+}

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -131,3 +131,7 @@ export {
   generateZshUnhooks,
   generateBashUnhooks,
 } from "./observation/shell-hooks.js";
+
+// Connectors
+export { loadADOConfig, fetchActiveWorkItems } from "./connectors/azure-devops.js";
+export type { ADOConfig, WorkItem } from "./connectors/azure-devops.js";


### PR DESCRIPTION
## Summary
- Adds `zam connector setup ado` — interactive setup for Azure DevOps (org URL, project, PAT)
- Adds `zam connector tasks` — lists active work items assigned to the user
- Adds `zam connector clear ado` — removes stored credentials
- Makes `--task` optional on `zam session start` — when omitted, shows interactive work item picker from ADO (or free-text input if no connector configured)

## How it works
- ADO config stored in existing `user_config` table (no schema changes)
- WIQL query fetches assigned, non-closed work items
- Batch GET retrieves work item details (title, state, type)
- Node.js built-in `fetch` — no new dependencies

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test` — 47/47 pass
- [x] `zam connector tasks` without config shows helpful error
- [x] `zam session start --task "manual"` still works as before
- [ ] `zam connector setup ado` with real ADO instance (needs PAT)
- [ ] `zam session start` interactive picker with real ADO data

🤖 Generated with [Claude Code](https://claude.com/claude-code)