### PR TITLE
chore: release 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Version bump to **0.3.7** — the first npm version that works on Windows ARM64. Published 0.3.6 still imports native `libsql` unconditionally and crashes there; main has since switched local storage to `better-sqlite3` (win32-arm64 prebuilds available) with `libsql` demoted to an optional, lazily-loaded dependency for Turso sync.

This is Increment 10 / Phase 0 (ARM64 release closure). After merge, `v0.3.7` will be tagged to exercise the desktop release matrix including `aarch64-pc-windows-msvc`; `npm publish` follows from the tagged commit.

## Test plan

- [ ] CI green including `windows-arm64`
- [ ] Tagged desktop release builds all five targets (draft)
- [ ] `npm publish` from the tagged commit (requires npm auth)
- [ ] `npx zam@0.3.7 setup` on physical ARM64 hardware (Thomas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)