### PR TITLE
fix: add Codex skill distribution

### DIFF
--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: zam
+description: Use ZAM during real tasks or knowledge reviews to build lasting skills with active recall and FSRS spaced repetition. Use for `$zam`, ZAM learning sessions, due-card reviews, task decomposition into knowledge tokens, or monitored practice.
+user-invocable: true
+---
+
+# ZAM — Symbiotic Learning Agent
+
+In Codex, invoke this workflow as `$zam` or select `zam` through `/skills`.
+Codex does not expose repository skills as custom `/zam` slash commands.
+
+You are a kind, patient skills trainer. Your mission: build lasting autonomy through conceptual knowledge, not rote procedure. You think like a university professor designing a curriculum — but you teach during real work, not in a classroom. Celebrate every honest attempt. A rating of 1 is not failure; it is the discovery of the next thing to learn.
+
+**Baseline assumption:** The user has finished secondary school. They understand basic concepts of their domain. Treat them as an intelligent adult who simply hasn't been exposed to these specific tools or ideas yet.
+
+---
+
+## ZAM CLI Tool
+
+All knowledge management is done through the `zam` CLI:
+
+```bash
+# First-time setup (only needed once)
+zam init
+
+# Token management
+zam token register --slug <slug> --concept "<one sentence>" --domain <d> --bloom <1-5> [--source-link <link>]
+zam token find --query "<keywords>"
+zam token list [--domain <d>]
+zam token prereq --token <child> --requires <parent>
+zam token deprecate --slug <slug>          # mark outdated knowledge
+
+# Card & review management
+zam card due --user <username>
+zam card update --user <username> --token <slug> --rating <1-4>
+zam card unblock --user <username>
+
+# Sessions
+zam session start --user <username> --task "<description>" [--context shell|ui|reallife]
+zam session log --session <id> --token <slug> --done-by <user|agent> [--rating <n>]
+zam session end --session <id>
+
+# Stats
+zam stats --user <username>
+
+# Agent skills (task recipes)
+zam skill list
+zam skill show --slug <slug>
+zam skill add --slug <slug> --description "<text>" --steps '<json>' [--tokens <slugs>]
+
+# User settings
+zam settings show                                      # display all settings
+zam settings get --key <key>                           # get a single setting
+zam settings set --key <key> --value <value>           # set a setting
+zam settings delete --key <key>                        # delete a setting
+
+# Shell monitoring (observation mode)
+zam monitor open --session <id> [--dir <path>]        # open a monitored terminal window
+zam monitor start --session <id> [--shell zsh|bash|pwsh] # output hook code (eval/Invoke-Expression)
+zam monitor stop --session <id>                        # output unhook code (eval/Invoke-Expression)
+zam monitor status --session <id>                      # check monitoring stats
+
+# Bridge (machine-readable JSON protocol)
+zam bridge check-due --user <username>
+zam bridge get-review --user <username>
+zam bridge submit --user <username> --card-id <id> --rating <1-4>
+zam bridge get-skill --slug <slug>
+zam bridge get-monitor --session <id>                 # read monitor log as JSON
+echo '{"patterns":[...]}' | zam bridge analyze-monitor --session <id>  # auto-rate from log
+```
+
+---
+
+## What is a Knowledge Token?
+
+A token is one atomic fact, concept, or principle a person must carry in their head. Not a step. Not a procedure. A transferable understanding.
+
+Good token (atomic, transferable):
+> "AppTraces is the Log Analytics table that stores application trace logs"
+
+Too coarse (covers many separate concepts):
+> "How to write a KQL investigation query"
+
+Too fine (not worth a card):
+> "The letter K in KQL stands for Kusto"
+
+Each token has:
+- **slug** — machine key (`kql-apptrace-table`)
+- **concept** — one sentence what it teaches
+- **domain** — e.g. `python`, `azure`, `kubernetes`, `git`
+- **bloom_level** — 1=remember a fact, 2=understand a concept, 3=apply in context, 4=analyze trade-offs, 5=synthesize novel solutions
+
+Prerequisites: "to understand A, you must first know B." Register edges with `zam token prereq`.
+
+---
+
+## Two Modes of Knowledge Assessment
+
+**Observation (primary)**: Agent watches the user do the task. If done correctly without help or hesitation → silently rate all touched tokens as 4. No interruption, no questions. Like a driving examiner in the back seat.
+
+**Verbal probing (secondary)**: Used when observation is insufficient — conceptual sessions with no executable output, or when a token hasn't been exercised in a long time and a practice task isn't appropriate.
+
+Always prefer observation over probing. Talking interrupts flow. The best ZAM session is one the user barely notices.
+
+---
+
+## Observation Levels
+
+- **Level 1 — Shell** (current): Agent reads shell command history and output to infer success/failure
+- **Level 2 — Screen** (future): Agent observes full screen, guides UI interaction, auto-rates based on what it sees
+- **Level 3 — Real life** (future): Voice + visual overlay on device (phone, AR). The agent is an overlay; the user lives in their world.
+
+The interface is pluggable — future observers replace Level 1 shell calls with their own primitives. Today: always Level 1.
+
+---
+
+## Session Protocol
+
+### STEP 1 — Start session & check status
+```bash
+zam card unblock --user <username> --quiet
+zam stats --user <username>
+```
+Show stats as a brief friendly greeting. Mention how many tokens are due, how many are blocked.
+
+For **review/conceptual** sessions, use `--summary` to avoid spoiling answers:
+```bash
+zam card due --user <username> --summary
+```
+For **executable/task** sessions, the full listing is fine since the agent needs to plan.
+
+Classify session type:
+- **Executable** — real commands, code, or file edits (e.g. "set up Homebrew", "commit this change")
+- **Conceptual** — pure review with no concrete output (e.g. `$zam repeat`)
+
+### STEP 2 — Generate the knowledge plan
+
+Think: *"What must a person know and understand to plan and then execute this task?"*
+
+Decompose into a dependency-ordered list of knowledge tokens.
+
+**Deduplication before registering:**
+```bash
+zam token find --query "<keywords>"
+```
+Only register genuinely new concepts. Reuse existing slugs where the concept matches.
+
+**Register tokens and prerequisites:**
+```bash
+zam token register --slug <slug> --concept "<one sentence>" --domain <d> --bloom <1-5>
+zam token prereq --token <child> --requires <parent>
+```
+
+### STEP 3 — Start a session
+
+**For review/conceptual sessions**, load review data into a temp file so it stays out of the conversation, then start the session quietly:
+```bash
+zam bridge check-due --user <username> > /tmp/zam-review.json
+zam session start --user <username> --task "<description>" --context shell --quiet
+```
+Read `/tmp/zam-review.json` with an available file-reading tool to load card data silently. This gives you all cardIds, slugs, concepts, domains, and bloom levels for the session. **Do not call `bridge get-review` per card** — iterate through the cards from this data.
+
+**For executable/task sessions**, the normal start is fine:
+```bash
+zam session start --user <username> --task "<description>" --context shell
+```
+
+### STEP 4 — Hand off, observe, rate
+
+> **Spoiler-free console option:** For pure conceptual recall, you can hand the
+> whole review off to the standalone console harness instead of probing card by
+> card here:
+> > "Let's do your reviews in the dedicated console — run `zam learn` and rate
+> > yourself. I'll wait."
+>
+> `zam learn` shows a concept-free cue, captures the answer, and only then
+> reveals the stored answer (concept + context + resolved `source_link`) before a
+> single 1–4 self-rating — all in-process. This sidesteps agent-CLI autocomplete
+> that would otherwise ghost the answer, and the per-subcommand permission
+> prompts from chained `card update` / `session log` calls. Use the verbal
+> probing below when you want to drive the discussion yourself or add depth a
+> stored answer can't (that richer mode will later be backed by an LLM).
+
+**For executable tasks (observation mode):**
+
+Hand off to the user:
+> "This is now your job. Good luck!"
+
+Step back. Do not interrupt unless the user asks for help.
+
+**Two ways to observe:**
+
+Check the user's preference first:
+```bash
+zam settings get --key monitor_method
+```
+If set to `terminal`, default to Approach B. If set to `inline` or not set, ask the user which they prefer on first use and save it:
+```bash
+zam settings set --key monitor_method --value terminal --quiet
+```
+
+**Approach A — Inline (inside Codex):** When the user chooses agent-assisted execution, run commands with Codex's command tools so command and output remain in the conversation. For user-practice sessions, prefer Approach B so the user performs the work and ZAM can observe it.
+
+**Approach B — Shell monitor (separate terminal):** The preferred approach for real tasks. The agent opens a monitored terminal automatically:
+
+```bash
+zam monitor open --session <session-id> --dir /path/to/project
+```
+
+This spawns a new terminal window (Terminal.app or iTerm2 on macOS), already `cd`'d to the task directory, with observation hooks installed. The user just sees a shell and starts working. Tell them:
+
+> "I've opened a terminal for you. Go ahead and work there — come back here when you're done."
+
+Shell hooks silently capture every command with timestamps, exit codes, and working directory to a JSONL log. When the user returns:
+
+```bash
+# Read the raw command log
+zam bridge get-monitor --session <session-id>
+
+# Auto-rate tokens by matching commands to patterns
+echo '{"patterns":[{"slug":"docker-build","patterns":["docker build","docker image build"]}]}' \
+  | zam bridge analyze-monitor --session <session-id>
+```
+
+The analyzer infers ratings from:
+- **Help-seeking**: `--help`, `man`, `tldr` before a matching command → lower rating
+- **Error rate**: non-zero exit codes → lower rating
+- **Speed**: inter-command gaps, thinking pauses → lower if slow
+- **Self-corrections**: same command prefix run repeatedly with different args → lower rating
+
+Review the suggested ratings before submitting. Override if the heuristic seems wrong.
+
+When done, the user can simply close the monitored terminal window — hooks only live in that shell process. No cleanup command needed.
+
+**Rating scale (both approaches):**
+- Completed correctly, no hesitation, no help → **4**
+- Slight pause or looked something up → **3**
+- Made errors, corrected themselves → **2**
+- Asked for help or couldn't proceed → **1** (then explain the concept and continue)
+
+```bash
+zam card update --user <username> --token <slug> --rating <n> --quiet
+zam session log --session <id> --token <slug> --done-by user --rating <n> --quiet
+```
+
+Use `--quiet` to suppress FSRS internals — the learner does not need to see stability, reps, or next-due dates during a session.
+
+For tokens the user never touched (agent did them silently): log `--done-by agent`, no rating.
+
+**For conceptual sessions (verbal probing):**
+
+For each due token, ask a conceptual question at the right Bloom level:
+
+| Level | Test format | Example |
+|-------|------------|---------|
+| 1 Remember | "What is X?" | "What table stores app logs?" |
+| 2 Understand | "How does X work?" | "Why does bin() only produce non-empty buckets?" |
+| 3 Apply | "Write/Do X" | "Write a filter for this specific message" |
+| 4 Analyze | "Why X over Y?" | "Why is == more efficient than contains?" |
+| 5 Synthesize | "Design a..." | "Build the full query from scratch" |
+
+**CRITICAL: Stop and WAIT for the user to provide their answer. Do not ask for the rating until the user has attempted to answer the conceptual question.**
+
+After the user answers, ask:
+> "How did that feel? 1 = drew a blank, 2 = hard recall, 3 = knew it, 4 = instant"
+
+**WAIT for the user to provide a rating (1-4).**
+
+Submit the rating and log the step.
+
+#### Leveraging Source Links for AI Agent Context
+When a token has a `source_link`, `zam bridge get-review` resolves it for you and returns a `resolvedContext` object alongside `prompt` — you no longer need to fetch the file or URL yourself. Its shape:
+
+- `sourceType: "local" | "remote_web"` → `content` is the literal file/page text, already line-sliced when the link carried a `#L10-L25` anchor. Ground your question and verification directly in it.
+- `sourceType: "dynamic_search"` → `content` is a `QUERY_DIRECTIVE: Run web search for "..."`. Run that web search yourself, then ground the review in the results.
+- `truncated: true` → the content was capped; fetch the full `filePath`/`url` only if you need more.
+- `resolvedContext: null` → no link, or resolution was disabled (`--no-resolve`); fall back to the one-sentence concept, or inspect the path yourself.
+
+Use it to:
+1. **Formulate Contextual Questions**: Instead of asking generic questions based strictly on the one-sentence concept text, use the resolved code or documentation to ask targeted, realistic, deep conceptual questions (e.g., at Bloom level 2, 3, or 4).
+2. **Verify Responses Precisely**: Reference the resolved material to verify the user's answers, addressing specific edge cases, syntax, or trade-offs present in the actual codebase or documentation.
+
+### STEP 5 — End session
+```bash
+zam session end --session <id>
+zam stats --user <username>
+```
+Show progress. Be honest about what the user did vs. what the agent did. Mention 1-2 things to look forward to in the next session.
+
+---
+
+## Practice Tasks for Stale Skills
+
+When a token is long overdue and has no upcoming executable task to surface it naturally, propose a harmless practice task:
+
+> "You haven't done X in a while. Want to practice? We can install ripgrep via Homebrew, then remove it — just to keep the muscle memory alive."
+
+This is preferable to repeated verbal drilling. Doing > reciting.
+
+---
+
+## When the Agent Doesn't Know How
+
+If the agent cannot execute a step:
+
+1. Admit it explicitly: *"I'm not sure how to do this — I would try X or Y. Should I attempt it?"*
+2. If the user guides: attempt it, note what works
+3. Register any new concepts discovered as tokens (dedup first) — these are facts the user might later forget (e.g. "Azure DevOps Problem items require a priority field before creation"). Create user cards for them.
+4. Save the successful approach as an agent skill entry:
+   ```bash
+   zam skill add --slug <slug> --description "<one sentence>" --steps '<json array>' --tokens <related-slugs>
+   ```
+5. The linked tokens get user cards — they will decay via FSRS and resurface for review like any other card. Automation does not replace retention.
+
+---
+
+## Blocking Rule
+
+ A token is blocked when:
+- The user rated it 1 (forgot), AND
+- Its prerequisites have not yet been recalled at least once
+
+The agent works on prerequisites first. When all direct prerequisites reach `reps >= 1`, `zam card unblock` promotes the token back automatically (run at session start).
+
+Never present a blocked token to the user.
+
+---
+
+## Token Deprecation
+
+Knowledge goes stale. If a token comes up for review and the user indicates it's outdated ("that's not how it works anymore"):
+
+1. Ask: *"Should we drop this, update the concept, or keep it for legacy context?"*
+2. If drop: `zam token deprecate --slug <slug>` — archived, excluded from future reviews
+3. If update: `zam token register` a replacement token, then deprecate the old one
+4. Deprecated tokens are not deleted — they can be consulted, but won't appear in the review queue
+
+---
+
+## Three Symbiosis Modes
+
+| Mode | When | How |
+|------|------|-----|
+| **Shadowing** | User is learning the domain | Agent plans, user executes. Agent observes silently and rates. |
+| **Co-Pilot** | User has basic competence | Agent and user alternate. Agent observes and rates what user does. |
+| **Autonomy** | User has high retention | Agent handles routine. Periodic practice tasks keep skills alive. |
+
+Use `zam stats` domain competence to determine the right mode for each domain.
+
+---
+
+## Safety Rules
+
+- Never present a blocked token to the user
+- Never probe synthesis (bloom 5) before all prerequisites reach reps >= 1
+- Never register a token that already exists under a different slug — dedup first
+- Never skip the knowledge plan — it's what makes this a training session, not just a task
+- Be honest in the session summary about what the agent did vs. what the user did
+- Rating scale is 1-4 (not 0-3 like the old PoC)
+- Agent execution (`done-by agent`) does NOT advance FSRS state — only user-rated recalls do
+- Observation ratings (from watching the user work) DO count — they are user actions
+- Prefer observation over verbal probing; interrupting flow has a cost
+- Never show card slugs or concept text to the user before asking a review question — they spoil the answer. Use `--summary` for due listings during review sessions.
+- Do not deprecate tokens without the user's confirmation

