### PR TITLE
feat: add review maintenance actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ Get started: `zam whoami --set <your-id>`
 
 ---
 
+## 🧹 Review maintenance
+
+Review sessions are not limited to `1`-`4` recall ratings anymore. When a card is wrong, obsolete, or unwanted, the review flow can now:
+
+- edit token fields inline
+- deprecate the token
+- hard-delete the token after an impact preview + confirmation
+- delete only your personal card while keeping the token
+
+The same maintenance actions are also available from the CLI:
+
+- `zam token edit --slug <slug> ...`
+- `zam token delete --slug <slug>` for preview, then `--force` to delete
+- `zam card delete --user <id> --token <slug>`
+- `zam bridge review-action ...` for AI clients
+
+Token deletion is global. Card deletion is per-user.
+
+---
+
 ## 🏛 Vision: A Flourishing Future
 
 ZAM is a tool for the transition to a world where care and shared growth are the common currency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zam",
+  "name": "zam-core",
   "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zam",
+      "name": "zam-core",
       "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/bridge/protocol.ts
+++ b/src/bridge/protocol.ts
@@ -53,6 +53,110 @@ export interface SubmitRatingResponse {
   };
 }
 
+// ── Review Action ───────────────────────────────────────────────────────────
+
+export type ReviewActionType =
+  | "rate"
+  | "skip"
+  | "edit-token"
+  | "deprecate-token"
+  | "delete-token"
+  | "delete-card"
+  | "stop";
+
+export interface ReviewActionRequest {
+  cardId: string;
+  action: ReviewActionType;
+  rating?: 1 | 2 | 3 | 4;
+  concept?: string;
+  domain?: string;
+  bloomLevel?: number;
+  context?: string;
+  symbiosisMode?: "shadowing" | "copilot" | "autonomy" | "none";
+  confirm?: boolean;
+}
+
+export interface ReviewActionResponse {
+  success: boolean;
+  action: ReviewActionType;
+  preview?: boolean;
+  requiresConfirmation?: boolean;
+  token: {
+    slug: string;
+    tokenId: string;
+  };
+  rating?: 1 | 2 | 3 | 4 | null;
+  evaluation?: {
+    nextDueAt: string;
+    stability: number;
+    scheduledDays: number;
+    state: string;
+    reps: number;
+    lapses: number;
+  } | null;
+  blocked?: {
+    blockedSlug: string;
+    prerequisites: Array<{ slug: string; concept: string; bloomLevel: number }>;
+  } | null;
+  updatedToken?: {
+    id: string;
+    slug: string;
+    concept: string;
+    domain: string;
+    bloom_level: number;
+    context: string;
+    symbiosis_mode: "shadowing" | "copilot" | "autonomy" | null;
+    created_at: string;
+    updated_at: string;
+    deprecated_at: string | null;
+  } | null;
+  deletedToken?: {
+    token: {
+      id: string;
+      slug: string;
+      concept: string;
+      domain: string;
+      bloom_level: number;
+      context: string;
+      symbiosis_mode: "shadowing" | "copilot" | "autonomy" | null;
+      created_at: string;
+      updated_at: string;
+      deprecated_at: string | null;
+    };
+    impact: {
+      cards: number;
+      review_logs: number;
+      prerequisite_edges_from_token: number;
+      prerequisite_edges_to_token: number;
+      session_steps: number;
+      sessions_touched: number;
+      agent_skills: number;
+    };
+  } | null;
+  deletedCard?: {
+    card: {
+      id: string;
+      token_id: string;
+      user_id: string;
+      stability: number;
+      difficulty: number;
+      elapsed_days: number;
+      scheduled_days: number;
+      reps: number;
+      lapses: number;
+      state: "new" | "learning" | "review" | "relearning";
+      due_at: string;
+      last_review_at: string | null;
+      blocked: number;
+    };
+    impact: {
+      review_logs: number;
+    };
+  } | null;
+  skipped?: boolean;
+  stopped?: boolean;
+}
+
 // ── Add Token ───────────────────────────────────────────────────────────────
 
 export interface AddTokenRequest {

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -12,12 +12,9 @@ import {
   getDueCards,
   buildReviewQueue,
   generatePrompt,
-  evaluateRating,
   ensureCard,
   createToken,
   getTokenBySlug,
-  cascadeBlock,
-  getPrerequisites,
   getAgentSkill,
   listAgentSkills,
   readMonitorLog,
@@ -25,8 +22,17 @@ import {
   analyzeObservation,
   monitorLogExists,
   discoverSkills,
+  executeReviewAction,
+  getTokenDeleteImpact,
+  getCardDeletionImpact,
 } from "../../kernel/index.js";
-import type { Rating, BloomLevel, TokenPattern } from "../../kernel/index.js";
+import type {
+  Rating,
+  BloomLevel,
+  TokenPattern,
+  ReviewActionType,
+  SymbiosisMode,
+} from "../../kernel/index.js";
 import { readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -52,6 +58,69 @@ function withDb(fn: (db: Database) => void): void {
   } finally {
     db?.close();
   }
+}
+
+interface ReviewTargetRow {
+  card_id: string;
+  token_id: string;
+  user_id: string;
+  slug: string;
+}
+
+function getReviewTarget(db: Database, cardId: string, userId: string): ReviewTargetRow {
+  const target = db
+    .prepare(
+      `SELECT c.id AS card_id, c.token_id, c.user_id, t.slug
+       FROM cards c
+       JOIN tokens t ON t.id = c.token_id
+       WHERE c.id = ?`,
+    )
+    .get(cardId) as ReviewTargetRow | undefined;
+
+  if (!target) {
+    jsonError(`Card not found: ${cardId}`);
+  }
+  if (target.user_id !== userId) {
+    jsonError(`Card ${cardId} does not belong to user ${userId}`);
+  }
+
+  return target!;
+}
+
+function parseTokenUpdates(opts: {
+  concept?: string;
+  domain?: string;
+  bloom?: string;
+  context?: string;
+  mode?: string;
+}): {
+  concept?: string;
+  domain?: string;
+  bloom_level?: BloomLevel;
+  context?: string;
+  symbiosis_mode?: SymbiosisMode | null;
+} {
+  const updates: {
+    concept?: string;
+    domain?: string;
+    bloom_level?: BloomLevel;
+    context?: string;
+    symbiosis_mode?: SymbiosisMode | null;
+  } = {};
+
+  if (opts.concept !== undefined) updates.concept = opts.concept;
+  if (opts.domain !== undefined) updates.domain = opts.domain;
+  if (opts.bloom !== undefined) updates.bloom_level = Number(opts.bloom) as BloomLevel;
+  if (opts.context !== undefined) updates.context = opts.context;
+  if (opts.mode !== undefined) {
+    const validModes = ["shadowing", "copilot", "autonomy", "none"];
+    if (!validModes.includes(opts.mode)) {
+      jsonError(`Invalid mode: ${opts.mode}`);
+    }
+    updates.symbiosis_mode = opts.mode === "none" ? null : opts.mode as SymbiosisMode;
+  }
+
+  return updates;
 }
 
 export const bridgeCommand = new Command("bridge")
@@ -148,41 +217,107 @@ bridgeCommand
         jsonError("Rating must be between 1 and 4");
       }
 
-      // Look up the card to get tokenId
-      const card = db
-        .prepare("SELECT * FROM cards WHERE id = ?")
-        .get(opts.cardId) as { id: string; token_id: string; user_id: string } | undefined;
-
-      if (!card) {
-        jsonError(`Card not found: ${opts.cardId}`);
-      }
-
-      const result = evaluateRating(db, {
+      const result = executeReviewAction(db, {
+        action: "rate",
         cardId: opts.cardId,
-        tokenId: card!.token_id,
         userId,
         rating,
       });
 
-      let blocked = null;
-      if (rating === 1) {
-        const token = db
-          .prepare("SELECT slug FROM tokens WHERE id = ?")
-          .get(card!.token_id) as { slug: string } | undefined;
-
-        if (token) {
-          const prereqs = getPrerequisites(db, card!.token_id);
-          if (prereqs.length > 0) {
-            blocked = cascadeBlock(db, userId, token.slug);
-          }
-        }
-      }
-
       jsonOut({
         success: true,
         rating,
-        evaluation: result,
-        blocked,
+        evaluation: result.evaluation,
+        blocked: result.blocked ?? null,
+      });
+    });
+  });
+
+// ── zam bridge review-action ───────────────────────────────────────────────
+
+bridgeCommand
+  .command("review-action")
+  .description("Apply a review action (JSON)")
+  .option("--user <id>", "User ID (default: whoami)")
+  .requiredOption("--card-id <id>", "Card ID")
+  .requiredOption("--action <action>", "Action: rate | skip | edit-token | deprecate-token | delete-token | delete-card | stop")
+  .option("--rating <n>", "Rating (1-4) for action=rate")
+  .option("--concept <concept>", "Updated concept text for action=edit-token")
+  .option("--domain <domain>", "Updated domain for action=edit-token")
+  .option("--bloom <level>", "Updated Bloom level for action=edit-token")
+  .option("--context <context>", "Updated context for action=edit-token")
+  .option("--mode <mode>", "Updated symbiosis mode for action=edit-token")
+  .option("--confirm", "Confirm destructive delete actions")
+  .action((opts) => {
+    withDb((db) => {
+      const userId = resolveUser(opts, db, { json: true });
+      const action = opts.action as ReviewActionType;
+      const validActions: ReviewActionType[] = [
+        "rate",
+        "skip",
+        "edit-token",
+        "deprecate-token",
+        "delete-token",
+        "delete-card",
+        "stop",
+      ];
+      if (!validActions.includes(action)) {
+        jsonError(`Unsupported action: ${opts.action}`);
+      }
+
+      const target = getReviewTarget(db, opts.cardId, userId);
+      if ((action === "delete-token" || action === "delete-card") && !opts.confirm) {
+        if (action === "delete-token") {
+          jsonOut({
+            success: true,
+            action,
+            preview: true,
+            requiresConfirmation: true,
+            token: { slug: target.slug, tokenId: target.token_id },
+            impact: getTokenDeleteImpact(db, target.slug),
+          });
+          return;
+        }
+
+        jsonOut({
+          success: true,
+          action,
+          preview: true,
+          requiresConfirmation: true,
+          token: { slug: target.slug, tokenId: target.token_id },
+          impact: getCardDeletionImpact(db, target.token_id, userId),
+        });
+        return;
+      }
+
+      const rating = opts.rating !== undefined ? Number(opts.rating) as Rating : undefined;
+      if (action === "rate" && (rating == null || rating < 1 || rating > 4)) {
+        jsonError("Rating must be between 1 and 4 for action=rate");
+      }
+
+      const result = executeReviewAction(db, {
+        action,
+        cardId: opts.cardId,
+        userId,
+        rating,
+        tokenUpdates: action === "edit-token" ? parseTokenUpdates(opts) : undefined,
+      });
+
+      jsonOut({
+        success: true,
+        action,
+        token: {
+          slug: result.token.slug,
+          tokenId: result.token.id,
+        },
+        rating: rating ?? null,
+        evaluation: result.evaluation ?? null,
+        blocked: result.blocked ?? null,
+        updatedToken: result.updatedToken ?? null,
+        deletedToken: result.deletedToken ?? null,
+        deletedCard: result.deletedCard ?? null,
+        skipped: result.skipped ?? false,
+        stopped: result.stopped ?? false,
       });
     });
   });

