### PR TITLE
fix(ci): ARM64 smoke-test identity; amend Increment 10 plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,4 +115,5 @@ jobs:
       - name: Smoke-test local database
         run: |
           node dist/cli/index.js setup --skip-claude-md --skip-agents-md
+          node dist/cli/index.js whoami --set ci
           node dist/cli/index.js stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'
@@ -88,10 +88,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
 

--- a/increments/10 - Async Database Providers & Turso Sync.md
+++ b/increments/10 - Async Database Providers & Turso Sync.md
@@ -5,6 +5,11 @@
 Planned for later implementation. This increment is not required for the
 Windows ARM64 local-storage fix delivered in Increment 9.
 
+Only Phase 0 (ARM64 release closure) is near-term work. All later phases stay
+gated until cross-platform Turso access and multi-device sync become the
+active product priority, and Phase 4 is additionally gated on upstream
+Windows ARM64 support (see below).
+
 ## Goal
 
 Replace ZAM's synchronous database dependency boundary with an asynchronous
@@ -20,6 +25,19 @@ The legacy `libsql` Node binding has no native Windows ARM64 artifact. Using an
 async HTTP client solves remote Turso access on that platform, but does not make
 legacy embedded replicas architecture-independent. Turso now recommends Turso
 Sync for new applications that need true local-first push/pull synchronization.
+
+Windows ARM64 is not an edge case: Snapdragon-based Windows laptops are a
+growing mainstream platform, and every new ZAM user on one of them gets the
+local-only path by default. Verified platform facts (2026-06-09):
+
+- `libsql` 0.5.29 publishes no `@libsql/win32-arm64-msvc` package, so neither
+  remote Turso nor embedded replicas work natively on Windows ARM64 today.
+- The new Turso stack has the same gap: `@tursodatabase/database` and
+  `@tursodatabase/sync` 0.6.1 ship darwin-arm64, linux-x64/arm64, and
+  win32-x64 binaries only. Turso Sync therefore does not currently run on the
+  platform that motivates this increment.
+- `better-sqlite3` 12.10.0 ships win32-arm64 prebuilds for Node 22/24+, which
+  is why local mode already works.
 
 ZAM therefore needs to separate three concerns instead of selecting one database
 package for all of them:
@@ -42,6 +60,9 @@ AsyncDatabase
 - Wrap the existing local SQLite implementation in Promise-based methods.
 - Preserve the current SQLite file format and migrations.
 - Remain the default provider and work fully offline.
+- Evaluate `node:sqlite` (built into Node >= 22, which ZAM already requires)
+  behind the same contract; adopting it would remove the last native module
+  from local mode and make installs architecture-independent.
 
 ### RemoteTursoProvider
 
@@ -49,15 +70,36 @@ AsyncDatabase
 - Avoid native libSQL bindings.
 - Support authenticated remote reads, writes, batches, and transactions on all
   supported architectures, including native Windows ARM64.
+- Intended audience: administrative and reporting commands (for example
+  `zam stats --user <id>` against the cloud database) and cloud access from
+  architectures without native sync support.
+- Not a supported configuration for interactive review sessions: a network
+  round trip per review and broken offline behavior contradict ZAM's
+  local-first learning loop.
 
 ### TursoSyncProvider
 
 - Use Turso Sync rather than legacy embedded replicas.
 - Support explicit pull/push operations and offline-first writes.
 - Define conflict behavior before enabling automatic background sync.
-- Remain optional until Turso Sync is stable enough for ZAM's data guarantees.
+- Remain optional until Turso Sync is stable enough for ZAM's data guarantees
+  and upstream publishes Windows ARM64 npm binaries (missing as of
+  `@tursodatabase/sync` 0.6.1; track the upstream issue before starting
+  Phase 4).
 
 ## Implementation Phases
+
+### Phase 0: ARM64 Release Closure (prerequisite, no async work)
+
+- Fix the Windows ARM64 CI smoke test to set an identity before `zam stats`.
+- Release `zam-core` 0.3.7: the published 0.3.6 still imports native `libsql`
+  unconditionally and crashes on Windows ARM64.
+- Validate `npx zam setup` plus one review on physical Windows ARM64 hardware.
+- Verify one tagged desktop release including the `aarch64-pc-windows-msvc`
+  artifact.
+
+After Phase 0, local-only ZAM fully supports Windows ARM64. Everything below
+is deferred until sync becomes the active priority.
 
 ### Phase 1: Async Database Contract
 
@@ -94,6 +136,18 @@ AsyncDatabase
 - Remove legacy embedded-replica metadata recovery code.
 - Publish upgrade and rollback instructions.
 
