### PR TITLE
feat: markdown goal engine and skill discovery

### DIFF
--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -19,12 +19,17 @@ import {
   cascadeBlock,
   getPrerequisites,
   getAgentSkill,
+  listAgentSkills,
   readMonitorLog,
   pairCommands,
   analyzeObservation,
   monitorLogExists,
+  discoverSkills,
 } from "../../kernel/index.js";
 import type { Rating, BloomLevel, TokenPattern } from "../../kernel/index.js";
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { resolveUser } from "./resolve-user.js";
 
 function jsonOut(data: unknown): void {
@@ -369,5 +374,77 @@ bridgeCommand
       if ((err as Error).message) {
         jsonError((err as Error).message);
       }
+    }
+  });
+
+// ── zam bridge discover-skills ──────────────────────────────────────────────
+
+bridgeCommand
+  .command("discover-skills")
+  .description("Analyze monitor logs across sessions to discover recurring patterns")
+  .option("--min-sessions <n>", "Minimum sessions a pattern must appear in (default: 2)", "2")
+  .option("--limit <n>", "Max number of sessions to analyze (default: 20)", "20")
+  .action((opts) => {
+    try {
+      const monitorDir = join(homedir(), ".zam", "monitor");
+      let files: string[];
+      try {
+        files = readdirSync(monitorDir).filter((f) => f.endsWith(".jsonl"));
+      } catch {
+        jsonOut({ proposals: [], message: "No monitor logs found." });
+        return;
+      }
+
+      if (files.length === 0) {
+        jsonOut({ proposals: [], message: "No monitor logs found." });
+        return;
+      }
+
+      // Take the most recent N sessions by file modification time
+      const limit = Number(opts.limit);
+      const sorted = files
+        .map((f) => ({ name: f, path: join(monitorDir, f) }))
+        .sort((a, b) => b.name.localeCompare(a.name)) // ULID session IDs sort chronologically
+        .slice(0, limit);
+
+      // Load and parse each session's commands
+      const sessionCommands = new Map<string, ReturnType<typeof pairCommands>>();
+      for (const file of sorted) {
+        const sessionId = file.name.replace(".jsonl", "");
+        const events = readMonitorLog(sessionId);
+        const commands = pairCommands(events);
+        if (commands.length > 0) {
+          sessionCommands.set(sessionId, commands);
+        }
+      }
+
+      if (sessionCommands.size === 0) {
+        jsonOut({ proposals: [], message: "No command data in monitor logs." });
+        return;
+      }
+
+      // Get existing skills to exclude
+      let existingSkillSlugs: string[] = [];
+      let db;
+      try {
+        db = openDatabase();
+        existingSkillSlugs = listAgentSkills(db).map((s) => s.slug);
+      } catch {
+        // DB not available — proceed without exclusion
+      } finally {
+        db?.close();
+      }
+
+      const proposals = discoverSkills(sessionCommands, {
+        minSessions: Number(opts.minSessions),
+        existingSkillSlugs,
+      });
+
+      jsonOut({
+        sessionsAnalyzed: sessionCommands.size,
+        proposals,
+      });
+    } catch (err) {
+      jsonError((err as Error).message);
     }
   });