--- a/README.de.md
+++ b/README.de.md
@@ -49,7 +49,7 @@ Agenten kommunizieren untereinander, um Bedarfe und Angebote der Gemeinschaft ab
 
 ZAM ist als **KI-agnostischer Kernel** konzipiert — ein CLI-Tool, das sich nahtlos in bestehende Workflows integriert:
 
-- **CLI-Integration** — Kompatibel mit `Claude Code`, `Copilot CLI` und `Gemini CLI`.
+- **CLI-Integration** — Kompatibel mit `Claude Code`, `Codex`, `Copilot CLI` und `Gemini CLI`.
 - **Modularität** — Das System kann für länderspezifische oder kulturelle Eigenheiten „geforkt" werden (*Social Forking*).
 
 ### Zwei Repositories, ein System

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Agents communicate with each other to match community needs and offerings:
 
 ZAM is designed as an **AI-agnostic kernel** — a CLI tool that integrates seamlessly into existing workflows:
 
-- **CLI Integration** — Compatible with `Claude Code`, `Copilot CLI`, and `Gemini CLI`.
+- **CLI Integration** — Compatible with `Claude Code`, `Codex`, `Copilot CLI`, and `Gemini CLI`.
 - **Modularity** — The system can be forked for region- or culture-specific adaptations (*Social Forking*).
 
 ### Two Repositories, One System

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
 
 ZAM is built on three principles:
 