--- a/src/cli/commands/card.ts
+++ b/src/cli/commands/card.ts
@@ -13,6 +13,8 @@ import {
   cascadeBlock,
   unblockReady,
   getPrerequisites,
+  getCardDeletionImpact,
+  deleteCardForUser,
 } from "../../kernel/index.js";
 import type { Rating } from "../../kernel/index.js";
 import { resolveUser } from "./resolve-user.js";
@@ -186,5 +188,43 @@ cardCommand
           console.log(`  - ${u.slug}: ${u.concept}`);
         }
       }
+    });
+  });
+
+// ── zam card delete ───────────────────────────────────────────────────────
+
+cardCommand
+  .command("delete")
+  .description("Delete one user's card for a token")
+  .option("--user <id>", "User ID (default: whoami)")
+  .requiredOption("--token <slug>", "Token slug")
+  .option("--json", "Output as JSON")
+  .action((opts) => {
+    withDb((db) => {
+      const userId = resolveUser(opts, db);
+      const token = getTokenBySlug(db, opts.token);
+      if (!token) {
+        console.error(`Token not found: ${opts.token}`);
+        process.exit(1);
+      }
+
+      const impact = getCardDeletionImpact(db, token.id, userId);
+      const result = deleteCardForUser(db, token.id, userId);
+
+      if (opts.json) {
+        console.log(JSON.stringify({
+          token: opts.token,
+          userId,
+          deleted: true,
+          cardId: result.card.id,
+          impact: result.impact,
+        }, null, 2));
+        return;
+      }
+
+      console.log(`Deleted card for ${opts.token}`);
+      console.log(`  User:               ${userId}`);
+      console.log(`  Card ID:            ${result.card.id}`);
+      console.log(`  Review logs removed: ${impact.review_logs}`);
     });
   });

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -4,17 +4,14 @@
 
 import { Command } from "commander";
 import type { Database } from "libsql";
-import { select, input } from "@inquirer/prompts";
 import {
   openDatabase,
   buildReviewQueue,
   generatePrompt,
-  evaluateRating,
-  cascadeBlock,
-  getPrerequisites,
 } from "../../kernel/index.js";
 import type { Rating, BloomLevel } from "../../kernel/index.js";
 import { resolveUser } from "./resolve-user.js";
+import { runInteractiveReviewAction } from "../review-actions.js";
 
 export const reviewCommand = new Command("review")
   .description("Start an interactive review session")
@@ -45,15 +42,15 @@ export const reviewCommand = new Command("review")
       console.log();
 
       let completed = 0;
+      let stoppedEarly = false;
+      let maintenanceActions = 0;
       const results: Array<{
         slug: string;
         rating: number;
         nextDue: string;
       }> = [];
 
