### PR TITLE
fix(desktop): locate the CLI bridge independent of the working directory

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,45 +1,85 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-use std::process::Command;
 use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+fn cli_in(root: &Path) -> PathBuf {
+    root.join("dist").join("cli").join("index.js")
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("USERPROFILE")
+        .or_else(|| env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+/// Locate the compiled ZAM CLI (`dist/cli/index.js`) independently of the
+/// process working directory, so the installed GUI works when launched from
+/// the Start menu / Program Files (where the cwd is NOT the repo).
+fn resolve_cli_path() -> Option<PathBuf> {
+    // 1. Explicit override.
+    if let Some(home) = env::var_os("ZAM_HOME") {
+        let p = cli_in(&PathBuf::from(home));
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    // 2. Repo root recorded by the ZAM CLI (`zam ui` writes ~/.zam/cli_path).
+    if let Some(h) = home_dir() {
+        if let Ok(contents) = fs::read_to_string(h.join(".zam").join("cli_path")) {
+            let root = contents.trim();
+            if !root.is_empty() {
+                let p = cli_in(Path::new(root));
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+        }
+    }
+
+    // 3. Working-directory fallbacks (running from the repo in dev mode).
+    if let Ok(cwd) = env::current_dir() {
+        for rel in [".", "..", "../.."] {
+            let p = cli_in(&cwd.join(rel));
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+
+    None
+}
+
 #[tauri::command]
 fn execute_zam_bridge(cmd: String, args: Vec<String>) -> Result<String, String> {
-    let current_dir = env::current_dir().map_err(|e| e.to_string())?;
-    
-    // Resolve compiled CLI path in workspace root
-    let mut cli_path = current_dir.join("dist").join("cli").join("index.js");
-    
-    if !cli_path.exists() {
-        cli_path = current_dir.join("..").join("dist").join("cli").join("index.js");
-    }
-    if !cli_path.exists() {
-        cli_path = current_dir.join("..").join("..").join("dist").join("cli").join("index.js");
-    }
-    
-    if !cli_path.exists() {
-        return Err(format!("Could not locate ZAM CLI build at {:?}", cli_path));
-    }
-    
+    let cli_path = resolve_cli_path().ok_or_else(|| {
+        "Could not locate the ZAM CLI build (dist/cli/index.js). Set the ZAM_HOME \
+         environment variable to your repo, or run `zam ui` once from the repo to record it."
+            .to_string()
+    })?;
+
     // Run command: node <cli_path> bridge <cmd> <args...>
     let mut command = Command::new("node");
-    command.arg(cli_path);
+    command.arg(&cli_path);
     command.arg("bridge");
     command.arg(cmd);
-    
+
     for arg in args {
         command.arg(arg);
     }
-    
+
     let output = command.output().map_err(|e| e.to_string())?;
-    
+
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    
+
     if output.status.success() {
         Ok(stdout)
     } else {

--- a/src/cli/commands/ui.ts
+++ b/src/cli/commands/ui.ts
@@ -15,7 +15,8 @@
  */
 
 import { type SpawnSyncOptions, spawn, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
@@ -152,6 +153,21 @@ function warnIfCliMissing(repoRoot: string): void {
   }
 }
 
+/**
+ * Record this repo root in ~/.zam/cli_path so the installed GUI can locate the
+ * CLI bridge regardless of where it is launched from (Start menu / Program
+ * Files have no idea where the repo lives). The Tauri backend reads this file.
+ */
+function recordCliHome(repoRoot: string): void {
+  try {
+    const zamDir = join(homedir(), ".zam");
+    if (!existsSync(zamDir)) mkdirSync(zamDir, { recursive: true });
+    writeFileSync(join(zamDir, "cli_path"), repoRoot, "utf8");
+  } catch {
+    // best-effort: a missing marker just falls back to cwd resolution
+  }
+}
+
 function launchApp(appPath: string, repoRoot: string): void {
   // Run from the repo root so the Tauri backend resolves dist/cli/index.js.
   console.log(`${C.green}✓ Launching ZAM Desktop...${C.reset}`);
@@ -224,6 +240,10 @@ export const uiCommand = new Command("ui")
     }
     const repoRoot = dirname(desktopDir);
 
+    // Record where the CLI lives so the installed GUI can always find the
+    // bridge, no matter which directory it is launched from.
+    recordCliHome(repoRoot);
+
     // --build: compile the native installer.
     if (opts.build) {
       if (!requireRust()) process.exit(1);
@@ -246,6 +266,9 @@ export const uiCommand = new Command("ui")
         );
         console.log(
           `${C.dim}Run that installer once — it adds ZAM to the Start menu and Desktop automatically.${C.reset}`,
+        );
+        console.log(
+          `${C.dim}Recorded this repo (${repoRoot}) in ~/.zam/cli_path so the installed app finds the CLI.${C.reset}`,
         );
       }
       process.exit(code);


### PR DESCRIPTION
## Problem

After installing the desktop GUI via the installer, it launches but can't run
the CLI bridge: the Tauri backend searched for `dist/cli/index.js` relative to
the **working directory**, which for a Start-menu / Program Files launch is not
the repo. Net effect: the app "doesn't know where the working directory is".

## Fix

`desktop/src-tauri/src/lib.rs` now resolves the CLI independent of cwd:

1. `$ZAM_HOME/dist/cli/index.js` — explicit override
2. the repo root recorded in `~/.zam/cli_path`
3. cwd-relative fallbacks — dev mode

`zam ui` writes the repo root to `~/.zam/cli_path` on every run, so building or
launching from the repo auto-configures the installed app (no manual env var).

## Apply (one-time rebuild)

```
cd C:\src\zam-Thomas        # your repo
git pull
npm run build
zam ui --build              # records ~/.zam/cli_path and rebuilds the installer
# run the new installer
```

## Verification

- CLI/TS side: `npm run build` ✅, `npm run lint` ✅ exit 0, `npm run test` ✅ 103/103
- `zam ui` confirmed to write `~/.zam/cli_path`
- Rust change is small/idiomatic but compiled by the author's rebuild (no Rust toolchain in CI here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
