### PR TITLE
feat(desktop): auto-start the local LLM from the GUI on launch

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -5,6 +5,8 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
   en: {
     ai_status_offline: "Local AI Offline",
     ai_status_online: "Local AI Online",
+    ai_status_starting: "Starting Local AI...",
+    ai_status_model_missing: "Local AI: model not found",
     lbl_due_reviews: "Due Reviews",
     lbl_caught_up: "You're all caught up!",
     lbl_domains: "Active Domains",
@@ -41,6 +43,8 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
   de: {
     ai_status_offline: "Lokale KI offline",
     ai_status_online: "Lokale KI online",
+    ai_status_starting: "Starte lokale KI...",
+    ai_status_model_missing: "Lokale KI: Modell fehlt",
     lbl_due_reviews: "Anstehende Wiederholungen",
     lbl_caught_up: "Du bist voll auf dem Laufenden!",
     lbl_domains: "Aktive Wissensbereiche",
@@ -235,18 +239,34 @@ async function loadDashboard() {
       domainsContainer.appendChild(span);
     }
 
-    // 3. Check Local LLM Status
-    const llmStatus = await runBridge<{ enabled: boolean; online: boolean }>("check-llm");
+    // 3. Bring the local LLM online (auto-starts the server like `zam learn`)
+    //    and reflect status. Don't block the dashboard on model load — show a
+    //    "starting" state and update the badge once it resolves.
     const aiStatusLabel = document.getElementById("ai-status-label")!;
     const pulseDot = document.querySelector(".pulse-dot")!;
-    
-    if (llmStatus.enabled && llmStatus.online) {
-      aiStatusLabel.textContent = t("ai_status_online");
-      pulseDot.className = "pulse-dot green";
-    } else {
-      aiStatusLabel.textContent = t("ai_status_offline");
-      pulseDot.className = "pulse-dot gray";
-    }
+    aiStatusLabel.textContent = t("ai_status_starting");
+    pulseDot.className = "pulse-dot amber";
+
+    runBridge<{ usable: boolean; online: boolean; reason?: string }>("ensure-llm", [
+      "--timeout",
+      "45000",
+    ])
+      .then((llm) => {
+        if (llm.usable) {
+          aiStatusLabel.textContent = t("ai_status_online");
+          pulseDot.className = "pulse-dot green";
+        } else if (llm.reason === "model-not-found") {
+          aiStatusLabel.textContent = t("ai_status_model_missing");
+          pulseDot.className = "pulse-dot gray";
+        } else {
+          aiStatusLabel.textContent = t("ai_status_offline");
+          pulseDot.className = "pulse-dot gray";
+        }
+      })
+      .catch(() => {
+        aiStatusLabel.textContent = t("ai_status_offline");
+        pulseDot.className = "pulse-dot gray";
+      });
   } catch (err) {
     console.error("Failed to load dashboard:", err);
   }

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -176,6 +176,20 @@ body {
   background-color: var(--clr-text-muted);
 }
 
+.pulse-dot.amber {
+  background-color: #f5a623;
+  box-shadow: 0 0 10px #f5a623;
+}
+
+.pulse-dot.amber::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  border-radius: 50%;
+  border: 1px solid #f5a623;
+  animation: pulseAnimation 2s infinite ease-out;
+}
+
 @keyframes pulseAnimation {
   0% { transform: scale(1); opacity: 1; }
   100% { transform: scale(3.5); opacity: 0; }

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -41,6 +41,7 @@ import {
 } from "../../kernel/index.js";
 import {
   ensureHighQualityQuestion,
+  ensureLlmReadyHeadless,
   evaluateAnswerViaLLM,
   getAvailableModels,
   getLlmConfig,
@@ -734,6 +735,27 @@ bridgeCommand
         modelAvailable,
         availableModels,
       });
+    });
+  });
+
+// ── zam bridge ensure-llm ─────────────────────────────────────────────────
+
+bridgeCommand
+  .command("ensure-llm")
+  .description(
+    "Start the local LLM server if needed and report readiness (JSON)",
+  )
+  .option(
+    "--timeout <ms>",
+    "Max time to wait for the server to come online",
+    "25000",
+  )
+  .action(async (opts) => {
+    await withDbAsync(async (db) => {
+      const result = await ensureLlmReadyHeadless(db, {
+        timeoutMs: Number(opts.timeout),
+      });
+      jsonOut(result);
     });
   });
 

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -311,16 +311,14 @@ export interface LlmReadiness {
   reason?: "disabled" | "offline" | "model-not-found";
 }
 
