### PR TITLE
docs: reframe Increment 10 around the online-first assumption

### DIFF
--- a/increments/10 - Async Database Providers & Turso Sync.md
+++ b/increments/10 - Async Database Providers & Turso Sync.md
@@ -5,19 +5,29 @@
 Planned for later implementation. This increment is not required for the
 Windows ARM64 local-storage fix delivered in Increment 9.
 
-Only Phase 0 (ARM64 release closure) is near-term work. All later phases stay
-gated until cross-platform Turso access and multi-device sync become the
-active product priority, and Phase 4 is additionally gated on upstream
-Windows ARM64 support (see below).
+Only Phase 0 (ARM64 release closure) is near-term work. Later phases stay
+gated until cloud database access from every architecture becomes the active
+product priority. Turso Sync is parked; see Product Assumptions and the
+parked provider section.
 
 ## Goal
 
 Replace ZAM's synchronous database dependency boundary with an asynchronous
 provider interface so every supported architecture can use:
 
-- local SQLite without network access,
+- local SQLite for zero-account onboarding,
 - remote Turso without native libSQL binaries, and
-- a future local-first synchronization provider based on Turso Sync.
+- (parked) a local-first synchronization provider based on Turso Sync, only
+  if offline-first ever becomes a requirement.
+
+## Product Assumptions (2026-06-09)
+
+- Users are online in practice (around 99% of the time); offline capability
+  is not a product goal. In the rare offline moments, learning can wait.
+- The local LLM exists for cost saving, not for offline operation.
+- The local database exists for fast, zero-account onboarding, not for
+  offline operation. Once cloud credentials are configured, the cloud
+  database is the source of truth.
 
 ## Why
 
@@ -44,7 +54,7 @@ package for all of them:
 
 1. Local persistence.
 2. Remote database access.
-3. Local-first synchronization.
+3. Local-first synchronization (parked).
 
 ## Target Architecture
 
@@ -52,7 +62,7 @@ package for all of them:
 AsyncDatabase
 |- LocalSQLiteProvider
 |- RemoteTursoProvider