-      for (const item of queue.items) {
-        completed++;
-
+      for (const [index, item] of queue.items.entries()) {
         const prompt = generatePrompt({
           cardId: item.cardId,
           tokenId: item.tokenId,
@@ -63,60 +60,50 @@ export const reviewCommand = new Command("review")
           bloomLevel: item.bloomLevel as BloomLevel,
         });
 
-        console.log(`\n[${ completed }/${queue.items.length}] ${prompt.bloomVerb} (Bloom ${prompt.bloomLevel})`);
+        console.log(`\n[${index + 1}/${queue.items.length}] ${prompt.bloomVerb} (Bloom ${prompt.bloomLevel})`);
         console.log(`Domain: ${prompt.domain || "(none)"}`);
         console.log(`\n  ${prompt.question}\n`);
 
-        const rating = await select({
-          message: "How did you do?",
-          choices: [
-            { name: "1 - Again (forgot)", value: 1 },
-            { name: "2 - Hard", value: 2 },
-            { name: "3 - Good", value: 3 },
-            { name: "4 - Easy", value: 4 },
-          ],
-        }) as Rating;
-
-        const evalResult = evaluateRating(db, {
-          cardId: item.cardId,
-          tokenId: item.tokenId,
+        const action = await runInteractiveReviewAction({
+          db,
           userId,
-          rating,
+          item,
+          mode: "review",
         });
 
-        // If rating 1 and token has prereqs, cascade block
-        if (rating === 1) {
-          const prereqs = getPrerequisites(db, item.tokenId);
-          if (prereqs.length > 0) {
-            const blockResult = cascadeBlock(db, userId, item.slug);
-            console.log(`  Blocked ${blockResult.blockedSlug}. Review these prerequisites:`);
-            for (const p of blockResult.prerequisites) {
-              console.log(`    - ${p.slug}: ${p.concept}`);
-            }
-          }
+        if (action.action === "stop") {
+          stoppedEarly = true;
+          console.log("\nStopping review.");
+          break;
         }
 
-        const ratingLabels: Record<number, string> = { 1: "Again", 2: "Hard", 3: "Good", 4: "Easy" };
-        console.log(`  ${ratingLabels[rating]} — next due: ${evalResult.nextDueAt}`);
-
-        results.push({
-          slug: item.slug,
-          rating,
-          nextDue: evalResult.nextDueAt,
-        });
+        if (action.action === "rate") {
+          results.push({
+            slug: item.slug,
+            rating: action.rating!,
+            nextDue: action.result.evaluation!.nextDueAt,
+          });
+        } else if (action.action !== "skip") {
+          maintenanceActions++;
+        }
       }
 
       // Session summary
       console.log("\n" + "═".repeat(50));
-      console.log("Review session complete!");
-      console.log(`  Cards reviewed: ${results.length}`);
+      console.log(stoppedEarly ? "Review session ended." : "Review session complete!");
+      console.log(`  Cards rated: ${results.length}`);
+      if (maintenanceActions > 0) {
+        console.log(`  Maintenance actions: ${maintenanceActions}`);
+      }
 
-      const avgRating = results.reduce((s, r) => s + r.rating, 0) / results.length;
-      console.log(`  Average rating: ${avgRating.toFixed(1)}`);
+      if (results.length > 0) {
+        const avgRating = results.reduce((s, r) => s + r.rating, 0) / results.length;
+        console.log(`  Average rating: ${avgRating.toFixed(1)}`);
 
-      const forgot = results.filter((r) => r.rating === 1).length;
-      if (forgot > 0) {
-        console.log(`  Forgot: ${forgot} card(s)`);
+        const forgot = results.filter((r) => r.rating === 1).length;
+        if (forgot > 0) {
+          console.log(`  Forgot: ${forgot} card(s)`);
+        }
       }
 
       db.close();

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -20,13 +20,11 @@ import {
   fetchActiveWorkItems,
   buildReviewQueue,
   generatePrompt,
-  evaluateRating,
-  cascadeBlock,
-  getPrerequisites,
   getSetting,
 } from "../../kernel/index.js";
-import type { ExecutionContext, Rating, BloomLevel } from "../../kernel/index.js";
+import type { ExecutionContext, BloomLevel } from "../../kernel/index.js";
 import { resolveUser } from "./resolve-user.js";
+import { runInteractiveReviewAction } from "../review-actions.js";
 
 function withDb(fn: (db: Database) => void): void {
   let db: Database | undefined;
@@ -125,6 +123,7 @@ sessionCommand
 
 interface RepetitionResult {
   reviewed: number;
+  maintained: number;
   skipped: boolean;
 }
 
@@ -137,7 +136,7 @@ async function runRepetitionPhase(
 
   if (queue.items.length === 0) {
     console.log("No cards due for review — moving to task selection.\n");
-    return { reviewed: 0, skipped: false };
+    return { reviewed: 0, maintained: 0, skipped: false };
   }
 
   console.log("═".repeat(50));
@@ -152,15 +151,14 @@ async function runRepetitionPhase(
   const startTime = Date.now();
   const timeLimitMs = maxMinutes * 60 * 1000;
   let reviewed = 0;
+  let maintained = 0;
 
-  for (const item of queue.items) {
+  for (const [index, item] of queue.items.entries()) {
     // Check time limit
     if (Date.now() - startTime >= timeLimitMs) {
       console.log(`\nTime limit reached (${maxMinutes} min). Moving to task selection.`);
       break;
     }
-
-    reviewed++;
 
     const prompt = generatePrompt({
       cardId: item.cardId,
@@ -172,55 +170,38 @@ async function runRepetitionPhase(
     });
 
     const elapsed = Math.round((Date.now() - startTime) / 60000);
-    console.log(`[${reviewed}/${queue.items.length}] ${prompt.bloomVerb} (Bloom ${prompt.bloomLevel}) — ${elapsed}/${maxMinutes} min`);
+    console.log(`[${index + 1}/${queue.items.length}] ${prompt.bloomVerb} (Bloom ${prompt.bloomLevel}) — ${elapsed}/${maxMinutes} min`);
     console.log(`Domain: ${prompt.domain || "(none)"}`);
     console.log(`\n  ${prompt.question}\n`);
 
-    const rating = await select({
-      message: "How did you do?",
-      choices: [
-        { name: "1 - Again (forgot)", value: 1 },
-        { name: "2 - Hard", value: 2 },
-        { name: "3 - Good", value: 3 },
-        { name: "4 - Easy", value: 4 },
-        { name: "s - Skip to task selection", value: 0 },
-      ],
-    }) as number;
-
-    if (rating === 0) {
-      console.log("Skipping to task selection.");
-      reviewed--; // Don't count the skipped card
-      return { reviewed, skipped: true };
-    }
-
-    const evalResult = evaluateRating(db, {
-      cardId: item.cardId,
-      tokenId: item.tokenId,
+    const action = await runInteractiveReviewAction({
+      db,
       userId,
-      rating: rating as Rating,
+      item,
+      mode: "session",
     });
 
-    if (rating === 1) {
-      const prereqs = getPrerequisites(db, item.tokenId);
-      if (prereqs.length > 0) {
-        const blockResult = cascadeBlock(db, userId, item.slug);
-        console.log(`  Blocked ${blockResult.blockedSlug}. Review these prerequisites:`);
-        for (const p of blockResult.prerequisites) {
-          console.log(`    - ${p.slug}: ${p.concept}`);
-        }
-      }
+    if (action.action === "stop") {
+      console.log("Stopping review and moving to task selection.");
+      return { reviewed, maintained, skipped: true };
     }
 
-    const ratingLabels: Record<number, string> = { 1: "Again", 2: "Hard", 3: "Good", 4: "Easy" };
-    console.log(`  ${ratingLabels[rating]} — next due: ${evalResult.nextDueAt}\n`);
+    if (action.action === "rate") {
+      reviewed++;
+    } else if (action.action !== "skip") {
+      maintained++;
+    }
   }
 
-  if (reviewed > 0) {
+  if (reviewed > 0 || maintained > 0) {
     console.log("─".repeat(50));
-    console.log(`Repetition complete — ${reviewed} card(s) reviewed.`);
+    console.log(`Repetition complete — ${reviewed} card(s) rated.`);
+    if (maintained > 0) {
+      console.log(`Maintenance actions: ${maintained}`);
+    }
   }
 
-  return { reviewed, skipped: false };
+  return { reviewed, maintained, skipped: false };
 }
 
 // ── Phase 2: Task Selection ─────────────────────────────────────────────────

--- a/src/cli/commands/token.ts
+++ b/src/cli/commands/token.ts
@@ -7,17 +7,19 @@ import type { Database } from "libsql";
 import {
   openDatabase,
   createToken,
+  updateToken,
   findTokens,
   listTokens,
   getTokenBySlug,
   addPrerequisite,
   getPrerequisites,
   getDependents,
-  ensureCard,
   getCard,
   deprecateToken,
+  getTokenDeleteImpact,
+  deleteToken,
 } from "../../kernel/index.js";
-import type { BloomLevel } from "../../kernel/index.js";
+import type { BloomLevel, SymbiosisMode } from "../../kernel/index.js";
 import { resolveUser } from "./resolve-user.js";
 
 function withDb(fn: (db: Database) => void): void {
@@ -31,6 +33,10 @@ function withDb(fn: (db: Database) => void): void {
   } finally {
     db?.close();
   }
+}
+
+function jsonOut(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
 }
 
 export const tokenCommand = new Command("token")
@@ -134,6 +140,57 @@ tokenCommand
     });
   });
 
+// ── zam token edit ────────────────────────────────────────────────────────
+
+tokenCommand
+  .command("edit")
+  .description("Edit a token's mutable fields")
+  .requiredOption("--slug <slug>", "Token slug")
+  .option("--concept <concept>", "Updated concept text")
+  .option("--domain <domain>", "Updated domain (blank allowed)")
+  .option("--bloom <level>", "Updated Bloom taxonomy level (1-5)")
+  .option("--context <context>", "Updated context (blank allowed)")
+  .option("--mode <mode>", "Updated symbiosis mode: shadowing | copilot | autonomy | none")
+  .option("--json", "Output as JSON")
+  .action((opts) => {
+    withDb((db) => {
+      const updates: {
+        concept?: string;
+        domain?: string;
+        bloom_level?: BloomLevel;
+        context?: string;
+        symbiosis_mode?: SymbiosisMode | null;
+      } = {};
+
+      if (opts.concept !== undefined) updates.concept = opts.concept;
+      if (opts.domain !== undefined) updates.domain = opts.domain;
+      if (opts.bloom !== undefined) updates.bloom_level = Number(opts.bloom) as BloomLevel;
+      if (opts.context !== undefined) updates.context = opts.context;
+      if (opts.mode !== undefined) {
+        const validModes = ["shadowing", "copilot", "autonomy", "none"];
+        if (!validModes.includes(opts.mode)) {
+          console.error(`Invalid --mode: ${opts.mode}`);
+          process.exit(1);
+        }
+        updates.symbiosis_mode = opts.mode === "none" ? null : opts.mode as SymbiosisMode;
+      }
+
+      const token = updateToken(db, opts.slug, updates);
+
+      if (opts.json) {
+        jsonOut(token);
+        return;
+      }
+
+      console.log(`Updated token: ${token.slug}`);
+      console.log(`  Concept: ${token.concept}`);
+      console.log(`  Domain:  ${token.domain || "(none)"}`);
+      console.log(`  Bloom:   ${token.bloom_level}`);
+      console.log(`  Context: ${token.context || "(none)"}`);
+      console.log(`  Mode:    ${token.symbiosis_mode ?? "none"}`);
+    });
+  });
+
 // ── zam token prereq ─────────────────────────────────────────────────────
 
 tokenCommand
@@ -184,6 +241,62 @@ tokenCommand
         console.log(`  Concept: ${token.concept}`);
         console.log(`  At:      ${token.deprecated_at}`);
       }
+    });
+  });
+
+// ── zam token delete ──────────────────────────────────────────────────────
+
+tokenCommand
+  .command("delete")
+  .description("Hard-delete a token and its dependent learning data")
+  .requiredOption("--slug <slug>", "Token slug to delete")
+  .option("--force", "Actually delete the token")
+  .option("--json", "Output as JSON")
+  .action((opts) => {
+    withDb((db) => {
+      const impact = getTokenDeleteImpact(db, opts.slug);
+
+      if (!opts.force) {
+        const preview = {
+          slug: opts.slug,
+          deleted: false,
+          requiresForce: true,
+          impact,
+        };
+
+        if (opts.json) {
+          jsonOut(preview);
+          return;
+        }
+
+        console.log(`Delete preview for ${opts.slug}:`);
+        console.log(`  Cards:                 ${impact.cards}`);
+        console.log(`  Review logs:           ${impact.review_logs}`);
+        console.log(`  Prereq edges from it:  ${impact.prerequisite_edges_from_token}`);
+        console.log(`  Prereq edges to it:    ${impact.prerequisite_edges_to_token}`);
+        console.log(`  Session steps:         ${impact.session_steps}`);
+        console.log(`  Sessions touched:      ${impact.sessions_touched}`);
+        console.log(`  Agent skills updated:  ${impact.agent_skills}`);
+        console.log("\nRe-run with --force to delete.");
+        return;
+      }
+
+      const result = deleteToken(db, opts.slug);
+
+      if (opts.json) {
+        jsonOut({
+          slug: result.token.slug,
+          deleted: true,
+          impact: result.impact,
+        });
+        return;
+      }
+
+      console.log(`Deleted token: ${result.token.slug}`);
+      console.log(`  Cards removed:         ${result.impact.cards}`);
+      console.log(`  Review logs removed:   ${result.impact.review_logs}`);
+      console.log(`  Session steps removed: ${result.impact.session_steps}`);
+      console.log(`  Agent skills updated:  ${result.impact.agent_skills}`);
     });
   });
 

--- a/src/cli/review-actions.ts
+++ b/src/cli/review-actions.ts
@@ -1,0 +1,302 @@
+import { confirm, input, select } from "@inquirer/prompts";
+import type { Database } from "libsql";
+import {
+  executeReviewAction,
+  generatePrompt,
+  getCardDeletionImpact,
+  getTokenById,
+  getTokenDeleteImpact,
+} from "../kernel/index.js";
+import type {
+  BloomLevel,
+  Rating,
+  ReviewActionResult,
+  ReviewQueueItem,
+  SymbiosisMode,
+  Token,
+  UpdateTokenInput,
+} from "../kernel/index.js";
+
+type InteractiveTerminalAction =
+  | "rate"
+  | "skip"
+  | "deprecate-token"
+  | "delete-token"
+  | "delete-card"
+  | "stop";
+
+export interface RunInteractiveReviewActionInput {
+  db: Database;
+  userId: string;
+  item: ReviewQueueItem;
+  mode: "review" | "session";
+}
+
+export interface RunInteractiveReviewActionResult {
+  action: InteractiveTerminalAction;
+  result: ReviewActionResult;
+  rating?: Rating;
+}
+
+export async function runInteractiveReviewAction(
+  inputData: RunInteractiveReviewActionInput,
+): Promise<RunInteractiveReviewActionResult> {
+  let currentItem = { ...inputData.item };
+
+  while (true) {
+    const choice = await select({
+      message: "What next?",
+      choices: [
+        { name: "1 - Again (forgot)", value: 1 },
+        { name: "2 - Hard", value: 2 },
+        { name: "3 - Good", value: 3 },
+        { name: "4 - Easy", value: 4 },
+        { name: "Skip this card", value: "skip" },
+        { name: "Edit token", value: "edit-token" },
+        { name: "Deprecate token", value: "deprecate-token" },
+        { name: "Delete token", value: "delete-token" },
+        { name: "Delete my card", value: "delete-card" },
+        {
+          name: inputData.mode === "session"
+            ? "Stop review and continue to task selection"
+            : "Stop review",
+          value: "stop",
+        },
+      ],
+    }) as Rating | InteractiveTerminalAction | "edit-token";
+
+    if (typeof choice === "number") {
+      const result = executeReviewAction(inputData.db, {
+        action: "rate",
+        cardId: currentItem.cardId,
+        userId: inputData.userId,
+        rating: choice,
+      });
+
+      const ratingLabels: Record<number, string> = { 1: "Again", 2: "Hard", 3: "Good", 4: "Easy" };
+      console.log(`  ${ratingLabels[choice]} — next due: ${result.evaluation!.nextDueAt}`);
+
+      if (result.blocked) {
+        console.log(`  Blocked ${result.blocked.blockedSlug}. Review these prerequisites:`);
+        for (const prereq of result.blocked.prerequisites) {
+          console.log(`    - ${prereq.slug}: ${prereq.concept}`);
+        }
+      }
+
+      console.log();
+      return { action: "rate", result, rating: choice };
+    }
+
+    if (choice === "skip") {
+      console.log("Skipped this card.\n");
+      return {
+        action: "skip",
+        result: executeReviewAction(inputData.db, {
+          action: "skip",
+          cardId: currentItem.cardId,
+          userId: inputData.userId,
+        }),
+      };
+    }
+
+    if (choice === "stop") {
+      return {
+        action: "stop",
+        result: executeReviewAction(inputData.db, {
+          action: "stop",
+          cardId: currentItem.cardId,
+          userId: inputData.userId,
+        }),
+      };
+    }
+
+    if (choice === "edit-token") {
+      const token = getTokenById(inputData.db, currentItem.tokenId);
+      if (!token) {
+        throw new Error(`Token not found: ${currentItem.tokenId}`);
+      }
+
+      const updates = await promptTokenEdit(token);
+      if (!updates) {
+        console.log("No token changes made.\n");
+        continue;
+      }
+
+      const result = executeReviewAction(inputData.db, {
+        action: "edit-token",
+        cardId: currentItem.cardId,
+        userId: inputData.userId,
+        tokenUpdates: updates,
+      });
+
+      const updatedToken = result.updatedToken!;
+      currentItem = {
+        ...currentItem,
+        slug: updatedToken.slug,
+        concept: updatedToken.concept,
+        domain: updatedToken.domain,
+        bloomLevel: updatedToken.bloom_level,
+      };
+
+      const refreshedPrompt = generatePrompt({
+        cardId: currentItem.cardId,
+        tokenId: currentItem.tokenId,
+        slug: currentItem.slug,
+        concept: currentItem.concept,
+        domain: currentItem.domain,
+        bloomLevel: currentItem.bloomLevel as BloomLevel,
+      });
+
+      console.log(`Updated token: ${updatedToken.slug}`);
+      console.log(`  Concept: ${updatedToken.concept}`);
+      console.log(`  Domain:  ${updatedToken.domain || "(none)"}`);
+      console.log(`  Bloom:   ${updatedToken.bloom_level}`);
+      console.log(`\n  ${refreshedPrompt.question}\n`);
+      continue;
+    }
+
+    if (choice === "deprecate-token") {
+      const approved = await confirm({
+        message: `Deprecate ${currentItem.slug} so it stops appearing in review queues?`,
+        default: false,
+      });
+      if (!approved) {
+        console.log("Token deprecation cancelled.\n");
+        continue;
+      }
+
+      const result = executeReviewAction(inputData.db, {
+        action: "deprecate-token",
+        cardId: currentItem.cardId,
+        userId: inputData.userId,
+      });
+
+      console.log(`Deprecated token: ${currentItem.slug}\n`);
+      return { action: "deprecate-token", result };
+    }
+
+    if (choice === "delete-token") {
+      const impact = getTokenDeleteImpact(inputData.db, currentItem.slug);
+      console.log(`Delete token ${currentItem.slug}?`);
+      console.log(`  Cards:                 ${impact.cards}`);
+      console.log(`  Review logs:           ${impact.review_logs}`);
+      console.log(`  Prereq edges from it:  ${impact.prerequisite_edges_from_token}`);
+      console.log(`  Prereq edges to it:    ${impact.prerequisite_edges_to_token}`);
+      console.log(`  Session steps:         ${impact.session_steps}`);
+      console.log(`  Sessions touched:      ${impact.sessions_touched}`);
+      console.log(`  Agent skills updated:  ${impact.agent_skills}`);
+
+      const approved = await confirm({
+        message: "Permanently delete this token and its dependent learning data?",
+        default: false,
+      });
+      if (!approved) {
+        console.log("Token deletion cancelled.\n");
+        continue;
+      }
+
+      const result = executeReviewAction(inputData.db, {
+        action: "delete-token",
+        cardId: currentItem.cardId,
+        userId: inputData.userId,
+      });
+
+      console.log(`Deleted token: ${currentItem.slug}\n`);
+      return { action: "delete-token", result };
+    }
+
+    if (choice === "delete-card") {
+      const impact = getCardDeletionImpact(inputData.db, currentItem.tokenId, inputData.userId);
+      console.log(`Delete your card for ${currentItem.slug}?`);
+      console.log(`  Review logs removed: ${impact.review_logs}`);
+
+      const approved = await confirm({
+        message: "Delete only your card for this token?",
+        default: false,
+      });
+      if (!approved) {
+        console.log("Card deletion cancelled.\n");
+        continue;
+      }
+
+      const result = executeReviewAction(inputData.db, {
+        action: "delete-card",
+        cardId: currentItem.cardId,
+        userId: inputData.userId,
+      });
+
+      console.log(`Deleted your card for: ${currentItem.slug}\n`);
+      return { action: "delete-card", result };
+    }
+  }
+}
+
+async function promptTokenEdit(
+  token: Token,
+): Promise<UpdateTokenInput | null> {
+  const field = await select({
+    message: `Edit which field on ${token.slug}?`,
+    choices: [
+      { name: "Concept", value: "concept" },
+      { name: "Domain", value: "domain" },
+      { name: "Bloom level", value: "bloom_level" },
+      { name: "Context", value: "context" },
+      { name: "Symbiosis mode", value: "symbiosis_mode" },
+      { name: "Cancel", value: "cancel" },
+    ],
+  }) as keyof UpdateTokenInput | "cancel";
+
+  if (field === "cancel") {
+    return null;
+  }
+
+  switch (field) {
+    case "concept": {
+      const concept = await input({
+        message: "Concept:",
+        default: token.concept,
+      });
+      return concept === token.concept ? null : { concept };
+    }
+
+    case "domain": {
+      const domain = await input({
+        message: "Domain (blank allowed):",
+        default: token.domain,
+      });
+      return domain === token.domain ? null : { domain };
+    }
+
+    case "context": {
+      const context = await input({
+        message: "Context (blank allowed):",
+        default: token.context,
+      });
+      return context === token.context ? null : { context };
+    }
+
+    case "bloom_level": {
+      const bloom = await select({
+        message: "Bloom level:",
+        choices: [1, 2, 3, 4, 5].map((value) => ({
+          name: value === token.bloom_level ? `${value} (current)` : String(value),
+          value,
+        })),
+      }) as BloomLevel;
+      return bloom === token.bloom_level ? null : { bloom_level: bloom };
+    }
+
+    case "symbiosis_mode": {
+      const mode = await select({
+        message: "Symbiosis mode:",
+        choices: [
+          { name: token.symbiosis_mode === null ? "none (current)" : "none", value: null },
+          { name: token.symbiosis_mode === "shadowing" ? "shadowing (current)" : "shadowing", value: "shadowing" },
+          { name: token.symbiosis_mode === "copilot" ? "copilot (current)" : "copilot", value: "copilot" },
+          { name: token.symbiosis_mode === "autonomy" ? "autonomy (current)" : "autonomy", value: "autonomy" },
+        ],
+      }) as SymbiosisMode | null;
+      return mode === token.symbiosis_mode ? null : { symbiosis_mode: mode };
+    }
+  }
+}

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -13,15 +13,21 @@ export {
   createToken,
   getTokenBySlug,
   getTokenById,
+  updateToken,
   findTokens,
   listTokens,
   deprecateToken,
+  getTokenDeleteImpact,
+  deleteToken,
 } from "./models/token.js";
 export type {
   Token,
   CreateTokenInput,
+  UpdateTokenInput,
   BloomLevel,
   SymbiosisMode,
+  TokenDeleteImpact,
+  DeleteTokenResult,
 } from "./models/token.js";
 
 export {
@@ -34,11 +40,20 @@ export type { Prerequisite, PrerequisiteWithToken } from "./models/prerequisite.
 export {
   ensureCard,
   getCard,
+  getCardById,
   updateCard,
+  getCardDeletionImpact,
+  deleteCardForUser,
   getDueCards,
   getBlockedCards,
 } from "./models/card.js";
-export type { Card, CardState, UpdateCardInput } from "./models/card.js";
+export type {
+  Card,
+  CardState,
+  UpdateCardInput,
+  CardDeletionImpact,
+  DeleteCardResult,
+} from "./models/card.js";
 
 export { logReview, getReviewsForCard, getReviewsForUser } from "./models/review.js";
 export type { ReviewLog, CreateReviewInput } from "./models/review.js";
@@ -96,6 +111,9 @@ export type { RecallPrompt, PromptInput } from "./recall/prompter.js";
 
 export { evaluateRating } from "./recall/evaluator.js";
 export type { EvaluateInput, EvaluateResult } from "./recall/evaluator.js";
+
+export { executeReviewAction } from "./recall/actions.js";
+export type { ExecuteReviewActionInput, ReviewActionResult, ReviewActionType } from "./recall/actions.js";
 
 // Analytics
 export { getUserStats, getDomainCompetence } from "./analytics/stats.js";

--- a/src/kernel/models/card.ts
+++ b/src/kernel/models/card.ts
@@ -41,6 +41,15 @@ export interface UpdateCardInput {
   blocked?: number;
 }
 
+export interface CardDeletionImpact {
+  review_logs: number;
+}
+
+export interface DeleteCardResult {
+  card: Card;
+  impact: CardDeletionImpact;
+}
+
 /** A due card joined with its token details. */
 export interface DueCard extends Card {
   slug: string;
@@ -102,6 +111,16 @@ export function getCard(
   return db
     .prepare("SELECT * FROM cards WHERE token_id = ? AND user_id = ?")
     .get(tokenId, userId) as Card | undefined;
+}
+
+/**
+ * Get a card by its ULID.
+ */
+export function getCardById(
+  db: Database,
+  cardId: string,
+): Card | undefined {
+  return db.prepare("SELECT * FROM cards WHERE id = ?").get(cardId) as Card | undefined;
 }
 
 /**
@@ -174,6 +193,45 @@ export function updateCard(
   }
 
   return db.prepare("SELECT * FROM cards WHERE id = ?").get(cardId) as Card;
+}
+
+/**
+ * Preview the review-log rows that will be removed when deleting a user's card.
+ */
+export function getCardDeletionImpact(
+  db: Database,
+  tokenId: string,
+  userId: string,
+): CardDeletionImpact {
+  const card = getCard(db, tokenId, userId);
+  if (!card) {
+    throw new Error(`Card not found for token ${tokenId} and user ${userId}`);
+  }
+
+  const reviewLogs = db
+    .prepare("SELECT COUNT(*) AS n FROM review_logs WHERE card_id = ?")
+    .get(card.id) as { n: number };
+
+  return { review_logs: reviewLogs.n };
+}
+
+/**
+ * Delete one user's card for a token. Review logs cascade via FK.
+ */
+export function deleteCardForUser(
+  db: Database,
+  tokenId: string,
+  userId: string,
+): DeleteCardResult {
+  const card = getCard(db, tokenId, userId);
+  if (!card) {
+    throw new Error(`Card not found for token ${tokenId} and user ${userId}`);
+  }
+
+  const impact = getCardDeletionImpact(db, tokenId, userId);
+  db.prepare("DELETE FROM cards WHERE id = ?").run(card.id);
+
+  return { card, impact };
 }
 
 /**

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -36,8 +36,31 @@ export interface CreateTokenInput {
   symbiosis_mode?: SymbiosisMode | null;
 }
 
+export interface UpdateTokenInput {
+  concept?: string;
+  domain?: string;
+  bloom_level?: BloomLevel;
+  context?: string;
+  symbiosis_mode?: SymbiosisMode | null;
+}
+
 export interface ListTokensOptions {
   domain?: string;
+}
+
+export interface TokenDeleteImpact {
+  cards: number;
+  review_logs: number;
+  prerequisite_edges_from_token: number;
+  prerequisite_edges_to_token: number;
+  session_steps: number;
+  sessions_touched: number;
+  agent_skills: number;
+}
+
+export interface DeleteTokenResult {
+  token: Token;
+  impact: TokenDeleteImpact;
 }
 
 // ── Scored result from fuzzy search ──────────────────────────────────────────
@@ -96,6 +119,65 @@ export function getTokenById(db: Database, id: string): Token | undefined {
 }
 
 /**
+ * Update mutable fields on a token.
+ *
+ * Slug is intentionally immutable in v1 because it is referenced by other
+ * parts of the system (for example agent skill metadata).
+ */
+export function updateToken(
+  db: Database,
+  slug: string,
+  updates: UpdateTokenInput,
+): Token {
+  const token = getTokenBySlug(db, slug);
+  if (!token) {
+    throw new Error(`Token not found: ${slug}`);
+  }
+
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  if (updates.concept !== undefined) {
+    fields.push("concept = ?");
+    values.push(updates.concept);
+  }
+  if (updates.domain !== undefined) {
+    fields.push("domain = ?");
+    values.push(updates.domain);
+  }
+  if (updates.bloom_level !== undefined) {
+    if (updates.bloom_level < 1 || updates.bloom_level > 5) {
+      throw new Error(`bloom_level must be between 1 and 5, got ${updates.bloom_level}`);
+    }
+    fields.push("bloom_level = ?");
+    values.push(updates.bloom_level);
+  }
+  if (updates.context !== undefined) {
+    fields.push("context = ?");
+    values.push(updates.context);
+  }
+  if (updates.symbiosis_mode !== undefined) {
+    const validModes = ["shadowing", "copilot", "autonomy"];
+    if (updates.symbiosis_mode !== null && !validModes.includes(updates.symbiosis_mode)) {
+      throw new Error(`Invalid symbiosis_mode: ${updates.symbiosis_mode}`);
+    }
+    fields.push("symbiosis_mode = ?");
+    values.push(updates.symbiosis_mode);
+  }
+
+  if (fields.length === 0) {
+    throw new Error("updateToken called with no fields to update");
+  }
+
+  fields.push("updated_at = ?");
+  values.push(new Date().toISOString());
+  values.push(slug);
+
+  db.prepare(`UPDATE tokens SET ${fields.join(", ")} WHERE slug = ?`).run(...values);
+  return getTokenBySlug(db, slug)!;
+}
+
+/**
  * Mark a token as deprecated. Deprecated tokens are excluded from review queues
  * and search results but are not deleted — they can still be consulted.
  *
@@ -118,6 +200,96 @@ export function deprecateToken(db: Database, slug: string): Token {
   );
 
   return getTokenBySlug(db, slug)!;
+}
+
+/**
+ * Preview the rows that will be removed or updated when deleting a token.
+ */
+export function getTokenDeleteImpact(
+  db: Database,
+  slug: string,
+): TokenDeleteImpact {
+  const token = getTokenBySlug(db, slug);
+  if (!token) {
+    throw new Error(`Token not found: ${slug}`);
+  }
+
+  const cards = db
+    .prepare("SELECT COUNT(*) AS n FROM cards WHERE token_id = ?")
+    .get(token.id) as { n: number };
+  const reviewLogs = db
+    .prepare("SELECT COUNT(*) AS n FROM review_logs WHERE token_id = ?")
+    .get(token.id) as { n: number };
+  const prereqsFrom = db
+    .prepare("SELECT COUNT(*) AS n FROM prerequisites WHERE token_id = ?")
+    .get(token.id) as { n: number };
+  const prereqsTo = db
+    .prepare("SELECT COUNT(*) AS n FROM prerequisites WHERE requires_id = ?")
+    .get(token.id) as { n: number };
+  const sessionSteps = db
+    .prepare("SELECT COUNT(*) AS n FROM session_steps WHERE token_id = ?")
+    .get(token.id) as { n: number };
+  const sessionsTouched = db
+    .prepare("SELECT COUNT(DISTINCT session_id) AS n FROM session_steps WHERE token_id = ?")
+    .get(token.id) as { n: number };
+
+  const skillRows = db
+    .prepare("SELECT token_slugs FROM agent_skills")
+    .all() as Array<{ token_slugs: string }>;
+  const agentSkills = skillRows.filter((row) => {
+    const tokenSlugs = JSON.parse(row.token_slugs) as string[];
+    return tokenSlugs.includes(slug);
+  }).length;
+
+  return {
+    cards: cards.n,
+    review_logs: reviewLogs.n,
+    prerequisite_edges_from_token: prereqsFrom.n,
+    prerequisite_edges_to_token: prereqsTo.n,
+    session_steps: sessionSteps.n,
+    sessions_touched: sessionsTouched.n,
+    agent_skills: agentSkills,
+  };
+}
+
+/**
+ * Hard-delete a token and clean up non-FK references that point at its slug.
+ */
+export function deleteToken(
+  db: Database,
+  slug: string,
+): DeleteTokenResult {
+  const token = getTokenBySlug(db, slug);
+  if (!token) {
+    throw new Error(`Token not found: ${slug}`);
+  }
+
+  const impact = getTokenDeleteImpact(db, slug);
+
+  db.exec("BEGIN");
+  try {
+    const now = new Date().toISOString();
+    const skillRows = db
+      .prepare("SELECT id, token_slugs FROM agent_skills")
+      .all() as Array<{ id: string; token_slugs: string }>;
+
+    for (const row of skillRows) {
+      const tokenSlugs = JSON.parse(row.token_slugs) as string[];
+      const filtered = tokenSlugs.filter((tokenSlug) => tokenSlug !== slug);
+      if (filtered.length !== tokenSlugs.length) {
+        db.prepare("UPDATE agent_skills SET token_slugs = ?, updated_at = ? WHERE id = ?")
+          .run(JSON.stringify(filtered), now, row.id);
+      }
+    }
+
+    db.prepare("DELETE FROM tokens WHERE id = ?").run(token.id);
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+
+  return { token, impact };
 }
 
 /**

--- a/src/kernel/recall/actions.ts
+++ b/src/kernel/recall/actions.ts
@@ -1,0 +1,153 @@
+import type { Database } from "libsql";
+import {
+  getCardById,
+  deleteCardForUser,
+} from "../models/card.js";
+import {
+  getTokenById,
+  updateToken,
+  deprecateToken,
+  deleteToken,
+} from "../models/token.js";
+import { getPrerequisites } from "../models/prerequisite.js";
+import { cascadeBlock } from "../scheduler/blocker.js";
+import { evaluateRating } from "./evaluator.js";
+import type { Rating } from "../scheduler/fsrs.js";
+import type { UpdateTokenInput, Token, DeleteTokenResult } from "../models/token.js";
+import type { DeleteCardResult } from "../models/card.js";
+import type { EvaluateResult } from "./evaluator.js";
+import type { CascadeBlockResult } from "../scheduler/blocker.js";
+
+export type ReviewActionType =
+  | "rate"
+  | "skip"
+  | "edit-token"
+  | "deprecate-token"
+  | "delete-token"
+  | "delete-card"
+  | "stop";
+
+export interface ExecuteReviewActionInput {
+  cardId: string;
+  userId: string;
+  action: ReviewActionType;
+  rating?: Rating;
+  tokenUpdates?: UpdateTokenInput;
+}
+
+export interface ReviewActionResult {
+  action: ReviewActionType;
+  token: Token;
+  evaluation?: EvaluateResult;
+  blocked?: CascadeBlockResult;
+  updatedToken?: Token;
+  deletedToken?: DeleteTokenResult;
+  deletedCard?: DeleteCardResult;
+  skipped?: boolean;
+  stopped?: boolean;
+}
+
+function getReviewTarget(
+  db: Database,
+  cardId: string,
+  userId: string,
+): { cardId: string; token: Token } {
+  const card = getCardById(db, cardId);
+  if (!card) {
+    throw new Error(`Card not found: ${cardId}`);
+  }
+  if (card.user_id !== userId) {
+    throw new Error(`Card ${cardId} does not belong to user ${userId}`);
+  }
+
+  const token = getTokenById(db, card.token_id);
+  if (!token) {
+    throw new Error(`Token not found for card ${cardId}`);
+  }
+
+  return { cardId: card.id, token };
+}
+
+export function executeReviewAction(
+  db: Database,
+  input: ExecuteReviewActionInput,
+): ReviewActionResult {
+  const target = getReviewTarget(db, input.cardId, input.userId);
+
+  switch (input.action) {
+    case "rate": {
+      if (input.rating == null) {
+        throw new Error("rating is required for action=rate");
+      }
+
+      const evaluation = evaluateRating(db, {
+        cardId: target.cardId,
+        tokenId: target.token.id,
+        userId: input.userId,
+        rating: input.rating,
+      });
+
+      let blocked: CascadeBlockResult | undefined;
+      if (input.rating === 1) {
+        const prereqs = getPrerequisites(db, target.token.id);
+        if (prereqs.length > 0) {
+          blocked = cascadeBlock(db, input.userId, target.token.slug);
+        }
+      }
+
+      return {
+        action: input.action,
+        token: target.token,
+        evaluation,
+        blocked,
+      };
+    }
+
+    case "skip":
+      return { action: input.action, token: target.token, skipped: true };
+
+    case "stop":
+      return { action: input.action, token: target.token, stopped: true };
+
+    case "edit-token": {
+      const updatedToken = updateToken(db, target.token.slug, input.tokenUpdates ?? {});
+      return {
+        action: input.action,
+        token: target.token,
+        updatedToken,
+      };
+    }
+
+    case "deprecate-token": {
+      const updatedToken = deprecateToken(db, target.token.slug);
+      return {
+        action: input.action,
+        token: target.token,
+        updatedToken,
+      };
+    }
+
+    case "delete-token": {
+      const deletedToken = deleteToken(db, target.token.slug);
+      return {
+        action: input.action,
+        token: target.token,
+        deletedToken,
+      };
+    }
+
+    case "delete-card": {
+      const deletedCard = deleteCardForUser(db, target.token.id, input.userId);
+      return {
+        action: input.action,
+        token: target.token,
+        deletedCard,
+      };
+    }
+
+    default: {
+      const exhaustive: never = input.action;
+      throw new Error(`Unsupported review action: ${exhaustive}`);
+    }
+  }
+}

--- a/tests/kernel/review-maintenance.test.ts
+++ b/tests/kernel/review-maintenance.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "libsql";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openDatabase,
+  createToken,
+  updateToken,
+  getTokenBySlug,
+  getTokenDeleteImpact,
+  deleteToken,
+  addPrerequisite,
+  getPrerequisites,
+  ensureCard,
+  getCard,
+  getCardDeletionImpact,
+  deleteCardForUser,
+  getReviewsForCard,
+  startSession,
+  logStep,
+  getSessionSummary,
+  createAgentSkill,
+  listAgentSkills,
+  executeReviewAction,
+} from "../../src/kernel/index.js";
+
+describe("review maintenance primitives", () => {
+  let db: Database;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-core-"));
+    db = openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+    try {
+      rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    } catch {
+      // Best-effort cleanup only: Windows may hold SQLite sidecar files briefly.
+    }
+  });
+
+  it("updates mutable token fields without changing the slug", () => {
+    const token = createToken(db, {
+      slug: "git-current-branch",
+      concept: "git branch shows branches",
+      domain: "git",
+      bloom_level: 1,
+    });
+
+    const updated = updateToken(db, token.slug, {
+      concept: "git branch marks the current branch with *",
+      domain: "github",
+      bloom_level: 2,
+      context: "cli",
+      symbiosis_mode: "copilot",
+    });
+
+    expect(updated.slug).toBe(token.slug);
+    expect(updated.concept).toBe("git branch marks the current branch with *");
+    expect(updated.domain).toBe("github");
+    expect(updated.bloom_level).toBe(2);
+    expect(updated.context).toBe("cli");
+    expect(updated.symbiosis_mode).toBe("copilot");
+  });
+
+  it("previews and deletes a token with dependent learning data and skill references", () => {
+    const prerequisite = createToken(db, {
+      slug: "shell-start-dir",
+      concept: "find starts from a directory",
+      domain: "shell",
+      bloom_level: 1,
+    });
+    const target = createToken(db, {
+      slug: "shell-find-command",
+      concept: "find recursively searches directory trees",
+      domain: "shell",
+      bloom_level: 2,
+    });
+
+    addPrerequisite(db, target.id, prerequisite.id);
+
+    const card = ensureCard(db, prerequisite.id, "thomas");
+    executeReviewAction(db, {
+      action: "rate",
+      cardId: card.id,
+      userId: "thomas",
+      rating: 3,
+    });
+
+    const session = startSession(db, {
+      user_id: "thomas",
+      task: "Review shell concepts",
+    });
+    logStep(db, {
+      session_id: session.id,
+      token_id: prerequisite.id,
+      done_by: "user",
+      rating: 3,
+    });
+
+    createAgentSkill(db, {
+      slug: "shell-find-workflow",
+      description: "Use find to scan a tree",
+      steps: ["open terminal", "run find"],
+      token_slugs: [prerequisite.slug, target.slug],
+    });
+
+    const impact = getTokenDeleteImpact(db, prerequisite.slug);
+    expect(impact).toEqual({
+      cards: 1,
+      review_logs: 1,
+      prerequisite_edges_from_token: 0,
+      prerequisite_edges_to_token: 1,
+      session_steps: 1,
+      sessions_touched: 1,
+      agent_skills: 1,
+    });
+
+    const deleted = deleteToken(db, prerequisite.slug);
+    expect(deleted.impact).toEqual(impact);
+    expect(getTokenBySlug(db, prerequisite.slug)).toBeUndefined();
+    expect(getCard(db, prerequisite.id, "thomas")).toBeUndefined();
+    expect(getReviewsForCard(db, card.id)).toHaveLength(0);
+    expect(getPrerequisites(db, target.id)).toEqual([]);
+    expect(listAgentSkills(db)[0].token_slugs).toEqual([target.slug]);
+  });
+
+  it("deletes one user's card while preserving the token and session history", () => {
+    const token = createToken(db, {
+      slug: "zam-token-vs-card",
+      concept: "tokens define concepts while cards track user state",
+      domain: "zam",
+      bloom_level: 2,
+    });
+
+    const card = ensureCard(db, token.id, "thomas");
+    executeReviewAction(db, {
+      action: "rate",
+      cardId: card.id,
+      userId: "thomas",
+      rating: 4,
+    });
+
+    const session = startSession(db, {
+      user_id: "thomas",
+      task: "Review ZAM concepts",
+    });
+    logStep(db, {
+      session_id: session.id,
+      token_id: token.id,
+      done_by: "user",
+      rating: 4,
+    });
+
+    expect(getCardDeletionImpact(db, token.id, "thomas")).toEqual({ review_logs: 1 });
+
+    const deleted = deleteCardForUser(db, token.id, "thomas");
+    expect(deleted.impact).toEqual({ review_logs: 1 });
+    expect(getTokenBySlug(db, token.slug)).toBeTruthy();
+    expect(getCard(db, token.id, "thomas")).toBeUndefined();
+    expect(getReviewsForCard(db, card.id)).toHaveLength(0);
+    expect(getSessionSummary(db, session.id).steps).toHaveLength(1);
+  });
+
+  it("routes rating=1 through prerequisite blocking in executeReviewAction", () => {
+    const prerequisite = createToken(db, {
+      slug: "git-branches",
+      concept: "branches isolate lines of work",
+      domain: "git",
+      bloom_level: 1,
+    });
+    const target = createToken(db, {
+      slug: "git-show-current",
+      concept: "git branch --show-current prints the current branch",
+      domain: "git",
+      bloom_level: 2,
+    });
+
+    addPrerequisite(db, target.id, prerequisite.id);
+    const card = ensureCard(db, target.id, "thomas");
+
+    const result = executeReviewAction(db, {
+      action: "rate",
+      cardId: card.id,
+      userId: "thomas",
+      rating: 1,
+    });
+
+    expect(result.evaluation?.state).toBe("learning");
+    expect(result.blocked?.blockedSlug).toBe(target.slug);
+    expect(result.blocked?.prerequisites).toHaveLength(1);
+    expect(result.blocked?.prerequisites[0]?.slug).toBe(prerequisite.slug);
+  });
+
+  it("edits and short-circuits review actions without mutating scheduling unexpectedly", () => {
+    const token = createToken(db, {
+      slug: "macos-brew-cask",
+      concept: "brew install --cask installs GUI apps",
+      domain: "macos",
+      bloom_level: 2,
+    });
+    const card = ensureCard(db, token.id, "thomas");
+
+    const edited = executeReviewAction(db, {
+      action: "edit-token",
+      cardId: card.id,
+      userId: "thomas",
+      tokenUpdates: { concept: "brew install --cask installs GUI macOS apps" },
+    });
+    expect(edited.updatedToken?.concept).toBe("brew install --cask installs GUI macOS apps");
+
+    const skipped = executeReviewAction(db, {
+      action: "skip",
+      cardId: card.id,
+      userId: "thomas",
+    });
+    expect(skipped.skipped).toBe(true);
+
+    const stopped = executeReviewAction(db, {
+      action: "stop",
+      cardId: card.id,
+      userId: "thomas",
+    });
+    expect(stopped.stopped).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add inline review maintenance actions for interactive review flows
- add token edit/delete and card delete command support
- add bridge support for non-rating review actions and focused kernel tests

## Validation
- npm test
- npm run build

## Notes
- npm run lint still fails because of the pre-existing Biome config/schema mismatch in this repo