### PR TITLE
fix(tooling): enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Normalize all text files to LF in the repository AND in the working tree,
+# regardless of the contributor's core.autocrlf setting. This keeps Biome's
+# formatter (lineEnding: lf) green on Windows checkouts and silences the
+# perpetual "LF will be replaced by CRLF" warnings.
+* text=auto eol=lf
+
+# Binary assets — never apply EOL conversion to these.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.icns binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.otf   binary


### PR DESCRIPTION
## Summary

Follow-up to #21. With the Biome linter restored, Windows checkouts (default
`core.autocrlf=true`, no `.gitattributes`) produced CRLF working trees that
Biome's LF formatter flagged as ~53 errors — and emitted constant
"LF will be replaced by CRLF" git warnings.

The committed blobs were already LF, so this only pins the working-tree EOL:
`.gitattributes` with `* text=auto eol=lf` (binary asset types marked `binary`).

## Verification

- working tree re-checked out as LF
- `npm run build` ✅
- `npm run test` ✅ 103/103
- `npm run lint` ✅ exit 0 (54 pre-existing style warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
