### PR TITLE
feat: resolve source_link into review context (+ git-sync & add-token fixes)

### DIFF
--- a/.agent/skills/zam/SKILL.md
+++ b/.agent/skills/zam/SKILL.md
@@ -252,10 +252,16 @@ After the user answers, ask:
 Submit the rating and log the step.
 
 #### Leveraging Source Links for AI Agent Context
-Each due token in a review session may contain a `sourceLink` attribute (which can be a workspace-relative file path like `src/db/connection.ts#L45-L60` or a remote documentation URL):
-1. **Retrieve the Context**: Before presenting the review question, the AI agent must attempt to inspect the referenced file or document. For local repository paths, use the `view_file` tool. For external URLs, use `read_url_content`.
-2. **Formulate Contextual Questions**: Instead of asking generic questions based strictly on the one-sentence concept text, use the retrieved code or documentation context to ask highly targeted, realistic, and deep conceptual questions (e.g., at Bloom level 2, 3, or 4).
-3. **Verify Responses Precisely**: Reference the retrieved material to precisely verify the user's answers, addressing specific edge cases, syntax, or trade-offs present in the actual codebase or documentation.
+When a token has a `source_link`, `zam bridge get-review` resolves it for you and returns a `resolvedContext` object alongside `prompt` — you no longer need to fetch the file or URL yourself. Its shape:
+
+- `sourceType: "local" | "remote_web"` → `content` is the literal file/page text, already line-sliced when the link carried a `#L10-L25` anchor. Ground your question and verification directly in it.
+- `sourceType: "dynamic_search"` → `content` is a `QUERY_DIRECTIVE: Run web search for "..."`. Run that web search yourself, then ground the review in the results.
+- `truncated: true` → the content was capped; fetch the full `filePath`/`url` only if you need more.
+- `resolvedContext: null` → no link, or resolution was disabled (`--no-resolve`); fall back to the one-sentence concept, or inspect the path yourself.
+
+Use it to:
+1. **Formulate Contextual Questions**: Instead of asking generic questions based strictly on the one-sentence concept text, use the resolved code or documentation to ask targeted, realistic, deep conceptual questions (e.g., at Bloom level 2, 3, or 4).
+2. **Verify Responses Precisely**: Reference the resolved material to verify the user's answers, addressing specific edge cases, syntax, or trade-offs present in the actual codebase or documentation.
 
 ### STEP 5 — End session
 ```bash

--- a/src/bridge/protocol.ts
+++ b/src/bridge/protocol.ts
@@ -21,6 +21,24 @@ export interface CheckDueResponse {
 
 // ── Get Review ──────────────────────────────────────────────────────────────
 
+/**
+ * A token's source_link resolved into ready-to-use context.
+ *
+ * `sourceType` tells the AI client how to treat `content`:
+ * - `local` / `remote_web`: the literal file/page text (already line-sliced
+ *   when the link carried a `#Lx-Ly` anchor). Ground questions in it directly.
+ * - `dynamic_search`: `content` is a `QUERY_DIRECTIVE` — run the web search it
+ *   names, then ground the review in the results.
+ */
+export interface ResolvedReviewContext {
+  sourceLink: string;
+  sourceType: "local" | "remote_web" | "dynamic_search";
+  content: string;
+  filePath?: string;
+  url?: string;
+  truncated: boolean;
+}
+
 export interface GetReviewResponse {
   cardId: string;
   tokenId: string;
@@ -32,6 +50,8 @@ export interface GetReviewResponse {
   question: string;
   state: string;
   sourceLink?: string | null;
+  /** Present when the token has a source_link and resolution was not disabled. */
+  resolvedContext?: ResolvedReviewContext | null;
 }
 
 // ── Submit Rating ───────────────────────────────────────────────────────────
@@ -170,6 +190,7 @@ export interface AddTokenRequest {
   bloomLevel: number;
   context?: string;
   symbiosisMode?: "shadowing" | "copilot" | "autonomy";
+  source_link?: string | null; // file path / reference URL; stdin payload is snake_case
   prerequisites?: string[]; // slugs of prerequisite tokens
   userId?: string;          // if provided, ensures a card is created
 }

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -25,6 +25,7 @@ import {
   executeReviewAction,
   getTokenDeleteImpact,
   getCardDeletionImpact,
+  resolveReviewContext,
 } from "../../kernel/index.js";
 import type {
   Rating,
@@ -52,6 +53,19 @@ function withDb(fn: (db: Database) => void): void {
   try {
     db = openDatabase();
     fn(db);
+  } catch (err) {
+    db?.close();
+    jsonError((err as Error).message);
+  } finally {
+    db?.close();
+  }
+}
+
+async function withDbAsync(fn: (db: Database) => Promise<void>): Promise<void> {
+  let db: Database | undefined;
+  try {
+    db = openDatabase();
+    await fn(db);
   } catch (err) {
     db?.close();
     jsonError((err as Error).message);
@@ -168,8 +182,9 @@ bridgeCommand
   .command("get-review")
   .description("Get next review card with prompt (JSON)")
   .option("--user <id>", "User ID (default: whoami)")
-  .action((opts) => {
-    withDb((db) => {
+  .option("--no-resolve", "Skip resolving the token's source_link into context")
+  .action(async (opts) => {
+    await withDbAsync(async (db) => {
       const userId = resolveUser(opts, db, { json: true });
       const queue = buildReviewQueue(db, { userId, maxReviews: 1, maxNew: 1 });
 
@@ -179,6 +194,7 @@ bridgeCommand
           hasReview: false,
           card: null,
           prompt: null,
+          resolvedContext: null,
           queueSize: 0,
         });
         return;
@@ -195,6 +211,17 @@ bridgeCommand
         sourceLink: item.sourceLink,
       });
 
+      // Resolve the source_link into ready-to-use context for the AI client.
+      // Defensive: never let a bad/unreachable reference break the review payload.
+      let resolvedContext = null;
+      if (opts.resolve !== false) {
+        try {
+          resolvedContext = await resolveReviewContext(item.sourceLink);
+        } catch {
+          resolvedContext = null;
+        }
+      }
+
       // Get full queue size for context
       const fullQueue = buildReviewQueue(db, { userId });
 
@@ -203,6 +230,7 @@ bridgeCommand
         hasReview: true,
         card: item,
         prompt,
+        resolvedContext,
         queueSize: fullQueue.items.length,
       });
     });
@@ -471,6 +499,7 @@ bridgeCommand
         bloom_level?: number;
         context?: string;
         symbiosis_mode?: string | null;
+        source_link?: string | null;
       };
 
       try {
@@ -493,6 +522,7 @@ bridgeCommand
         bloom_level: (data!.bloom_level ?? 1) as BloomLevel,
         context: data!.context,
         symbiosis_mode: data!.symbiosis_mode as "shadowing" | "copilot" | "autonomy" | null | undefined,
+        source_link: data!.source_link ?? null,
       });
 
       const card = ensureCard(db, token.id, userId);

--- a/src/cli/commands/git-sync.ts
+++ b/src/cli/commands/git-sync.ts
@@ -129,8 +129,10 @@ export const gitSyncCommand = new Command("git-sync")
       for (const token of matchedTokens) {
         const card = getCard(db, token.id, userId);
         if (card) {
-          // Reset interval / decay stability: FSRS stability is cut significantly to trigger quick review
-          const newStability = Math.min(0.2, card.stability / 4.0);
+          // Decay stability to a quarter (concept's source changed → likely stale),
+          // with a 0.2-day floor so the card surfaces for review soon. Using max,
+          // not min: min would collapse every card to <=0.2 regardless of prior strength.
+          const newStability = Math.max(0.2, card.stability / 4.0);
           
           db.prepare(`
             UPDATE cards

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -8,6 +8,7 @@ import {
   openDatabase,
   buildReviewQueue,
   generatePrompt,
+  resolveReviewContext,
 } from "../../kernel/index.js";
 import type { Rating, BloomLevel } from "../../kernel/index.js";
 import { resolveUser } from "./resolve-user.js";
@@ -18,6 +19,7 @@ export const reviewCommand = new Command("review")
   .option("--user <id>", "User ID (default: whoami)")
   .option("--max-new <n>", "Maximum new cards", "10")
   .option("--max-reviews <n>", "Maximum review cards", "50")
+  .option("--no-resolve", "Skip resolving source_link into inline context")
   .action(async (opts) => {
     let db: Database | undefined;
     try {
@@ -65,6 +67,25 @@ export const reviewCommand = new Command("review")
         console.log(`Domain: ${prompt.domain || "(none)"}`);
         if (prompt.sourceLink) {
           console.log(`Source: ${prompt.sourceLink}`);
+          if (opts.resolve !== false) {
+            const ctx = await resolveReviewContext(item.sourceLink, { maxChars: 1200 }).catch(
+              () => null,
+            );
+            if (ctx && ctx.sourceType === "dynamic_search") {
+              console.log(`  ↳ ${ctx.content}`);
+            } else if (ctx?.content.trim()) {
+              const indented = ctx.content
+                .trimEnd()
+                .split("\n")
+                .map((line) => `  │ ${line}`)
+                .join("\n");
+              console.log("  Context:");
+              console.log(indented);
+              if (ctx.truncated) {
+                console.log("  │ … (truncated)");
+              }
+            }
+          }
         }
         console.log(`\n  ${prompt.question}\n`);
 

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -108,8 +108,14 @@ export type { ReviewQueue, ReviewQueueItem, ReviewQueueOptions } from "./schedul
 // Recall
 export { generatePrompt } from "./recall/prompter.js";
 export type { RecallPrompt, PromptInput } from "./recall/prompter.js";
-export { resolveReference, matchesFilePath, normalizePath } from "./recall/reference-resolver.js";
-export type { ResolvedReference } from "./recall/reference-resolver.js";
+export {
+  resolveReference,
+  resolveReviewContext,
+  matchesFilePath,
+  normalizePath,
+  DEFAULT_REVIEW_CONTEXT_MAX_CHARS,
+} from "./recall/reference-resolver.js";
+export type { ResolvedReference, ReviewContext } from "./recall/reference-resolver.js";
 
 export { evaluateRating } from "./recall/evaluator.js";
 export type { EvaluateInput, EvaluateResult } from "./recall/evaluator.js";

--- a/src/kernel/recall/reference-resolver.ts
+++ b/src/kernel/recall/reference-resolver.ts
@@ -9,6 +9,22 @@ export interface ResolvedReference {
 }
 
 /**
+ * A source reference resolved and bounded for inclusion in a review payload.
+ * Same shape as ResolvedReference plus the originating link and a truncation flag.
+ */
+export interface ReviewContext {
+  sourceLink: string;
+  sourceType: ResolvedReference["sourceType"];
+  content: string;
+  filePath?: string;
+  url?: string;
+  truncated: boolean;
+}
+
+/** Default cap on resolved content length, so bridge JSON / terminal output stays bounded. */
+export const DEFAULT_REVIEW_CONTEXT_MAX_CHARS = 6000;
+
+/**
  * Strips HTML tags and attempts to convert basic structure to readable text/markdown.
  */
 function htmlToText(html: string): string {
@@ -187,6 +203,40 @@ export async function resolveReference(sourceLink: string): Promise<ResolvedRefe
     sourceType: "local",
     content: `Local reference file not found or unreadable.\nReference: ${cleaned}`,
     filePath: absolutePath,
+  };
+}
+
+/**
+ * Resolve a token's source_link into bounded, review-ready context.
+ *
+ * Wraps {@link resolveReference} for the review/bridge flow: returns `null`
+ * for empty links and caps content length so the surrounding payload (bridge
+ * JSON or terminal output) stays manageable, flagging when truncation occurred.
+ */
+export async function resolveReviewContext(
+  sourceLink: string | null | undefined,
+  opts: { maxChars?: number } = {},
+): Promise<ReviewContext | null> {
+  const cleaned = sourceLink?.trim();
+  if (!cleaned) return null;
+
+  const maxChars = opts.maxChars ?? DEFAULT_REVIEW_CONTEXT_MAX_CHARS;
+  const resolved = await resolveReference(cleaned);
+
+  let content = resolved.content;
+  let truncated = false;
+  if (content.length > maxChars) {
+    content = content.slice(0, maxChars);
+    truncated = true;
+  }
+
+  return {
+    sourceLink: cleaned,
+    sourceType: resolved.sourceType,
+    content,
+    filePath: resolved.filePath,
+    url: resolved.url,
+    truncated,
   };
 }
 

--- a/tests/kernel/reference-resolver.test.ts
+++ b/tests/kernel/reference-resolver.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   resolveReference,
+  resolveReviewContext,
   matchesFilePath,
   normalizePath,
 } from "../../src/kernel/index.js";
@@ -99,6 +100,42 @@ describe("ZAM Reference Resolver & Path Matching", () => {
       const resultSingle = await resolveReference(`${testFilePath}#L5`);
       expect(resultSingle.sourceType).toBe("local");
       expect(resultSingle.content).toBe("Line 5");
+    });
+  });
+
+  describe("resolveReviewContext", () => {
+    it("returns null for empty or whitespace-only links", async () => {
+      expect(await resolveReviewContext(null)).toBeNull();
+      expect(await resolveReviewContext(undefined)).toBeNull();
+      expect(await resolveReviewContext("   ")).toBeNull();
+    });
+
+    it("wraps resolved content with the originating link and a truncation flag", async () => {
+      const testFilePath = join(tempDir, "ctx.txt");
+      writeFileSync(testFilePath, "alpha\nbeta\ngamma", "utf-8");
+
+      const ctx = await resolveReviewContext(`${testFilePath}#L2`);
+      expect(ctx).not.toBeNull();
+      expect(ctx?.sourceLink).toBe(`${testFilePath}#L2`);
+      expect(ctx?.sourceType).toBe("local");
+      expect(ctx?.content).toBe("beta");
+      expect(ctx?.truncated).toBe(false);
+    });
+
+    it("caps oversized content and flags truncation", async () => {
+      const testFilePath = join(tempDir, "big.txt");
+      writeFileSync(testFilePath, "x".repeat(5000), "utf-8");
+
+      const ctx = await resolveReviewContext(testFilePath, { maxChars: 100 });
+      expect(ctx?.content.length).toBe(100);
+      expect(ctx?.truncated).toBe(true);
+    });
+
+    it("passes through dynamic search directives", async () => {
+      const ctx = await resolveReviewContext("search://websearch?q=spaced+repetition");
+      expect(ctx?.sourceType).toBe("dynamic_search");
+      expect(ctx?.content).toBe('QUERY_DIRECTIVE: Run web search for "spaced repetition"');
+      expect(ctx?.truncated).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Completes the `source_link` feature started in `9d31f82` + `3830bae`: the
reference-resolver was built, tested, and exported but **never called outside
tests**. Reviews still handed AI clients a raw link string. This wires the
resolver into the review flow and fixes two related bugs.

### Feature — resolved source context in reviews
- **kernel:** new `resolveReviewContext()` — resolves a token's `source_link`
  (local file, line-anchored `#L10-L25`, GitHub raw, `search://` directive),
  caps content length with a `truncated` flag, returns `null` for empty links.
- **bridge `get-review`:** now async, emits a `resolvedContext` object next to
  `prompt`; `--no-resolve` opts out.
- **`review` (human):** renders bounded, indented source context inline.
- **protocol:** adds `ResolvedReviewContext` + `GetReviewResponse.resolvedContext`.
- **SKILL.md:** agents consume `resolvedContext` directly instead of fetching
  links themselves; clear handling for `dynamic_search` directives.

### Fixes
- **`bridge add-token` dropped `source_link`** — the stdin schema ignored it, so
  cards created via the bridge could never carry a source. Now passed through.
- **`git-sync` collapsed every card to 0.2 stability** — `Math.min(0.2, S/4)`
  reset any card with stability > 0.8 to exactly 0.2, wiping FSRS history. Now
  `Math.max` — quartered with a 0.2-day floor.

## Testing
- `npm run test` → **82/82** green (4 new `resolveReviewContext` tests).
- `npm run build` green (incl. DTS typecheck).
- End-to-end against an **isolated** temp `USERPROFILE` (real user DB untouched):
  - `get-review` returns `resolvedContext` with exactly the `#L2-L3` slice; `--no-resolve` → `null`.
  - `add-token` with `source_link` persists it on the token.
  - `git-sync` decays stability 15.47 → 3.87 (¼, not 0.2); state → `review`, due now.

> Note: `npm run lint` remains globally broken (pre-existing Biome config drift,
> `files.ignore` → `files.includes`) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