-1. **AI-agnostic kernel** — The learning engine has zero LLM dependencies. It is pure learning science: spaced repetition (FSRS-5), Bloom taxonomy, prerequisite graphs, and review scheduling. Any AI CLI (Claude Code, Copilot CLI, Gemini CLI, or future systems) integrates through a JSON bridge protocol.
+1. **AI-agnostic kernel** — The learning engine has zero LLM dependencies. It is pure learning science: spaced repetition (FSRS-5), Bloom taxonomy, prerequisite graphs, and review scheduling. Any AI CLI (Claude Code, Codex, Copilot CLI, Gemini CLI, or future systems) integrates through a JSON bridge protocol.
 
 2. **Local-first** — All data lives in a single SQLite file at `~/.zam/zam.db`, owned by the user. WAL mode enables concurrent access from multiple CLI processes.
 
@@ -23,7 +23,7 @@ ZAM is built on three principles:
 ```
 ┌──────────────────────────────────────────────────────────┐
 │  AI Skill Layer  (SKILL.md)                              │
-│  Claude Code / Copilot CLI / Gemini CLI / Voice / AR     │
+│  Claude Code / Codex / Copilot / Gemini / Voice / AR     │
 │  ─ Reads SKILL.md instructions                           │
 │  ─ Drives session protocol (observe → probe → rate)      │
 │  ─ Calls zam bridge commands for data                    │

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -58,6 +58,7 @@ repo in `~/.zam/zam.db`.
 ```
 zam-personal/           ← GitHub template repo
 ├── CLAUDE.md           ← Context for Claude Code before skill files exist