--- a/src/cli/commands/goal.ts
+++ b/src/cli/commands/goal.ts
@@ -1,0 +1,259 @@
+/**
+ * `zam goal` — Goal management subcommand group.
+ *
+ * Goals are markdown files in the personal repo's goals/ directory.
+ * The directory is configured via the `personal.goals_dir` setting,
+ * or defaults to `./goals` relative to the current working directory.
+ */
+
+import { Command } from "commander";
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { input, select } from "@inquirer/prompts";
+import {
+  openDatabase,
+  getSetting,
+  listGoals,
+  getGoal,
+  createGoal,
+  updateGoalStatus,
+  getGoalTree,
+  extractTasks,
+  extractTokenRefs,
+} from "../../kernel/index.js";
+import type { GoalStatus } from "../../kernel/index.js";
+
+function resolveGoalsDir(): string {
+  let goalsDir: string | undefined;
+
+  let db;
+  try {
+    db = openDatabase();
+    goalsDir = getSetting(db, "personal.goals_dir");
+  } catch {
+    // DB not available — fall back to default
+  } finally {
+    db?.close();
+  }
+
+  return goalsDir ? resolve(goalsDir) : resolve("goals");
+}
+
+export const goalCommand = new Command("goal")
+  .description("Manage learning goals (markdown files)");
+
+// ── zam goal list ────────────────────────────────────────────────────────────
+
+goalCommand
+  .command("list")
+  .description("List all goals")
+  .option("--status <status>", "Filter by status (active, completed, paused, abandoned)")
+  .option("--tree", "Show goals as a tree with parent/child relationships")
+  .option("--json", "Output as JSON")
+  .action((opts) => {
+    const goalsDir = resolveGoalsDir();
+
+    if (!existsSync(goalsDir)) {
+      console.error(`Goals directory not found: ${goalsDir}`);
+      console.error("Set it with: zam settings set personal.goals_dir /path/to/goals");
+      process.exit(1);
+    }
+
+    if (opts.tree) {
+      const tree = getGoalTree(goalsDir);
+      const filtered = opts.status
+        ? tree.filter((g) => g.status === opts.status)
+        : tree;
+
+      if (opts.json) {
+        console.log(JSON.stringify(filtered, null, 2));
+        return;
+      }
+
+      if (filtered.length === 0) {
+        console.log("No goals found.");
+        return;
+      }
+
+      for (const root of filtered) {
+        printGoalLine(root, 0);
+        for (const child of root.children) {
+          printGoalLine(child, 1);
+        }
+      }
+      return;
+    }
+
+    let goals = listGoals(goalsDir);
+
+    if (opts.status) {
+      goals = goals.filter((g) => g.status === opts.status);
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(goals, null, 2));
+      return;
+    }
+
+    if (goals.length === 0) {
+      console.log("No goals found.");
+      return;
+    }
+
+    console.log("Goals:");
+    console.log("  " + "─".repeat(70));
+    for (const g of goals) {
+      printGoalLine(g, 0);
+    }
+  });
+
+function printGoalLine(
+  g: { slug: string; title: string; status: string; taskCount: number; tasksDone: number },
+  indent: number,
+): void {
+  const prefix = "  ".repeat(indent + 1);
+  const statusIcon: Record<string, string> = {
+    active: "[*]",
+    paused: "[-]",
+    completed: "[x]",
+    abandoned: "[ ]",
+  };
+  const icon = statusIcon[g.status] || "[ ]";
+  const tasks = g.taskCount > 0 ? ` (${g.tasksDone}/${g.taskCount} tasks)` : "";
+  console.log(`${prefix}${icon} ${g.title}${tasks}  — ${g.slug}`);
+}
+
+// ── zam goal show ────────────────────────────────────────────────────────────
+
+goalCommand
+  .command("show <slug>")
+  .description("Show a goal's details")
+  .option("--json", "Output as JSON")
+  .action((slug, opts) => {
+    const goalsDir = resolveGoalsDir();
+    const goal = getGoal(goalsDir, slug);
+
+    if (!goal) {
+      console.error(`Goal not found: ${slug}`);
+      process.exit(1);
+    }
+
+    if (opts.json) {
+      const tasks = extractTasks(goal.body);
+      const tokens = extractTokenRefs(goal.body);
+      console.log(JSON.stringify({ ...goal, tasks, tokens }, null, 2));
+      return;
+    }
+
+    console.log(`Title:   ${goal.title}`);
+    console.log(`Slug:    ${goal.slug}`);
+    console.log(`Status:  ${goal.status}`);
+    if (goal.parent) console.log(`Parent:  ${goal.parent}`);
+    console.log(`Created: ${goal.created}`);
+    console.log(`Updated: ${goal.updated}`);
+
+    const tasks = extractTasks(goal.body);
+    if (tasks.length > 0) {
+      console.log(`\nTasks (${tasks.filter((t) => t.done).length}/${tasks.length}):`);
+      for (const t of tasks) {
+        console.log(`  [${t.done ? "x" : " "}] ${t.text}`);
+      }
+    }
+
+    const tokens = extractTokenRefs(goal.body);
+    if (tokens.length > 0) {
+      console.log(`\nTokens:`);
+      for (const ref of tokens) {
+        console.log(`  - ${ref}`);
+      }
+    }
+
+    if (goal.body) {
+      console.log(`\n${"─".repeat(50)}`);
+      console.log(goal.body);
+    }
+  });
+
+// ── zam goal create ──────────────────────────────────────────────────────────
+
+goalCommand
+  .command("create")
+  .description("Create a new goal")
+  .option("--slug <slug>", "Goal slug (used as filename)")
+  .option("--title <title>", "Goal title")
+  .option("--parent <slug>", "Parent goal slug")
+  .option("--description <text>", "Goal description")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const goalsDir = resolveGoalsDir();
+
+    if (!existsSync(goalsDir)) {
+      mkdirSync(goalsDir, { recursive: true });
+    }
+
+    let slug = opts.slug;
+    let title = opts.title;
+    const parent = opts.parent;
+    const description = opts.description;
+
+    // Interactive mode if slug or title not provided
+    if (!slug || !title) {
+      try {
+        if (!title) {
+          title = await input({ message: "Goal title:" });
+        }
+        if (!slug) {
+          const suggested = title
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-|-$/g, "");
+          slug = await input({
+            message: "Goal slug (filename):",
+            default: suggested,
+          });
+        }
+      } catch (err) {
+        if ((err as Error).name === "ExitPromptError") {
+          console.log("\nCancelled.");
+          process.exit(0);
+        }
+        throw err;
+      }
+    }
+
+    const goal = createGoal(goalsDir, { slug, title, parent, description });
+
+    if (opts.json) {
+      console.log(JSON.stringify(goal, null, 2));
+      return;
+    }
+
+    console.log(`Goal created: ${goal.slug}`);
+    console.log(`  Title:  ${goal.title}`);
+    console.log(`  Status: ${goal.status}`);
+    console.log(`  File:   ${goal.filePath}`);
+  });
+
+// ── zam goal status ──────────────────────────────────────────────────────────
+
+goalCommand
+  .command("status <slug> <status>")
+  .description("Update a goal's status (active, paused, completed, abandoned)")
+  .option("--json", "Output as JSON")
+  .action((slug, status, opts) => {
+    const validStatuses: GoalStatus[] = ["active", "completed", "paused", "abandoned"];
+    if (!validStatuses.includes(status)) {
+      console.error(`Invalid status: ${status}. Must be one of: ${validStatuses.join(", ")}`);
+      process.exit(1);
+    }
+
+    const goalsDir = resolveGoalsDir();
+    const goal = updateGoalStatus(goalsDir, slug, status);
+
+    if (opts.json) {
+      console.log(JSON.stringify(goal, null, 2));
+      return;
+    }
+
+    console.log(`Goal ${slug} updated to: ${status}`);
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { monitorCommand } from "./commands/monitor.js";
 import { settingsCommand } from "./commands/settings.js";
 import { whoamiCommand } from "./commands/whoami.js";
 import { connectorCommand } from "./commands/connector.js";
+import { goalCommand } from "./commands/goal.js";
 
 const program = new Command();
 
@@ -33,5 +34,6 @@ program.addCommand(monitorCommand);
 program.addCommand(settingsCommand);
 program.addCommand(whoamiCommand);
 program.addCommand(connectorCommand);
+program.addCommand(goalCommand);
 
 program.parse();

--- a/src/kernel/goals/engine.ts
+++ b/src/kernel/goals/engine.ts
@@ -1,0 +1,174 @@
+/**
+ * Goal Engine — manages goal lifecycle via markdown files.
+ *
+ * Goals live as markdown files in a directory (typically the personal repo's
+ * goals/ folder). The engine reads, creates, and updates these files.
+ * It does not depend on the database — goals are git-tracked, not DB-tracked.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, basename } from "node:path";
+import {
+  parseGoalFile,
+  serializeGoal,
+  extractTasks,
+  extractTokenRefs,
+} from "./parser.js";
+import type { Goal, GoalStatus } from "./parser.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface GoalSummary {
+  slug: string;
+  title: string;
+  status: GoalStatus;
+  parent: string | null;
+  taskCount: number;
+  tasksDone: number;
+  tokenCount: number;
+}
+
+export interface CreateGoalInput {
+  slug: string;
+  title: string;
+  status?: GoalStatus;
+  parent?: string;
+  description?: string;
+}
+
+// ── Functions ────────────────────────────────────────────────────────────────
+
+/**
+ * List all goals in the goals directory.
+ * Returns summaries sorted by status (active first) then title.
+ */
+export function listGoals(goalsDir: string): GoalSummary[] {
+  if (!existsSync(goalsDir)) return [];
+
+  const files = readdirSync(goalsDir).filter(
+    (f) => f.endsWith(".md") && f !== "README.md",
+  );
+
+  const summaries: GoalSummary[] = [];
+
+  for (const file of files) {
+    const filePath = join(goalsDir, file);
+    const content = readFileSync(filePath, "utf-8");
+    const slug = basename(file, ".md");
+    const goal = parseGoalFile(content, slug, filePath);
+    const tasks = extractTasks(goal.body);
+    const tokens = extractTokenRefs(goal.body);
+
+    summaries.push({
+      slug: goal.slug,
+      title: goal.title,
+      status: goal.status,
+      parent: goal.parent,
+      taskCount: tasks.length,
+      tasksDone: tasks.filter((t) => t.done).length,
+      tokenCount: tokens.length,
+    });
+  }
+
+  const statusOrder: Record<GoalStatus, number> = {
+    active: 0,
+    paused: 1,
+    completed: 2,
+    abandoned: 3,
+  };
+
+  summaries.sort((a, b) => {
+    const statusDiff = statusOrder[a.status] - statusOrder[b.status];
+    if (statusDiff !== 0) return statusDiff;
+    return a.title.localeCompare(b.title);
+  });
+
+  return summaries;
+}
+
+/**
+ * Get a single goal by slug (filename without .md).
+ * Returns undefined if the file doesn't exist.
+ */
+export function getGoal(goalsDir: string, slug: string): Goal | undefined {
+  const filePath = join(goalsDir, `${slug}.md`);
+  if (!existsSync(filePath)) return undefined;
+
+  const content = readFileSync(filePath, "utf-8");
+  return parseGoalFile(content, slug, filePath);
+}
+
+/**
+ * Create a new goal file. Throws if a goal with this slug already exists.
+ */
+export function createGoal(goalsDir: string, input: CreateGoalInput): Goal {
+  const filePath = join(goalsDir, `${input.slug}.md`);
+
+  if (existsSync(filePath)) {
+    throw new Error(`Goal already exists: ${input.slug}`);
+  }
+
+  const now = new Date().toISOString().slice(0, 10);
+
+  const goal: Goal = {
+    slug: input.slug,
+    title: input.title,
+    status: input.status ?? "active",
+    parent: input.parent ?? null,
+    created: now,
+    updated: now,
+    body: input.description
+      ? `## Description\n${input.description}\n\n## Tasks\n\n## Tokens`
+      : "## Description\n\n## Tasks\n\n## Tokens",
+    filePath,
+  };
+
+  writeFileSync(filePath, serializeGoal(goal), "utf-8");
+  return goal;
+}
+
+/**
+ * Update a goal's status. Writes the updated file back to disk.
+ */
+export function updateGoalStatus(
+  goalsDir: string,
+  slug: string,
+  status: GoalStatus,
+): Goal {
+  const goal = getGoal(goalsDir, slug);
+  if (!goal) throw new Error(`Goal not found: ${slug}`);
+
+  goal.status = status;
+  goal.updated = new Date().toISOString().slice(0, 10);
+
+  writeFileSync(goal.filePath, serializeGoal(goal), "utf-8");
+  return goal;
+}
+
+/**
+ * Get the goal tree — goals organized by parent relationships.
+ * Returns root goals (no parent) with nested children.
+ */
+export function getGoalTree(goalsDir: string): Array<GoalSummary & { children: GoalSummary[] }> {
+  const all = listGoals(goalsDir);
+  const bySlug = new Map(all.map((g) => [g.slug, g]));
+
+  const roots: Array<GoalSummary & { children: GoalSummary[] }> = [];
+  const children = new Map<string, GoalSummary[]>();
+
+  for (const g of all) {
+    if (g.parent && bySlug.has(g.parent)) {
+      const list = children.get(g.parent) ?? [];
+      list.push(g);
+      children.set(g.parent, list);
+    }
+  }
+
+  for (const g of all) {
+    if (!g.parent || !bySlug.has(g.parent)) {
+      roots.push({ ...g, children: children.get(g.slug) ?? [] });
+    }
+  }
+
+  return roots;
+}

--- a/src/kernel/goals/parser.ts
+++ b/src/kernel/goals/parser.ts
@@ -1,0 +1,175 @@
+/**
+ * Goal file parser — reads markdown files with YAML-style frontmatter.
+ *
+ * Goals are persisted as markdown files in the personal repo.
+ * Each file has simple key: value frontmatter (no nested structures)
+ * and a markdown body with description, tasks, and token references.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type GoalStatus = "active" | "completed" | "paused" | "abandoned";
+
+export interface Goal {
+  slug: string;          // derived from filename (e.g., "learn-rust" from "learn-rust.md")
+  title: string;
+  status: GoalStatus;
+  parent: string | null; // slug of parent goal
+  created: string;       // ISO date
+  updated: string;       // ISO date
+  body: string;          // markdown body after frontmatter
+  filePath: string;      // absolute path to the file
+}
+
+export interface GoalFrontmatter {
+  title?: string;
+  status?: string;
+  parent?: string;
+  created?: string;
+  updated?: string;
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a goal markdown file into a Goal object.
+ *
+ * Expected format:
+ * ```
+ * ---
+ * title: Learn Rust fundamentals
+ * status: active
+ * parent: become-systems-programmer
+ * created: 2026-03-28
+ * updated: 2026-03-28
+ * ---
+ *
+ * ## Description
+ * ...
+ * ```
+ *
+ * @param content - Raw file content
+ * @param slug - Goal slug (derived from filename by caller)
+ * @param filePath - Absolute path to the file
+ */
+export function parseGoalFile(content: string, slug: string, filePath: string): Goal {
+  const { frontmatter, body } = splitFrontmatter(content);
+
+  const validStatuses: GoalStatus[] = ["active", "completed", "paused", "abandoned"];
+  const status = validStatuses.includes(frontmatter.status as GoalStatus)
+    ? (frontmatter.status as GoalStatus)
+    : "active";
+
+  const now = new Date().toISOString().slice(0, 10);
+
+  return {
+    slug,
+    title: frontmatter.title || slug,
+    status,
+    parent: frontmatter.parent || null,
+    created: frontmatter.created || now,
+    updated: frontmatter.updated || now,
+    body,
+    filePath,
+  };
+}
+
+/**
+ * Serialize a Goal back to markdown with frontmatter.
+ */
+export function serializeGoal(goal: Goal): string {
+  const lines = [
+    "---",
+    `title: ${goal.title}`,
+    `status: ${goal.status}`,
+  ];
+
+  if (goal.parent) {
+    lines.push(`parent: ${goal.parent}`);
+  }
+
+  lines.push(`created: ${goal.created}`);
+  lines.push(`updated: ${goal.updated}`);
+  lines.push("---");
+  lines.push("");
+
+  if (goal.body.trim()) {
+    lines.push(goal.body.trim());
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Extract tasks (checklist items) from goal body.
+ * Returns items like { text: "Complete Rustlings", done: false }.
+ */
+export function extractTasks(body: string): Array<{ text: string; done: boolean }> {
+  const tasks: Array<{ text: string; done: boolean }> = [];
+  const taskRegex = /^[-*]\s+\[([ xX])\]\s+(.+)$/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = taskRegex.exec(body)) !== null) {
+    tasks.push({
+      done: match[1] !== " ",
+      text: match[2].trim(),
+    });
+  }
+
+  return tasks;
+}
+
+/**
+ * Extract token references from goal body.
+ * Looks for lines like `- token/slug` under a "## Tokens" section.
+ */
+export function extractTokenRefs(body: string): string[] {
+  const tokensSection = body.match(/## Tokens\n([\s\S]*?)(?=\n## |\n*$)/);
+  if (!tokensSection) return [];
+
+  const refs: string[] = [];
+  const lines = tokensSection[1].split("\n");
+
+  for (const line of lines) {
+    const match = line.match(/^[-*]\s+(\S+)/);
+    if (match) {
+      refs.push(match[1]);
+    }
+  }
+
+  return refs;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+function splitFrontmatter(content: string): { frontmatter: GoalFrontmatter; body: string } {
+  const trimmed = content.trim();
+
+  if (!trimmed.startsWith("---")) {
+    return { frontmatter: {}, body: trimmed };
+  }
+
+  const endIndex = trimmed.indexOf("---", 3);
+  if (endIndex === -1) {
+    return { frontmatter: {}, body: trimmed };
+  }
+
+  const fmBlock = trimmed.slice(3, endIndex).trim();
+  const body = trimmed.slice(endIndex + 3).trim();
+
+  const frontmatter: GoalFrontmatter = {};
+  for (const line of fmBlock.split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+
+    if (key && value) {
+      (frontmatter as Record<string, string>)[key] = value;
+    }
+  }
+
+  return { frontmatter, body };
+}

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -132,6 +132,31 @@ export {
   generateBashUnhooks,
 } from "./observation/shell-hooks.js";
 
+export { discoverSkills } from "./observation/skill-discovery.js";
+export type {
+  CommandSequence,
+  SkillProposal,
+  DiscoveryOptions,
+} from "./observation/skill-discovery.js";
+
+// Goals
+export {
+  listGoals,
+  getGoal,
+  createGoal,
+  updateGoalStatus,
+  getGoalTree,
+} from "./goals/engine.js";
+export type { GoalSummary, CreateGoalInput } from "./goals/engine.js";
+
+export {
+  parseGoalFile,
+  serializeGoal,
+  extractTasks,
+  extractTokenRefs,
+} from "./goals/parser.js";
+export type { Goal, GoalStatus, GoalFrontmatter } from "./goals/parser.js";
+
 // Connectors
 export { loadADOConfig, fetchActiveWorkItems } from "./connectors/azure-devops.js";
 export type { ADOConfig, WorkItem } from "./connectors/azure-devops.js";

--- a/src/kernel/observation/skill-discovery.ts
+++ b/src/kernel/observation/skill-discovery.ts
@@ -1,0 +1,292 @@
+/**
+ * Skill Discovery — identifies recurring non-standard command patterns
+ * across multiple sessions and proposes them as minimal reusable skills.
+ *
+ * The key insight from Increment 2: "The human's demonstrated competence
+ * is the gate for automation — not the other way around." A pattern must
+ * appear consistently across sessions before being proposed as a skill.
+ *
+ * Pure functions — no DB access. Callers provide command records and
+ * existing skills; this module returns proposed skills.
+ */
+
+import type { CommandRecord } from "./analyzer.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface CommandSequence {
+  /** The ordered command prefixes forming the pattern (e.g., ["git checkout", "npm install", "npm run build"]) */
+  steps: string[];
+  /** How many sessions contained this sequence */
+  sessionCount: number;
+  /** Total occurrences across all sessions */
+  totalOccurrences: number;
+  /** Example full commands from the most recent occurrence */
+  examples: string[];
+}
+
+export interface SkillProposal {
+  /** Suggested slug for the skill */
+  slug: string;
+  /** Human-readable description of what the pattern does */
+  description: string;
+  /** The command steps forming the skill */
+  steps: string[];
+  /** How many sessions demonstrated this pattern */
+  sessionCount: number;
+  /** Confidence that this is a real, repeatable skill */
+  confidence: "high" | "medium" | "low";
+  /** Example commands from actual usage */
+  examples: string[];
+}
+
+export interface DiscoveryOptions {
+  /** Minimum number of sessions a pattern must appear in (default: 2) */
+  minSessions?: number;
+  /** Minimum sequence length to consider (default: 2) */
+  minSequenceLength?: number;
+  /** Maximum sequence length to consider (default: 5) */
+  maxSequenceLength?: number;
+  /** Existing skill slugs to exclude from proposals */
+  existingSkillSlugs?: string[];
+}
+
+// ── Discovery ────────────────────────────────────────────────────────────────
+
+/**
+ * Discover recurring command patterns across multiple sessions.
+ *
+ * Takes a map of session ID → command records, finds command sequences
+ * that appear in multiple sessions, and proposes them as skills.
+ *
+ * @param sessionCommands - Map of session ID to that session's commands
+ * @param options - Discovery configuration
+ * @returns Array of skill proposals, sorted by confidence then session count
+ */
+export function discoverSkills(
+  sessionCommands: Map<string, CommandRecord[]>,
+  options: DiscoveryOptions = {},
+): SkillProposal[] {
+  const minSessions = options.minSessions ?? 2;
+  const minLen = options.minSequenceLength ?? 2;
+  const maxLen = options.maxSequenceLength ?? 5;
+  const existing = new Set(options.existingSkillSlugs ?? []);
+
+  // Step 1: Extract normalized command sequences from each session
+  const sessionSequences = new Map<string, string[][]>();
+  for (const [sessionId, commands] of sessionCommands) {
+    const sequences = extractSequences(commands, minLen, maxLen);
+    if (sequences.length > 0) {
+      sessionSequences.set(sessionId, sequences);
+    }
+  }
+
+  // Step 2: Count how many sessions contain each unique sequence
+  const sequenceIndex = new Map<string, CommandSequence>();
+
+  for (const [, sequences] of sessionSequences) {
+    // Deduplicate within a session — count each sequence once per session
+    const seen = new Set<string>();
+    for (const seq of sequences) {
+      const key = seq.join(" → ");
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const entry = sequenceIndex.get(key);
+      if (entry) {
+        entry.sessionCount++;
+        entry.totalOccurrences++;
+      } else {
+        sequenceIndex.set(key, {
+          steps: seq,
+          sessionCount: 1,
+          totalOccurrences: 1,
+          examples: [],
+        });
+      }
+    }
+  }
+
+  // Step 3: Collect examples from the most recent session for qualifying sequences
+  const lastSessionId = [...sessionCommands.keys()].pop();
+  if (lastSessionId) {
+    const lastCommands = sessionCommands.get(lastSessionId)!;
+    for (const [key, entry] of sequenceIndex) {
+      if (entry.sessionCount >= minSessions) {
+        entry.examples = findExamplesForSequence(lastCommands, entry.steps);
+      }
+    }
+  }
+
+  // Step 4: Filter to patterns that appear in enough sessions
+  const candidates = [...sequenceIndex.values()].filter(
+    (s) => s.sessionCount >= minSessions,
+  );
+
+  // Step 5: Remove subsequences of longer patterns (prefer maximal patterns)
+  const pruned = removeSubsequences(candidates);
+
+  // Step 6: Convert to skill proposals
+  const proposals: SkillProposal[] = [];
+  for (const seq of pruned) {
+    const slug = generateSlug(seq.steps);
+
+    // Skip if this skill already exists
+    if (existing.has(slug)) continue;
+
+    proposals.push({
+      slug,
+      description: describeSequence(seq.steps),
+      steps: seq.steps,
+      sessionCount: seq.sessionCount,
+      confidence: seq.sessionCount >= 4 ? "high" : seq.sessionCount >= 3 ? "medium" : "low",
+      examples: seq.examples,
+    });
+  }
+
+  // Sort: high confidence first, then by session count
+  const confidenceOrder = { high: 0, medium: 1, low: 2 };
+  proposals.sort((a, b) => {
+    const confDiff = confidenceOrder[a.confidence] - confidenceOrder[b.confidence];
+    if (confDiff !== 0) return confDiff;
+    return b.sessionCount - a.sessionCount;
+  });
+
+  return proposals;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a command to its tool + subcommand prefix.
+ * "git checkout -b feat/foo" → "git checkout"
+ * "npm run build" → "npm run build"
+ * "docker compose up -d" → "docker compose up"
+ */
+function normalizeCommand(command: string): string {
+  const parts = command.trim().split(/\s+/);
+
+  // Known multi-word tools
+  const multiWord = ["docker compose", "npm run", "npx", "git"];
+  const lower = command.toLowerCase();
+
+  for (const mw of multiWord) {
+    if (lower.startsWith(mw) && parts.length >= mw.split(" ").length + 1) {
+      return parts.slice(0, mw.split(" ").length + 1).join(" ").toLowerCase();
+    }
+  }
+
+  // Default: first two words
+  return parts.slice(0, Math.min(2, parts.length)).join(" ").toLowerCase();
+}
+
+/**
+ * Extract all command subsequences of length minLen..maxLen from a session.
+ * Uses normalized command prefixes for comparison.
+ */
+function extractSequences(
+  commands: CommandRecord[],
+  minLen: number,
+  maxLen: number,
+): string[][] {
+  // Filter out trivial commands
+  const filtered = commands.filter((c) => {
+    const lower = c.command.toLowerCase().trim();
+    return (
+      lower.length > 0 &&
+      !lower.startsWith("cd ") &&
+      lower !== "cd" &&
+      lower !== "ls" &&
+      lower !== "pwd" &&
+      lower !== "clear" &&
+      lower !== "exit" &&
+      !lower.startsWith("echo ")
+    );
+  });
+
+  const normalized = filtered.map((c) => normalizeCommand(c.command));
+  const sequences: string[][] = [];
+
+  for (let len = minLen; len <= maxLen; len++) {
+    for (let i = 0; i <= normalized.length - len; i++) {
+      const seq = normalized.slice(i, i + len);
+      // Only include if at least 2 distinct commands (not just "git commit" repeated)
+      if (new Set(seq).size >= 2) {
+        sequences.push(seq);
+      }
+    }
+  }
+
+  return sequences;
+}
+
+/**
+ * Find example full commands for a given normalized sequence in a command list.
+ */
+function findExamplesForSequence(
+  commands: CommandRecord[],
+  steps: string[],
+): string[] {
+  const normalized = commands.map((c) => ({
+    norm: normalizeCommand(c.command),
+    full: c.command,
+  }));
+
+  for (let i = 0; i <= normalized.length - steps.length; i++) {
+    let match = true;
+    for (let j = 0; j < steps.length; j++) {
+      if (normalized[i + j].norm !== steps[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      return normalized.slice(i, i + steps.length).map((n) => n.full);
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Remove sequences that are strict subsequences of longer qualifying sequences.
+ */
+function removeSubsequences(candidates: CommandSequence[]): CommandSequence[] {
+  // Sort by length descending so we check long sequences first
+  const sorted = [...candidates].sort((a, b) => b.steps.length - a.steps.length);
+  const result: CommandSequence[] = [];
+
+  for (const candidate of sorted) {
+    const key = candidate.steps.join(" → ");
+    const isSubsequence = result.some((longer) => {
+      const longerKey = longer.steps.join(" → ");
+      return longerKey.includes(key) && longerKey !== key;
+    });
+
+    if (!isSubsequence) {
+      result.push(candidate);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Generate a slug from command steps.
+ * ["git checkout", "npm install", "npm run build"] → "checkout-install-build"
+ */
+function generateSlug(steps: string[]): string {
+  return steps
+    .map((s) => {
+      const parts = s.split(/\s+/);
+      return parts[parts.length - 1]; // last word of each step
+    })
+    .join("-");
+}
+
+/**
+ * Generate a human-readable description of what a command sequence does.
+ */
+function describeSequence(steps: string[]): string {
+  return `Recurring pattern: ${steps.join(" → ")}`;
+}

--- a/tests/kernel/goals/parser.test.ts
+++ b/tests/kernel/goals/parser.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseGoalFile,
+  serializeGoal,
+  extractTasks,
+  extractTokenRefs,
+} from "../../../src/kernel/goals/parser.js";
+
+describe("parseGoalFile", () => {
+  it("parses a complete goal file with frontmatter", () => {
+    const content = `---
+title: Learn Rust fundamentals
+status: active
+parent: become-systems-programmer
+created: 2026-03-01
+updated: 2026-03-15
+---
+
+## Description
+Learn the core Rust language features.
+
+## Tasks
+- [ ] Complete Rustlings exercises
+- [x] Read the Rust Book
+
+## Tokens
+- rust/ownership
+- rust/borrowing`;
+
+    const goal = parseGoalFile(content, "learn-rust", "/tmp/learn-rust.md");
+
+    expect(goal.slug).toBe("learn-rust");
+    expect(goal.title).toBe("Learn Rust fundamentals");
+    expect(goal.status).toBe("active");
+    expect(goal.parent).toBe("become-systems-programmer");
+    expect(goal.created).toBe("2026-03-01");
+    expect(goal.updated).toBe("2026-03-15");
+    expect(goal.filePath).toBe("/tmp/learn-rust.md");
+    expect(goal.body).toContain("## Description");
+  });
+
+  it("defaults to slug as title when title is missing", () => {
+    const content = `---
+status: paused
+---
+
+Some body.`;
+
+    const goal = parseGoalFile(content, "my-goal", "/tmp/my-goal.md");
+    expect(goal.title).toBe("my-goal");
+    expect(goal.status).toBe("paused");
+    expect(goal.parent).toBeNull();
+  });
+
+  it("defaults to active status for invalid status values", () => {
+    const content = `---
+title: Test
+status: invalid
+---`;
+
+    const goal = parseGoalFile(content, "test", "/tmp/test.md");
+    expect(goal.status).toBe("active");
+  });
+
+  it("handles files with no frontmatter", () => {
+    const content = "Just a body with no frontmatter.";
+    const goal = parseGoalFile(content, "plain", "/tmp/plain.md");
+
+    expect(goal.title).toBe("plain");
+    expect(goal.status).toBe("active");
+    expect(goal.body).toBe("Just a body with no frontmatter.");
+  });
+});
+
+describe("serializeGoal", () => {
+  it("round-trips through parse and serialize", () => {
+    const original = `---
+title: Learn Rust fundamentals
+status: active
+parent: become-systems-programmer
+created: 2026-03-01
+updated: 2026-03-15
+---
+
+## Description
+Learn the core Rust language features.`;
+
+    const goal = parseGoalFile(original, "learn-rust", "/tmp/learn-rust.md");
+    const serialized = serializeGoal(goal);
+
+    expect(serialized).toContain("title: Learn Rust fundamentals");
+    expect(serialized).toContain("status: active");
+    expect(serialized).toContain("parent: become-systems-programmer");
+    expect(serialized).toContain("## Description");
+  });
+
+  it("omits parent when null", () => {
+    const content = `---
+title: Solo goal
+status: active
+created: 2026-03-01
+updated: 2026-03-01
+---`;
+
+    const goal = parseGoalFile(content, "solo", "/tmp/solo.md");
+    const serialized = serializeGoal(goal);
+
+    expect(serialized).not.toContain("parent:");
+  });
+});
+
+describe("extractTasks", () => {
+  it("extracts checked and unchecked tasks", () => {
+    const body = `## Tasks
+- [ ] Complete Rustlings exercises
+- [x] Read the Rust Book
+- [X] Install Rust toolchain
+- [ ] Build a CLI tool`;
+
+    const tasks = extractTasks(body);
+    expect(tasks).toHaveLength(4);
+    expect(tasks[0]).toEqual({ text: "Complete Rustlings exercises", done: false });
+    expect(tasks[1]).toEqual({ text: "Read the Rust Book", done: true });
+    expect(tasks[2]).toEqual({ text: "Install Rust toolchain", done: true });
+    expect(tasks[3]).toEqual({ text: "Build a CLI tool", done: false });
+  });
+
+  it("returns empty array when no tasks", () => {
+    expect(extractTasks("No tasks here.")).toEqual([]);
+  });
+});
+
+describe("extractTokenRefs", () => {
+  it("extracts token references from Tokens section", () => {
+    const body = `## Description
+Some text.
+
+## Tokens
+- rust/ownership
+- rust/borrowing
+- git/branching`;
+
+    const refs = extractTokenRefs(body);
+    expect(refs).toEqual(["rust/ownership", "rust/borrowing", "git/branching"]);
+  });
+
+  it("returns empty array when no Tokens section", () => {
+    expect(extractTokenRefs("Just text.")).toEqual([]);
+  });
+});

--- a/tests/kernel/observation/skill-discovery.test.ts
+++ b/tests/kernel/observation/skill-discovery.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { discoverSkills } from "../../../src/kernel/observation/skill-discovery.js";
+import type { CommandRecord } from "../../../src/kernel/observation/analyzer.js";
+
+function makeCommand(command: string, seq: number): CommandRecord {
+  return {
+    seq,
+    pid: 1000,
+    command,
+    cwd: "/home/user",
+    startedAt: new Date(2026, 2, 28, 10, 0, seq).toISOString(),
+    endedAt: new Date(2026, 2, 28, 10, 0, seq + 1).toISOString(),
+    durationMs: 1000,
+    exitCode: 0,
+  };
+}
+
+describe("discoverSkills", () => {
+  it("discovers a pattern that appears in multiple sessions", () => {
+    const pattern = [
+      makeCommand("git checkout -b feat/new", 1),
+      makeCommand("npm install", 2),
+      makeCommand("npm run build", 3),
+    ];
+
+    const sessions = new Map<string, CommandRecord[]>();
+    sessions.set("session-1", [...pattern]);
+    sessions.set("session-2", [...pattern]);
+    sessions.set("session-3", [...pattern]);
+
+    const proposals = discoverSkills(sessions, { minSessions: 2 });
+
+    expect(proposals.length).toBeGreaterThan(0);
+    expect(proposals[0].steps).toContain("git checkout");
+    expect(proposals[0].sessionCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns no proposals when pattern appears in only one session", () => {
+    const sessions = new Map<string, CommandRecord[]>();
+    sessions.set("session-1", [
+      makeCommand("git checkout -b feat/new", 1),
+      makeCommand("npm install", 2),
+      makeCommand("npm run build", 3),
+    ]);
+    sessions.set("session-2", [
+      makeCommand("docker compose up", 1),
+      makeCommand("curl localhost:3000", 2),
+    ]);
+
+    const proposals = discoverSkills(sessions, { minSessions: 2 });
+
+    // The git checkout → npm install → npm run build sequence only appears in session-1
+    const gitPattern = proposals.find((p) => p.steps.includes("git checkout"));
+    expect(gitPattern).toBeUndefined();
+  });
+
+  it("excludes existing skills", () => {
+    const pattern = [
+      makeCommand("git checkout -b feat/new", 1),
+      makeCommand("npm install", 2),
+    ];
+
+    const sessions = new Map<string, CommandRecord[]>();
+    sessions.set("session-1", [...pattern]);
+    sessions.set("session-2", [...pattern]);
+
+    const proposals = discoverSkills(sessions, {
+      minSessions: 2,
+      existingSkillSlugs: ["checkout-install"],
+    });
+
+    const matching = proposals.find((p) => p.slug === "checkout-install");
+    expect(matching).toBeUndefined();
+  });
+
+  it("filters out trivial commands (cd, ls, pwd)", () => {
+    const sessions = new Map<string, CommandRecord[]>();
+
+    // Sessions with only trivial commands between real ones
+    for (const id of ["s1", "s2", "s3"]) {
+      sessions.set(id, [
+        makeCommand("cd /project", 1),
+        makeCommand("ls", 2),
+        makeCommand("git status", 3),
+        makeCommand("pwd", 4),
+        makeCommand("git add .", 5),
+      ]);
+    }
+
+    const proposals = discoverSkills(sessions, { minSessions: 2 });
+
+    // Should find git status → git add pattern but not cd/ls/pwd
+    for (const p of proposals) {
+      expect(p.steps).not.toContain("cd /project");
+      expect(p.steps).not.toContain("ls");
+      expect(p.steps).not.toContain("pwd");
+    }
+  });
+
+  it("returns empty array when no sessions provided", () => {
+    const proposals = discoverSkills(new Map());
+    expect(proposals).toEqual([]);
+  });
+
+  it("assigns higher confidence to patterns seen in more sessions", () => {
+    const pattern = [
+      makeCommand("git add .", 1),
+      makeCommand("git commit -m 'test'", 2),
+    ];
+
+    const sessions = new Map<string, CommandRecord[]>();
+    for (let i = 0; i < 5; i++) {
+      sessions.set(`session-${i}`, [...pattern]);
+    }
+
+    const proposals = discoverSkills(sessions, { minSessions: 2 });
+    const addCommit = proposals.find((p) =>
+      p.steps.includes("git add") && p.steps.includes("git commit"),
+    );
+
+    expect(addCommit).toBeDefined();
+    expect(addCommit!.confidence).toBe("high");
+  });
+});


### PR DESCRIPTION
## Summary
- **Goal Engine** (Increment 2, Change #5): Goals as markdown files with YAML frontmatter. `zam goal list/show/create/status` commands with tree view and JSON output. Goals reference tasks (checklists) and tokens, supporting the hierarchy: Goals → Tasks → Tokens.
- **Skill Discovery** (Increment 2, Change #7): Cross-session pattern detection from monitor logs via `zam bridge discover-skills`. Analyzes command sequences across sessions, identifies recurring non-standard patterns, and proposes them as minimal reusable skills. Confidence scoring based on session count.
- 16 new tests (10 parser + 6 discovery), all 63 tests pass.

Completes all 7 Increment 2 changes.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test` — 63 tests pass (47 existing + 16 new)
- [x] `zam goal list` — lists goals from configured directory
- [x] `zam goal create --slug test --title "Test"` — creates markdown file
- [x] `zam goal show test` — displays goal details with tasks and tokens
- [x] `zam bridge discover-skills --help` — shows options

🤖 Generated with [Claude Code](https://claude.com/claude-code)