-/**
- * Detect the configured runner and start it, then poll until the server is
- * online (or the user opts out). Returns true once reachable, false otherwise.
- */
-async function startLocalRunner(
+type RunnerKind = "fastflowlm" | "ollama" | "generic" | "unknown";
+
+/** Pick the local runner from the URL port / model name (shared heuristic). */
+function detectRunner(
   url: string,
   model: string,
-  locale: SupportedLocale,
-): Promise<boolean> {
-  let runner: "fastflowlm" | "ollama" | "generic" | "unknown" = "unknown";
+): { runner: RunnerKind; port: string } {
+  let runner: RunnerKind = "unknown";
   let port = "8000";
   try {
     const urlObj = new URL(url);
@@ -338,6 +336,44 @@ async function startLocalRunner(
   } catch {
     runner = getSystemProfile().recommendedRunner;
   }
+  return { runner, port };
+}
+
+/**
+ * Best-effort, SILENT runner start for non-interactive contexts (bridge / GUI).
+ * No console output, no prompts — just spawn the detached server if we can.
+ */
+function spawnLocalRunner(url: string, model: string): void {
+  const { runner, port } = detectRunner(url, model);
+  try {
+    if (runner === "fastflowlm") {
+      const flmExe = existsSync("C:\\Program Files\\flm\\flm.exe")
+        ? "C:\\Program Files\\flm\\flm.exe"
+        : "flm";
+      if (!hasCommand("flm") && flmExe === "flm") return;
+      spawn(flmExe, ["serve", model, "--port", port], {
+        detached: true,
+        stdio: "ignore",
+      }).unref();
+    } else if (runner === "ollama" || runner === "generic") {
+      if (!hasCommand("ollama")) return;
+      spawn("ollama", ["serve"], { detached: true, stdio: "ignore" }).unref();
+    }
+  } catch {
+    // best-effort: caller polls for the server and reports offline if it fails
+  }
+}
+
+/**
+ * Detect the configured runner and start it, then poll until the server is
+ * online (or the user opts out). Returns true once reachable, false otherwise.
+ */
+async function startLocalRunner(
+  url: string,
+  model: string,
+  locale: SupportedLocale,
+): Promise<boolean> {
+  const { runner, port } = detectRunner(url, model);
 
   if (runner === "fastflowlm") {
     const flmExe = existsSync("C:\\Program Files\\flm\\flm.exe")
@@ -480,6 +516,76 @@ export async function ensureLocalLlmRunning(
   }
 
   return { usable: true };
+}
+
+/** Readiness plus the live status details a UI needs to render. */
+export interface LlmReadyResult extends LlmReadiness {
+  online: boolean;
+  model: string;
+  availableModels: string[];
+}
+
+/**
+ * Non-interactive readiness check for the bridge / desktop GUI: start the local
+ * runner if needed, wait (bounded) for it to come online, validate the model —
+ * all WITHOUT console output or prompts, so the bridge's JSON stays clean.
+ */
+export async function ensureLlmReadyHeadless(
+  db: Database,
+  opts: { timeoutMs?: number } = {},
+): Promise<LlmReadyResult> {
+  const timeoutMs = opts.timeoutMs ?? 25000;
+  const { enabled, url, model, apiKey } = getLlmConfig(db);
+  if (!enabled) {
+    return {
+      usable: false,
+      reason: "disabled",
+      online: false,
+      model,
+      availableModels: [],
+    };
+  }
+
+  const isLocal = url.includes("localhost") || url.includes("127.0.0.1");
+
+  let online = await isLlmOnline(url);
+  if (!online && isLocal) {
+    spawnLocalRunner(url, model);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 1000));
+      if (await isLlmOnline(url)) {
+        online = true;
+        break;
+      }
+    }
+  }
+
+  if (!online) {
+    return {
+      usable: false,
+      reason: "offline",
+      online: false,
+      model,
+      availableModels: [],
+    };
+  }
+
+  const availableModels = await getAvailableModels(url, apiKey);
+  const modelKnown =
+    availableModels.length === 0 ||
+    availableModels.some((m) => m.toLowerCase() === model.toLowerCase());
+  if (!modelKnown) {
+    return {
+      usable: false,
+      reason: "model-not-found",
+      online: true,
+      model,
+      availableModels,
+    };
+  }
+
+  return { usable: true, online: true, model, availableModels };
 }
 
 /**


### PR DESCRIPTION
## Summary

The desktop GUI now starts the local LLM itself, instead of only checking
status. Opening the app is enough to bring the AI online — no manual
`flm serve` first.

## Changes

- **New bridge command `zam bridge ensure-llm`** (JSON): starts the configured
  runner if offline, waits (bounded) for it, validates the model, returns
  `{ usable, online, reason, model, availableModels }`. Non-interactive (no
  console output / prompts) so the bridge JSON stays clean.
- **client.ts**: extracted `detectRunner()`; added silent `spawnLocalRunner()`
  and `ensureLlmReadyHeadless()` (reused by the bridge).
- **GUI**: dashboard shows a pulsing "Starting Local AI…" badge and calls
  `ensure-llm` without blocking card loading, then flips to online / offline /
  "model not found". Amber status dot + en/de strings added.

## Verification

- `npm run build` ✅, `npm run lint` ✅ exit 0, `npm run test` ✅ 103/103
- `tsc -p desktop/tsconfig.json --noEmit` ✅
- Live: `zam bridge ensure-llm` started flm and returned `usable: true` with
  `gemma4-it:e4b` present in `availableModels`

## Apply

Frontend is bundled at build time, so this lands in the installed app after a
one-time `zam ui --build` + reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