+├── AGENTS.md           ← Context for Codex before skill files exist
 ├── README.md           ← How to create and set up a personal instance
 ├── .gitignore          ← Excludes node_modules/, .zam/*.db
 ├── package.json        ← { "dependencies": { "zam-core": "^x.y.z" } }
@@ -67,18 +68,22 @@ zam-personal/           ← GitHub template repo
 │   └── README.md       ← What beliefs are; Miller's number (max 7)
 ├── goals/
 │   └── README.md       ← What goals are; decomposition model
-└── .claude/
-    └── skills/
-        └── setup/
-            └── SKILL.md ← /setup onboarding skill (static, always present)
+├── .claude/skills/setup/SKILL.md ← Claude onboarding skill (static)
+├── .gemini/skills/setup/SKILL.md ← Gemini onboarding skill (static)
+└── .agents/skills/setup/SKILL.md ← Codex onboarding skill (static)
 ```
 
-After running `/setup`, `zam-core` distributes its own skill file:
+After running the setup skill, `zam-core` distributes its own skill file:
 
 ```
 .claude/skills/zam/SKILL.md    ← from node_modules/zam-core/.claude/skills/zam/
-.gemini/skills/zam/SKILL.md    ← from node_modules/zam-core/.gemini/skills/zam/
+.agent/skills/zam/SKILL.md     ← from node_modules/zam-core/.agent/skills/zam/
+.agents/skills/zam/SKILL.md    ← from node_modules/zam-core/.agents/skills/zam/
 ```
+
+Claude- and Gemini-compatible clients invoke their skills with `/setup` and
+`/zam`. Codex invokes repository skills with `$setup` and `$zam`, or selects
+them through `/skills`.
 
 ### Personal config schema (`.zam/config.yaml`)
 
@@ -123,6 +128,7 @@ published identity) but may be private for internal teams.
 ```
 zam-community/          ← GitHub template repo
 ├── CLAUDE.md           ← Context for Claude Code
+├── AGENTS.md           ← Context for Codex
 ├── README.md           ← How to create and set up a community instance
 ├── .gitignore          ← Excludes node_modules/, .zam/*.db
 ├── package.json        ← { "dependencies": { "zam-core": "^x.y.z" } }
@@ -134,10 +140,9 @@ zam-community/          ← GitHub template repo
 │   └── README.md       ← Community's shared objectives
 ├── members/
 │   └── README.md       ← Membership model; how to join
-└── .claude/
-    └── skills/
-        └── setup/
-            └── SKILL.md ← /setup skill (community-aware)
+├── .claude/skills/setup/SKILL.md ← Claude setup skill
+├── .gemini/skills/setup/SKILL.md ← Gemini setup skill
+└── .agents/skills/setup/SKILL.md ← Codex setup skill
 ```
 
 ### Community config schema (`.zam/config.yaml`)
@@ -160,7 +165,7 @@ repos:                   # source repositories members should clone
 
 ## Setup Protocol
 
-The `/setup` skill in a personal instance follows this sequence:
+The `setup` skill in a personal instance follows this sequence:
 
 ```
 1. Read .zam/config.yaml
@@ -185,7 +190,7 @@ The `/setup` skill in a personal instance follows this sequence:
 This means the personal setup skill does **not** hardcode community-specific logic.
 The community's config drives what gets cloned and linked. Adding a new community
 to a personal instance is as simple as appending to `communities:` and re-running
-`/setup`.
+the setup skill.
 
 ---
 
@@ -221,7 +226,7 @@ communities:
     role: developer
 ```
 
-When `/setup` runs on such a personal instance, it automatically clones all three
+When the setup skill runs on such a personal instance, it automatically clones all three
 repos and sets up the `npm link` chain — no manual steps, no tribal knowledge.
 
 ---
@@ -232,11 +237,12 @@ Skill files always travel with the package that defines them:
 
 | Package / repo | Owns skill group | Distributes via |
 |----------------|-----------------|-----------------|
-| `zam-core` | `.claude/skills/zam/` | `zam setup` (copies from `node_modules/zam-core/`) |
-| `zam-community` | `.claude/skills/setup/` | Static in template (always present before setup runs) |
-| Future: `zam-devops` | `.claude/skills/devops/` | `devops setup` (copies from `node_modules/zam-devops/`) |
+| `zam-core` | `.claude/skills/zam/`, `.agent/skills/zam/`, `.agents/skills/zam/` | `zam setup` (copies from `node_modules/zam-core/`) |
+| Personal/community template | `.claude/skills/setup/`, `.gemini/skills/setup/`, `.agents/skills/setup/` | Static in template (always present before setup runs) |
+| Future: `zam-devops` | Per-client `skills/devops/` | `devops setup` (copies from `node_modules/zam-devops/`) |
 
-The naming convention `<ai-cli>/skills/<group>/SKILL.md` provides natural namespacing.
+The naming convention `<ai-cli>/skills/<group>/SKILL.md` provides natural
+namespacing. Codex specifically requires the plural `.agents/skills` path.
 No central registry is needed — each package owns its subdirectory.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "zam-core",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "files": [
     "dist/",
-    ".claude/",
-    ".agent/",
+    ".claude/skills/zam/",
+    ".agent/skills/zam/",
+    ".agents/skills/zam/",
     "README.md",
     "LICENSE"
   ],

--- a/src/bridge/protocol.ts
+++ b/src/bridge/protocol.ts
@@ -2,7 +2,7 @@
  * ZAM Bridge Protocol — JSON IPC for AI CLI Integration
  *
  * Defines the request/response shapes for communication between
- * AI CLI skills (Claude Code, Copilot CLI, Gemini CLI) and the
+ * AI CLI skills (Claude Code, Codex, Copilot CLI, Gemini CLI) and the
  * ZAM Learning Kernel.
  *
  * The bridge uses stdin/stdout JSON: the AI CLI calls `zam bridge <command>`

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,7 +1,7 @@
 /**
  * `zam setup` — Distribute skill files from the zam package into the current
- * personal instance's .claude/ and .agent/ directories, and optionally
- * initialize the ZAM database and generate a CLAUDE.md.
+ * personal instance's agent skill directories, and optionally initialize the
+ * ZAM database and generate agent-specific instruction files.
  *
  * Run this once after cloning a ZAM personal instance, and again after
  * upgrading zam (with --force) to refresh the skill files.
@@ -13,11 +13,14 @@ import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import { getDefaultDbPath, openDatabaseWithSync } from "../../kernel/index.js";
 
-// The compiled CLI lives at dist/cli/index.js inside the package.
-// Two levels up from there is the package root (dist/ â†’ package root).
-// This same relative path also works when running via `tsx src/cli/index.ts`
-// (src/ â†’ package root), so no branch logic is needed.
-const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
+// The bundled CLI resolves from dist/cli/index.js; source tests resolve from
+// src/cli/commands/setup.ts. Select the first candidate containing package.json.
+const packageRoot =
+  [
+    fileURLToPath(new URL("../..", import.meta.url)),
+    fileURLToPath(new URL("../../..", import.meta.url)),
+  ].find((candidate) => existsSync(join(candidate, "package.json"))) ??
+  fileURLToPath(new URL("../..", import.meta.url));
 
 const SKILL_PAIRS: Array<{ from: string; to: string }> = [
   {
@@ -28,10 +31,13 @@ const SKILL_PAIRS: Array<{ from: string; to: string }> = [
     from: join(packageRoot, ".agent", "skills", "zam", "SKILL.md"),
     to: join(".agent", "skills", "zam", "SKILL.md"),
   },
+  {
+    from: join(packageRoot, ".agents", "skills", "zam", "SKILL.md"),
+    to: join(".agents", "skills", "zam", "SKILL.md"),
+  },
 ];
 
-function copySkills(force: boolean): void {
-  const cwd = process.cwd();
+export function copySkills(force: boolean, cwd: string = process.cwd()): void {
   let anyAction = false;
 
   for (const { from, to } of SKILL_PAIRS) {
@@ -79,16 +85,19 @@ function initDatabase(skipInit: boolean): void {
   }
 }
 
-function writeClaudeMd(skipClaudeMd: boolean): void {
+export function writeClaudeMd(
+  skipClaudeMd: boolean,
+  cwd: string = process.cwd(),
+): void {
   if (skipClaudeMd) return;
 
-  const dest = join(process.cwd(), "CLAUDE.md");
+  const dest = join(cwd, "CLAUDE.md");
   if (existsSync(dest)) {
     console.log(`  skip  CLAUDE.md (already present)`);
     return;
   }
 
-  const name = basename(process.cwd());
+  const name = basename(cwd);
   writeFileSync(
     dest,
     `# ZAM Personal Kernel â€” ${name}
@@ -116,6 +125,53 @@ Use \`zam connector setup turso\` to store cloud credentials in
   console.log(`  write CLAUDE.md`);
 }
 
+export function writeAgentsMd(
+  skipAgentsMd: boolean,
+  cwd: string = process.cwd(),
+): void {
+  if (skipAgentsMd) return;
+
+  const dest = join(cwd, "AGENTS.md");
+  if (existsSync(dest)) {
+    console.log(`  skip  AGENTS.md (already present)`);
+    return;
+  }
+
+  const name = basename(cwd);
+  writeFileSync(
+    dest,
+    `# ZAM Personal Kernel - ${name}
+
+This is a ZAM personal instance. ZAM builds lasting skills through spaced
+repetition during real work, not separate study sessions.
+
+## First time here?
+Run \`zam setup\` from the shell. When this repository includes
+\`.agents/skills/setup/\`, you can instead select \`setup\` through \`/skills\`
+or invoke \`$setup\`.
+
+## Regular use
+Select the \`zam\` skill through \`/skills\` or invoke \`$zam\` to start a
+learning session on whatever you are working on.
+
+## What lives here
+- \`beliefs/\` - your worldview, approved by git commit
+- \`goals/\` - your objectives, decomposed into tasks and learning tokens
+
+## Fast-changing data
+Learning tokens, cards, and review history live in local SQLite by default.
+Use \`zam connector setup turso\` to store cloud credentials in
+\`~/.zam/credentials.json\` and use a Turso database across machines.
+
+## Codex skills
+Codex discovers repository skills under \`.agents/skills/\`. Run
+\`zam setup --force\` after upgrading \`zam-core\` to refresh them.
+`,
+    "utf8",
+  );
+  console.log(`  write AGENTS.md`);
+}
+
 export const setupCommand = new Command("setup")
   .description(
     "Distribute ZAM skill files into this personal instance and initialize the database",
@@ -127,16 +183,23 @@ export const setupCommand = new Command("setup")
   )
   .option("--skip-init", "skip database initialization", false)
   .option("--skip-claude-md", "skip CLAUDE.md generation", false)
+  .option("--skip-agents-md", "skip AGENTS.md generation", false)
   .action(
-    (opts: { force: boolean; skipInit: boolean; skipClaudeMd: boolean }) => {
+    (opts: {
+      force: boolean;
+      skipInit: boolean;
+      skipClaudeMd: boolean;
+      skipAgentsMd: boolean;
+    }) => {
       console.log(`Setting up ZAM in ${process.cwd()}\n`);
 
       copySkills(opts.force);
       initDatabase(opts.skipInit);
       writeClaudeMd(opts.skipClaudeMd);
+      writeAgentsMd(opts.skipAgentsMd);
 
       console.log(
-        "\nDone. Run `zam whoami --set <your-id>` to set your identity, then open Claude Code or Antigravity CLI and run /zam to start a learning session.",
+        "\nDone. Run `zam whoami --set <your-id>` to set your identity. Start the `zam` skill with `/zam` in Claude/Gemini-compatible clients or `$zam` (or `/skills`) in Codex.",
       );
     },
   );

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -77,7 +77,7 @@ workspaceCommand
     if (!existsSync(gitignorePath)) {
       writeFileSync(
         gitignorePath,
-        "node_modules/\n.agent/\n.claude/\n.gemini/\n.goose/\n*.log\n",
+        "node_modules/\n.agent/\n.agents/\n.claude/\n.gemini/\n.goose/\n*.log\n",
         "utf8",
       );
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,7 +25,7 @@ program
   .description(
     "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   )
-  .version("0.3.4");
+  .version("0.3.5");
 
 program.addCommand(initCommand);
 program.addCommand(setupCommand);

--- a/src/kernel/system/hooks.ts
+++ b/src/kernel/system/hooks.ts
@@ -14,9 +14,36 @@ const HOME = homedir();
 /**
  * Get the path to ZAM's internal package SKILL.md.
  */
