### PR TITLE
feat: cloud-ready database with Turso sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",
+        "libsql": "^0.5.29",
         "ulid": "^3.0.2"
       },
       "bin": {
@@ -19,7 +19,6 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.5.0",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
@@ -1045,6 +1044,123 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz",
+      "integrity": "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.29.tgz",
+      "integrity": "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-gnueabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.29.tgz",
+      "integrity": "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-musleabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.29.tgz",
+      "integrity": "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.29.tgz",
+      "integrity": "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.29.tgz",
+      "integrity": "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.29.tgz",
+      "integrity": "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.29.tgz",
+      "integrity": "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.29.tgz",
+      "integrity": "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -1061,6 +1177,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.120.0",
@@ -1759,16 +1881,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1947,84 +2059,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -2082,12 +2116,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
@@ -2149,46 +2177,14 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2250,15 +2246,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2311,12 +2298,6 @@
         }
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -2328,12 +2309,6 @@
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2363,12 +2338,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
-    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -2385,38 +2354,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
-    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -2425,6 +2362,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/libsql": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.29.tgz",
+      "integrity": "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32",
+        "arm"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.29",
+        "@libsql/darwin-x64": "0.5.29",
+        "@libsql/linux-arm-gnueabihf": "0.5.29",
+        "@libsql/linux-arm-musleabihf": "0.5.29",
+        "@libsql/linux-arm64-gnu": "0.5.29",
+        "@libsql/linux-arm64-musl": "0.5.29",
+        "@libsql/linux-x64-gnu": "0.5.29",
+        "@libsql/linux-x64-musl": "0.5.29",
+        "@libsql/win32-x64-msvc": "0.5.29"
+      }
+    },
+    "node_modules/libsql/node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lightningcss": {
@@ -2740,33 +2718,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -2827,24 +2778,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2865,15 +2798,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2996,72 +2920,6 @@
         }
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3175,43 +3033,11 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -3230,51 +3056,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -3311,24 +3092,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -3360,34 +3123,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/thenify": {
@@ -3552,18 +3287,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3599,12 +3322,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -3793,12 +3510,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,13 +33,12 @@
   "homepage": "https://github.com/zam-os/zam#readme",
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "better-sqlite3": "^12.8.0",
     "commander": "^14.0.3",
+    "libsql": "^0.5.29",
     "ulid": "^3.0.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.5.0",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -6,7 +6,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   getDueCards,

--- a/src/cli/commands/card.ts
+++ b/src/cli/commands/card.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   getDueCards,

--- a/src/cli/commands/connector.ts
+++ b/src/cli/commands/connector.ts
@@ -3,10 +3,12 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { input, password } from "@inquirer/prompts";
 import {
   openDatabase,
+  openDatabaseWithSync,
+  getSetting,
   setSetting,
   deleteSetting,
 } from "../../kernel/index.js";
@@ -36,10 +38,13 @@ export const connectorCommand = new Command("connector")
 connectorCommand
   .command("setup")
   .description("Configure a connector")
-  .argument("<type>", "Connector type (ado)")
+  .argument("<type>", "Connector type (ado, turso)")
   .action(async (type) => {
+    if (type === "turso") {
+      return setupTurso();
+    }
     if (type !== "ado") {
-      console.error(`Unknown connector type: ${type}. Supported: ado`);
+      console.error(`Unknown connector type: ${type}. Supported: ado, turso`);
       process.exit(1);
     }
 
@@ -130,10 +135,19 @@ connectorCommand
 connectorCommand
   .command("clear")
   .description("Remove a connector configuration")
-  .argument("<type>", "Connector type (ado)")
+  .argument("<type>", "Connector type (ado, turso)")
   .action((type) => {
+    if (type === "turso") {
+      withDb((db) => {
+        deleteSetting(db, "turso.url");
+        deleteSetting(db, "turso.token");
+        console.log("Turso cloud sync removed. Database remains local-only.");
+      });
+      return;
+    }
+
     if (type !== "ado") {
-      console.error(`Unknown connector type: ${type}. Supported: ado`);
+      console.error(`Unknown connector type: ${type}. Supported: ado, turso`);
       process.exit(1);
     }
 
@@ -144,3 +158,66 @@ connectorCommand
       console.log("Azure DevOps connector removed.");
     });
   });