-`- TursoSyncProvider
+`- TursoSyncProvider (parked)
 ```
 
 ### LocalSQLiteProvider
@@ -70,22 +80,20 @@ AsyncDatabase
 - Avoid native libSQL bindings.
 - Support authenticated remote reads, writes, batches, and transactions on all
   supported architectures, including native Windows ARM64.
-- Intended audience: administrative and reporting commands (for example
-  `zam stats --user <id>` against the cloud database) and cloud access from
-  architectures without native sync support.
-- Not a supported configuration for interactive review sessions: a network
-  round trip per review and broken offline behavior contradict ZAM's
-  local-first learning loop.
+- Primary cloud mode for all architectures, including interactive review
+  sessions: the per-review local LLM call dominates latency, so an HTTP
+  round trip per query is acceptable under the online-first assumption.
+- Also serves administrative and reporting commands (for example
+  `zam stats --user <id>` against the cloud database).
 
-### TursoSyncProvider
+### TursoSyncProvider (parked)
 
-- Use Turso Sync rather than legacy embedded replicas.
-- Support explicit pull/push operations and offline-first writes.
-- Define conflict behavior before enabling automatic background sync.
-- Remain optional until Turso Sync is stable enough for ZAM's data guarantees
-  and upstream publishes Windows ARM64 npm binaries (missing as of
-  `@tursodatabase/sync` 0.6.1; track the upstream issue before starting
-  Phase 4).
+Parked indefinitely: synchronization exists to serve offline-first usage,
+which is not a product goal. With the online-first assumption, every device
+talks to the same remote database directly and no conflict semantics are
+needed. Revisit only if that assumption changes, and then only once Turso
+Sync is stable enough for ZAM's data guarantees and upstream publishes
+Windows ARM64 npm binaries (missing as of `@tursodatabase/sync` 0.6.1).
 
 ## Implementation Phases
 
@@ -99,7 +107,7 @@ AsyncDatabase
   artifact.
 
 After Phase 0, local-only ZAM fully supports Windows ARM64. Everything below
-is deferred until sync becomes the active priority.
+is deferred until cloud database access becomes the active priority.
 
 ### Phase 1: Async Database Contract
 
@@ -122,12 +130,14 @@ is deferred until sync becomes the active priority.
 - Add timeout, retry, authentication, and actionable offline errors.
 - Test the provider on Windows ARM64 CI.
 
-### Phase 4: Local-First Sync
+### Phase 4: Local-to-Cloud Promotion
 
-- Evaluate the current Turso Sync SDK and storage support.
-- Define ownership and conflict rules for cards, reviews, settings, and tokens.
-- Implement explicit sync status, pull, push, and recovery commands.
-- Add interruption, conflict, and multi-device integration tests.
+- Implement a one-time promotion command that uploads an existing local
+  onboarding database into a configured cloud database.
+- Verify row counts after promotion and keep the local file as a backup
+  until the user confirms.
+- Document the onboarding ramp: start local with zero accounts, attach cloud
+  credentials later, promote history, continue remote.
 
 ### Phase 5: Remove Legacy Backend
 
@@ -150,15 +160,17 @@ is deferred until sync becomes the active priority.
 
 ## Acceptance Criteria
 
-- Local-only ZAM behavior remains available without network access.
+- Local mode remains the zero-configuration onboarding default.
 - Remote Turso works with native Windows ARM64 Node.js.
 - No kernel or public API type depends on a concrete database package.
 - Provider contract tests run against local SQLite and remote Turso.
 - Schema migrations are atomic and equivalent across providers.
 - Multi-step model operations preserve transaction guarantees.
-- Sync conflicts never silently discard learning or review history.
-- The Turso Sync provider ships only after upstream publishes Windows ARM64
-  binaries.
+- Local-to-cloud promotion transfers existing history losslessly and
+  verifiably.
+- If a sync provider ever ships: conflicts never silently discard learning
+  or review history, and it ships only after upstream publishes Windows
+  ARM64 binaries.
 - The legacy native `libsql` dependency is removed from installation.
 
 ## Non-Goals
@@ -168,6 +180,8 @@ is deferred until sync becomes the active priority.
   Postgres service); it would duplicate integration surface without solving
   Windows ARM64.
 - Making every CLI command concurrent.
+- Offline capability as a product goal; ZAM assumes users are online and
+  lets learning wait in rare offline moments.
 - Enabling automatic background sync before conflict semantics are defined.
 - Treating the legacy embedded-replica API as the final sync architecture.
 

--- a/increments/README.md
+++ b/increments/README.md
@@ -17,7 +17,7 @@ override the evidence in the repository.
 | 7 - Locale-aware recall | Partial product coverage | Seven-locale CLI i18n, locale detection/settings, localized LLM generation and evaluation | Desktop static chrome currently has dedicated English/German copy and English fallback for five locales |
 | 8 - Tauri recall studio | Implemented, release verification pending | Tauri UI, secure CLI bridge, self-contained CLI/Node resources, CSP, native release matrix | Exercise the release workflow from a tag and add automated frontend interaction tests |
 | 9 - Release hardening | In progress | See `9 - Release Hardening & Distribution Integrity.md` | Complete the acceptance checklist and validate CI on GitHub |
-| 10 - Async database providers and Turso Sync | Planned | Windows ARM64 local SQLite and an internal database contract provide the migration foundation | Phase 0 ARM64 release closure (`zam-core` 0.3.7), then async kernel migration, remote HTTP Turso provider, local-first Turso Sync gated on upstream Windows ARM64 binaries, and removal of native libSQL |
+| 10 - Async database providers and Turso Sync | Planned | Windows ARM64 local SQLite and an internal database contract provide the migration foundation | Phase 0 ARM64 release closure (`zam-core` 0.3.7), then async kernel migration, remote HTTP Turso as the primary cloud mode, local-to-cloud promotion, and removal of native libSQL; Turso Sync parked while offline-first stays a non-goal |
 
 ## Current Product Sequence
 
@@ -27,8 +27,8 @@ override the evidence in the repository.
 3. Implement the missing generalized connector and active-task workflow from Increment 2.
 4. Select exactly one Increment 3 product direction before implementing more
    proactive or governance behavior.
-5. Implement Increment 10 when cross-platform Turso access and multi-device
-   local-first sync become the active product priority.
+5. Implement Increment 10 when cloud database access from every architecture
+   becomes the active product priority.
 
 The files named `Josefczak.thoughts` and `Gemini.retro` are planning inputs, not
 separate shipped increments. The three numbered Increment 3 specifications are


### PR DESCRIPTION
## Summary

Follow-up to #27, incorporating the product owner's clarified assumptions: users are online ~99% of the time, offline capability is not a goal (learning can wait in the rare offline moments), the local LLM is for cost saving, and the local database is for fast zero-account onboarding.

- New **Product Assumptions** section in `increments/10` recording exactly that, dated.
- **RemoteTursoProvider rescoped as the primary cloud mode for all architectures, including interactive review sessions** — the per-review local LLM call dominates latency, so an HTTP round trip per query is acceptable. This replaces the previous "not for interactive sessions" framing.
- **TursoSyncProvider parked indefinitely**: synchronization exists to serve offline-first usage. Online-first means every device talks to the same remote database directly — no conflict semantics needed. This also dissolves the dependency on the missing win32-arm64 `@tursodatabase/sync` binaries.
- **Phase 4 replaced**: was "Local-First Sync", now "Local-to-Cloud Promotion" — a one-time verified upload of a local onboarding database into a configured cloud database, documenting the ramp: start local with zero accounts, attach credentials later, promote history, continue remote.
- Acceptance criteria, non-goals, and the increments README updated to match.

Phase 0 (ARM64 release closure, `zam-core` 0.3.7) is unchanged and remains the only near-term work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)