-export function getPackageSkillPath(): string {
-  // relative to built dist/kernel/system/hooks.js -> packageRoot/.agent/skills/zam/SKILL.md
-  const packageRoot = fileURLToPath(new URL("../../..", import.meta.url));
+export function getPackageSkillPath(
+  agent: "default" | "claude" | "codex" = "default",
+): string {
+  // Support source modules plus the dist/index.js and dist/cli/index.js bundles.
+  const packageRoot =
+    [
+      fileURLToPath(new URL("../../..", import.meta.url)),
+      fileURLToPath(new URL("../..", import.meta.url)),
+      fileURLToPath(new URL("..", import.meta.url)),
+    ].find((candidate) => existsSync(join(candidate, "package.json"))) ?? "";
+
+  if (!packageRoot) return "";
+
+  if (agent === "codex") {
+    const codexPath = join(packageRoot, ".agents", "skills", "zam", "SKILL.md");
+    if (existsSync(codexPath)) return codexPath;
+    return "";
+  }
+
+  if (agent === "claude") {
+    const claudePath = join(
+      packageRoot,
+      ".claude",
+      "skills",
+      "zam",
+      "SKILL.md",
+    );
+    if (existsSync(claudePath)) return claudePath;
+    return "";
+  }
 
   // Try .agent first
   let path = join(packageRoot, ".agent", "skills", "zam", "SKILL.md");
@@ -31,14 +58,16 @@ export function getPackageSkillPath(): string {
 
 /**
  * Distribute the ZAM active-recall training skill globally.
- * Copies SKILL.md into global directories for Claude Code and Gemini.
+ * Copies SKILL.md into global directories for supported coding agents.
  */
-export function distributeGlobalSkills(): Array<{
+export function distributeGlobalSkills(home: string = HOME): Array<{
   name: string;
   path: string;
   success: boolean;
 }> {
   const sourceSkill = getPackageSkillPath();
+  const claudeSourceSkill = getPackageSkillPath("claude");
+  const codexSourceSkill = getPackageSkillPath("codex");
   const results: Array<{ name: string; path: string; success: boolean }> = [];
 
   if (!sourceSkill) {
@@ -47,10 +76,13 @@ export function distributeGlobalSkills(): Array<{
   }
 
   // 1. Claude Code global directory
-  const claudeSkillsDir = join(HOME, ".claude", "skills", "zam");
+  const claudeSkillsDir = join(home, ".claude", "skills", "zam");
   try {
+    if (!claudeSourceSkill) {
+      throw new Error("Claude skill source not found");
+    }
     mkdirSync(claudeSkillsDir, { recursive: true });
-    copyFileSync(sourceSkill, join(claudeSkillsDir, "SKILL.md"));
+    copyFileSync(claudeSourceSkill, join(claudeSkillsDir, "SKILL.md"));
     results.push({
       name: "Claude Code Global",
       path: join(claudeSkillsDir, "SKILL.md"),
@@ -65,7 +97,7 @@ export function distributeGlobalSkills(): Array<{
   }
 
   // 2. Gemini/agy global directory
-  const geminiSkillsDir = join(HOME, ".gemini", "skills", "zam");
+  const geminiSkillsDir = join(home, ".gemini", "skills", "zam");
   try {
     mkdirSync(geminiSkillsDir, { recursive: true });
     copyFileSync(sourceSkill, join(geminiSkillsDir, "SKILL.md"));
@@ -82,8 +114,29 @@ export function distributeGlobalSkills(): Array<{
     });
   }
 
-  // 3. Goose skills directory
-  const gooseSkillsDir = join(HOME, ".goose", "skills", "zam");
+  // 3. Codex global skills directory
+  const codexSkillsDir = join(home, ".agents", "skills", "zam");
+  try {
+    if (!codexSourceSkill) {
+      throw new Error("Codex skill source not found");
+    }
+    mkdirSync(codexSkillsDir, { recursive: true });
+    copyFileSync(codexSourceSkill, join(codexSkillsDir, "SKILL.md"));
+    results.push({
+      name: "Codex Global",
+      path: join(codexSkillsDir, "SKILL.md"),
+      success: true,
+    });
+  } catch (_err) {
+    results.push({
+      name: "Codex Global",
+      path: codexSkillsDir,
+      success: false,
+    });
+  }
+
+  // 4. Goose skills directory
+  const gooseSkillsDir = join(home, ".goose", "skills", "zam");
   try {
     mkdirSync(gooseSkillsDir, { recursive: true });
     copyFileSync(sourceSkill, join(gooseSkillsDir, "SKILL.md"));

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -1,0 +1,65 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  copySkills,
+  writeAgentsMd,
+} from "../../src/cli/commands/setup.js";
+
+describe("setup command helpers", () => {
+  it("copies ZAM skills for Claude, shared agents, and Codex", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "zam-setup-skills-"));
+
+    try {
+      copySkills(false, cwd);
+
+      const destinations = [
+        join(cwd, ".claude", "skills", "zam", "SKILL.md"),
+        join(cwd, ".agent", "skills", "zam", "SKILL.md"),
+        join(cwd, ".agents", "skills", "zam", "SKILL.md"),
+      ];
+
+      for (const destination of destinations) {
+        expect(existsSync(destination)).toBe(true);
+      }
+      expect(readFileSync(destinations[2], "utf8")).toContain("$zam");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("generates Codex repository instructions", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "zam-agents-md-"));
+
+    try {
+      writeAgentsMd(false, cwd);
+
+      const content = readFileSync(join(cwd, "AGENTS.md"), "utf8");
+      expect(content).toContain("$setup");
+      expect(content).toContain("$zam");
+      expect(content).toContain(".agents/skills/");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ships valid frontmatter for every packaged ZAM skill", () => {
+    for (const directory of [".claude", ".agent", ".agents"]) {
+      const content = readFileSync(
+        join(process.cwd(), directory, "skills", "zam", "SKILL.md"),
+        "utf8",
+      );
+      const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+
+      expect(frontmatter, `${directory} frontmatter`).not.toBeNull();
+      expect(frontmatter?.[1]).toMatch(/^name:\s+\S+/m);
+      expect(frontmatter?.[1]).toMatch(/^description:\s+.+/m);
+    }
+  });
+});

--- a/tests/kernel/system.test.ts
+++ b/tests/kernel/system.test.ts
@@ -1,5 +1,14 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  distributeGlobalSkills,
   getPackageSkillPath,
   getSystemProfile,
   hasCommand,
@@ -43,6 +52,42 @@ describe("System Profiling & Tool Detections", () => {
       expect(typeof path).toBe("string");
       if (path) {
         expect(path).toContain("SKILL.md");
+      }
+    });
+
+    it("resolves the Codex-specific skill source", () => {
+      const path = getPackageSkillPath("codex");
+
+      expect(path).toContain(join(".agents", "skills", "zam", "SKILL.md"));
+      expect(readFileSync(path, "utf8")).toContain("$zam");
+    });
+  });
+
+  describe("distributeGlobalSkills", () => {
+    it("installs the Codex-specific skill under the user .agents directory", () => {
+      const home = mkdtempSync(join(tmpdir(), "zam-global-skills-"));
+
+      try {
+        const results = distributeGlobalSkills(home);
+        const codexPath = join(
+          home,
+          ".agents",
+          "skills",
+          "zam",
+          "SKILL.md",
+        );
+
+        expect(results).toContainEqual({
+          name: "Codex Global",
+          path: codexPath,
+          success: true,
+        });
+        expect(existsSync(codexPath)).toBe(true);
+        expect(readFileSync(codexPath, "utf8")).toContain(
+          "Codex does not expose repository skills",
+        );
+      } finally {
+        rmSync(home, { recursive: true, force: true });
       }
     });
   });


### PR DESCRIPTION
## Summary
- package a Codex-specific ZAM skill under `.agents/skills/zam`
- distribute repository and global Codex skills and generate `AGENTS.md`
- retain existing Claude, Gemini, Copilot, and Goose behavior
- narrow npm package contents to skill directories only

## Verification
- `npm run lint`
- `npm run test` (115 tests)
- `npm run build`
- `npm pack --dry-run --json` includes exactly the three agent skill trees
- built `zam setup` copied `.agents/skills/zam/SKILL.md` in an isolated directory
- fresh `codex exec` discovered `setup` and `zam` in the live instance