+
+// ── zam connector sync ──────────────────────────────────────────────────────
+
+connectorCommand
+  .command("sync")
+  .description("Trigger a manual sync with Turso cloud database")
+  .action(() => {
+    let db: Database | undefined;
+    try {
+      db = openDatabaseWithSync();
+      const url = getSetting(db, "turso.url");
+      if (!url) {
+        console.error("No Turso cloud database configured. Run: zam connector setup turso");
+        process.exit(1);
+      }
+      (db as unknown as { sync: () => void }).sync();
+      console.log(`Synced with ${url}`);
+      db.close();
+    } catch (err) {
+      db?.close();
+      console.error("Error:", (err as Error).message);
+      process.exit(1);
+    }
+  });
+
+// ── Turso setup helper ──────────────────────────────────────────────────────
+
+async function setupTurso(): Promise<void> {
+  let db: Database | undefined;
+  try {
+    const url = await input({
+      message: "Turso database URL (e.g. libsql://my-db-user.turso.io):",
+    });
+    const token = await password({
+      message: "Auth token:",
+    });
+
+    if (!url || !token) {
+      console.error("Both URL and token are required.");
+      process.exit(1);
+    }
+
+    db = openDatabase();
+    setSetting(db, "turso.url", url);
+    setSetting(db, "turso.token", token);
+    db.close();
+
+    // Verify by opening with sync
+    db = openDatabaseWithSync();
+    (db as unknown as { sync: () => void }).sync();
+    db.close();
+
+    console.log(`Turso cloud sync configured and verified: ${url}`);
+  } catch (err) {
+    db?.close();
+    if ((err as Error).name === "ExitPromptError") {
+      console.log("\nSetup cancelled.");
+      process.exit(0);
+    }
+    console.error("Error:", (err as Error).message);
+    process.exit(1);
+  }
+}

--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -16,7 +16,7 @@ import { basename, join } from "node:path";
 import { execSync } from "node:child_process";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   ensureMonitorDir,