+## Interim Measures (independent of this increment)
+
+- `zam backup` / `zam restore`: an explicit SQL text dump to a user-chosen
+  folder (for example a OneDrive-synced directory) covers device loss for
+  local-only users without sync semantics, accounts, or async migration. Do
+  not sync the live `.db` file through a file-sync service; WAL plus file
+  sync risks corruption. This closes the backup/restore gap already tracked
+  as Increment 3A remaining work and stays useful after real sync exists.
+- New cloud users need no new database provider: additional free databases
+  under the existing Turso organization cover per-user cloud storage with
+  zero new code.
+
 ## Acceptance Criteria
 
 - Local-only ZAM behavior remains available without network access.
@@ -103,11 +157,16 @@ AsyncDatabase
 - Schema migrations are atomic and equivalent across providers.
 - Multi-step model operations preserve transaction guarantees.
 - Sync conflicts never silently discard learning or review history.
+- The Turso Sync provider ships only after upstream publishes Windows ARM64
+  binaries.
 - The legacy native `libsql` dependency is removed from installation.
 
 ## Non-Goals
 
 - Replacing SQLite as ZAM's local storage format.
+- Adding a second cloud database provider (for example Cloudflare D1 or a
+  Postgres service); it would duplicate integration surface without solving
+  Windows ARM64.
 - Making every CLI command concurrent.
 - Enabling automatic background sync before conflict semantics are defined.
 - Treating the legacy embedded-replica API as the final sync architecture.

--- a/increments/README.md
+++ b/increments/README.md
@@ -17,11 +17,12 @@ override the evidence in the repository.
 | 7 - Locale-aware recall | Partial product coverage | Seven-locale CLI i18n, locale detection/settings, localized LLM generation and evaluation | Desktop static chrome currently has dedicated English/German copy and English fallback for five locales |
 | 8 - Tauri recall studio | Implemented, release verification pending | Tauri UI, secure CLI bridge, self-contained CLI/Node resources, CSP, native release matrix | Exercise the release workflow from a tag and add automated frontend interaction tests |
 | 9 - Release hardening | In progress | See `9 - Release Hardening & Distribution Integrity.md` | Complete the acceptance checklist and validate CI on GitHub |
-| 10 - Async database providers and Turso Sync | Planned | Windows ARM64 local SQLite and an internal database contract provide the migration foundation | Async kernel migration, remote HTTP Turso provider, local-first Turso Sync, and removal of native libSQL |
+| 10 - Async database providers and Turso Sync | Planned | Windows ARM64 local SQLite and an internal database contract provide the migration foundation | Phase 0 ARM64 release closure (`zam-core` 0.3.7), then async kernel migration, remote HTTP Turso provider, local-first Turso Sync gated on upstream Windows ARM64 binaries, and removal of native libSQL |
 
 ## Current Product Sequence
 
-1. Finish Increment 9 and publish a signed/test release candidate.
+1. Finish Increment 9 and publish a signed/test release candidate, including
+   `zam-core` 0.3.7 so npm installs work on Windows ARM64.
 2. Close the user-visible gaps in Increment 7 and add desktop interaction tests.
 3. Implement the missing generalized connector and active-task workflow from Increment 2.
 4. Select exactly one Increment 3 product direction before implementing more


### PR DESCRIPTION
## Summary

- **CI fix**: the `windows-11-arm` job's final step failed because `zam stats` correctly exits 1 without a configured identity. The smoke test now runs `zam whoami --set ci` between `setup` and `stats`, exercising the real onboarding sequence. Everything before that step (npm ci with better-sqlite3 win32-arm64 prebuilds, build, 130 tests, local DB init) already passed on the ARM64 runner.
- **Increment 10 amendments** (`increments/10 - Async Database Providers & Turso Sync.md`):
  - New **Phase 0 (ARM64 release closure)**: this CI fix, a `zam-core` 0.3.7 release (published 0.3.6 imports native `libsql` unconditionally and crashes on Windows ARM64), validation on physical hardware, and one tagged desktop release with the `aarch64-pc-windows-msvc` artifact.
  - **Verified platform facts (2026-06-09)**: `@tursodatabase/database`/`@tursodatabase/sync` 0.6.1 ship no win32-arm64 binaries, so Phase 4 (Turso Sync) is explicitly gated on upstream ARM64 support — it does not currently run on the platform that motivates the increment.
  - **Remote HTTP provider rescoped** to admin/reporting and ARM64 cloud access; interactive review sessions remain local-first.
  - **`node:sqlite`** noted as a future zero-native-dependency local backend option (Node >= 22 is already required).
  - **Interim measures**: `zam backup`/`zam restore` via SQL text dump (closes the Increment 3A backup gap; explicitly not live-`.db` file sync), and per-user databases under the existing Turso organization instead of integrating a second cloud provider.

## Test plan

- [ ] `windows-arm64` CI job passes end-to-end, including the previously failing `Smoke-test local database` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)