### PR TITLE
fix(release): use the published tauri-action tag (v0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: npm ci
 
       - name: Build Tauri Desktop Application & Publish Draft Release
-        uses: tauri-apps/tauri-action@v2
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

The v0.3.7 tag run failed in 9s on all five matrix jobs: `Unable to resolve action tauri-apps/tauri-action@v2`. The action is published under the `v0` major tag (currently v0.6.2) even though it builds Tauri v2 apps. This was latent until now because no tag had ever exercised `release.yml` (Increment 9 checklist item).

After merge, the `v0.3.7` tag will be re-pointed at main so the release workflow runs with the fixed workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)