--- a/src/cli/commands/resolve-user.ts
+++ b/src/cli/commands/resolve-user.ts
@@ -2,7 +2,7 @@
  * Resolve the active user ID from --user flag or stored whoami setting.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { getSetting } from "../../kernel/index.js";
 
 export interface ResolveUserOptions {

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { select, input } from "@inquirer/prompts";
 import {
   openDatabase,

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { select, input } from "@inquirer/prompts";
 import {
   openDatabase,

--- a/src/cli/commands/settings.ts
+++ b/src/cli/commands/settings.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   getSetting,

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   createAgentSkill,

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   getUserStats,

--- a/src/cli/commands/token.ts
+++ b/src/cli/commands/token.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   createToken,

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import {
   openDatabase,
   getSetting,

--- a/src/kernel/analytics/stats.ts
+++ b/src/kernel/analytics/stats.ts
@@ -5,7 +5,7 @@
  * Ported from PoC's `stats` command with additions for FSRS and symbiosis modes.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 
 export interface UserStats {
   userId: string;

--- a/src/kernel/connectors/azure-devops.ts
+++ b/src/kernel/connectors/azure-devops.ts
@@ -2,7 +2,7 @@
  * Azure DevOps connector — fetches work items from ADO boards.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { getSetting } from "../models/settings.js";
 
 export interface ADOConfig {

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -1,4 +1,4 @@
-import Database, { type Database as DatabaseType } from "better-sqlite3";
+import Database, { type Database as DatabaseType } from "libsql";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -12,11 +12,16 @@ export interface ConnectionOptions {
   dbPath?: string;
   /** If true, create the directory and run schema migrations on open */
   initialize?: boolean;
+  /** Turso sync URL for cloud replication (e.g. libsql://db-name.turso.io) */
+  syncUrl?: string;
+  /** Turso auth token for cloud replication */
+  authToken?: string;
 }
 
 /**
  * Open (or create) the ZAM database.
  * Uses WAL mode for concurrent access from AI CLI and user CLI.
+ * When syncUrl is provided, enables embedded replica sync with Turso.
  */
 export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
   const dbPath = options.dbPath ?? DEFAULT_DB_PATH;
@@ -28,7 +33,16 @@ export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
     }
   }
 
-  const db = new Database(dbPath);
+  // Build constructor options for libsql
+  const dbOpts: Record<string, unknown> = {};
+  if (options.syncUrl) {
+    dbOpts.syncUrl = options.syncUrl;
+  }
+  if (options.authToken) {
+    dbOpts.authToken = options.authToken;
+  }
+
+  const db = new Database(dbPath, dbOpts as Database.Options);
 
   // Enable WAL mode and foreign keys
   db.pragma("journal_mode = WAL");
@@ -41,7 +55,30 @@ export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
 
   runMigrations(db);
 
+  // Sync after migrations if cloud is configured
+  if (options.syncUrl) {
+    (db as unknown as { sync: () => void }).sync();
+  }
+
   return db;
+}
+
+/**
+ * Open the database with Turso cloud sync auto-detected from stored settings.
+ * Reads turso.url and turso.token from user_config. If present, reopens
+ * the database with embedded replica sync enabled.
+ */
+export function openDatabaseWithSync(options: Omit<ConnectionOptions, "syncUrl" | "authToken"> = {}): DatabaseType {
+  // First open locally to read settings
+  const db = openDatabase(options);
+  const syncUrl = db.prepare("SELECT value FROM user_config WHERE key = ?").get("turso.url") as { value: string } | undefined;
+  const authToken = db.prepare("SELECT value FROM user_config WHERE key = ?").get("turso.token") as { value: string } | undefined;
+
+  if (!syncUrl || !authToken) return db;
+
+  // Reopen with sync enabled
+  db.close();
+  return openDatabase({ ...options, syncUrl: syncUrl.value, authToken: authToken.value });
 }
 
 /** Get the default database path */

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Database
-export { openDatabase, getDefaultDbPath } from "./db/connection.js";
+export { openDatabase, openDatabaseWithSync, getDefaultDbPath } from "./db/connection.js";
 
 // Models
 export {

--- a/src/kernel/models/agent-skill.ts
+++ b/src/kernel/models/agent-skill.ts
@@ -6,7 +6,7 @@
  * FSRS decay naturally resurfaces them for review — automation ≠ retention.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { ulid } from "ulid";
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/src/kernel/models/card.ts
+++ b/src/kernel/models/card.ts
@@ -5,7 +5,7 @@
  * using FSRS fields (stability, difficulty, elapsed_days, etc.).
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { ulid } from "ulid";
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/src/kernel/models/prerequisite.ts
+++ b/src/kernel/models/prerequisite.ts
@@ -4,7 +4,7 @@
  * Models the dependency graph: "to learn token A, first know token B."
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/kernel/models/review.ts
+++ b/src/kernel/models/review.ts
@@ -6,7 +6,7 @@
  * learning history.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { ulid } from "ulid";
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/src/kernel/models/session.ts
+++ b/src/kernel/models/session.ts
@@ -5,7 +5,7 @@
  * record which tokens were touched and by whom (user or agent).
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { ulid } from "ulid";
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/src/kernel/models/settings.ts
+++ b/src/kernel/models/settings.ts
@@ -2,7 +2,7 @@
  * User settings — key/value store backed by the user_config table.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 
 export interface UserSetting {
   key: string;

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -5,7 +5,7 @@
  * and optional symbiosis modes (shadowing / copilot / autonomy).
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { ulid } from "ulid";
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/src/kernel/recall/evaluator.ts
+++ b/src/kernel/recall/evaluator.ts
@@ -5,7 +5,7 @@
  * Coordinates between FSRS scheduling, review logging, and blocking.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { ulid } from "ulid";
 import { updateCard } from "../models/card.js";
 import type { Rating, SchedulingCard } from "../scheduler/fsrs.js";

--- a/src/kernel/scheduler/blocker.ts
+++ b/src/kernel/scheduler/blocker.ts
@@ -8,7 +8,7 @@
  * the active deck. When all prerequisites are met, we unblock.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { ensureCard } from "../models/card.js";
 import { getTokenBySlug } from "../models/token.js";
 import { getPrerequisites } from "../models/prerequisite.js";

--- a/src/kernel/scheduler/queue.ts
+++ b/src/kernel/scheduler/queue.ts
@@ -5,7 +5,7 @@
  * and cross-domain interleaving into a single ready-to-review queue.
  */
 
-import type { Database } from "better-sqlite3";
+import type { Database } from "libsql";
 import { interleave } from "./interleaver.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replaces `better-sqlite3` with `libsql` — a drop-in replacement with identical synchronous API
- Adds Turso embedded replica support: local DB syncs with cloud when configured
- New commands: `zam connector setup turso`, `zam connector sync`, `zam connector clear turso`
- Local-first remains the default; cloud sync is opt-in

## How it works
- `libsql` provides the same `db.prepare().get/run/all()` API as better-sqlite3
- When `turso.url` and `turso.token` are in settings, `openDatabaseWithSync()` opens with embedded replica sync
- The local `~/.zam/zam.db` continues to work — cloud adds replication, not replacement

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test` — 47/47 pass
- [x] `zam whoami` — existing data accessible through libsql
- [x] `zam card due` — all queries work identically
- [x] `zam connector sync` — shows helpful error when not configured
- [ ] `zam connector setup turso` with real Turso instance (needs account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)