### PR TITLE
feat: Increment 10 — async database providers and remote Turso over HTTP

### DIFF
--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -47,9 +47,7 @@ import {
   translateQuestionViaLLM,
 } from "../llm/client.js";
 import { resolveUser } from "./resolve-user.js";
-import {
-  withDb as sharedWithDb,
-} from "./shared/db.js";
+import { withDb as sharedWithDb } from "./shared/db.js";
 
 function jsonOut(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
@@ -401,8 +399,8 @@ bridgeCommand
   .command("get-skill")
   .description("Get an agent skill by slug (JSON)")
   .requiredOption("--slug <slug>", "Skill slug")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    await withDb(async (db) => {
       const skill = await getAgentSkill(db, opts.slug);
       if (!skill) {
         jsonError(`Skill not found: ${opts.slug}`);

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -49,7 +49,6 @@ import {
 import { resolveUser } from "./resolve-user.js";
 import {
   withDb as sharedWithDb,
-  withDbAsync as sharedWithDbAsync,
 } from "./shared/db.js";
 
 function jsonOut(data: unknown): void {
@@ -61,12 +60,10 @@ function jsonError(message: string): never {
   process.exit(1);
 }
 
-function withDb(fn: (db: Database) => void): void {
-  sharedWithDb(fn, jsonError);
-}
-
-async function withDbAsync(fn: (db: Database) => Promise<void>): Promise<void> {
-  await sharedWithDbAsync(fn, jsonError);
+async function withDb(
+  fn: (db: Database) => void | Promise<void>,
+): Promise<void> {
+  await sharedWithDb(fn, jsonError);
 }
 
 interface ReviewTargetRow {
@@ -76,19 +73,19 @@ interface ReviewTargetRow {
   slug: string;
 }
 
-function getReviewTarget(
+async function getReviewTarget(
   db: Database,
   cardId: string,
   userId: string,
-): ReviewTargetRow {
-  const target = db
+): Promise<ReviewTargetRow> {
+  const target = (await db
     .prepare(
       `SELECT c.id AS card_id, c.token_id, c.user_id, t.slug
        FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.id = ?`,
     )
-    .get(cardId) as ReviewTargetRow | undefined;
+    .get(cardId)) as ReviewTargetRow | undefined;
 
   if (!target) {
     jsonError(`Card not found: ${cardId}`);
@@ -154,10 +151,10 @@ bridgeCommand
   .command("check-due")
   .description("Check due cards for a user (JSON)")
   .option("--user <id>", "User ID (default: whoami)")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db, { json: true });
-      const dueCards = getDueCards(db, userId);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db, { json: true });
+      const dueCards = await getDueCards(db, userId);
       const domains = [
         ...new Set(dueCards.map((c) => c.domain).filter(Boolean)),
       ].sort();
@@ -188,9 +185,13 @@ bridgeCommand
   .option("--user <id>", "User ID (default: whoami)")
   .option("--no-resolve", "Skip resolving the token's source_link into context")
   .action(async (opts) => {
-    await withDbAsync(async (db) => {
-      const userId = resolveUser(opts, db, { json: true });
-      const queue = buildReviewQueue(db, { userId, maxReviews: 1, maxNew: 1 });
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db, { json: true });
+      const queue = await buildReviewQueue(db, {
+        userId,
+        maxReviews: 1,
+        maxNew: 1,
+      });
 
       if (queue.items.length === 0) {
         jsonOut({
@@ -205,7 +206,7 @@ bridgeCommand
       }
 
       const item = queue.items[0];
-      const isLlmEnabled = getSetting(db, "llm.enabled") === "true";
+      const isLlmEnabled = (await getSetting(db, "llm.enabled")) === "true";
 
       // Dynamically generate a fresh, living active-recall question if LLM is enabled
       let resolvedQuestion = item.question;
@@ -251,7 +252,7 @@ bridgeCommand
       }
 
       // Get full queue size for context
-      const fullQueue = buildReviewQueue(db, { userId });
+      const fullQueue = await buildReviewQueue(db, { userId });
 
       jsonOut({
         userId,
@@ -272,15 +273,15 @@ bridgeCommand
   .option("--user <id>", "User ID (default: whoami)")
   .requiredOption("--card-id <id>", "Card ID")
   .requiredOption("--rating <n>", "Rating (1-4)")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db, { json: true });
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db, { json: true });
       const rating = Number(opts.rating) as Rating;
       if (rating < 1 || rating > 4) {
         jsonError("Rating must be between 1 and 4");
       }
 
-      const result = executeReviewAction(db, {
+      const result = await executeReviewAction(db, {
         action: "rate",
         cardId: opts.cardId,
         userId,
@@ -315,9 +316,9 @@ bridgeCommand
   .option("--mode <mode>", "Updated symbiosis mode for action=edit-token")
   .option("--source-link <link>", "Updated source link for action=edit-token")
   .option("--confirm", "Confirm destructive delete actions")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db, { json: true });
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db, { json: true });
       const action = opts.action as ReviewActionType;
       const validActions: ReviewActionType[] = [
         "rate",
@@ -332,7 +333,7 @@ bridgeCommand
         jsonError(`Unsupported action: ${opts.action}`);
       }
 
-      const target = getReviewTarget(db, opts.cardId, userId);
+      const target = await getReviewTarget(db, opts.cardId, userId);
       if (
         (action === "delete-token" || action === "delete-card") &&
         !opts.confirm
@@ -344,7 +345,7 @@ bridgeCommand
             preview: true,
             requiresConfirmation: true,
             token: { slug: target.slug, tokenId: target.token_id },
-            impact: getTokenDeleteImpact(db, target.slug),
+            impact: await getTokenDeleteImpact(db, target.slug),
           });
           return;
         }
@@ -355,7 +356,7 @@ bridgeCommand
           preview: true,
           requiresConfirmation: true,
           token: { slug: target.slug, tokenId: target.token_id },
-          impact: getCardDeletionImpact(db, target.token_id, userId),
+          impact: await getCardDeletionImpact(db, target.token_id, userId),
         });
         return;
       }
@@ -366,7 +367,7 @@ bridgeCommand
         jsonError("Rating must be between 1 and 4 for action=rate");
       }
 
-      const result = executeReviewAction(db, {
+      const result = await executeReviewAction(db, {
         action,
         cardId: opts.cardId,
         userId,
@@ -402,7 +403,7 @@ bridgeCommand
   .requiredOption("--slug <slug>", "Skill slug")
   .action((opts) => {
     withDb((db) => {
-      const skill = getAgentSkill(db, opts.slug);
+      const skill = await getAgentSkill(db, opts.slug);
       if (!skill) {
         jsonError(`Skill not found: ${opts.slug}`);
       }
@@ -560,10 +561,10 @@ bridgeCommand
         jsonError("JSON must include 'slug' and 'concept' fields");
       }
 
-      db = openDatabase();
-      const userId = resolveUser(opts, db, { json: true });
+      db = await openDatabase();
+      const userId = await resolveUser(opts, db, { json: true });
 
-      const token = createToken(db, {
+      const token = await createToken(db, {
         slug: data?.slug,
         concept: data?.concept,
         domain: data?.domain,
@@ -578,7 +579,7 @@ bridgeCommand
         source_link: data?.source_link ?? null,
       });
 
-      const card = ensureCard(db, token.id, userId);
+      const card = await ensureCard(db, token.id, userId);
 
       jsonOut({
         success: true,
@@ -593,9 +594,9 @@ bridgeCommand
         },
       });
 
-      db.close();
+      await db.close();
     } catch (err) {
-      db?.close();
+      await db?.close();
       // If it's already a JSON error exit, let it propagate
       if ((err as Error).message) {
         jsonError((err as Error).message);
@@ -620,7 +621,7 @@ bridgeCommand
     "Max number of sessions to analyze (default: 20)",
     "20",
   )
-  .action((opts) => {
+  .action(async (opts) => {
     try {
       const monitorDir = join(homedir(), ".zam", "monitor");
       let files: string[];
@@ -666,12 +667,12 @@ bridgeCommand
       let existingSkillSlugs: string[] = [];
       let db: Database | undefined;
       try {
-        db = openDatabase();
-        existingSkillSlugs = listAgentSkills(db).map((s) => s.slug);
+        db = await openDatabase();
+        existingSkillSlugs = (await listAgentSkills(db)).map((s) => s.slug);
       } catch {
         // DB not available — proceed without exclusion
       } finally {
-        db?.close();
+        await db?.close();
       }
 
       const proposals = discoverSkills(sessionCommands, {
@@ -694,8 +695,8 @@ bridgeCommand
   .command("check-llm")
   .description("Check if LLM is enabled and online (JSON)")
   .action(async () => {
-    await withDbAsync(async (db) => {
-      const { enabled, url, model, apiKey } = getLlmConfig(db);
+    await withDb(async (db) => {
+      const { enabled, url, model, apiKey } = await getLlmConfig(db);
       let online = false;
       let availableModels: string[] = [];
       let modelAvailable = false;
@@ -735,7 +736,7 @@ bridgeCommand
     "25000",
   )
   .action(async (opts) => {
-    await withDbAsync(async (db) => {
+    await withDb(async (db) => {
       const result = await ensureLlmReadyHeadless(db, {
         timeoutMs: Number(opts.timeout),
       });
@@ -750,8 +751,8 @@ bridgeCommand
   .description("Translate a question dynamically using the local LLM (JSON)")
   .requiredOption("--question <text>", "Question in English to translate")
   .action(async (opts) => {
-    await withDbAsync(async (db) => {
-      const isEnabled = getSetting(db, "llm.enabled") === "true";
+    await withDb(async (db) => {
+      const isEnabled = (await getSetting(db, "llm.enabled")) === "true";
       if (!isEnabled) {
         jsonOut({
           success: false,
@@ -789,8 +790,8 @@ bridgeCommand
   .option("--context <context>", "Optional token context details")
   .option("--source-link <link>", "Optional source link")
   .action(async (opts) => {
-    await withDbAsync(async (db) => {
-      const isEnabled = getSetting(db, "llm.enabled") === "true";
+    await withDb(async (db) => {
+      const isEnabled = (await getSetting(db, "llm.enabled")) === "true";
       if (!isEnabled) {
         jsonOut({
           success: false,
@@ -837,9 +838,9 @@ bridgeCommand
 bridgeCommand
   .command("get-settings")
   .description("Get active ZAM settings (JSON)")
-  .action(() => {
-    withDb((db) => {
-      const { enabled, url, model, locale } = getLlmConfig(db);
+  .action(async () => {
+    await withDb(async (db) => {
+      const { enabled, url, model, locale } = await getLlmConfig(db);
       jsonOut({
         locale,
         llm: {

--- a/src/cli/commands/card.ts
+++ b/src/cli/commands/card.ts
@@ -30,10 +30,10 @@ cardCommand
   .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
   .option("--summary", "Show only counts per domain (no slugs or concepts)")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db);
-      const dueCards = getDueCards(db, userId);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
+      const dueCards = await getDueCards(db, userId);
 
       if (opts.json) {
         console.log(JSON.stringify(dueCards, null, 2));
@@ -91,16 +91,16 @@ cardCommand
   .requiredOption("--rating <n>", "Rating (1=Again, 2=Hard, 3=Good, 4=Easy)")
   .option("--json", "Output as JSON")
   .option("--quiet", "Suppress output (exit code only)")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db);
-      const token = getTokenBySlug(db, opts.token);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
+      const token = await getTokenBySlug(db, opts.token);
       if (!token) {
         console.error(`Token not found: ${opts.token}`);
         process.exit(1);
       }
 
-      const card = ensureCard(db, token.id, userId);
+      const card = await ensureCard(db, token.id, userId);
       const rating = Number(opts.rating) as Rating;
 
       if (rating < 1 || rating > 4) {
@@ -108,7 +108,7 @@ cardCommand
         process.exit(1);
       }
 
-      const result = evaluateRating(db, {
+      const result = await evaluateRating(db, {
         cardId: card.id,
         tokenId: token.id,
         userId,
@@ -117,9 +117,9 @@ cardCommand
 
       // If rating is 1 (forgot) and token has prerequisites, cascade block
       if (rating === 1) {
-        const prereqs = getPrerequisites(db, token.id);
+        const prereqs = await getPrerequisites(db, token.id);
         if (prereqs.length > 0) {
-          const blockResult = cascadeBlock(db, userId, token.slug);
+          const blockResult = await cascadeBlock(db, userId, token.slug);
           if (opts.quiet) return;
           if (opts.json) {
             console.log(
@@ -173,10 +173,10 @@ cardCommand
   .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
   .option("--quiet", "Suppress output (exit code only)")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db);
-      const result = unblockReady(db, userId);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
+      const result = await unblockReady(db, userId);
 
       if (opts.quiet) return;
       if (opts.json) {
@@ -203,17 +203,17 @@ cardCommand
   .option("--user <id>", "User ID (default: whoami)")
   .requiredOption("--token <slug>", "Token slug")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db);
-      const token = getTokenBySlug(db, opts.token);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
+      const token = await getTokenBySlug(db, opts.token);
       if (!token) {
         console.error(`Token not found: ${opts.token}`);
         process.exit(1);
       }
 
-      const impact = getCardDeletionImpact(db, token.id, userId);
-      const result = deleteCardForUser(db, token.id, userId);
+      const impact = await getCardDeletionImpact(db, token.id, userId);
+      const result = await deleteCardForUser(db, token.id, userId);
 
       if (opts.json) {
         console.log(

--- a/src/cli/commands/connector.ts
+++ b/src/cli/commands/connector.ts
@@ -28,9 +28,17 @@ connectorCommand
   .argument("<type>", "Connector type (ado, turso)")
   .option("--url <url>", "Turso database URL (non-interactive)")
   .option("--token <token>", "Turso auth token (non-interactive)")
+  .option(
+    "--mode <mode>",
+    "Turso access mode: native (libsql driver) | remote (HTTP, works on Windows ARM64)",
+  )
   .action(async (type, opts) => {
     if (type === "turso") {
-      return setupTurso(opts.url, opts.token);
+      if (opts.mode && opts.mode !== "native" && opts.mode !== "remote") {
+        console.error(`Invalid --mode: ${opts.mode}. Use native or remote.`);
+        process.exit(1);
+      }
+      return setupTurso(opts.url, opts.token, opts.mode);
     }
     if (type !== "ado") {
       console.error(`Unknown connector type: ${type}. Supported: ado, turso`);
@@ -137,7 +145,7 @@ connectorCommand
 connectorCommand
   .command("sync")
   .description("Verify the Turso cloud database connection")
-  .action(() => {
+  .action(async () => {
     const turso = getTursoCredentials();
     if (!turso) {
       console.error(
@@ -148,12 +156,12 @@ connectorCommand
 
     let db: Database | undefined;
     try {
-      db = openDatabaseWithSync({ initialize: true });
-      db.prepare("SELECT 1").get();
+      db = await openDatabaseWithSync({ initialize: true });
+      await db.prepare("SELECT 1").get();
       console.log(`Connected to ${turso.url}`);
-      db.close();
+      await db.close();
     } catch (err) {
-      db?.close();
+      await db?.close();
       console.error("Error:", (err as Error).message);
       process.exit(1);
     }
@@ -161,7 +169,11 @@ connectorCommand
 
 // ── Turso setup helper ──────────────────────────────────────────────────────
 
-async function setupTurso(urlArg?: string, tokenArg?: string): Promise<void> {
+async function setupTurso(
+  urlArg?: string,
+  tokenArg?: string,
+  mode?: "native" | "remote",
+): Promise<void> {
   let db: Database | undefined;
   try {
     const url =
@@ -181,16 +193,19 @@ async function setupTurso(urlArg?: string, tokenArg?: string): Promise<void> {
     }
 
     // Store credentials outside the db so they survive db deletion
-    setTursoCredentials(url, token);
+    setTursoCredentials(url, token, undefined, mode);
 
     // Verify by opening the configured cloud database.
-    db = openDatabaseWithSync({ initialize: true });
-    db.prepare("SELECT 1").get();
-    db.close();
+    db = await openDatabaseWithSync({ initialize: true });
+    await db.prepare("SELECT 1").get();
+    await db.close();
 
-    console.log(`Turso cloud database configured and verified: ${url}`);
+    console.log(
+      `Turso cloud database configured and verified: ${url}` +
+        (mode ? ` (mode: ${mode})` : ""),
+    );
   } catch (err) {
-    db?.close();
+    await db?.close();
     if ((err as Error).name === "ExitPromptError") {
       console.log("\nSetup cancelled.");
       process.exit(0);

--- a/src/cli/commands/git-sync.ts
+++ b/src/cli/commands/git-sync.ts
@@ -56,14 +56,14 @@ export const gitSyncCommand = new Command("git-sync")
   .option("--user <id>", "User ID (default: whoami)")
   .option("--install", "Install git post-commit hook in current repo")
   .option("--quiet", "Suppress verbose output")
-  .action((opts) => {
+  .action(async (opts) => {
     if (opts.install) {
       installHook();
       return;
     }
 
-    withDb((db) => {
-      const userId = resolveUser(opts, db);
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
 
       let changedFiles: string[] = [];
       try {
@@ -95,13 +95,13 @@ export const gitSyncCommand = new Command("git-sync")
       }
 
       // Fetch active tokens
-      const tokens = db
+      const tokens = (await db
         .prepare(`
-        SELECT * FROM tokens 
-        WHERE source_link IS NOT NULL 
+        SELECT * FROM tokens
+        WHERE source_link IS NOT NULL
           AND deprecated_at IS NULL
       `)
-        .all() as Token[];
+        .all()) as Token[];
 
       const matchedTokens: Token[] = [];
 
@@ -127,14 +127,15 @@ export const gitSyncCommand = new Command("git-sync")
       const now = new Date().toISOString();
 
       for (const token of matchedTokens) {
-        const card = getCard(db, token.id, userId);
+        const card = await getCard(db, token.id, userId);
         if (card) {
           // Decay stability to a quarter (concept's source changed → likely stale),
           // with a 0.2-day floor so the card surfaces for review soon. Using max,
           // not min: min would collapse every card to <=0.2 regardless of prior strength.
           const newStability = Math.max(0.2, card.stability / 4.0);
 
-          db.prepare(`
+          await db
+            .prepare(`
             UPDATE cards
             SET due_at = ?,
                 stability = ?,
@@ -142,7 +143,8 @@ export const gitSyncCommand = new Command("git-sync")
                 elapsed_days = 0.0,
                 scheduled_days = 0.0
             WHERE id = ?
-          `).run(now, newStability, card.id);
+          `)
+            .run(now, newStability, card.id);
 
           decayedCount++;
           if (!opts.quiet) {

--- a/src/cli/commands/goal.ts
+++ b/src/cli/commands/goal.ts
@@ -23,17 +23,17 @@ import {
   updateGoalStatus,
 } from "../../kernel/index.js";
 
-function resolveGoalsDir(): string {
+async function resolveGoalsDir(): Promise<string> {
   let goalsDir: string | undefined;
 
-  let db: ReturnType<typeof openDatabase> | undefined;
+  let db: Awaited<ReturnType<typeof openDatabase>> | undefined;
   try {
-    db = openDatabase();
-    goalsDir = getSetting(db, "personal.goals_dir");
+    db = await openDatabase();
+    goalsDir = await getSetting(db, "personal.goals_dir");
   } catch {
     // DB not available — fall back to default
   } finally {
-    db?.close();
+    await db?.close();
   }
 
   return goalsDir ? resolve(goalsDir) : resolve("goals");

--- a/src/cli/commands/goal.ts
+++ b/src/cli/commands/goal.ts
@@ -54,8 +54,8 @@ goalCommand
   )
   .option("--tree", "Show goals as a tree with parent/child relationships")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    const goalsDir = resolveGoalsDir();
+  .action(async (opts) => {
+    const goalsDir = await resolveGoalsDir();
 
     if (!existsSync(goalsDir)) {
       console.error(`Goals directory not found: ${goalsDir}`);
@@ -141,8 +141,8 @@ goalCommand
   .command("show <slug>")
   .description("Show a goal's details")
   .option("--json", "Output as JSON")
-  .action((slug, opts) => {
-    const goalsDir = resolveGoalsDir();
+  .action(async (slug, opts) => {
+    const goalsDir = await resolveGoalsDir();
     const goal = getGoal(goalsDir, slug);
 
     if (!goal) {
@@ -199,7 +199,7 @@ goalCommand
   .option("--description <text>", "Goal description")
   .option("--json", "Output as JSON")
   .action(async (opts) => {
-    const goalsDir = resolveGoalsDir();
+    const goalsDir = await resolveGoalsDir();
 
     if (!existsSync(goalsDir)) {
       mkdirSync(goalsDir, { recursive: true });
@@ -254,7 +254,7 @@ goalCommand
   .command("status <slug> <status>")
   .description("Update a goal's status (active, paused, completed, abandoned)")
   .option("--json", "Output as JSON")
-  .action((slug, status, opts) => {
+  .action(async (slug, status, opts) => {
     const validStatuses: GoalStatus[] = [
       "active",
       "completed",
@@ -268,7 +268,7 @@ goalCommand
       process.exit(1);
     }
 
-    const goalsDir = resolveGoalsDir();
+    const goalsDir = await resolveGoalsDir();
     const goal = updateGoalStatus(goalsDir, slug, status);
 
     if (opts.json) {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -172,41 +172,41 @@ export const initCommand = new Command("init")
 
     // ── STEP 4: Initialize Database & Write Local Settings ─────────────────
     console.log("\n\x1b[1m[4/5] Bootstrapping database & settings...\x1b[0m");
-    let db: ReturnType<typeof openDatabaseWithSync> | undefined;
+    let db: Awaited<ReturnType<typeof openDatabaseWithSync>> | undefined;
     try {
-      db = openDatabaseWithSync({ initialize: true });
+      db = await openDatabaseWithSync({ initialize: true });
 
       // Save workspace directory to settings
-      setSetting(db, "personal.workspace_dir", workspacePath);
+      await setSetting(db, "personal.workspace_dir", workspacePath);
 
       // Auto-detect and save system locale
       const detectedLocale = detectSystemLocale();
-      setSetting(db, "system.locale", detectedLocale);
+      await setSetting(db, "system.locale", detectedLocale);
       console.log(
         `\x1b[32m✓ Detected and set system language to: ${detectedLocale}\x1b[0m`,
       );
 
       if (llmReady) {
-        setSetting(db, "llm.enabled", "true");
+        await setSetting(db, "llm.enabled", "true");
         if (profile.recommendedRunner === "fastflowlm") {
-          setSetting(db, "llm.url", "http://localhost:8000/v1");
+          await setSetting(db, "llm.url", "http://localhost:8000/v1");
         } else {
-          setSetting(db, "llm.url", "http://localhost:11434/v1");
+          await setSetting(db, "llm.url", "http://localhost:11434/v1");
         }
-        setSetting(db, "llm.model", profile.recommendedModel);
+        await setSetting(db, "llm.model", profile.recommendedModel);
         console.log(
           "\x1b[32m✓ Configured LLM runner settings in database.\x1b[0m",
         );
       } else {
-        setSetting(db, "llm.enabled", "false");
+        await setSetting(db, "llm.enabled", "false");
       }
-      db.close();
+      await db.close();
       console.log("\x1b[32m✓ Database initialized successfully.\x1b[0m");
     } catch (err) {
       console.error(
         `\x1b[31m✗ Database setup failed: ${(err as Error).message}\x1b[0m`,
       );
-      db?.close();
+      await db?.close();
     }
 
     // ── STEP 5: Distribute Agent Skills & Helpers ────────────────────────────

--- a/src/cli/commands/learn.ts
+++ b/src/cli/commands/learn.ts
@@ -54,21 +54,21 @@ export const learnCommand = new Command("learn")
   .action(async (opts) => {
     let db: Database | undefined;
     try {
-      db = openDatabase();
-      const userId = resolveUser(opts, db);
+      db = await openDatabase();
+      const userId = await resolveUser(opts, db);
 
-      const queue = buildReviewQueue(db, {
+      const queue = await buildReviewQueue(db, {
         userId,
         maxNew: Number(opts.maxNew),
         maxReviews: Number(opts.maxReviews),
       });
 
-      const locale = (getSetting(db, "system.locale") ||
+      const locale = ((await getSetting(db, "system.locale")) ||
         "en") as SupportedLocale;
 
       if (queue.items.length === 0) {
         console.log(t(locale, "nothing_due"));
-        db.close();
+        await db.close();
         return;
       }
 
@@ -174,7 +174,7 @@ export const learnCommand = new Command("learn")
             () => null,
           );
         }
-        const token = getTokenById(db, item.tokenId);
+        const token = await getTokenById(db, item.tokenId);
 
         // Perform LLM evaluation if enabled and there is a typed answer
         if (isLlmEnabled && answer.trim().length > 0) {
@@ -265,9 +265,9 @@ export const learnCommand = new Command("learn")
         }
       }
 
-      db.close();
+      await db.close();
     } catch (err) {
-      db?.close();
+      await db?.close();
       if ((err as Error).name === "ExitPromptError") {
         console.log("\nLearning session cancelled.");
         process.exit(0);

--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -83,7 +83,7 @@ monitorCommand
     "--shell <type>",
     "Shell type: zsh | bash | pwsh | powershell (auto-detected)",
   )
-  .action((opts) => {
+  .action(async (opts) => {
     let shell: MonitorShell;
     try {
       shell = normalizeShell(opts.shell);
@@ -95,10 +95,10 @@ monitorCommand
     // Validate session exists
     let db: Database | undefined;
     try {
-      db = openDatabase();
-      const session = db
+      db = await openDatabase();
+      const session = (await db
         .prepare("SELECT id, completed_at FROM sessions WHERE id = ?")
-        .get(opts.session) as
+        .get(opts.session)) as
         | { id: string; completed_at: string | null }
         | undefined;
 
@@ -114,7 +114,7 @@ monitorCommand
       console.error(`# Error: ${(err as Error).message}`);
       process.exit(1);
     } finally {
-      db?.close();
+      await db?.close();
     }
 
     ensureMonitorDir();
@@ -326,7 +326,7 @@ monitorCommand
     "--shell <type>",
     "Shell type: zsh | bash | pwsh | powershell (auto-detected)",
   )
-  .action((opts) => {
+  .action(async (opts) => {
     let shell: MonitorShell;
     try {
       shell = normalizeShell(opts.shell);
@@ -338,10 +338,10 @@ monitorCommand
     // Validate session exists
     let db: Database | undefined;
     try {
-      db = openDatabase();
-      const session = db
+      db = await openDatabase();
+      const session = (await db
         .prepare("SELECT id, completed_at FROM sessions WHERE id = ?")
-        .get(opts.session) as
+        .get(opts.session)) as
         | { id: string; completed_at: string | null }
         | undefined;
 
@@ -355,14 +355,14 @@ monitorCommand
       }
 
       // Save monitor preference so the agent knows to default to terminal
-      if (!getSetting(db, "monitor_method")) {
-        setSetting(db, "monitor_method", "terminal");
+      if (!(await getSetting(db, "monitor_method"))) {
+        await setSetting(db, "monitor_method", "terminal");
       }
     } catch (err) {
       console.error(`Error: ${(err as Error).message}`);
       process.exit(1);
     } finally {
-      db?.close();
+      await db?.close();
     }
 
     const dir = opts.dir ?? process.cwd();

--- a/src/cli/commands/resolve-user.ts
+++ b/src/cli/commands/resolve-user.ts
@@ -14,14 +14,14 @@ export interface ResolveUserOptions {
  * Returns the user ID from the explicit --user flag, or falls back to the
  * stored `user.id` setting. Exits with an error if neither is available.
  */
-export function resolveUser(
+export async function resolveUser(
   opts: { user?: string },
   db: Database,
   resolveOpts?: ResolveUserOptions,
-): string {
+): Promise<string> {
   if (opts.user) return opts.user;
 
-  const stored = getSetting(db, "user.id");
+  const stored = await getSetting(db, "user.id");
   if (stored) return stored;
 
   const message =

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -22,10 +22,10 @@ export const reviewCommand = new Command("review")
   .action(async (opts) => {
     let db: Database | undefined;
     try {
-      db = openDatabase();
-      const userId = resolveUser(opts, db);
+      db = await openDatabase();
+      const userId = await resolveUser(opts, db);
 
-      const queue = buildReviewQueue(db, {
+      const queue = await buildReviewQueue(db, {
         userId,
         maxNew: Number(opts.maxNew),
         maxReviews: Number(opts.maxReviews),
@@ -33,7 +33,7 @@ export const reviewCommand = new Command("review")
 
       if (queue.items.length === 0) {
         console.log("No cards due for review. You're all caught up!");
-        db.close();
+        await db.close();
         return;
       }
 
@@ -137,9 +137,9 @@ export const reviewCommand = new Command("review")
         }
       }
 
-      db.close();
+      await db.close();
     } catch (err) {
-      db?.close();
+      await db?.close();
       // User cancelled with Ctrl+C — exit gracefully
       if ((err as Error).name === "ExitPromptError") {
         console.log("\nReview session cancelled.");

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -59,7 +59,7 @@ sessionCommand
   .action(async (opts) => {
     let db: Database | undefined;
     try {
-      db = openDatabase();
+      db = await openDatabase();
 
       const validContexts = ["shell", "ui", "reallife"];
       if (!validContexts.includes(opts.context)) {
@@ -69,7 +69,7 @@ sessionCommand
         process.exit(1);
       }
 
-      const userId = resolveUser(opts, db);
+      const userId = await resolveUser(opts, db);
       const reviewMinutes = Number(opts.reviewMinutes);
 
       // ── Phase 1: Repetition ────────────────────────────────────────────
@@ -99,13 +99,13 @@ sessionCommand
         process.exit(1);
       }
 
-      const session = startSession(db, {
+      const session = await startSession(db, {
         user_id: userId,
         task,
         execution_context: opts.context as ExecutionContext,
       });
 
-      db.close();
+      await db.close();
 
       if (opts.quiet) {
         console.log(session.id);
@@ -119,7 +119,7 @@ sessionCommand
         console.log(`  Started: ${session.started_at}`);
       }
     } catch (err) {
-      db?.close();
+      await db?.close();
       if ((err as Error).name === "ExitPromptError") {
         console.log("\nSession cancelled.");
         process.exit(0);
@@ -142,7 +142,7 @@ async function runRepetitionPhase(
   userId: string,
   maxMinutes: number,
 ): Promise<RepetitionResult> {
-  const queue = buildReviewQueue(db, { userId });
+  const queue = await buildReviewQueue(db, { userId });
 
   if (queue.items.length === 0) {
     console.log("No cards due for review — moving to task selection.\n");
@@ -264,15 +264,15 @@ sessionCommand
   .option("--rating <n>", "Rating (1-4)")
   .option("--json", "Output as JSON")
   .option("--quiet", "Suppress output (exit code only)")
-  .action((opts) => {
-    withDb((db) => {
-      const token = getTokenBySlug(db, opts.token);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const token = await getTokenBySlug(db, opts.token);
       if (!token) {
         console.error(`Token not found: ${opts.token}`);
         process.exit(1);
       }
 
-      const step = logStep(db, {
+      const step = await logStep(db, {
         session_id: opts.session,
         token_id: token.id,
         done_by: opts.doneBy as "user" | "agent",
@@ -300,10 +300,10 @@ sessionCommand
   .description("End a session and show summary")
   .requiredOption("--session <id>", "Session ID")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      endSession(db, opts.session);
-      const summary = getSessionSummary(db, opts.session);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      await endSession(db, opts.session);
+      const summary = await getSessionSummary(db, opts.session);
 
       if (opts.json) {
         console.log(JSON.stringify(summary, null, 2));

--- a/src/cli/commands/settings.ts
+++ b/src/cli/commands/settings.ts
@@ -24,14 +24,14 @@ settingsCommand
   .command("show")
   .description("Show all settings")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    await withDb(async (db) => {
       if (opts.json) {
-        console.log(JSON.stringify(getAllSettings(db), null, 2));
+        console.log(JSON.stringify(await getAllSettings(db), null, 2));
         return;
       }
 
-      const settings = getAllSettingsDetailed(db);
+      const settings = await getAllSettingsDetailed(db);
       if (settings.length === 0) {
         console.log("No settings configured.");
         return;
@@ -54,9 +54,9 @@ settingsCommand
   .command("get <key>")
   .description("Get a single setting")
   .option("--json", "Output as JSON")
-  .action((key, opts) => {
-    withDb((db) => {
-      const value = getSetting(db, key);
+  .action(async (key, opts) => {
+    await withDb(async (db) => {
+      const value = await getSetting(db, key);
 
       if (opts.json) {
         console.log(JSON.stringify({ key, value: value ?? null }));
@@ -77,8 +77,8 @@ settingsCommand
   .command("set <key> <value>")
   .description("Set a setting")
   .option("--quiet", "Suppress output")
-  .action((key, value, opts) => {
-    withDb((db) => {
+  .action(async (key, value, opts) => {
+    await withDb(async (db) => {
       let parsedVal = value;
       if (key === "llm.enabled") {
         const lower = value.toLowerCase();
@@ -98,7 +98,7 @@ settingsCommand
           parsedVal = "false";
         }
       }
-      setSetting(db, key, parsedVal);
+      await setSetting(db, key, parsedVal);
       if (!opts.quiet) {
         console.log(`Set ${key} = ${parsedVal}`);
       }
@@ -111,9 +111,9 @@ settingsCommand
   .command("delete <key>")
   .description("Delete a setting")
   .option("--quiet", "Suppress output")
-  .action((key, opts) => {
-    withDb((db) => {
-      const deleted = deleteSetting(db, key);
+  .action(async (key, opts) => {
+    await withDb(async (db) => {
+      const deleted = await deleteSetting(db, key);
       if (!opts.quiet) {
         if (deleted) {
           console.log(`Deleted: ${key}`);
@@ -131,10 +131,10 @@ settingsCommand
   .description(
     "Quickly enable/disable or check local LLM integration (on/off/enable/disable)",
   )
-  .action((state) => {
-    withDb((db) => {
+  .action(async (state) => {
+    await withDb(async (db) => {
       if (!state) {
-        const enabled = getSetting(db, "llm.enabled") || "false";
+        const enabled = (await getSetting(db, "llm.enabled")) || "false";
         console.log(
           `LLM Integration is currently: ${
             enabled === "true"
@@ -168,7 +168,7 @@ settingsCommand
         process.exit(1);
       }
 
-      setSetting(db, "llm.enabled", value);
+      await setSetting(db, "llm.enabled", value);
       console.log(
         `LLM Integration is now: ${
           value === "true"
@@ -186,10 +186,10 @@ settingsCommand
   .description(
     "Quickly set or check manual ZAM language override (en/de/es/fr/pt/zh/ja)",
   )
-  .action((lang) => {
-    withDb((db) => {
+  .action(async (lang) => {
+    await withDb(async (db) => {
       if (!lang) {
-        const locale = getSetting(db, "system.locale") || "en";
+        const locale = (await getSetting(db, "system.locale")) || "en";
         console.log(`Active language (locale): \x1b[36m${locale}\x1b[0m`);
         return;
       }
@@ -203,7 +203,7 @@ settingsCommand
         process.exit(1);
       }
 
-      setSetting(db, "system.locale", lower);
+      await setSetting(db, "system.locale", lower);
       console.log(`Language set to: \x1b[32m${lower}\x1b[0m`);
     });
   });
@@ -216,22 +216,22 @@ settingsCommand
   .option("--personal <path>", "Set the Personal Repository path")
   .option("--team <path>", "Set the Team Repository path")
   .option("--org <path>", "Set the Organization Repository path")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    await withDb(async (db) => {
       let changed = false;
 
       if (opts.personal !== undefined) {
-        setSetting(db, "repo.personal", opts.personal);
+        await setSetting(db, "repo.personal", opts.personal);
         console.log(`Set repo.personal = ${opts.personal}`);
         changed = true;
       }
       if (opts.team !== undefined) {
-        setSetting(db, "repo.team", opts.team);
+        await setSetting(db, "repo.team", opts.team);
         console.log(`Set repo.team = ${opts.team}`);
         changed = true;
       }
       if (opts.org !== undefined) {
-        setSetting(db, "repo.org", opts.org);
+        await setSetting(db, "repo.org", opts.org);
         console.log(`Set repo.org = ${opts.org}`);
         changed = true;
       }
@@ -242,7 +242,7 @@ settingsCommand
         console.log("Repository Settings:\n");
       }
 
-      const paths = getRepoPaths(db);
+      const paths = await getRepoPaths(db);
       console.log(
         `Personal Repo:  ${
           paths.personal

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -66,13 +66,13 @@ export function copySkills(force: boolean, cwd: string = process.cwd()): void {
   }
 }
 
-function initDatabase(skipInit: boolean): void {
+async function initDatabase(skipInit: boolean): Promise<void> {
   if (skipInit) return;
 
   try {
     const dbPath = getDefaultDbPath();
-    const db = openDatabaseWithSync({ initialize: true });
-    db.close();
+    const db = await openDatabaseWithSync({ initialize: true });
+    await db.close();
     console.log(`  init  ZAM database at ${dbPath}`);
   } catch (err) {
     // Database may already exist â€” not an error during setup.
@@ -185,7 +185,7 @@ export const setupCommand = new Command("setup")
   .option("--skip-claude-md", "skip CLAUDE.md generation", false)
   .option("--skip-agents-md", "skip AGENTS.md generation", false)
   .action(
-    (opts: {
+    async (opts: {
       force: boolean;
       skipInit: boolean;
       skipClaudeMd: boolean;
@@ -194,7 +194,7 @@ export const setupCommand = new Command("setup")
       console.log(`Setting up ZAM in ${process.cwd()}\n`);
 
       copySkills(opts.force);
-      initDatabase(opts.skipInit);
+      await initDatabase(opts.skipInit);
       writeClaudeMd(opts.skipClaudeMd);
       writeAgentsMd(opts.skipAgentsMd);
 

--- a/src/cli/commands/shared/db.ts
+++ b/src/cli/commands/shared/db.ts
@@ -15,35 +15,19 @@ function defaultErrorHandler(message: string): void {
   process.exit(1);
 }
 
-/** Synchronous wrapper: opens DB, calls fn, closes DB, handles errors. */
-export function withDb(
-  fn: (db: Database) => void,
-  onError: ErrorHandler = defaultErrorHandler,
-): void {
-  let db: Database | undefined;
-  try {
-    db = openDatabase();
-    fn(db);
-  } catch (err) {
-    onError((err as Error).message);
-  } finally {
-    db?.close();
-  }
-}
-
-/** Asynchronous wrapper for commands that need async operations (LLM, etc.). */
-export async function withDbAsync(
-  fn: (db: Database) => Promise<void>,
+/** Opens the DB, awaits fn, closes the DB, handles errors. */
+export async function withDb(
+  fn: (db: Database) => void | Promise<void>,
   onError: ErrorHandler = defaultErrorHandler,
 ): Promise<void> {
   let db: Database | undefined;
   try {
-    db = openDatabase();
+    db = await openDatabase();
     await fn(db);
   } catch (err) {
     onError((err as Error).message);
   } finally {
-    db?.close();
+    await db?.close();
   }
 }
 

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -20,9 +20,9 @@ skillCommand
   .command("list")
   .description("List all agent skills")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const skills = listAgentSkills(db);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const skills = await listAgentSkills(db);
 
       if (opts.json) {
         console.log(JSON.stringify(skills, null, 2));
@@ -54,9 +54,9 @@ skillCommand
   .description("Show a specific agent skill")
   .requiredOption("--slug <slug>", "Skill slug")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const skill = getAgentSkill(db, opts.slug);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const skill = await getAgentSkill(db, opts.slug);
       if (!skill) {
         console.error(`Skill not found: ${opts.slug}`);
         process.exit(1);
@@ -97,8 +97,8 @@ skillCommand
     "learned",
   )
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    await withDb(async (db) => {
       let steps: string[];
       try {
         steps = JSON.parse(opts.steps) as string[];
@@ -116,7 +116,7 @@ skillCommand
             .filter(Boolean)
         : [];
 
-      const skill = createAgentSkill(db, {
+      const skill = await createAgentSkill(db, {
         slug: opts.slug,
         description: opts.description,
         steps,

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -11,11 +11,11 @@ export const statsCommand = new Command("stats")
   .description("Show learning dashboard for a user")
   .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db);
-      const stats = getUserStats(db, userId);
-      const domains = getDomainCompetence(db, userId);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
+      const stats = await getUserStats(db, userId);
+      const domains = await getDomainCompetence(db, userId);
 
       if (opts.json) {
         console.log(JSON.stringify({ stats, domains }, null, 2));

--- a/src/cli/commands/token.ts
+++ b/src/cli/commands/token.ts
@@ -38,8 +38,8 @@ tokenCommand
   .option("--source-link <link>", "Source file path or reference URL", "")
   .option("--question <question>", "Specific question prompt for recall", "")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    await withDb(async (db) => {
       // Token creation is the frontier model's job: the agent (Claude Code,
       // Copilot / Antigravity CLI, …) decomposes the concept into atomic units
       // and may pass an explicit --question. The local LLM is deliberately NOT
@@ -55,7 +55,7 @@ tokenCommand
         );
       }
 
-      const token = createToken(db, {
+      const token = await createToken(db, {
         slug: opts.slug,
         concept: opts.concept,
         domain: opts.domain,
@@ -86,9 +86,9 @@ tokenCommand
   .description("Fuzzy search for tokens")
   .requiredOption("--query <query>", "Search query")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const results = findTokens(db, opts.query);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const results = await findTokens(db, opts.query);
 
       if (opts.json) {
         console.log(JSON.stringify(results, null, 2));
@@ -120,9 +120,9 @@ tokenCommand
   .description("List all tokens")
   .option("--domain <domain>", "Filter by domain")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const tokens = listTokens(
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const tokens = await listTokens(
         db,
         opts.domain ? { domain: opts.domain } : undefined,
       );
@@ -170,8 +170,8 @@ tokenCommand
   )
   .option("--question <question>", "Updated question text (blank allowed)")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    await withDb(async (db) => {
       const updates: {
         concept?: string;
         domain?: string;
@@ -203,7 +203,7 @@ tokenCommand
           opts.mode === "none" ? null : (opts.mode as SymbiosisMode);
       }
 
-      const token = updateToken(db, opts.slug, updates);
+      const token = await updateToken(db, opts.slug, updates);
 
       if (opts.json) {
         jsonOut(token);
@@ -229,21 +229,21 @@ tokenCommand
   .requiredOption("--token <slug>", "Token that requires a prerequisite")
   .requiredOption("--requires <slug>", "Required prerequisite token")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const token = getTokenBySlug(db, opts.token);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const token = await getTokenBySlug(db, opts.token);
       if (!token) {
         console.error(`Token not found: ${opts.token}`);
         process.exit(1);
       }
 
-      const requires = getTokenBySlug(db, opts.requires);
+      const requires = await getTokenBySlug(db, opts.requires);
       if (!requires) {
         console.error(`Prerequisite token not found: ${opts.requires}`);
         process.exit(1);
       }
 
-      addPrerequisite(db, token.id, requires.id);
+      await addPrerequisite(db, token.id, requires.id);
 
       if (opts.json) {
         console.log(
@@ -270,9 +270,9 @@ tokenCommand
   )
   .requiredOption("--slug <slug>", "Token slug to deprecate")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const token = deprecateToken(db, opts.slug);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const token = await deprecateToken(db, opts.slug);
 
       if (opts.json) {
         console.log(JSON.stringify(token, null, 2));
@@ -292,9 +292,9 @@ tokenCommand
   .requiredOption("--slug <slug>", "Token slug to delete")
   .option("--force", "Actually delete the token")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const impact = getTokenDeleteImpact(db, opts.slug);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const impact = await getTokenDeleteImpact(db, opts.slug);
 
       if (!opts.force) {
         const preview = {
@@ -325,7 +325,7 @@ tokenCommand
         return;
       }
 
-      const result = deleteToken(db, opts.slug);
+      const result = await deleteToken(db, opts.slug);
 
       if (opts.json) {
         jsonOut({
@@ -352,18 +352,18 @@ tokenCommand
   .requiredOption("--token <slug>", "Token slug")
   .option("--user <id>", "User ID (default: whoami)")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
-      const userId = resolveUser(opts, db);
-      const token = getTokenBySlug(db, opts.token);
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
+      const token = await getTokenBySlug(db, opts.token);
       if (!token) {
         console.error(`Token not found: ${opts.token}`);
         process.exit(1);
       }
 
-      const card = getCard(db, token.id, userId);
-      const prereqs = getPrerequisites(db, token.id);
-      const dependents = getDependents(db, token.id);
+      const card = await getCard(db, token.id, userId);
+      const prereqs = await getPrerequisites(db, token.id);
+      const dependents = await getDependents(db, token.id);
 
       const status = {
         token,

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -11,10 +11,10 @@ export const whoamiCommand = new Command("whoami")
   .option("--set <id>", "Set the default user ID")
   .option("--clear", "Remove the default user ID")
   .option("--json", "Output as JSON")
-  .action((opts) => {
-    withDb((db) => {
+  .action(async (opts) => {
+    await withDb(async (db) => {
       if (opts.set) {
-        setSetting(db, "user.id", opts.set);
+        await setSetting(db, "user.id", opts.set);
         if (opts.json) {
           console.log(JSON.stringify({ userId: opts.set }));
         } else {
@@ -24,7 +24,7 @@ export const whoamiCommand = new Command("whoami")
       }
 
       if (opts.clear) {
-        const deleted = deleteSetting(db, "user.id");
+        const deleted = await deleteSetting(db, "user.id");
         if (opts.json) {
           console.log(JSON.stringify({ userId: null, cleared: deleted }));
         } else if (deleted) {
@@ -35,7 +35,7 @@ export const whoamiCommand = new Command("whoami")
         return;
       }
 
-      const userId = getSetting(db, "user.id");
+      const userId = await getSetting(db, "user.id");
       if (opts.json) {
         console.log(JSON.stringify({ userId: userId ?? null }));
         return;

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -36,16 +36,16 @@ workspaceCommand
   .command("publish")
   .description("Publish your local workspace sandbox to GitHub")
   .action(async () => {
-    let db: ReturnType<typeof openDatabase> | undefined;
+    let db: Awaited<ReturnType<typeof openDatabase>> | undefined;
     let workspaceDir = "";
 
     try {
-      db = openDatabase();
-      workspaceDir = getSetting(db, "personal.workspace_dir") || "";
-      db.close();
+      db = await openDatabase();
+      workspaceDir = (await getSetting(db, "personal.workspace_dir")) || "";
+      await db.close();
     } catch {
       // Fallback if DB doesn't exist
-      db?.close();
+      await db?.close();
     }
 
     if (!workspaceDir) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,4 +54,4 @@ program.addCommand(goalCommand);
 program.addCommand(gitSyncCommand);
 program.addCommand(workspaceCommand);
 
-program.parse();
+await program.parseAsync();

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -38,13 +38,14 @@ export interface LlmConfig {
 }
 
 /** Read all LLM-related settings at once, applying defaults in one place. */
-export function getLlmConfig(db: Database): LlmConfig {
+export async function getLlmConfig(db: Database): Promise<LlmConfig> {
   return {
-    enabled: getSetting(db, "llm.enabled") === "true",
-    url: getSetting(db, "llm.url") || DEFAULT_LLM_URL,
-    model: getSetting(db, "llm.model") || DEFAULT_LLM_MODEL,
-    apiKey: getSetting(db, "llm.api_key") || DEFAULT_LLM_API_KEY,
-    locale: (getSetting(db, "system.locale") || "en") as SupportedLocale,
+    enabled: (await getSetting(db, "llm.enabled")) === "true",
+    url: (await getSetting(db, "llm.url")) || DEFAULT_LLM_URL,
+    model: (await getSetting(db, "llm.model")) || DEFAULT_LLM_MODEL,
+    apiKey: (await getSetting(db, "llm.api_key")) || DEFAULT_LLM_API_KEY,
+    locale: ((await getSetting(db, "system.locale")) ||
+      "en") as SupportedLocale,
   };
 }
 
@@ -110,7 +111,7 @@ export async function generateQuestionViaLLM(
     sourceLinkContent?: string | null;
   },
 ): Promise<string> {
-  const cfg = getLlmConfig(db);
+  const cfg = await getLlmConfig(db);
   if (!cfg.enabled) {
     throw new Error("LLM integration is disabled in settings (llm.enabled)");
   }
@@ -177,7 +178,7 @@ export async function evaluateAnswerViaLLM(
     sourceLinkContent?: string | null;
   },
 ): Promise<string> {
-  const cfg = getLlmConfig(db);
+  const cfg = await getLlmConfig(db);
   if (!cfg.enabled) {
     throw new Error("LLM integration is disabled in settings (llm.enabled)");
   }
@@ -241,7 +242,7 @@ export async function translateQuestionViaLLM(
   db: Database,
   question: string,
 ): Promise<string> {
-  const cfg = getLlmConfig(db);
+  const cfg = await getLlmConfig(db);
   if (!cfg.enabled) {
     throw new Error("LLM integration is disabled in settings");
   }
@@ -496,7 +497,7 @@ async function startLocalRunner(
 export async function ensureLocalLlmRunning(
   db: Database,
 ): Promise<LlmReadiness> {
-  const cfg = getLlmConfig(db);
+  const cfg = await getLlmConfig(db);
   if (!cfg.enabled) {
     return { usable: false, reason: "disabled" };
   }
@@ -562,7 +563,7 @@ export async function ensureLlmReadyHeadless(
   opts: { timeoutMs?: number } = {},
 ): Promise<LlmReadyResult> {
   const timeoutMs = opts.timeoutMs ?? 25000;
-  const { enabled, url, model, apiKey } = getLlmConfig(db);
+  const { enabled, url, model, apiKey } = await getLlmConfig(db);
   if (!enabled) {
     return {
       usable: false,
@@ -698,7 +699,7 @@ export async function ensureHighQualityQuestion(
     question?: string | null;
   },
 ): Promise<string | null> {
-  const { enabled } = getLlmConfig(db);
+  const { enabled } = await getLlmConfig(db);
 
   if (enabled) {
     try {
@@ -722,7 +723,7 @@ export async function ensureHighQualityQuestion(
 
       if (generated && generated.trim().length > 0) {
         // Persist the latest high-quality question as the offline fallback.
-        updateToken(db, token.slug, { question: generated });
+        await updateToken(db, token.slug, { question: generated });
         return generated;
       }
     } catch {

--- a/src/cli/review-actions.ts
+++ b/src/cli/review-actions.ts
@@ -81,7 +81,7 @@ export async function runInteractiveReviewAction(
     });
 
     if (typeof choice === "number") {
-      const result = executeReviewAction(inputData.db, {
+      const result = await executeReviewAction(inputData.db, {
         action: "rate",
         cardId: currentItem.cardId,
         userId: inputData.userId,
@@ -115,7 +115,7 @@ export async function runInteractiveReviewAction(
       console.log("Skipped this card.\n");
       return {
         action: "skip",
-        result: executeReviewAction(inputData.db, {
+        result: await executeReviewAction(inputData.db, {
           action: "skip",
           cardId: currentItem.cardId,
           userId: inputData.userId,
@@ -126,7 +126,7 @@ export async function runInteractiveReviewAction(
     if (choice === "stop") {
       return {
         action: "stop",
-        result: executeReviewAction(inputData.db, {
+        result: await executeReviewAction(inputData.db, {
           action: "stop",
           cardId: currentItem.cardId,
           userId: inputData.userId,
@@ -135,7 +135,7 @@ export async function runInteractiveReviewAction(
     }
 
     if (choice === "edit-token") {
-      const token = getTokenById(inputData.db, currentItem.tokenId);
+      const token = await getTokenById(inputData.db, currentItem.tokenId);
       if (!token) {
         throw new Error(`Token not found: ${currentItem.tokenId}`);
       }
@@ -146,7 +146,7 @@ export async function runInteractiveReviewAction(
         continue;
       }
 
-      const result = executeReviewAction(inputData.db, {
+      const result = await executeReviewAction(inputData.db, {
         action: "edit-token",
         cardId: currentItem.cardId,
         userId: inputData.userId,
@@ -192,7 +192,7 @@ export async function runInteractiveReviewAction(
         continue;
       }
 
-      const result = executeReviewAction(inputData.db, {
+      const result = await executeReviewAction(inputData.db, {
         action: "deprecate-token",
         cardId: currentItem.cardId,
         userId: inputData.userId,
@@ -203,7 +203,7 @@ export async function runInteractiveReviewAction(
     }
 
     if (choice === "delete-token") {
-      const impact = getTokenDeleteImpact(inputData.db, currentItem.slug);
+      const impact = await getTokenDeleteImpact(inputData.db, currentItem.slug);
       console.log(`Delete token ${currentItem.slug}?`);
       console.log(`  Cards:                 ${impact.cards}`);
       console.log(`  Review logs:           ${impact.review_logs}`);
@@ -227,7 +227,7 @@ export async function runInteractiveReviewAction(
         continue;
       }
 
-      const result = executeReviewAction(inputData.db, {
+      const result = await executeReviewAction(inputData.db, {
         action: "delete-token",
         cardId: currentItem.cardId,
         userId: inputData.userId,
@@ -238,7 +238,7 @@ export async function runInteractiveReviewAction(
     }
 
     if (choice === "delete-card") {
-      const impact = getCardDeletionImpact(
+      const impact = await getCardDeletionImpact(
         inputData.db,
         currentItem.tokenId,
         inputData.userId,
@@ -255,7 +255,7 @@ export async function runInteractiveReviewAction(
         continue;
       }
 
-      const result = executeReviewAction(inputData.db, {
+      const result = await executeReviewAction(inputData.db, {
         action: "delete-card",
         cardId: currentItem.cardId,
         userId: inputData.userId,

--- a/src/kernel/analytics/stats.ts
+++ b/src/kernel/analytics/stats.ts
@@ -28,64 +28,67 @@ export interface DomainCompetence {
   suggestedMode: "shadowing" | "copilot" | "autonomy";
 }
 
-function q(db: Database, sql: string, ...params: unknown[]) {
-  return db.prepare(sql).get(...params) as Record<string, unknown>;
+async function q(db: Database, sql: string, ...params: unknown[]) {
+  return (await db.prepare(sql).get(...params)) as Record<string, unknown>;
+}
+
+async function count(
+  db: Database,
+  sql: string,
+  ...params: unknown[]
+): Promise<number> {
+  return ((await q(db, sql, ...params)) as { n: number }).n;
 }
 
 /**
  * Get overall learning stats for a user (ported from PoC's `stats` command).
  */
-export function getUserStats(db: Database, userId: string): UserStats {
+export async function getUserStats(
+  db: Database,
+  userId: string,
+): Promise<UserStats> {
+  const avgRow = (await q(
+    db,
+    "SELECT AVG(stability) as v FROM cards WHERE user_id = ? AND reps > 0",
+    userId,
+  )) as { v: number | null };
+
+  const lastSessionRow = (await db
+    .prepare(
+      "SELECT started_at FROM sessions WHERE user_id = ? ORDER BY started_at DESC LIMIT 1",
+    )
+    .get(userId)) as { started_at: string } | undefined;
+
   return {
     userId,
-    totalTokens: (q(db, "SELECT COUNT(*) as n FROM tokens") as { n: number }).n,
-    cardsInDeck: (
-      q(db, "SELECT COUNT(*) as n FROM cards WHERE user_id = ?", userId) as {
-        n: number;
-      }
-    ).n,
-    dueToday: (
-      q(
-        db,
-        "SELECT COUNT(*) as n FROM cards WHERE user_id = ? AND blocked = 0 AND due_at <= datetime('now')",
-        userId,
-      ) as { n: number }
-    ).n,
-    blocked: (
-      q(
-        db,
-        "SELECT COUNT(*) as n FROM cards WHERE user_id = ? AND blocked = 1",
-        userId,
-      ) as { n: number }
-    ).n,
-    mature: (
-      q(
-        db,
-        "SELECT COUNT(*) as n FROM cards WHERE user_id = ? AND reps >= 3 AND stability >= 21",
-        userId,
-      ) as { n: number }
-    ).n,
-    avgStability: (() => {
-      const v = q(
-        db,
-        "SELECT AVG(stability) as v FROM cards WHERE user_id = ? AND reps > 0",
-        userId,
-      ) as { v: number | null };
-      return v.v ? Math.round(v.v * 100) / 100 : null;
-    })(),
-    totalSessions: (
-      q(db, "SELECT COUNT(*) as n FROM sessions WHERE user_id = ?", userId) as {
-        n: number;
-      }
-    ).n,
-    lastSession: (() => {
-      const r = db
-        .prepare(
-          "SELECT started_at FROM sessions WHERE user_id = ? ORDER BY started_at DESC LIMIT 1",
-        )
-        .get(userId) as { started_at: string } | undefined;
-      return r?.started_at ?? null;
-    })(),
+    totalTokens: await count(db, "SELECT COUNT(*) as n FROM tokens"),
+    cardsInDeck: await count(
+      db,
+      "SELECT COUNT(*) as n FROM cards WHERE user_id = ?",
+      userId,
+    ),
+    dueToday: await count(
+      db,
+      "SELECT COUNT(*) as n FROM cards WHERE user_id = ? AND blocked = 0 AND due_at <= datetime('now')",
+      userId,
+    ),
+    blocked: await count(
+      db,
+      "SELECT COUNT(*) as n FROM cards WHERE user_id = ? AND blocked = 1",
+      userId,
+    ),
+    mature: await count(
+      db,
+      "SELECT COUNT(*) as n FROM cards WHERE user_id = ? AND reps >= 3 AND stability >= 21",
+      userId,
+    ),
+    avgStability: avgRow.v ? Math.round(avgRow.v * 100) / 100 : null,
+    totalSessions: await count(
+      db,
+      "SELECT COUNT(*) as n FROM sessions WHERE user_id = ?",
+      userId,
+    ),
+    lastSession: lastSessionRow?.started_at ?? null,
   };
 }
 
@@ -93,55 +96,52 @@ export function getUserStats(db: Database, userId: string): UserStats {
  * Get competence per domain for a user.
  * Used to suggest symbiosis mode transitions.
  */
-export function getDomainCompetence(
+export async function getDomainCompetence(
   db: Database,
   userId: string,
-): DomainCompetence[] {
-  const domains = db
+): Promise<DomainCompetence[]> {
+  const domains = (await db
     .prepare(
       `SELECT DISTINCT t.domain FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.user_id = ? AND t.domain != ''`,
     )
-    .all(userId) as { domain: string }[];
+    .all(userId)) as { domain: string }[];
 
-  return domains.map((d) => {
-    const total = (
-      q(
-        db,
-        `SELECT COUNT(*) as n FROM cards c
+  const competences: DomainCompetence[] = [];
+  for (const d of domains) {
+    const total = await count(
+      db,
+      `SELECT COUNT(*) as n FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.user_id = ? AND t.domain = ?`,
-        userId,
-        d.domain,
-      ) as { n: number }
-    ).n;
+      userId,
+      d.domain,
+    );
 
-    const mature = (
-      q(
-        db,
-        `SELECT COUNT(*) as n FROM cards c
+    const mature = await count(
+      db,
+      `SELECT COUNT(*) as n FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.user_id = ? AND t.domain = ? AND c.reps >= 3 AND c.stability >= 21`,
-        userId,
-        d.domain,
-      ) as { n: number }
-    ).n;
+      userId,
+      d.domain,
+    );
 
     const avgStab =
       (
-        q(
+        (await q(
           db,
           `SELECT AVG(c.stability) as v FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.user_id = ? AND t.domain = ? AND c.reps > 0`,
           userId,
           d.domain,
-        ) as { v: number | null }
+        )) as { v: number | null }
       ).v ?? 0;
 
     // Estimate retention from review history
-    const reviews = q(
+    const reviews = (await q(
       db,
       `SELECT COUNT(*) as total,
               SUM(CASE WHEN rating >= 2 THEN 1 ELSE 0 END) as passed
@@ -149,7 +149,7 @@ export function getDomainCompetence(
        WHERE user_id = ? AND token_id IN (SELECT id FROM tokens WHERE domain = ?)`,
       userId,
       d.domain,
-    ) as { total: number; passed: number };
+    )) as { total: number; passed: number };
 
     const retentionRate =
       reviews.total > 0 ? reviews.passed / reviews.total : 0;
@@ -163,13 +163,14 @@ export function getDomainCompetence(
       suggestedMode = "shadowing";
     }
 
-    return {
+    competences.push({
       domain: d.domain,
       totalCards: total,
       matureCards: mature,
       avgStability: Math.round(avgStab * 100) / 100,
       retentionRate: Math.round(retentionRate * 1000) / 1000,
       suggestedMode,
-    };
-  });
+    });
+  }
+  return competences;
 }

--- a/src/kernel/credentials.ts
+++ b/src/kernel/credentials.ts
@@ -16,6 +16,11 @@ const DEFAULT_CREDENTIALS_PATH = join(homedir(), ".zam", "credentials.json");
 export interface TursoCredentials {
   url: string;
   token: string;
+  /**
+   * Database access mode: "native" uses the legacy libsql driver, "remote"
+   * uses the HTTP provider (no native bindings; required on Windows ARM64).
+   */
+  mode?: "native" | "remote";
 }
 
 export interface ADOCredentials {
@@ -54,7 +59,11 @@ export function saveCredentials(creds: Credentials, path?: string): void {
 export function getTursoCredentials(path?: string): TursoCredentials | null {
   const creds = loadCredentials(path);
   if (creds.turso?.url && creds.turso?.token) {
-    return { url: creds.turso.url, token: creds.turso.token };
+    return {
+      url: creds.turso.url,
+      token: creds.turso.token,
+      ...(creds.turso.mode ? { mode: creds.turso.mode } : {}),
+    };
   }
   return null;
 }
@@ -64,9 +73,10 @@ export function setTursoCredentials(
   url: string,
   token: string,
   path?: string,
+  mode?: TursoCredentials["mode"],
 ): void {
   const creds = loadCredentials(path);
-  creds.turso = { url, token };
+  creds.turso = { url, token, ...(mode ? { mode } : {}) };
   saveCredentials(creds, path);
 }
 

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -4,8 +4,10 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import BetterSqlite3 from "better-sqlite3";
 import { getTursoCredentials } from "../credentials.js";
+import { openRemoteDatabase } from "./remote/provider.js";
 import { SCHEMA } from "./schema.js";
-import type { Database as DatabaseType } from "./types.js";
+import { wrapSyncDatabase } from "./sync-adapter.js";
+import type { Database, SyncDatabase } from "./types.js";
 
 const DEFAULT_DB_DIR = join(homedir(), ".zam");
 const DEFAULT_DB_PATH = join(DEFAULT_DB_DIR, "zam.db");
@@ -14,7 +16,14 @@ const require = createRequire(import.meta.url);
 type LibsqlConstructor = new (
   path: string,
   options?: Record<string, unknown>,
-) => DatabaseType;
+) => SyncDatabase;
+
+/**
+ * - `local`: better-sqlite3 file database (default without cloud credentials)
+ * - `native`: legacy native libsql driver (remote URLs and embedded replicas)
+ * - `remote`: Turso over HTTP, no native bindings (works on Windows ARM64)
+ */
+export type DatabaseProvider = "local" | "native" | "remote";
 
 export interface ConnectionOptions {
   /** Path to the SQLite database file. Defaults to ~/.zam/zam.db */
@@ -27,14 +36,20 @@ export interface ConnectionOptions {
   authToken?: string;
   /** If false, ignore ~/.zam/credentials.json and force the local/default database. */
   useConfiguredCloud?: boolean;
+  /** Explicit provider; overrides ZAM_DB_PROVIDER and the credentials mode. */
+  provider?: DatabaseProvider;
 }
 
 function isRemoteDatabasePath(dbPath: string): boolean {
-  return /^(libsql|https?):\/\//i.test(dbPath);
+  return /^(libsql|https?|wss?):\/\//i.test(dbPath);
 }
 
-function openLocalSqlite(dbPath: string): DatabaseType {
-  return new BetterSqlite3(dbPath) as unknown as DatabaseType;
+function isDatabaseProvider(value: unknown): value is DatabaseProvider {
+  return value === "local" || value === "native" || value === "remote";
+}
+
+function openLocalSqlite(dbPath: string): SyncDatabase {
+  return new BetterSqlite3(dbPath) as unknown as SyncDatabase;
 }
 
 function loadLibsql(): LibsqlConstructor {
@@ -47,7 +62,9 @@ function loadLibsql(): LibsqlConstructor {
     const detail = err instanceof Error ? ` ${err.message}` : "";
     throw new Error(
       "Turso sync requires the optional native libsql backend, which is not " +
-        `available for ${process.platform}/${process.arch}.${detail}`,
+        `available for ${process.platform}/${process.arch}. Switch to the ` +
+        "HTTP provider instead: zam connector setup turso --mode remote " +
+        `(or set ZAM_DB_PROVIDER=remote).${detail}`,
     );
   }
 }
@@ -58,7 +75,9 @@ function loadLibsql(): LibsqlConstructor {
  * Falls back to local SQLite and WAL mode when no cloud credentials exist.
  * When syncUrl is provided explicitly, enables embedded replica sync with Turso.
  */
-export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
+export async function openDatabase(
+  options: ConnectionOptions = {},
+): Promise<Database> {
   const configuredCloud =
     options.useConfiguredCloud !== false && !options.dbPath && !options.syncUrl
       ? getTursoCredentials()
@@ -89,6 +108,26 @@ export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
   const dbPath = configuredCloud?.url ?? options.dbPath ?? DEFAULT_DB_PATH;
   const isRemote = isRemoteDatabasePath(dbPath);
   const isEmbeddedReplica = Boolean(options.syncUrl);
+  const provider = resolveProvider(options, configuredCloud?.mode, isRemote);
+
+  if (provider === "remote") {
+    const url = isRemote ? dbPath : options.syncUrl;
+    if (!url) {
+      throw new Error(
+        "The remote database provider is selected but no Turso URL is " +
+          "configured. Run: zam connector setup turso",
+      );
+    }
+    const db = openRemoteDatabase({
+      url,
+      authToken: configuredCloud?.token ?? options.authToken,
+    });
+    if (options.initialize) {
+      await db.exec(SCHEMA);
+    }
+    await runMigrations(db);
+    return db;
+  }
 
   if (options.initialize && !isRemote) {
     const dir = dirname(dbPath);
@@ -107,9 +146,9 @@ export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
     // it was created by libsql.
     //
     // If the db exists WITHOUT metadata, it was created before Turso was
-    // configured â€” delete it so libsql can sync fresh from cloud.
+    // configured — delete it so libsql can sync fresh from cloud.
     //
-    // If metadata exists WITHOUT the db, libsql throws InvalidLocalState â€”
+    // If metadata exists WITHOUT the db, libsql throws InvalidLocalState —
     // delete the metadata so it can start fresh.
     const metaPath = `${dbPath}.meta`;
     const infoPath = `${dbPath}-info`;
@@ -132,11 +171,11 @@ export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
     dbOpts.authToken = authToken;
   }
 
-  let db: DatabaseType;
+  let driver: SyncDatabase;
   if (isRemote || isEmbeddedReplica) {
     const LibsqlDatabase = loadLibsql();
     try {
-      db = new LibsqlDatabase(dbPath, dbOpts);
+      driver = new LibsqlDatabase(dbPath, dbOpts);
     } catch (err) {
       const msg = (err as Error).message;
       if (msg.includes("InvalidLocalState") && options.syncUrl) {
@@ -145,38 +184,56 @@ export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
         const infoPath = `${dbPath}-info`;
         if (existsSync(metaPath)) rmSync(metaPath);
         if (existsSync(infoPath)) rmSync(infoPath);
-        db = new LibsqlDatabase(dbPath, dbOpts);
+        driver = new LibsqlDatabase(dbPath, dbOpts);
       } else {
         throw err;
       }
     }
   } else {
-    db = openLocalSqlite(dbPath);
+    driver = openLocalSqlite(dbPath);
   }
 
   // Enable WAL mode and foreign keys for local SQLite.
   // Remote Turso databases and embedded replicas manage their own journaling.
   if (!isRemote && !isEmbeddedReplica) {
-    db.pragma("journal_mode = WAL");
+    driver.pragma("journal_mode = WAL");
   }
-  db.pragma("foreign_keys = ON");
+  driver.pragma("foreign_keys = ON");
   if (!isRemote) {
-    db.pragma("busy_timeout = 5000");
+    driver.pragma("busy_timeout = 5000");
   }
+
+  const db = wrapSyncDatabase(driver);
 
   // For embedded replicas: sync from cloud FIRST so the local file has the
   // primary's schema before we try to run migrations or create tables.
   if (isEmbeddedReplica) {
-    db.sync?.();
+    await db.sync?.();
   }
 
   if (options.initialize) {
-    db.exec(SCHEMA);
+    await db.exec(SCHEMA);
   }
 
-  runMigrations(db);
+  await runMigrations(db);
 
   return db;
+}
+
+function resolveProvider(
+  options: ConnectionOptions,
+  credentialsMode: string | undefined,
+  isRemote: boolean,
+): DatabaseProvider {
+  if (options.provider) return options.provider;
+  const env = process.env.ZAM_DB_PROVIDER;
+  if (isDatabaseProvider(env)) return env;
+  if (isDatabaseProvider(credentialsMode) && (isRemote || options.syncUrl)) {
+    return credentialsMode;
+  }
+  // Legacy default: cloud URLs and embedded replicas use the native driver.
+  if (isRemote || options.syncUrl) return "native";
+  return "local";
 }
 
 /**
@@ -185,9 +242,9 @@ export function openDatabase(options: ConnectionOptions = {}): DatabaseType {
  * machine only has to collect missing secrets instead of bootstrapping local
  * state first.
  */
-export function openDatabaseWithSync(
+export async function openDatabaseWithSync(
   options: Omit<ConnectionOptions, "syncUrl" | "authToken"> = {},
-): DatabaseType {
+): Promise<Database> {
   return openDatabase(options);
 }
 
@@ -198,47 +255,46 @@ export function getDefaultDbPath(): string {
 
 /**
  * Run incremental schema migrations on every open.
- * Each migration is idempotent â€” safe to run repeatedly.
+ * Each migration is idempotent — safe to run repeatedly.
  */
-function runMigrations(db: DatabaseType): void {
+async function runMigrations(db: Database): Promise<void> {
   // M001: add execution_context to sessions
-  const sessionCols = db.pragma("table_info(sessions)") as Array<{
+  const sessionCols = (await db.pragma("table_info(sessions)")) as Array<{
     name: string;
   }>;
   if (
     sessionCols.length > 0 &&
     !sessionCols.some((c) => c.name === "execution_context")
   ) {
-    db.exec(
+    await db.exec(
       `ALTER TABLE sessions ADD COLUMN execution_context TEXT NOT NULL DEFAULT 'shell'`,
     );
   }
 
   // M002: add deprecated_at to tokens
-  const tokenCols = db.pragma("table_info(tokens)") as Array<{ name: string }>;
+  const tokenCols = (await db.pragma("table_info(tokens)")) as Array<{
+    name: string;
+  }>;
   if (
     tokenCols.length > 0 &&
     !tokenCols.some((c) => c.name === "deprecated_at")
   ) {
-    db.exec(`ALTER TABLE tokens ADD COLUMN deprecated_at TEXT`);
+    await db.exec(`ALTER TABLE tokens ADD COLUMN deprecated_at TEXT`);
   }
 
   // M004: add source_link to tokens
-  if (
-    tokenCols.length > 0 &&
-    !tokenCols.some((c) => c.name === "source_link")
-  ) {
-    db.exec(`ALTER TABLE tokens ADD COLUMN source_link TEXT`);
+  if (tokenCols.length > 0 && !tokenCols.some((c) => c.name === "source_link")) {
+    await db.exec(`ALTER TABLE tokens ADD COLUMN source_link TEXT`);
   }
 
   // M005: add question to tokens
   if (tokenCols.length > 0 && !tokenCols.some((c) => c.name === "question")) {
-    db.exec(`ALTER TABLE tokens ADD COLUMN question TEXT`);
+    await db.exec(`ALTER TABLE tokens ADD COLUMN question TEXT`);
   }
 
   // M003: create agent_skills table (idempotent via IF NOT EXISTS in SCHEMA,
   // but also needed for databases that skipped the init path)
-  db.exec(`
+  await db.exec(`
     CREATE TABLE IF NOT EXISTS agent_skills (
       id          TEXT PRIMARY KEY,
       slug        TEXT NOT NULL UNIQUE,

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -283,7 +283,10 @@ async function runMigrations(db: Database): Promise<void> {
   }
 
   // M004: add source_link to tokens
-  if (tokenCols.length > 0 && !tokenCols.some((c) => c.name === "source_link")) {
+  if (
+    tokenCols.length > 0 &&
+    !tokenCols.some((c) => c.name === "source_link")
+  ) {
     await db.exec(`ALTER TABLE tokens ADD COLUMN source_link TEXT`);
   }
 

--- a/src/kernel/db/remote/hrana.ts
+++ b/src/kernel/db/remote/hrana.ts
@@ -1,0 +1,255 @@
+/**
+ * Minimal Hrana v3 over HTTP transport for Turso/libsql servers.
+ *
+ * Implements exactly the subset ZAM needs — execute, sequence, close, and
+ * baton-scoped streams for transactions — over plain `fetch`, so it runs on
+ * every architecture Node.js supports (including Windows ARM64, which has no
+ * native libsql binding).
+ *
+ * Protocol reference: https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md
+ */
+
+export interface HranaTransportOptions {
+  /** Database URL (libsql://, https:// or http://). */
+  url: string;
+  /** Turso auth token; omitted for unauthenticated local servers. */
+  authToken?: string;
+  /** Per-request timeout in milliseconds. */
+  timeoutMs?: number;
+  /**
+   * Total attempts for requests that failed at the transport level before a
+   * response was received. Stateful stream requests (open batons) are never
+   * retried.
+   */
+  maxAttempts?: number;
+}
+
+export type HranaValue =
+  | { type: "null" }
+  | { type: "integer"; value: string }
+  | { type: "float"; value: number }
+  | { type: "text"; value: string }
+  | { type: "blob"; base64: string };
+
+export interface HranaStmt {
+  sql: string;
+  args?: HranaValue[];
+  want_rows: boolean;
+}
+
+export type HranaRequest =
+  | { type: "execute"; stmt: HranaStmt }
+  | { type: "sequence"; sql: string }
+  | { type: "close" };
+
+export interface HranaStmtResult {
+  cols: Array<{ name: string | null }>;
+  rows: HranaValue[][];
+  affected_row_count: number;
+  last_insert_rowid: string | null;
+}
+
+interface HranaPipelineResponse {
+  baton: string | null;
+  base_url: string | null;
+  results: Array<
+    | { type: "ok"; response: { type: string; result?: HranaStmtResult } }
+    | { type: "error"; error: { message: string; code?: string | null } }
+  >;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+/** Convert libsql:// and ws(s):// URLs to their HTTP equivalents. */
+export function toHttpUrl(url: string): string {
+  return url
+    .replace(/^libsql:\/\//i, "https://")
+    .replace(/^wss:\/\//i, "https://")
+    .replace(/^ws:\/\//i, "http://")
+    .replace(/\/+$/, "");
+}
+
+export function encodeValue(param: unknown): HranaValue {
+  if (param === null) return { type: "null" };
+  if (typeof param === "string") return { type: "text", value: param };
+  if (typeof param === "bigint") {
+    return { type: "integer", value: param.toString() };
+  }
+  if (typeof param === "number") {
+    if (Number.isSafeInteger(param)) {
+      return { type: "integer", value: param.toString() };
+    }
+    return { type: "float", value: param };
+  }
+  if (param instanceof Uint8Array) {
+    return { type: "blob", base64: Buffer.from(param).toString("base64") };
+  }
+  throw new TypeError(
+    `Cannot bind a value of type ${typeof param} to a SQL parameter`,
+  );
+}
+
+export function decodeValue(value: HranaValue): unknown {
+  switch (value.type) {
+    case "null":
+      return null;
+    case "integer":
+      return Number(value.value);
+    case "float":
+      return value.value;
+    case "text":
+      return value.value;
+    case "blob":
+      return new Uint8Array(Buffer.from(value.base64, "base64"));
+  }
+}
+
+export function rowsToObjects(
+  result: HranaStmtResult,
+): Record<string, unknown>[] {
+  return result.rows.map((row) => {
+    const obj: Record<string, unknown> = {};
+    row.forEach((value, i) => {
+      obj[result.cols[i]?.name ?? `col${i}`] = decodeValue(value);
+    });
+    return obj;
+  });
+}
+
+/**
+ * Only failures that provably happened before the server could have seen the
+ * request are retried; anything else (timeouts, resets mid-response) might
+ * have executed the statement already, and retrying could duplicate a write.
+ */
+function isRetryableTransportError(err: unknown): boolean {
+  if (!(err instanceof Error) || err.name === "HranaResponseError") {
+    return false;
+  }
+  const code = (err.cause as { code?: string } | undefined)?.code;
+  return (
+    code === "ECONNREFUSED" || code === "ENOTFOUND" || code === "EAI_AGAIN"
+  );
+}
+
+class HranaResponseError extends Error {
+  override name = "HranaResponseError";
+}
+
+/**
+ * A Hrana stream. Stateless requests use a fresh stream per call (the
+ * pipeline ends with `close`); transactions keep the stream open via the
+ * baton returned by the server.
+ */
+export class HranaTransport {
+  private readonly pipelineUrl: string;
+  private readonly authToken?: string;
+  private readonly timeoutMs: number;
+  private readonly maxAttempts: number;
+
+  constructor(options: HranaTransportOptions) {
+    this.pipelineUrl = `${toHttpUrl(options.url)}/v3/pipeline`;
+    this.authToken = options.authToken;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  }
+
+  /**
+   * POST one pipeline of requests. Returns the server results plus the baton
+   * for continuing an open stream. Retries transport-level failures only for
+   * stateless pipelines (no baton involved on either side).
+   */
+  async pipeline(
+    requests: HranaRequest[],
+    baton?: string | null,
+    baseUrl?: string | null,
+  ): Promise<HranaPipelineResponse> {
+    const url = baseUrl
+      ? `${toHttpUrl(baseUrl)}/v3/pipeline`
+      : this.pipelineUrl;
+    const keepsState =
+      baton != null || !requests.some((r) => r.type === "close");
+    const attempts = keepsState ? 1 : this.maxAttempts;
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        return await this.post(url, { baton: baton ?? null, requests });
+      } catch (err) {
+        lastError = err;
+        if (!isRetryableTransportError(err) || attempt === attempts) {
+          throw this.offline(err);
+        }
+      }
+    }
+    throw this.offline(lastError);
+  }
+
+  private async post(
+    url: string,
+    body: unknown,
+  ): Promise<HranaPipelineResponse> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(this.authToken
+            ? { authorization: `Bearer ${this.authToken}` }
+            : {}),
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new HranaResponseError(
+        `Turso rejected the configured credentials (HTTP ${response.status}). ` +
+          "Refresh the token with: zam connector setup turso",
+      );
+    }
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new HranaResponseError(
+        `Turso request failed with HTTP ${response.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+      );
+    }
+    return (await response.json()) as HranaPipelineResponse;
+  }
+
+  private offline(err: unknown): Error {
+    if (err instanceof HranaResponseError) return err;
+    const cause =
+      err instanceof Error
+        ? ((err.cause as Error | undefined)?.message ?? err.message)
+        : String(err);
+    return new HranaResponseError(
+      `Cannot reach the Turso database at ${this.pipelineUrl}: ${cause}. ` +
+        "Check your network connection, or switch to the local provider " +
+        "(ZAM_DB_PROVIDER=local).",
+    );
+  }
+}
+
+/** Unwrap a single pipeline result entry, throwing on stream-level errors. */
+export function unwrapResult(
+  response: HranaPipelineResponse,
+  index: number,
+): HranaStmtResult | undefined {
+  const entry = response.results[index];
+  if (!entry) {
+    throw new HranaResponseError(
+      `Turso response is missing result #${index}`,
+    );
+  }
+  if (entry.type === "error") {
+    throw new Error(entry.error.message);
+  }
+  return entry.response.result;
+}

--- a/src/kernel/db/remote/hrana.ts
+++ b/src/kernel/db/remote/hrana.ts
@@ -244,9 +244,7 @@ export function unwrapResult(
 ): HranaStmtResult | undefined {
   const entry = response.results[index];
   if (!entry) {
-    throw new HranaResponseError(
-      `Turso response is missing result #${index}`,
-    );
+    throw new HranaResponseError(`Turso response is missing result #${index}`);
   }
   if (entry.type === "error") {
     throw new Error(entry.error.message);

--- a/src/kernel/db/remote/provider.ts
+++ b/src/kernel/db/remote/provider.ts
@@ -1,0 +1,157 @@
+/**
+ * RemoteTursoProvider — implements the async `Database` contract directly
+ * against a Turso/libsql server over HTTP (Hrana v3).
+ *
+ * No native bindings and no extra runtime dependencies, so this provider is
+ * the cloud path for architectures without a native libsql artifact (for
+ * example Windows ARM64). Under ZAM's online-first assumption it is suitable
+ * for interactive sessions: the per-review LLM call dominates latency.
+ */
+
+import type { Database, RunResult, Statement } from "../types.js";
+import {
+  encodeValue,
+  HranaTransport,
+  type HranaRequest,
+  type HranaStmtResult,
+  type HranaTransportOptions,
+  rowsToObjects,
+  unwrapResult,
+} from "./hrana.js";
+
+const TABLE_INFO_PRAGMA = /^\s*table_info\s*\(\s*['"]?(\w+)['"]?\s*\)\s*$/i;
+
+function toRunResult(result: HranaStmtResult | undefined): RunResult {
+  return {
+    changes: result?.affected_row_count ?? 0,
+    lastInsertRowid:
+      result?.last_insert_rowid != null ? Number(result.last_insert_rowid) : 0,
+  };
+}
+
+/** A pipeline executor; stateless by default, baton-scoped in transactions. */
+type RunPipeline = (
+  requests: HranaRequest[],
+) => Promise<{ results: Array<HranaStmtResult | undefined> }>;
+
+function makeStatement(sql: string, run: RunPipeline): Statement {
+  const execute = async (params: unknown[], wantRows: boolean) => {
+    const { results } = await run([
+      {
+        type: "execute",
+        stmt: { sql, args: params.map(encodeValue), want_rows: wantRows },
+      },
+    ]);
+    return results[0];
+  };
+
+  return {
+    async run(...params: unknown[]) {
+      return toRunResult(await execute(params, false));
+    },
+    async get(...params: unknown[]) {
+      const result = await execute(params, true);
+      return result ? rowsToObjects(result)[0] : undefined;
+    },
+    async all(...params: unknown[]) {
+      const result = await execute(params, true);
+      return result ? rowsToObjects(result) : [];
+    },
+  };
+}
+
+function makeDatabase(run: RunPipeline, transport: HranaTransport): Database {
+  let txTail: Promise<unknown> = Promise.resolve();
+
+  const db: Database = {
+    prepare(sql: string) {
+      return makeStatement(sql, run);
+    },
+
+    async exec(sql: string) {
+      await run([{ type: "sequence", sql }]);
+    },
+
+    async pragma(source: string) {
+      const tableInfo = TABLE_INFO_PRAGMA.exec(source);
+      const sql = tableInfo
+        ? `SELECT * FROM pragma_table_info('${tableInfo[1]}')`
+        : `PRAGMA ${source}`;
+      return db.prepare(sql).all();
+    },
+
+    transaction<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+      const next = txTail.then(async () => {
+        const stream = openStream(transport);
+        try {
+          await stream.run([
+            { type: "execute", stmt: { sql: "BEGIN IMMEDIATE", want_rows: false } },
+          ]);
+          const result = await fn(makeDatabase(stream.run, transport));
+          await stream.run(
+            [{ type: "execute", stmt: { sql: "COMMIT", want_rows: false } }],
+            true,
+          );
+          return result;
+        } catch (err) {
+          await stream
+            .run(
+              [{ type: "execute", stmt: { sql: "ROLLBACK", want_rows: false } }],
+              true,
+            )
+            .catch(() => {});
+          throw err;
+        }
+      });
+      txTail = next.catch(() => {});
+      return next;
+    },
+
+    async close() {
+      // Stateless transport: nothing to release.
+    },
+  };
+
+  return db;
+}
+
+interface Stream {
+  run(requests: HranaRequest[], close?: boolean): ReturnType<RunPipeline>;
+}
+
+/** Open a baton-scoped stream that threads server state between pipelines. */
+function openStream(transport: HranaTransport): Stream {
+  let baton: string | null = null;
+  let baseUrl: string | null = null;
+
+  return {
+    async run(requests: HranaRequest[], close = false) {
+      const sent: HranaRequest[] = close
+        ? [...requests, { type: "close" }]
+        : requests;
+      const response = await transport.pipeline(sent, baton, baseUrl);
+      baton = response.baton;
+      baseUrl = response.base_url ?? baseUrl;
+      return {
+        results: requests.map((_, i) => unwrapResult(response, i)),
+      };
+    },
+  };
+}
+
+export type RemoteDatabaseOptions = HranaTransportOptions;
+
+/** Open a remote Turso database over HTTP. */
+export function openRemoteDatabase(options: RemoteDatabaseOptions): Database {
+  const transport = new HranaTransport(options);
+
+  const statelessRun: RunPipeline = async (requests) => {
+    const response = await transport.pipeline([
+      ...requests,
+      { type: "close" },
+    ]);
+    return { results: requests.map((_, i) => unwrapResult(response, i)) };
+  };
+
+  return makeDatabase(statelessRun, transport);
+}

--- a/src/kernel/db/remote/provider.ts
+++ b/src/kernel/db/remote/provider.ts
@@ -11,9 +11,9 @@
 import type { Database, RunResult, Statement } from "../types.js";
 import {
   encodeValue,
-  HranaTransport,
   type HranaRequest,
   type HranaStmtResult,
+  HranaTransport,
   type HranaTransportOptions,
   rowsToObjects,
   unwrapResult,
@@ -85,7 +85,10 @@ function makeDatabase(run: RunPipeline, transport: HranaTransport): Database {
         const stream = openStream(transport);
         try {
           await stream.run([
-            { type: "execute", stmt: { sql: "BEGIN IMMEDIATE", want_rows: false } },
+            {
+              type: "execute",
+              stmt: { sql: "BEGIN IMMEDIATE", want_rows: false },
+            },
           ]);
           const result = await fn(makeDatabase(stream.run, transport));
           await stream.run(
@@ -96,7 +99,12 @@ function makeDatabase(run: RunPipeline, transport: HranaTransport): Database {
         } catch (err) {
           await stream
             .run(
-              [{ type: "execute", stmt: { sql: "ROLLBACK", want_rows: false } }],
+              [
+                {
+                  type: "execute",
+                  stmt: { sql: "ROLLBACK", want_rows: false },
+                },
+              ],
               true,
             )
             .catch(() => {});
@@ -146,10 +154,7 @@ export function openRemoteDatabase(options: RemoteDatabaseOptions): Database {
   const transport = new HranaTransport(options);
 
   const statelessRun: RunPipeline = async (requests) => {
-    const response = await transport.pipeline([
-      ...requests,
-      { type: "close" },
-    ]);
+    const response = await transport.pipeline([...requests, { type: "close" }]);
     return { results: requests.map((_, i) => unwrapResult(response, i)) };
   };
 

--- a/src/kernel/db/sync-adapter.ts
+++ b/src/kernel/db/sync-adapter.ts
@@ -1,0 +1,70 @@
+/**
+ * Adapter that lifts a synchronous SQLite driver (better-sqlite3 or the
+ * optional libsql embedded replica) into the async `Database` contract.
+ *
+ * Statements execute synchronously under the hood, so per-statement atomicity
+ * is unchanged. Transactions are serialized through a promise queue because
+ * an async callback can yield between statements, and two interleaved
+ * BEGIN IMMEDIATE blocks on one connection would otherwise corrupt each
+ * other's boundaries.
+ */
+
+import type { Database, SyncDatabase } from "./types.js";
+
+export function wrapSyncDatabase(driver: SyncDatabase): Database {
+  let txTail: Promise<unknown> = Promise.resolve();
+
+  const db: Database = {
+    prepare(sql: string) {
+      return {
+        async run(...params: unknown[]) {
+          return driver.prepare(sql).run(...params);
+        },
+        async get(...params: unknown[]) {
+          return driver.prepare(sql).get(...params);
+        },
+        async all(...params: unknown[]) {
+          return driver.prepare(sql).all(...params);
+        },
+      };
+    },
+
+    async exec(sql: string) {
+      driver.exec(sql);
+    },
+
+    async pragma(source: string) {
+      return driver.pragma(source);
+    },
+
+    transaction<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+      const run = txTail.then(async () => {
+        driver.exec("BEGIN IMMEDIATE");
+        try {
+          const result = await fn(db);
+          driver.exec("COMMIT");
+          return result;
+        } catch (err) {
+          driver.exec("ROLLBACK");
+          throw err;
+        }
+      });
+      txTail = run.catch(() => {});
+      return run;
+    },
+
+    ...(driver.sync
+      ? {
+          async sync() {
+            driver.sync?.();
+          },
+        }
+      : {}),
+
+    async close() {
+      driver.close();
+    },
+  };
+
+  return db;
+}

--- a/src/kernel/db/types.ts
+++ b/src/kernel/db/types.ts
@@ -5,20 +5,53 @@ export interface RunResult {
   lastInsertRowid: number | bigint;
 }
 
+/**
+ * Asynchronous database contract used by the learning kernel.
+ *
+ * Every provider (local SQLite, optional libsql embedded replica, remote
+ * Turso over HTTP) implements this interface; no kernel or public API type
+ * depends on a concrete database package.
+ */
 export interface Statement {
+  run(...params: unknown[]): Promise<RunResult>;
+  get(...params: unknown[]): Promise<unknown>;
+  all(...params: unknown[]): Promise<unknown[]>;
+}
+
+export interface Database {
+  prepare(sql: string): Statement;
+  /** Execute one or more SQL statements without reading results. */
+  exec(sql: string): Promise<void>;
+  /**
+   * Run a PRAGMA. Local providers support the full pragma surface; the
+   * remote provider only supports read pragmas that have a table-valued
+   * function equivalent (e.g. `table_info(...)`).
+   */
+  pragma(source: string): Promise<unknown>;
+  /**
+   * Run `fn` inside a BEGIN IMMEDIATE … COMMIT/ROLLBACK transaction.
+   * Transactions are serialized per connection; nested calls deadlock by
+   * design rather than silently interleaving writes.
+   */
+  transaction<T>(fn: (db: Database) => Promise<T>): Promise<T>;
+  /** Pull changes from the cloud primary (embedded replicas only). */
+  sync?(): Promise<void>;
+  close(): Promise<void>;
+}
+
+/**
+ * Synchronous driver surface satisfied by better-sqlite3 and the optional
+ * libsql embedded-replica package. Internal: kernel code must use the async
+ * `Database` contract instead.
+ */
+export interface SyncStatement {
   run(...params: unknown[]): RunResult;
   get(...params: unknown[]): unknown;
   all(...params: unknown[]): unknown[];
 }
 
-/**
- * Synchronous database surface used by the learning kernel.
- *
- * Both better-sqlite3 and the optional libsql embedded-replica driver satisfy
- * this contract.
- */
-export interface Database {
-  prepare(sql: string): Statement;
+export interface SyncDatabase {
+  prepare(sql: string): SyncStatement;
   exec(sql: string): void;
   pragma(source: string): unknown;
   close(): void;

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -31,11 +31,17 @@ export {
   setTursoCredentials,
 } from "./credentials.js";
 // Database
+export type {
+  ConnectionOptions,
+  DatabaseProvider,
+} from "./db/connection.js";
 export {
   getDefaultDbPath,
   openDatabase,
   openDatabaseWithSync,
 } from "./db/connection.js";
+export type { RemoteDatabaseOptions } from "./db/remote/provider.js";
+export { openRemoteDatabase } from "./db/remote/provider.js";
 export type {
   Database,
   DatabaseValue,

--- a/src/kernel/models/agent-skill.ts
+++ b/src/kernel/models/agent-skill.ts
@@ -56,13 +56,13 @@ function parseRow(row: AgentSkillRow): AgentSkill {
 
 // ── Functions ────────────────────────────────────────────────────────────────
 
-export function createAgentSkill(
+export async function createAgentSkill(
   db: Database,
   input: CreateAgentSkillInput,
-): AgentSkill {
-  const existing = db
+): Promise<AgentSkill> {
+  const existing = (await db
     .prepare("SELECT * FROM agent_skills WHERE slug = ?")
-    .get(input.slug) as AgentSkillRow | undefined;
+    .get(input.slug)) as AgentSkillRow | undefined;
 
   if (existing) {
     throw new Error(`Agent skill already exists: ${input.slug}`);
@@ -71,42 +71,44 @@ export function createAgentSkill(
   const id = ulid();
   const now = new Date().toISOString();
 
-  db.prepare(
-    `INSERT INTO agent_skills (id, slug, description, steps, token_slugs, source, created_at, updated_at)
+  await db
+    .prepare(
+      `INSERT INTO agent_skills (id, slug, description, steps, token_slugs, source, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    input.slug,
-    input.description,
-    JSON.stringify(input.steps),
-    JSON.stringify(input.token_slugs ?? []),
-    input.source ?? "learned",
-    now,
-    now,
-  );
+    )
+    .run(
+      id,
+      input.slug,
+      input.description,
+      JSON.stringify(input.steps),
+      JSON.stringify(input.token_slugs ?? []),
+      input.source ?? "learned",
+      now,
+      now,
+    );
 
   return parseRow(
-    db
+    (await db
       .prepare("SELECT * FROM agent_skills WHERE id = ?")
-      .get(id) as AgentSkillRow,
+      .get(id)) as AgentSkillRow,
   );
 }
 
-export function getAgentSkill(
+export async function getAgentSkill(
   db: Database,
   slug: string,
-): AgentSkill | undefined {
-  const row = db
+): Promise<AgentSkill | undefined> {
+  const row = (await db
     .prepare("SELECT * FROM agent_skills WHERE slug = ?")
-    .get(slug) as AgentSkillRow | undefined;
+    .get(slug)) as AgentSkillRow | undefined;
 
   return row ? parseRow(row) : undefined;
 }
 
-export function listAgentSkills(db: Database): AgentSkill[] {
-  const rows = db
+export async function listAgentSkills(db: Database): Promise<AgentSkill[]> {
+  const rows = (await db
     .prepare("SELECT * FROM agent_skills ORDER BY created_at ASC")
-    .all() as AgentSkillRow[];
+    .all()) as AgentSkillRow[];
 
   return rows.map(parseRow);
 }

--- a/src/kernel/models/card.ts
+++ b/src/kernel/models/card.ts
@@ -76,46 +76,51 @@ export interface BlockedCard extends Card {
  *
  * Ported from the PoC's ensureCard helper.
  */
-export function ensureCard(
+export async function ensureCard(
   db: Database,
   tokenId: string,
   userId: string,
-): Card {
-  const existing = db
+): Promise<Card> {
+  const existing = (await db
     .prepare("SELECT * FROM cards WHERE token_id = ? AND user_id = ?")
-    .get(tokenId, userId) as Card | undefined;
+    .get(tokenId, userId)) as Card | undefined;
 
   if (existing) return existing;
 
   const id = ulid();
   const now = new Date().toISOString();
 
-  db.prepare(
-    `INSERT INTO cards (id, token_id, user_id, due_at)
+  await db
+    .prepare(
+      `INSERT INTO cards (id, token_id, user_id, due_at)
      VALUES (?, ?, ?, ?)`,
-  ).run(id, tokenId, userId, now);
+    )
+    .run(id, tokenId, userId, now);
 
-  return db.prepare("SELECT * FROM cards WHERE id = ?").get(id) as Card;
+  return (await db.prepare("SELECT * FROM cards WHERE id = ?").get(id)) as Card;
 }
 
 /**
  * Get a card by token+user. Returns undefined if no card exists.
  */
-export function getCard(
+export async function getCard(
   db: Database,
   tokenId: string,
   userId: string,
-): Card | undefined {
-  return db
+): Promise<Card | undefined> {
+  return (await db
     .prepare("SELECT * FROM cards WHERE token_id = ? AND user_id = ?")
-    .get(tokenId, userId) as Card | undefined;
+    .get(tokenId, userId)) as Card | undefined;
 }
 
 /**
  * Get a card by its ULID.
  */
-export function getCardById(db: Database, cardId: string): Card | undefined {
-  return db.prepare("SELECT * FROM cards WHERE id = ?").get(cardId) as
+export async function getCardById(
+  db: Database,
+  cardId: string,
+): Promise<Card | undefined> {
+  return (await db.prepare("SELECT * FROM cards WHERE id = ?").get(cardId)) as
     | Card
     | undefined;
 }
@@ -126,11 +131,11 @@ export function getCardById(db: Database, cardId: string): Card | undefined {
  * Only the fields present in `updates` are changed. Throws if the card
  * does not exist.
  */
-export function updateCard(
+export async function updateCard(
   db: Database,
   cardId: string,
   updates: UpdateCardInput,
-): Card {
+): Promise<Card> {
   const fields: string[] = [];
   const values: unknown[] = [];
 
@@ -181,7 +186,7 @@ export function updateCard(
 
   values.push(cardId);
 
-  const result = db
+  const result = await db
     .prepare(`UPDATE cards SET ${fields.join(", ")} WHERE id = ?`)
     .run(...values);
 
@@ -189,25 +194,27 @@ export function updateCard(
     throw new Error(`Card not found: ${cardId}`);
   }
 
-  return db.prepare("SELECT * FROM cards WHERE id = ?").get(cardId) as Card;
+  return (await db
+    .prepare("SELECT * FROM cards WHERE id = ?")
+    .get(cardId)) as Card;
 }
 
 /**
  * Preview the review-log rows that will be removed when deleting a user's card.
  */
-export function getCardDeletionImpact(
+export async function getCardDeletionImpact(
   db: Database,
   tokenId: string,
   userId: string,
-): CardDeletionImpact {
-  const card = getCard(db, tokenId, userId);
+): Promise<CardDeletionImpact> {
+  const card = await getCard(db, tokenId, userId);
   if (!card) {
     throw new Error(`Card not found for token ${tokenId} and user ${userId}`);
   }
 
-  const reviewLogs = db
+  const reviewLogs = (await db
     .prepare("SELECT COUNT(*) AS n FROM review_logs WHERE card_id = ?")
-    .get(card.id) as { n: number };
+    .get(card.id)) as { n: number };
 
   return { review_logs: reviewLogs.n };
 }
@@ -215,18 +222,18 @@ export function getCardDeletionImpact(
 /**
  * Delete one user's card for a token. Review logs cascade via FK.
  */
-export function deleteCardForUser(
+export async function deleteCardForUser(
   db: Database,
   tokenId: string,
   userId: string,
-): DeleteCardResult {
-  const card = getCard(db, tokenId, userId);
+): Promise<DeleteCardResult> {
+  const card = await getCard(db, tokenId, userId);
   if (!card) {
     throw new Error(`Card not found for token ${tokenId} and user ${userId}`);
   }
 
-  const impact = getCardDeletionImpact(db, tokenId, userId);
-  db.prepare("DELETE FROM cards WHERE id = ?").run(card.id);
+  const impact = await getCardDeletionImpact(db, tokenId, userId);
+  await db.prepare("DELETE FROM cards WHERE id = ?").run(card.id);
 
   return { card, impact };
 }
@@ -240,14 +247,14 @@ export function deleteCardForUser(
  *
  * Ported from the PoC's due-tokens command.
  */
-export function getDueCards(
+export async function getDueCards(
   db: Database,
   userId: string,
   now?: string,
-): DueCard[] {
+): Promise<DueCard[]> {
   const cutoff = now ?? new Date().toISOString();
 
-  return db
+  return (await db
     .prepare(
       `SELECT c.*, t.slug, t.concept, t.domain, t.bloom_level
        FROM cards c
@@ -255,7 +262,7 @@ export function getDueCards(
        WHERE c.user_id = ? AND c.blocked = 0 AND c.due_at <= ?
        ORDER BY t.bloom_level ASC, c.due_at ASC`,
     )
-    .all(userId, cutoff) as DueCard[];
+    .all(userId, cutoff)) as DueCard[];
 }
 
 /**
@@ -264,8 +271,11 @@ export function getDueCards(
  * Returns cards joined with their token details so the caller can
  * see what is waiting and why.
  */
-export function getBlockedCards(db: Database, userId: string): BlockedCard[] {
-  return db
+export async function getBlockedCards(
+  db: Database,
+  userId: string,
+): Promise<BlockedCard[]> {
+  return (await db
     .prepare(
       `SELECT c.*, t.slug, t.concept, t.domain, t.bloom_level
        FROM cards c
@@ -273,5 +283,5 @@ export function getBlockedCards(db: Database, userId: string): BlockedCard[] {
        WHERE c.user_id = ? AND c.blocked = 1
        ORDER BY t.bloom_level ASC, t.slug ASC`,
     )
-    .all(userId) as BlockedCard[];
+    .all(userId)) as BlockedCard[];
 }

--- a/src/kernel/models/prerequisite.ts
+++ b/src/kernel/models/prerequisite.ts
@@ -29,10 +29,12 @@ export interface PrerequisiteWithToken extends Prerequisite {
  * Only used for cycle detection; the full graph is loaded once per
  * addPrerequisite call (small N in practice).
  */
-function buildAncestorMap(db: Database): Map<string, Set<string>> {
-  const rows = db
+async function buildAncestorMap(
+  db: Database,
+): Promise<Map<string, Set<string>>> {
+  const rows = (await db
     .prepare("SELECT token_id, requires_id FROM prerequisites")
-    .all() as Array<{ token_id: string; requires_id: string }>;
+    .all()) as Array<{ token_id: string; requires_id: string }>;
   const map = new Map<string, Set<string>>();
   for (const row of rows) {
     let ancestors = map.get(row.token_id);
@@ -50,19 +52,19 @@ function buildAncestorMap(db: Database): Map<string, Set<string>> {
  * Uses BFS from requiresId: if tokenId is reachable, adding the edge closes
  * a loop.
  */
-export function wouldCreateCycle(
+export async function wouldCreateCycle(
   db: Database,
   tokenId: string,
   requiresId: string,
-): boolean {
+): Promise<boolean> {
   if (tokenId === requiresId) return true;
 
-  const ancestors = buildAncestorMap(db);
+  const ancestors = await buildAncestorMap(db);
   const visited = new Set<string>();
   const queue = [requiresId];
 
   while (queue.length > 0) {
-    const current = queue.shift()!;
+    const current = queue.shift() as string;
     if (current === tokenId) return true;
     if (visited.has(current)) continue;
     visited.add(current);
@@ -87,25 +89,27 @@ export function wouldCreateCycle(
  * Throws if a token is declared as its own prerequisite.
  * Throws if the edge would create a cycle in the prerequisite graph.
  */
-export function addPrerequisite(
+export async function addPrerequisite(
   db: Database,
   tokenId: string,
   requiresId: string,
-): void {
+): Promise<void> {
   if (tokenId === requiresId) {
     throw new Error("A token cannot be a prerequisite of itself");
   }
 
-  if (wouldCreateCycle(db, tokenId, requiresId)) {
+  if (await wouldCreateCycle(db, tokenId, requiresId)) {
     throw new Error(
       `Cannot add prerequisite: would create a cycle. ` +
         `${requiresId} already depends on ${tokenId} (directly or transitively).`,
     );
   }
 
-  db.prepare(
-    "INSERT OR IGNORE INTO prerequisites (token_id, requires_id) VALUES (?, ?)",
-  ).run(tokenId, requiresId);
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO prerequisites (token_id, requires_id) VALUES (?, ?)",
+    )
+    .run(tokenId, requiresId);
 }
 
 /**
@@ -113,18 +117,18 @@ export function addPrerequisite(
  *
  * Returns prerequisite rows joined with the required token's details.
  */
-export function getPrerequisites(
+export async function getPrerequisites(
   db: Database,
   tokenId: string,
-): PrerequisiteWithToken[] {
-  return db
+): Promise<PrerequisiteWithToken[]> {
+  return (await db
     .prepare(
       `SELECT p.token_id, p.requires_id, t.slug, t.concept, t.domain, t.bloom_level
        FROM prerequisites p
        JOIN tokens t ON t.id = p.requires_id
        WHERE p.token_id = ?`,
     )
-    .all(tokenId) as PrerequisiteWithToken[];
+    .all(tokenId)) as PrerequisiteWithToken[];
 }
 
 /**
@@ -132,16 +136,16 @@ export function getPrerequisites(
  *
  * Returns prerequisite rows joined with the dependent token's details.
  */
-export function getDependents(
+export async function getDependents(
   db: Database,
   tokenId: string,
-): PrerequisiteWithToken[] {
-  return db
+): Promise<PrerequisiteWithToken[]> {
+  return (await db
     .prepare(
       `SELECT p.token_id, p.requires_id, t.slug, t.concept, t.domain, t.bloom_level
        FROM prerequisites p
        JOIN tokens t ON t.id = p.token_id
        WHERE p.requires_id = ?`,
     )
-    .all(tokenId) as PrerequisiteWithToken[];
+    .all(tokenId)) as PrerequisiteWithToken[];
 }

--- a/src/kernel/models/review.ts
+++ b/src/kernel/models/review.ts
@@ -50,7 +50,10 @@ export interface ListReviewsOptions {
  * Validates that the rating is between 1 and 4 (matching the schema CHECK).
  * Returns the created review log entry.
  */
-export function logReview(db: Database, input: CreateReviewInput): ReviewLog {
+export async function logReview(
+  db: Database,
+  input: CreateReviewInput,
+): Promise<ReviewLog> {
   if (input.rating < 1 || input.rating > 4) {
     throw new Error(`Rating must be between 1 and 4, got ${input.rating}`);
   }
@@ -58,35 +61,40 @@ export function logReview(db: Database, input: CreateReviewInput): ReviewLog {
   const id = ulid();
   const now = new Date().toISOString();
 
-  db.prepare(
-    `INSERT INTO review_logs (id, card_id, token_id, user_id, rating, response_time_ms, reviewed_at, scheduled_at, session_id)
+  await db
+    .prepare(
+      `INSERT INTO review_logs (id, card_id, token_id, user_id, rating, response_time_ms, reviewed_at, scheduled_at, session_id)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    input.card_id,
-    input.token_id,
-    input.user_id,
-    input.rating,
-    input.response_time_ms ?? null,
-    now,
-    input.scheduled_at,
-    input.session_id ?? null,
-  );
+    )
+    .run(
+      id,
+      input.card_id,
+      input.token_id,
+      input.user_id,
+      input.rating,
+      input.response_time_ms ?? null,
+      now,
+      input.scheduled_at,
+      input.session_id ?? null,
+    );
 
-  return db
+  return (await db
     .prepare("SELECT * FROM review_logs WHERE id = ?")
-    .get(id) as ReviewLog;
+    .get(id)) as ReviewLog;
 }
 
 /**
  * Get all reviews for a specific card, ordered by reviewed_at ascending.
  */
-export function getReviewsForCard(db: Database, cardId: string): ReviewLog[] {
-  return db
+export async function getReviewsForCard(
+  db: Database,
+  cardId: string,
+): Promise<ReviewLog[]> {
+  return (await db
     .prepare(
       "SELECT * FROM review_logs WHERE card_id = ? ORDER BY reviewed_at ASC",
     )
-    .all(cardId) as ReviewLog[];
+    .all(cardId)) as ReviewLog[];
 }
 
 /**
@@ -94,11 +102,11 @@ export function getReviewsForCard(db: Database, cardId: string): ReviewLog[] {
  *
  * Results are ordered by reviewed_at descending (most recent first).
  */
-export function getReviewsForUser(
+export async function getReviewsForUser(
   db: Database,
   userId: string,
   options?: ListReviewsOptions,
-): ReviewLog[] {
+): Promise<ReviewLog[]> {
   const conditions = ["user_id = ?"];
   const params: unknown[] = [userId];
 
@@ -118,5 +126,5 @@ export function getReviewsForUser(
     params.push(options.limit);
   }
 
-  return db.prepare(sql).all(...params) as ReviewLog[];
+  return (await db.prepare(sql).all(...params)) as ReviewLog[];
 }

--- a/src/kernel/models/session.ts
+++ b/src/kernel/models/session.ts
@@ -65,17 +65,24 @@ export interface SessionSummary {
  *
  * Ported from the PoC's start-session command.
  */
-export function startSession(db: Database, input: CreateSessionInput): Session {
+export async function startSession(
+  db: Database,
+  input: CreateSessionInput,
+): Promise<Session> {
   const id = ulid();
   const now = new Date().toISOString();
   const ctx = input.execution_context ?? "shell";
 
-  db.prepare(
-    `INSERT INTO sessions (id, user_id, task, execution_context, started_at)
+  await db
+    .prepare(
+      `INSERT INTO sessions (id, user_id, task, execution_context, started_at)
      VALUES (?, ?, ?, ?, ?)`,
-  ).run(id, input.user_id, input.task, ctx, now);
+    )
+    .run(id, input.user_id, input.task, ctx, now);
 
-  return db.prepare("SELECT * FROM sessions WHERE id = ?").get(id) as Session;
+  return (await db
+    .prepare("SELECT * FROM sessions WHERE id = ?")
+    .get(id)) as Session;
 }
 
 /**
@@ -85,10 +92,13 @@ export function startSession(db: Database, input: CreateSessionInput): Session {
  *
  * Ported from the PoC's end-session command.
  */
-export function endSession(db: Database, sessionId: string): Session {
-  const session = db
+export async function endSession(
+  db: Database,
+  sessionId: string,
+): Promise<Session> {
+  const session = (await db
     .prepare("SELECT * FROM sessions WHERE id = ?")
-    .get(sessionId) as Session | undefined;
+    .get(sessionId)) as Session | undefined;
 
   if (!session) {
     throw new Error(`Session not found: ${sessionId}`);
@@ -98,14 +108,13 @@ export function endSession(db: Database, sessionId: string): Session {
   }
 
   const now = new Date().toISOString();
-  db.prepare("UPDATE sessions SET completed_at = ? WHERE id = ?").run(
-    now,
-    sessionId,
-  );
+  await db
+    .prepare("UPDATE sessions SET completed_at = ? WHERE id = ?")
+    .run(now, sessionId);
 
-  return db
+  return (await db
     .prepare("SELECT * FROM sessions WHERE id = ?")
-    .get(sessionId) as Session;
+    .get(sessionId)) as Session;
 }
 
 /**
@@ -116,7 +125,10 @@ export function endSession(db: Database, sessionId: string): Session {
  *
  * Ported from the PoC's log-step command.
  */
-export function logStep(db: Database, input: LogStepInput): SessionStep {
+export async function logStep(
+  db: Database,
+  input: LogStepInput,
+): Promise<SessionStep> {
   if (input.done_by !== "user" && input.done_by !== "agent") {
     throw new Error(
       `done_by must be 'user' or 'agent', got '${input.done_by}'`,
@@ -127,7 +139,7 @@ export function logStep(db: Database, input: LogStepInput): SessionStep {
   }
 
   // Verify the session exists
-  const session = db
+  const session = await db
     .prepare("SELECT id FROM sessions WHERE id = ?")
     .get(input.session_id);
   if (!session) {
@@ -137,22 +149,24 @@ export function logStep(db: Database, input: LogStepInput): SessionStep {
   const id = ulid();
   const now = new Date().toISOString();
 
-  db.prepare(
-    `INSERT INTO session_steps (id, session_id, token_id, done_by, rating, notes, created_at)
+  await db
+    .prepare(
+      `INSERT INTO session_steps (id, session_id, token_id, done_by, rating, notes, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    input.session_id,
-    input.token_id,
-    input.done_by,
-    input.rating ?? null,
-    input.notes ?? null,
-    now,
-  );
+    )
+    .run(
+      id,
+      input.session_id,
+      input.token_id,
+      input.done_by,
+      input.rating ?? null,
+      input.notes ?? null,
+      now,
+    );
 
-  return db
+  return (await db
     .prepare("SELECT * FROM session_steps WHERE id = ?")
-    .get(id) as SessionStep;
+    .get(id)) as SessionStep;
 }
 
 /**
@@ -162,19 +176,19 @@ export function logStep(db: Database, input: LogStepInput): SessionStep {
  * Ported from the PoC's session-summary command.
  * Throws if the session does not exist.
  */
-export function getSessionSummary(
+export async function getSessionSummary(
   db: Database,
   sessionId: string,
-): SessionSummary {
-  const session = db
+): Promise<SessionSummary> {
+  const session = (await db
     .prepare("SELECT * FROM sessions WHERE id = ?")
-    .get(sessionId) as Session | undefined;
+    .get(sessionId)) as Session | undefined;
 
   if (!session) {
     throw new Error(`Session not found: ${sessionId}`);
   }
 
-  const steps = db
+  const steps = (await db
     .prepare(
       `SELECT ss.*, t.slug, t.concept, t.domain, t.bloom_level
        FROM session_steps ss
@@ -182,7 +196,7 @@ export function getSessionSummary(
        WHERE ss.session_id = ?
        ORDER BY ss.created_at ASC`,
     )
-    .all(sessionId) as StepWithToken[];
+    .all(sessionId)) as StepWithToken[];
 
   return { session, steps };
 }

--- a/src/kernel/models/settings.ts
+++ b/src/kernel/models/settings.ts
@@ -11,18 +11,23 @@ export interface UserSetting {
 }
 
 /** Get a single setting by key. Returns undefined if not set. */
-export function getSetting(db: Database, key: string): string | undefined {
-  const row = db
+export async function getSetting(
+  db: Database,
+  key: string,
+): Promise<string | undefined> {
+  const row = (await db
     .prepare("SELECT value FROM user_config WHERE key = ?")
-    .get(key) as { value: string } | undefined;
+    .get(key)) as { value: string } | undefined;
   return row?.value;
 }
 
 /** Get all settings as a key-value map. */
-export function getAllSettings(db: Database): Record<string, string> {
-  const rows = db
+export async function getAllSettings(
+  db: Database,
+): Promise<Record<string, string>> {
+  const rows = (await db
     .prepare("SELECT key, value FROM user_config ORDER BY key")
-    .all() as { key: string; value: string }[];
+    .all()) as { key: string; value: string }[];
   const map: Record<string, string> = {};
   for (const row of rows) {
     map[row.key] = row.value;
@@ -31,23 +36,36 @@ export function getAllSettings(db: Database): Record<string, string> {
 }
 
 /** Get all settings with metadata. */
-export function getAllSettingsDetailed(db: Database): UserSetting[] {
-  return db
+export async function getAllSettingsDetailed(
+  db: Database,
+): Promise<UserSetting[]> {
+  return (await db
     .prepare("SELECT key, value, updated_at FROM user_config ORDER BY key")
-    .all() as UserSetting[];
+    .all()) as UserSetting[];
 }
 
 /** Set a setting (insert or update). */
-export function setSetting(db: Database, key: string, value: string): void {
-  db.prepare(
-    `INSERT INTO user_config (key, value, updated_at)
+export async function setSetting(
+  db: Database,
+  key: string,
+  value: string,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO user_config (key, value, updated_at)
      VALUES (?, ?, datetime('now'))
      ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-  ).run(key, value);
+    )
+    .run(key, value);
 }
 
 /** Delete a setting. Returns true if it existed. */
-export function deleteSetting(db: Database, key: string): boolean {
-  const result = db.prepare("DELETE FROM user_config WHERE key = ?").run(key);
+export async function deleteSetting(
+  db: Database,
+  key: string,
+): Promise<boolean> {
+  const result = await db
+    .prepare("DELETE FROM user_config WHERE key = ?")
+    .run(key);
   return result.changes > 0;
 }

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -81,7 +81,10 @@ export interface ScoredToken extends Token {
  * Create a new knowledge token.
  * Throws if a token with the same slug already exists.
  */
-export function createToken(db: Database, input: CreateTokenInput): Token {
+export async function createToken(
+  db: Database,
+  input: CreateTokenInput,
+): Promise<Token> {
   const id = ulid();
   const now = new Date().toISOString();
 
@@ -90,32 +93,37 @@ export function createToken(db: Database, input: CreateTokenInput): Token {
     throw new Error(`bloom_level must be between 1 and 5, got ${bloom}`);
   }
 
-  db.prepare(`
+  await db
+    .prepare(`
     INSERT INTO tokens (id, slug, concept, domain, bloom_level, context, symbiosis_mode, source_link, question, created_at, updated_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(
-    id,
-    input.slug,
-    input.concept,
-    input.domain ?? "",
-    bloom,
-    input.context ?? "",
-    input.symbiosis_mode ?? null,
-    input.source_link ?? null,
-    input.question ?? null,
-    now,
-    now,
-  );
+  `)
+    .run(
+      id,
+      input.slug,
+      input.concept,
+      input.domain ?? "",
+      bloom,
+      input.context ?? "",
+      input.symbiosis_mode ?? null,
+      input.source_link ?? null,
+      input.question ?? null,
+      now,
+      now,
+    );
 
-  return getTokenById(db, id)!;
+  return (await getTokenById(db, id)) as Token;
 }
 
 /**
  * Look up a token by its unique slug.
  * Returns undefined if not found.
  */
-export function getTokenBySlug(db: Database, slug: string): Token | undefined {
-  return db.prepare("SELECT * FROM tokens WHERE slug = ?").get(slug) as
+export async function getTokenBySlug(
+  db: Database,
+  slug: string,
+): Promise<Token | undefined> {
+  return (await db.prepare("SELECT * FROM tokens WHERE slug = ?").get(slug)) as
     | Token
     | undefined;
 }
@@ -124,8 +132,11 @@ export function getTokenBySlug(db: Database, slug: string): Token | undefined {
  * Look up a token by its ULID.
  * Returns undefined if not found.
  */
-export function getTokenById(db: Database, id: string): Token | undefined {
-  return db.prepare("SELECT * FROM tokens WHERE id = ?").get(id) as
+export async function getTokenById(
+  db: Database,
+  id: string,
+): Promise<Token | undefined> {
+  return (await db.prepare("SELECT * FROM tokens WHERE id = ?").get(id)) as
     | Token
     | undefined;
 }
@@ -136,12 +147,12 @@ export function getTokenById(db: Database, id: string): Token | undefined {
  * Slug is intentionally immutable in v1 because it is referenced by other
  * parts of the system (for example agent skill metadata).
  */
-export function updateToken(
+export async function updateToken(
   db: Database,
   slug: string,
   updates: UpdateTokenInput,
-): Token {
-  const token = getTokenBySlug(db, slug);
+): Promise<Token> {
+  const token = await getTokenBySlug(db, slug);
   if (!token) {
     throw new Error(`Token not found: ${slug}`);
   }
@@ -198,10 +209,10 @@ export function updateToken(
   values.push(new Date().toISOString());
   values.push(slug);
 
-  db.prepare(`UPDATE tokens SET ${fields.join(", ")} WHERE slug = ?`).run(
-    ...values,
-  );
-  return getTokenBySlug(db, slug)!;
+  await db
+    .prepare(`UPDATE tokens SET ${fields.join(", ")} WHERE slug = ?`)
+    .run(...values);
+  return (await getTokenBySlug(db, slug)) as Token;
 }
 
 /**
@@ -210,8 +221,11 @@ export function updateToken(
  *
  * Throws if the token does not exist or is already deprecated.
  */
-export function deprecateToken(db: Database, slug: string): Token {
-  const token = getTokenBySlug(db, slug);
+export async function deprecateToken(
+  db: Database,
+  slug: string,
+): Promise<Token> {
+  const token = await getTokenBySlug(db, slug);
   if (!token) {
     throw new Error(`Token not found: ${slug}`);
   }
@@ -220,49 +234,51 @@ export function deprecateToken(db: Database, slug: string): Token {
   }
 
   const now = new Date().toISOString();
-  db.prepare(
-    "UPDATE tokens SET deprecated_at = ?, updated_at = ? WHERE slug = ?",
-  ).run(now, now, slug);
+  await db
+    .prepare(
+      "UPDATE tokens SET deprecated_at = ?, updated_at = ? WHERE slug = ?",
+    )
+    .run(now, now, slug);
 
-  return getTokenBySlug(db, slug)!;
+  return (await getTokenBySlug(db, slug)) as Token;
 }
 
 /**
  * Preview the rows that will be removed or updated when deleting a token.
  */
-export function getTokenDeleteImpact(
+export async function getTokenDeleteImpact(
   db: Database,
   slug: string,
-): TokenDeleteImpact {
-  const token = getTokenBySlug(db, slug);
+): Promise<TokenDeleteImpact> {
+  const token = await getTokenBySlug(db, slug);
   if (!token) {
     throw new Error(`Token not found: ${slug}`);
   }
 
-  const cards = db
+  const cards = (await db
     .prepare("SELECT COUNT(*) AS n FROM cards WHERE token_id = ?")
-    .get(token.id) as { n: number };
-  const reviewLogs = db
+    .get(token.id)) as { n: number };
+  const reviewLogs = (await db
     .prepare("SELECT COUNT(*) AS n FROM review_logs WHERE token_id = ?")
-    .get(token.id) as { n: number };
-  const prereqsFrom = db
+    .get(token.id)) as { n: number };
+  const prereqsFrom = (await db
     .prepare("SELECT COUNT(*) AS n FROM prerequisites WHERE token_id = ?")
-    .get(token.id) as { n: number };
-  const prereqsTo = db
+    .get(token.id)) as { n: number };
+  const prereqsTo = (await db
     .prepare("SELECT COUNT(*) AS n FROM prerequisites WHERE requires_id = ?")
-    .get(token.id) as { n: number };
-  const sessionSteps = db
+    .get(token.id)) as { n: number };
+  const sessionSteps = (await db
     .prepare("SELECT COUNT(*) AS n FROM session_steps WHERE token_id = ?")
-    .get(token.id) as { n: number };
-  const sessionsTouched = db
+    .get(token.id)) as { n: number };
+  const sessionsTouched = (await db
     .prepare(
       "SELECT COUNT(DISTINCT session_id) AS n FROM session_steps WHERE token_id = ?",
     )
-    .get(token.id) as { n: number };
+    .get(token.id)) as { n: number };
 
-  const skillRows = db
+  const skillRows = (await db
     .prepare("SELECT token_slugs FROM agent_skills")
-    .all() as Array<{ token_slugs: string }>;
+    .all()) as Array<{ token_slugs: string }>;
   const agentSkills = skillRows.filter((row) => {
     const tokenSlugs = JSON.parse(row.token_slugs) as string[];
     return tokenSlugs.includes(slug);
@@ -282,37 +298,37 @@ export function getTokenDeleteImpact(
 /**
  * Hard-delete a token and clean up non-FK references that point at its slug.
  */
-export function deleteToken(db: Database, slug: string): DeleteTokenResult {
-  const token = getTokenBySlug(db, slug);
+export async function deleteToken(
+  db: Database,
+  slug: string,
+): Promise<DeleteTokenResult> {
+  const token = await getTokenBySlug(db, slug);
   if (!token) {
     throw new Error(`Token not found: ${slug}`);
   }
 
-  const impact = getTokenDeleteImpact(db, slug);
+  const impact = await getTokenDeleteImpact(db, slug);
 
-  db.exec("BEGIN");
-  try {
+  await db.transaction(async (tx) => {
     const now = new Date().toISOString();
-    const skillRows = db
+    const skillRows = (await tx
       .prepare("SELECT id, token_slugs FROM agent_skills")
-      .all() as Array<{ id: string; token_slugs: string }>;
+      .all()) as Array<{ id: string; token_slugs: string }>;
 
     for (const row of skillRows) {
       const tokenSlugs = JSON.parse(row.token_slugs) as string[];
       const filtered = tokenSlugs.filter((tokenSlug) => tokenSlug !== slug);
       if (filtered.length !== tokenSlugs.length) {
-        db.prepare(
-          "UPDATE agent_skills SET token_slugs = ?, updated_at = ? WHERE id = ?",
-        ).run(JSON.stringify(filtered), now, row.id);
+        await tx
+          .prepare(
+            "UPDATE agent_skills SET token_slugs = ?, updated_at = ? WHERE id = ?",
+          )
+          .run(JSON.stringify(filtered), now, row.id);
       }
     }
 
-    db.prepare("DELETE FROM tokens WHERE id = ?").run(token.id);
-    db.exec("COMMIT");
-  } catch (err) {
-    db.exec("ROLLBACK");
-    throw err;
-  }
+    await tx.prepare("DELETE FROM tokens WHERE id = ?").run(token.id);
+  });
 
   return { token, impact };
 }
@@ -329,7 +345,10 @@ export function deleteToken(db: Database, slug: string): DeleteTokenResult {
  * For very small search terms (< 3 chars) a light in-memory fallback is
  * used to avoid matching every token.
  */
-export function findTokens(db: Database, query: string): ScoredToken[] {
+export async function findTokens(
+  db: Database,
+  query: string,
+): Promise<ScoredToken[]> {
   const normalised = query.toLowerCase();
   const searchTokens = normalised
     .split(/[\s,.\-_/\\:;!?()[\]{}]+/)
@@ -350,7 +369,9 @@ export function findTokens(db: Database, query: string): ScoredToken[] {
 
   for (const term of longTerms) {
     const pattern = `%${term}%`;
-    const rows = db.prepare(likeSQL).all(pattern, pattern, pattern) as Token[];
+    const rows = (await db
+      .prepare(likeSQL)
+      .all(pattern, pattern, pattern)) as Token[];
     for (const row of rows) {
       const entry = scoreMap.get(row.id);
       if (entry) {
@@ -363,9 +384,9 @@ export function findTokens(db: Database, query: string): ScoredToken[] {
 
   // If there were short terms, or all terms were short, scan in-memory.
   if (shortTerms.length > 0 || longTerms.length === 0) {
-    const allTokens = db
+    const allTokens = (await db
       .prepare("SELECT * FROM tokens WHERE deprecated_at IS NULL")
-      .all() as Token[];
+      .all()) as Token[];
 
     for (const token of allTokens) {
       const words = `${token.slug} ${token.concept} ${token.domain}`
@@ -409,17 +430,20 @@ export function findTokens(db: Database, query: string): ScoredToken[] {
  * List all tokens, optionally filtered by domain.
  * Results are ordered by bloom_level then slug.
  */
-export function listTokens(db: Database, options?: ListTokensOptions): Token[] {
+export async function listTokens(
+  db: Database,
+  options?: ListTokensOptions,
+): Promise<Token[]> {
   if (options?.domain) {
-    return db
+    return (await db
       .prepare(
         "SELECT * FROM tokens WHERE domain = ? AND deprecated_at IS NULL ORDER BY bloom_level, slug",
       )
-      .all(options.domain) as Token[];
+      .all(options.domain)) as Token[];
   }
-  return db
+  return (await db
     .prepare(
       "SELECT * FROM tokens WHERE deprecated_at IS NULL ORDER BY bloom_level, domain, slug",
     )
-    .all() as Token[];
+    .all()) as Token[];
 }

--- a/src/kernel/recall/actions.ts
+++ b/src/kernel/recall/actions.ts
@@ -48,12 +48,12 @@ export interface ReviewActionResult {
   stopped?: boolean;
 }
 
-function getReviewTarget(
+async function getReviewTarget(
   db: Database,
   cardId: string,
   userId: string,
-): { cardId: string; token: Token } {
-  const card = getCardById(db, cardId);
+): Promise<{ cardId: string; token: Token }> {
+  const card = await getCardById(db, cardId);
   if (!card) {
     throw new Error(`Card not found: ${cardId}`);
   }
@@ -61,7 +61,7 @@ function getReviewTarget(
     throw new Error(`Card ${cardId} does not belong to user ${userId}`);
   }
 
-  const token = getTokenById(db, card.token_id);
+  const token = await getTokenById(db, card.token_id);
   if (!token) {
     throw new Error(`Token not found for card ${cardId}`);
   }
@@ -69,11 +69,11 @@ function getReviewTarget(
   return { cardId: card.id, token };
 }
 
-export function executeReviewAction(
+export async function executeReviewAction(
   db: Database,
   input: ExecuteReviewActionInput,
-): ReviewActionResult {
-  const target = getReviewTarget(db, input.cardId, input.userId);
+): Promise<ReviewActionResult> {
+  const target = await getReviewTarget(db, input.cardId, input.userId);
 
   switch (input.action) {
     case "rate": {
@@ -81,7 +81,7 @@ export function executeReviewAction(
         throw new Error("rating is required for action=rate");
       }
 
-      const evaluation = evaluateRating(db, {
+      const evaluation = await evaluateRating(db, {
         cardId: target.cardId,
         tokenId: target.token.id,
         userId: input.userId,
@@ -90,9 +90,9 @@ export function executeReviewAction(
 
       let blocked: CascadeBlockResult | undefined;
       if (input.rating === 1) {
-        const prereqs = getPrerequisites(db, target.token.id);
+        const prereqs = await getPrerequisites(db, target.token.id);
         if (prereqs.length > 0) {
-          blocked = cascadeBlock(db, input.userId, target.token.slug);
+          blocked = await cascadeBlock(db, input.userId, target.token.slug);
         }
       }
 
@@ -111,7 +111,7 @@ export function executeReviewAction(
       return { action: input.action, token: target.token, stopped: true };
 
     case "edit-token": {
-      const updatedToken = updateToken(
+      const updatedToken = await updateToken(
         db,
         target.token.slug,
         input.tokenUpdates ?? {},
@@ -124,7 +124,7 @@ export function executeReviewAction(
     }
 
     case "deprecate-token": {
-      const updatedToken = deprecateToken(db, target.token.slug);
+      const updatedToken = await deprecateToken(db, target.token.slug);
       return {
         action: input.action,
         token: target.token,
@@ -133,7 +133,7 @@ export function executeReviewAction(
     }
 
     case "delete-token": {
-      const deletedToken = deleteToken(db, target.token.slug);
+      const deletedToken = await deleteToken(db, target.token.slug);
       return {
         action: input.action,
         token: target.token,
@@ -142,7 +142,11 @@ export function executeReviewAction(
     }
 
     case "delete-card": {
-      const deletedCard = deleteCardForUser(db, target.token.id, input.userId);
+      const deletedCard = await deleteCardForUser(
+        db,
+        target.token.id,
+        input.userId,
+      );
       return {
         action: input.action,
         token: target.token,

--- a/src/kernel/recall/evaluator.ts
+++ b/src/kernel/recall/evaluator.ts
@@ -37,14 +37,14 @@ export interface EvaluateResult {
  * Note: blocking logic (cascade-block) is handled separately by the caller
  * when rating === 1 and the token has prerequisites.
  */
-export function evaluateRating(
+export async function evaluateRating(
   db: Database,
   input: EvaluateInput,
-): EvaluateResult {
+): Promise<EvaluateResult> {
   // Get current card state
-  const card = db
+  const card = (await db
     .prepare("SELECT * FROM cards WHERE id = ?")
-    .get(input.cardId) as
+    .get(input.cardId)) as
     | {
         stability: number;
         difficulty: number;
@@ -82,7 +82,7 @@ export function evaluateRating(
   const updated = fsrs.schedule(schedulingCard, input.rating, now);
 
   // Update the card in the DB
-  updateCard(db, input.cardId, {
+  await updateCard(db, input.cardId, {
     stability: updated.stability,
     difficulty: updated.difficulty,
     elapsed_days: updated.elapsedDays,
@@ -95,10 +95,12 @@ export function evaluateRating(
   });
 
   // Log the review (immutable)
-  db.prepare(
-    `INSERT INTO review_logs (id, card_id, token_id, user_id, rating, response_time_ms, reviewed_at, scheduled_at, session_id)
+  await db
+    .prepare(
+      `INSERT INTO review_logs (id, card_id, token_id, user_id, rating, response_time_ms, reviewed_at, scheduled_at, session_id)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
+    )
+    .run(
     ulid(),
     input.cardId,
     input.tokenId,

--- a/src/kernel/recall/evaluator.ts
+++ b/src/kernel/recall/evaluator.ts
@@ -101,16 +101,16 @@ export async function evaluateRating(
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
-    ulid(),
-    input.cardId,
-    input.tokenId,
-    input.userId,
-    input.rating,
-    input.responseTimeMs ?? null,
-    now.toISOString(),
-    card.due_at,
-    input.sessionId ?? null,
-  );
+      ulid(),
+      input.cardId,
+      input.tokenId,
+      input.userId,
+      input.rating,
+      input.responseTimeMs ?? null,
+      now.toISOString(),
+      card.due_at,
+      input.sessionId ?? null,
+    );
 
   return {
     nextDueAt: updated.dueAt.toISOString(),

--- a/src/kernel/scheduler/blocker.ts
+++ b/src/kernel/scheduler/blocker.ts
@@ -39,44 +39,46 @@ export interface UnblockResult {
  * @param tokenSlug - Slug of the token the user forgot
  * @returns Info about what was blocked and which prerequisites were surfaced
  */
-export function cascadeBlock(
+export async function cascadeBlock(
   db: Database,
   userId: string,
   tokenSlug: string,
-): CascadeBlockResult {
-  const token = getTokenBySlug(db, tokenSlug);
+): Promise<CascadeBlockResult> {
+  const token = await getTokenBySlug(db, tokenSlug);
   if (!token) {
     throw new Error(`Unknown token slug: ${tokenSlug}`);
   }
 
   // Ensure a card exists, then block it
-  ensureCard(db, token.id, userId);
-  db.prepare(
-    "UPDATE cards SET blocked = 1 WHERE token_id = ? AND user_id = ?",
-  ).run(token.id, userId);
+  await ensureCard(db, token.id, userId);
+  await db
+    .prepare("UPDATE cards SET blocked = 1 WHERE token_id = ? AND user_id = ?")
+    .run(token.id, userId);
 
   // Surface all direct prerequisites — ensure cards exist (unblocked, due now)
-  const prereqs = getPrerequisites(db, token.id);
+  const prereqs = await getPrerequisites(db, token.id);
   const surfaced: Array<{ slug: string; concept: string; bloomLevel: number }> =
     [];
 
   for (const prereq of prereqs) {
     // ensureCard creates a new card if missing (defaults: blocked=0, due_at=now)
-    const card = ensureCard(db, prereq.requires_id, userId);
+    const card = await ensureCard(db, prereq.requires_id, userId);
 
     // If the prerequisite card was somehow blocked with no prereqs of its own,
     // make sure it's unblocked and due now so it surfaces
     if (card.blocked === 1) {
-      const prereqOfPrereq = db
+      const prereqOfPrereq = (await db
         .prepare("SELECT COUNT(*) as n FROM prerequisites WHERE token_id = ?")
-        .get(prereq.requires_id) as { n: number };
+        .get(prereq.requires_id)) as { n: number };
 
       // Only force-unblock if it has no prerequisites of its own
       if (prereqOfPrereq.n === 0) {
         const now = new Date().toISOString();
-        db.prepare(
-          "UPDATE cards SET blocked = 0, due_at = ? WHERE token_id = ? AND user_id = ?",
-        ).run(now, prereq.requires_id, userId);
+        await db
+          .prepare(
+            "UPDATE cards SET blocked = 0, due_at = ? WHERE token_id = ? AND user_id = ?",
+          )
+          .run(now, prereq.requires_id, userId);
       }
     }
 
@@ -107,36 +109,45 @@ export function cascadeBlock(
  * @param userId - The user whose blocked cards to check
  * @returns List of cards that were unblocked
  */
-export function unblockReady(db: Database, userId: string): UnblockResult {
-  const blockedCards = db
+export async function unblockReady(
+  db: Database,
+  userId: string,
+): Promise<UnblockResult> {
+  const blockedCards = (await db
     .prepare(
       `SELECT c.token_id, t.slug, t.concept
        FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.user_id = ? AND c.blocked = 1`,
     )
-    .all(userId) as Array<{ token_id: string; slug: string; concept: string }>;
+    .all(userId)) as Array<{
+    token_id: string;
+    slug: string;
+    concept: string;
+  }>;
 
   const unblocked: Array<{ slug: string; concept: string }> = [];
 
   for (const card of blockedCards) {
-    const totalPrereqs = db
+    const totalPrereqs = (await db
       .prepare("SELECT COUNT(*) as n FROM prerequisites WHERE token_id = ?")
-      .get(card.token_id) as { n: number };
+      .get(card.token_id)) as { n: number };
 
-    const metPrereqs = db
+    const metPrereqs = (await db
       .prepare(
         `SELECT COUNT(*) as n FROM cards c
          JOIN prerequisites p ON p.requires_id = c.token_id
          WHERE p.token_id = ? AND c.user_id = ? AND c.reps >= 1 AND c.blocked = 0`,
       )
-      .get(card.token_id, userId) as { n: number };
+      .get(card.token_id, userId)) as { n: number };
 
     if (totalPrereqs.n === 0 || metPrereqs.n === totalPrereqs.n) {
       const now = new Date().toISOString();
-      db.prepare(
-        "UPDATE cards SET blocked = 0, due_at = ? WHERE token_id = ? AND user_id = ?",
-      ).run(now, card.token_id, userId);
+      await db
+        .prepare(
+          "UPDATE cards SET blocked = 0, due_at = ? WHERE token_id = ? AND user_id = ?",
+        )
+        .run(now, card.token_id, userId);
 
       unblocked.push({ slug: card.slug, concept: card.concept });
     }

--- a/src/kernel/scheduler/queue.ts
+++ b/src/kernel/scheduler/queue.ts
@@ -70,17 +70,17 @@ interface CardRow {
  * @param options - Queue building options
  * @returns The assembled review queue with metadata
  */
-export function buildReviewQueue(
+export async function buildReviewQueue(
   db: Database,
   options: ReviewQueueOptions,
-): ReviewQueue {
+): Promise<ReviewQueue> {
   const maxNew = options.maxNew ?? 10;
   const maxReviews = options.maxReviews ?? 50;
   const now = options.now ?? new Date();
   const nowISO = now.toISOString();
 
   // ── Step 1: Fetch due cards (review, relearning, learning — not new) ───
-  const dueRows = db
+  const dueRows = (await db
     .prepare(
       `SELECT
          c.id       AS card_id,
@@ -102,10 +102,10 @@ export function buildReviewQueue(
          AND t.deprecated_at IS NULL
        ORDER BY c.due_at ASC`,
     )
-    .all(options.userId, nowISO) as CardRow[];
+    .all(options.userId, nowISO)) as CardRow[];
 
   // ── Step 2: Fetch new cards ────────────────────────────────────────────
-  const newRows = db
+  const newRows = (await db
     .prepare(
       `SELECT
          c.id       AS card_id,
@@ -127,7 +127,7 @@ export function buildReviewQueue(
        ORDER BY t.bloom_level ASC, t.slug ASC
        LIMIT ?`,
     )
-    .all(options.userId, maxNew) as CardRow[];
+    .all(options.userId, maxNew)) as CardRow[];
 
   // ── Step 3: Sort overdue cards by urgency (most overdue first) ─────────
   const nowMs = now.getTime();

--- a/src/kernel/system/repos.ts
+++ b/src/kernel/system/repos.ts
@@ -13,11 +13,12 @@ export interface RepoPaths {
  * Resolve absolute paths for personal, team, and organization repositories.
  * Personal falls back to personal.workspace_dir if repo.personal is not set.
  */
-export function getRepoPaths(db: Database): RepoPaths {
+export async function getRepoPaths(db: Database): Promise<RepoPaths> {
   const personalSetting =
-    getSetting(db, "repo.personal") || getSetting(db, "personal.workspace_dir");
-  const teamSetting = getSetting(db, "repo.team");
-  const orgSetting = getSetting(db, "repo.org");
+    (await getSetting(db, "repo.personal")) ||
+    (await getSetting(db, "personal.workspace_dir"));
+  const teamSetting = await getSetting(db, "repo.team");
+  const orgSetting = await getSetting(db, "repo.org");
 
   return {
     personal: personalSetting ? resolve(personalSetting) : null,
@@ -29,11 +30,11 @@ export function getRepoPaths(db: Database): RepoPaths {
 /**
  * Resolve a specific repo's path, or null if not configured.
  */
-export function resolveRepoPath(
+export async function resolveRepoPath(
   db: Database,
   type: "personal" | "team" | "org",
-): string | null {
-  const paths = getRepoPaths(db);
+): Promise<string | null> {
+  const paths = await getRepoPaths(db);
   return paths[type];
 }
 
@@ -41,8 +42,8 @@ export function resolveRepoPath(
  * Resolve paths to all existing "/beliefs" directories in the hierarchy,
  * sorted from most specific (personal) to most general (org).
  */
-export function resolveAllBeliefPaths(db: Database): string[] {
-  const paths = getRepoPaths(db);
+export async function resolveAllBeliefPaths(db: Database): Promise<string[]> {
+  const paths = await getRepoPaths(db);
   const dirs: string[] = [];
 
   if (paths.personal) {
@@ -65,8 +66,8 @@ export function resolveAllBeliefPaths(db: Database): string[] {
  * Resolve paths to all existing "/goals" directories in the hierarchy,
  * sorted from most specific (personal) to most general (org).
  */
-export function resolveAllGoalPaths(db: Database): string[] {
-  const paths = getRepoPaths(db);
+export async function resolveAllGoalPaths(db: Database): Promise<string[]> {
+  const paths = await getRepoPaths(db);
   const dirs: string[] = [];
 
   if (paths.personal) {

--- a/tests/cli/llm.test.ts
+++ b/tests/cli/llm.test.ts
@@ -19,27 +19,27 @@ describe("LLM client utilities (CLI layer)", () => {
   });
 
   it("ensureLocalLlmRunning reports 'disabled' immediately if llm.enabled is false", async () => {
-    const db = openDatabase({
+    const db = await openDatabase({
       dbPath: ":memory:",
       initialize: true,
       useConfiguredCloud: false,
     });
-    setSetting(db, "llm.enabled", "false");
+    await setSetting(db, "llm.enabled", "false");
 
     const readiness = await ensureLocalLlmRunning(db);
     expect(readiness).toEqual({ usable: false, reason: "disabled" });
-    db.close();
+    await db.close();
   });
 
   it("ensureLocalLlmRunning reports 'model-not-found' when the server doesn't serve the configured model", async () => {
-    const db = openDatabase({
+    const db = await openDatabase({
       dbPath: ":memory:",
       initialize: true,
       useConfiguredCloud: false,
     });
-    setSetting(db, "llm.enabled", "true");
-    setSetting(db, "llm.url", "http://localhost:8000/v1");
-    setSetting(db, "llm.model", "gemma4-it:e4b");
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(db, "llm.url", "http://localhost:8000/v1");
+    await setSetting(db, "llm.model", "gemma4-it:e4b");
 
     const originalFetch = global.fetch;
     // Server is reachable, but /models lists a different model than configured.
@@ -53,7 +53,7 @@ describe("LLM client utilities (CLI layer)", () => {
       expect(readiness.reason).toBe("model-not-found");
     } finally {
       global.fetch = originalFetch;
-      db.close();
+      await db.close();
     }
   });
 
@@ -72,16 +72,16 @@ describe("LLM client utilities (CLI layer)", () => {
   });
 
   it("ensureHighQualityQuestion dynamically generates and self-heals a missing question when LLM is enabled", async () => {
-    const db = openDatabase({
+    const db = await openDatabase({
       dbPath: ":memory:",
       initialize: true,
       useConfiguredCloud: false,
     });
-    setSetting(db, "llm.enabled", "true");
-    setSetting(db, "llm.url", "http://dummy/v1");
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(db, "llm.url", "http://dummy/v1");
 
     const slug = "test-self-heal-" + Date.now();
-    const token = createToken(db, {
+    const token = await createToken(db, {
       slug,
       concept: "Azure DevOps secure HTTPS credential storage on macOS Keychain",
       domain: "DevOps",
@@ -119,13 +119,13 @@ describe("LLM client utilities (CLI layer)", () => {
       );
 
       // Verify that it self-healed in the database!
-      const updated = getTokenBySlug(db, slug);
+      const updated = await getTokenBySlug(db, slug);
       expect(updated?.question).toBe(
         "How do you securely store Azure DevOps HTTPS credentials on macOS?",
       );
     } finally {
       global.fetch = originalFetch;
-      db.close();
+      await db.close();
     }
   });
 });

--- a/tests/helpers/db-contract.ts
+++ b/tests/helpers/db-contract.ts
@@ -1,0 +1,188 @@
+/**
+ * Provider contract suite — every `Database` implementation must pass these,
+ * independent of the concrete database package behind it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../../src/kernel/db/types.js";
+
+export interface ContractContext {
+  db: Database;
+  cleanup(): Promise<void>;
+}
+
+export function describeDatabaseContract(
+  name: string,
+  open: () => Promise<ContractContext>,
+): void {
+  describe(`database contract: ${name}`, () => {
+    let ctx: ContractContext;
+
+    beforeEach(async () => {
+      ctx = await open();
+      await ctx.db.exec(
+        `CREATE TABLE items (
+           id INTEGER PRIMARY KEY AUTOINCREMENT,
+           label TEXT NOT NULL,
+           weight REAL,
+           payload BLOB
+         );
+         CREATE TABLE audit (item_id INTEGER NOT NULL);`,
+      );
+    });
+
+    afterEach(async () => {
+      await ctx.cleanup();
+    });
+
+    it("run reports changes and lastInsertRowid", async () => {
+      const first = await ctx.db
+        .prepare("INSERT INTO items (label) VALUES (?)")
+        .run("alpha");
+      expect(first.changes).toBe(1);
+      expect(Number(first.lastInsertRowid)).toBe(1);
+
+      const update = await ctx.db
+        .prepare("UPDATE items SET label = ? WHERE label = ?")
+        .run("beta", "alpha");
+      expect(update.changes).toBe(1);
+    });
+
+    it("get returns a plain row object, or undefined when empty", async () => {
+      await ctx.db.prepare("INSERT INTO items (label) VALUES (?)").run("alpha");
+
+      const row = (await ctx.db
+        .prepare("SELECT id, label FROM items WHERE label = ?")
+        .get("alpha")) as { id: number; label: string };
+      expect(row).toEqual({ id: 1, label: "alpha" });
+
+      const missing = await ctx.db
+        .prepare("SELECT id FROM items WHERE label = ?")
+        .get("nope");
+      expect(missing).toBeUndefined();
+    });
+
+    it("all returns every row in order", async () => {
+      const insert = ctx.db.prepare("INSERT INTO items (label) VALUES (?)");
+      await insert.run("a");
+      await insert.run("b");
+
+      const rows = (await ctx.db
+        .prepare("SELECT label FROM items ORDER BY id")
+        .all()) as Array<{ label: string }>;
+      expect(rows.map((r) => r.label)).toEqual(["a", "b"]);
+    });
+
+    it("round-trips text, integers, floats, nulls, and blobs", async () => {
+      const payload = new Uint8Array([0, 1, 254, 255]);
+      await ctx.db
+        .prepare(
+          "INSERT INTO items (label, weight, payload) VALUES (?, ?, ?)",
+        )
+        .run("blob-row", 2.5, payload);
+      await ctx.db
+        .prepare("INSERT INTO items (label, weight, payload) VALUES (?, ?, ?)")
+        .run("null-row", null, null);
+
+      const blobRow = (await ctx.db
+        .prepare("SELECT label, weight, payload FROM items WHERE label = ?")
+        .get("blob-row")) as {
+        label: string;
+        weight: number;
+        payload: Uint8Array;
+      };
+      expect(blobRow.weight).toBe(2.5);
+      expect(new Uint8Array(blobRow.payload)).toEqual(payload);
+
+      const nullRow = (await ctx.db
+        .prepare("SELECT weight, payload FROM items WHERE label = ?")
+        .get("null-row")) as { weight: null; payload: null };
+      expect(nullRow.weight).toBeNull();
+      expect(nullRow.payload).toBeNull();
+
+      const big = (await ctx.db
+        .prepare("SELECT 9007199254740991 AS n")
+        .get()) as { n: number };
+      expect(big.n).toBe(9007199254740991);
+    });
+
+    it("rejects parameters SQLite cannot bind", async () => {
+      const stmt = ctx.db.prepare("INSERT INTO items (label) VALUES (?)");
+      await expect(stmt.run(undefined)).rejects.toThrow();
+      await expect(stmt.run(true)).rejects.toThrow();
+    });
+
+    it("exec runs multiple statements", async () => {
+      await ctx.db.exec(
+        `INSERT INTO items (label) VALUES ('one');
+         INSERT INTO items (label) VALUES ('two');`,
+      );
+      const rows = await ctx.db.prepare("SELECT id FROM items").all();
+      expect(rows).toHaveLength(2);
+    });
+
+    it("pragma table_info describes columns on every provider", async () => {
+      const cols = (await ctx.db.pragma("table_info(items)")) as Array<{
+        name: string;
+      }>;
+      expect(cols.map((c) => c.name)).toEqual([
+        "id",
+        "label",
+        "weight",
+        "payload",
+      ]);
+    });
+
+    it("propagates SQL errors with their message", async () => {
+      await expect(
+        ctx.db.prepare("SELECT * FROM missing_table").all(),
+      ).rejects.toThrow(/missing_table/);
+    });
+
+    it("transaction commits multi-table writes atomically", async () => {
+      await ctx.db.transaction(async (tx) => {
+        const item = await tx
+          .prepare("INSERT INTO items (label) VALUES (?)")
+          .run("tx");
+        await tx
+          .prepare("INSERT INTO audit (item_id) VALUES (?)")
+          .run(item.lastInsertRowid);
+      });
+
+      expect(await ctx.db.prepare("SELECT * FROM audit").all()).toHaveLength(1);
+    });
+
+    it("transaction rolls back every write on error", async () => {
+      await expect(
+        ctx.db.transaction(async (tx) => {
+          await tx.prepare("INSERT INTO items (label) VALUES (?)").run("doomed");
+          await tx.prepare("INSERT INTO audit (item_id) VALUES (?)").run(1);
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      expect(await ctx.db.prepare("SELECT * FROM items").all()).toHaveLength(0);
+      expect(await ctx.db.prepare("SELECT * FROM audit").all()).toHaveLength(0);
+    });
+
+    it("serializes concurrent transactions instead of interleaving", async () => {
+      const order: string[] = [];
+      await Promise.all([
+        ctx.db.transaction(async (tx) => {
+          order.push("a:start");
+          await tx.prepare("INSERT INTO items (label) VALUES ('a')").run();
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          order.push("a:end");
+        }),
+        ctx.db.transaction(async (tx) => {
+          order.push("b:start");
+          await tx.prepare("INSERT INTO items (label) VALUES ('b')").run();
+          order.push("b:end");
+        }),
+      ]);
+
+      expect(order).toEqual(["a:start", "a:end", "b:start", "b:end"]);
+      expect(await ctx.db.prepare("SELECT * FROM items").all()).toHaveLength(2);
+    });
+  });
+}

--- a/tests/helpers/db-contract.ts
+++ b/tests/helpers/db-contract.ts
@@ -76,9 +76,7 @@ export function describeDatabaseContract(
     it("round-trips text, integers, floats, nulls, and blobs", async () => {
       const payload = new Uint8Array([0, 1, 254, 255]);
       await ctx.db
-        .prepare(
-          "INSERT INTO items (label, weight, payload) VALUES (?, ?, ?)",
-        )
+        .prepare("INSERT INTO items (label, weight, payload) VALUES (?, ?, ?)")
         .run("blob-row", 2.5, payload);
       await ctx.db
         .prepare("INSERT INTO items (label, weight, payload) VALUES (?, ?, ?)")
@@ -155,7 +153,9 @@ export function describeDatabaseContract(
     it("transaction rolls back every write on error", async () => {
       await expect(
         ctx.db.transaction(async (tx) => {
-          await tx.prepare("INSERT INTO items (label) VALUES (?)").run("doomed");
+          await tx
+            .prepare("INSERT INTO items (label) VALUES (?)")
+            .run("doomed");
           await tx.prepare("INSERT INTO audit (item_id) VALUES (?)").run(1);
           throw new Error("boom");
         }),

--- a/tests/helpers/hrana-stub.ts
+++ b/tests/helpers/hrana-stub.ts
@@ -161,9 +161,7 @@ export async function startHranaStub(options?: {
     }
   });
 
-  await new Promise<void>((resolve) =>
-    server.listen(0, "127.0.0.1", resolve),
-  );
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
   if (address === null || typeof address === "string") {
     throw new Error("Failed to bind hrana stub server");

--- a/tests/helpers/hrana-stub.ts
+++ b/tests/helpers/hrana-stub.ts
@@ -1,0 +1,181 @@
+/**
+ * In-process Hrana v3 HTTP stub backed by a real better-sqlite3 database.
+ *
+ * Lets the remote provider's full encode/transport/decode path run against
+ * genuine SQLite semantics in tests, without Turso credentials or network
+ * access. Implements the protocol subset ZAM uses: execute, sequence, close,
+ * and baton-scoped streams.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import BetterSqlite3 from "better-sqlite3";
+
+interface HranaValue {
+  type: "null" | "integer" | "float" | "text" | "blob";
+  value?: string | number;
+  base64?: string;
+}
+
+interface HranaRequestBody {
+  baton: string | null;
+  requests: Array<{
+    type: "execute" | "sequence" | "close";
+    stmt?: { sql: string; args?: HranaValue[]; want_rows?: boolean };
+    sql?: string;
+  }>;
+}
+
+function decodeArg(value: HranaValue): unknown {
+  switch (value.type) {
+    case "null":
+      return null;
+    case "integer":
+      return Number(value.value);
+    case "float":
+      return value.value;
+    case "text":
+      return value.value;
+    case "blob":
+      return Buffer.from(value.base64 ?? "", "base64");
+  }
+}
+
+function encodeCell(value: unknown): HranaValue {
+  if (value === null || value === undefined) return { type: "null" };
+  if (typeof value === "bigint") {
+    return { type: "integer", value: value.toString() };
+  }
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? { type: "integer", value: value.toString() }
+      : { type: "float", value };
+  }
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    return { type: "blob", base64: Buffer.from(value).toString("base64") };
+  }
+  return { type: "text", value: String(value) };
+}
+
+export interface HranaStub {
+  url: string;
+  /** Auth tokens accepted; empty set accepts everything. */
+  close(): Promise<void>;
+}
+
+export async function startHranaStub(options?: {
+  /** Require this bearer token and answer 401 otherwise. */
+  authToken?: string;
+  /** Delay every response (for timeout tests). */
+  delayMs?: number;
+}): Promise<HranaStub> {
+  const db = new BetterSqlite3(":memory:");
+  const openBatons = new Set<string>();
+
+  const handle = (body: HranaRequestBody) => {
+    const results: unknown[] = [];
+    let closed = false;
+
+    for (const request of body.requests) {
+      try {
+        if (request.type === "execute" && request.stmt) {
+          const stmt = db.prepare(request.stmt.sql);
+          const args = (request.stmt.args ?? []).map(decodeArg);
+          if (stmt.reader) {
+            const rows = stmt.raw(true).all(...args) as unknown[][];
+            results.push({
+              type: "ok",
+              response: {
+                type: "execute",
+                result: {
+                  cols: stmt.columns().map((c) => ({ name: c.name })),
+                  rows: rows.map((row) => row.map(encodeCell)),
+                  affected_row_count: 0,
+                  last_insert_rowid: null,
+                },
+              },
+            });
+          } else {
+            const info = stmt.run(...args);
+            results.push({
+              type: "ok",
+              response: {
+                type: "execute",
+                result: {
+                  cols: [],
+                  rows: [],
+                  affected_row_count: info.changes,
+                  last_insert_rowid: String(info.lastInsertRowid),
+                },
+              },
+            });
+          }
+        } else if (request.type === "sequence") {
+          db.exec(request.sql ?? "");
+          results.push({ type: "ok", response: { type: "sequence" } });
+        } else {
+          closed = true;
+          results.push({ type: "ok", response: { type: "close" } });
+        }
+      } catch (err) {
+        results.push({
+          type: "error",
+          error: { message: (err as Error).message },
+        });
+      }
+    }
+
+    if (body.baton) openBatons.delete(body.baton);
+    let baton: string | null = null;
+    if (!closed) {
+      baton = randomUUID();
+      openBatons.add(baton);
+    }
+    return { baton, base_url: null, results };
+  };
+
+  const server: Server = createServer((req, res) => {
+    const respond = () => {
+      if (
+        options?.authToken &&
+        req.headers.authorization !== `Bearer ${options.authToken}`
+      ) {
+        res.writeHead(401).end("unauthorized");
+        return;
+      }
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk as Buffer));
+      req.on("end", () => {
+        const body = JSON.parse(
+          Buffer.concat(chunks).toString(),
+        ) as HranaRequestBody;
+        res
+          .writeHead(200, { "content-type": "application/json" })
+          .end(JSON.stringify(handle(body)));
+      });
+    };
+    if (options?.delayMs) {
+      setTimeout(respond, options.delayMs);
+    } else {
+      respond();
+    }
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", resolve),
+  );
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Failed to bind hrana stub server");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    async close() {
+      db.close();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    },
+  };
+}

--- a/tests/integration/token-card-review.test.ts
+++ b/tests/integration/token-card-review.test.ts
@@ -9,15 +9,14 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   addPrerequisite,
-  type Database,
   buildReviewQueue,
   createToken,
+  type Database,
   ensureCard,
   evaluateRating,
   executeReviewAction,
   findTokens,
   getDependents,
-  getDueCards,
   getPrerequisites,
   getTokenBySlug,
   openDatabase,
@@ -29,16 +28,16 @@ describe("integration: token → card → review flow", () => {
   let db: Database;
   let tempDir: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), "zam-integration-"));
-    db = openDatabase({
+    db = await openDatabase({
       dbPath: join(tempDir, "zam-test.db"),
       initialize: true,
     });
   });
 
-  afterEach(() => {
-    db.close();
+  afterEach(async () => {
+    await db.close();
     try {
       rmSync(tempDir, {
         recursive: true,
@@ -54,85 +53,85 @@ describe("integration: token → card → review flow", () => {
   // ── Prerequisite cycle detection ─────────────────────────────────────────
 
   describe("prerequisite cycle detection", () => {
-    it("rejects a direct self-loop", () => {
-      const a = createToken(db, {
+    it("rejects a direct self-loop", async () => {
+      const a = await createToken(db, {
         slug: "token-a",
         concept: "Concept A",
         domain: "test",
         bloom_level: 1,
       });
-      expect(() => addPrerequisite(db, a.id, a.id)).toThrow(
+      await expect(addPrerequisite(db, a.id, a.id)).rejects.toThrow(
         "A token cannot be a prerequisite of itself",
       );
     });
 
-    it("rejects a direct back-edge (A → B, then B → A)", () => {
-      const a = createToken(db, {
+    it("rejects a direct back-edge (A → B, then B → A)", async () => {
+      const a = await createToken(db, {
         slug: "token-a",
         concept: "Concept A",
         domain: "test",
         bloom_level: 1,
       });
-      const b = createToken(db, {
+      const b = await createToken(db, {
         slug: "token-b",
         concept: "Concept B",
         domain: "test",
         bloom_level: 1,
       });
 
-      addPrerequisite(db, a.id, b.id);
-      expect(() => addPrerequisite(db, b.id, a.id)).toThrow(
+      await addPrerequisite(db, a.id, b.id);
+      await expect(addPrerequisite(db, b.id, a.id)).rejects.toThrow(
         "Cannot add prerequisite: would create a cycle",
       );
     });
 
-    it("rejects a transitive cycle (A → B → C, then C → A)", () => {
-      const a = createToken(db, {
+    it("rejects a transitive cycle (A → B → C, then C → A)", async () => {
+      const a = await createToken(db, {
         slug: "token-a",
         concept: "Concept A",
         domain: "test",
         bloom_level: 1,
       });
-      const b = createToken(db, {
+      const b = await createToken(db, {
         slug: "token-b",
         concept: "Concept B",
         domain: "test",
         bloom_level: 1,
       });
-      const c = createToken(db, {
+      const c = await createToken(db, {
         slug: "token-c",
         concept: "Concept C",
         domain: "test",
         bloom_level: 1,
       });
 
-      addPrerequisite(db, a.id, b.id);
-      addPrerequisite(db, b.id, c.id);
-      expect(() => addPrerequisite(db, c.id, a.id)).toThrow(
+      await addPrerequisite(db, a.id, b.id);
+      await addPrerequisite(db, b.id, c.id);
+      await expect(addPrerequisite(db, c.id, a.id)).rejects.toThrow(
         "Cannot add prerequisite: would create a cycle",
       );
     });
 
-    it("allows valid acyclic edges (diamond: D → B, D → C, B → A, C → A)", () => {
-      const a = createToken(db, {
+    it("allows valid acyclic edges (diamond: D → B, D → C, B → A, C → A)", async () => {
+      const a = await createToken(db, {
         slug: "token-a",
         concept: "Concept A",
         domain: "test",
         bloom_level: 1,
       });
-      const b = createToken(db, {
+      const b = await createToken(db, {
         slug: "token-b",
         concept: "Concept B",
         domain: "test",
         bloom_level: 1,
       });
-      const c = createToken(db, {
+      const c = await createToken(db, {
         slug: "token-c",
         concept: "Concept C",
         domain: "test",
         bloom_level: 1,
       });
-      const d = createToken(db, {
+      const d = await createToken(db, {
         slug: "token-d",
         concept: "Concept D",
         domain: "test",
@@ -140,70 +139,70 @@ describe("integration: token → card → review flow", () => {
       });
 
       // Diamond: D requires B and C; B and C both require A
-      addPrerequisite(db, b.id, a.id);
-      addPrerequisite(db, c.id, a.id);
-      addPrerequisite(db, d.id, b.id);
-      addPrerequisite(db, d.id, c.id);
+      await addPrerequisite(db, b.id, a.id);
+      await addPrerequisite(db, c.id, a.id);
+      await addPrerequisite(db, d.id, b.id);
+      await addPrerequisite(db, d.id, c.id);
 
       // Verify the structure
-      expect(getPrerequisites(db, d.id)).toHaveLength(2);
-      expect(getDependents(db, a.id)).toHaveLength(2);
+      expect(await getPrerequisites(db, d.id)).toHaveLength(2);
+      expect(await getDependents(db, a.id)).toHaveLength(2);
     });
 
-    it("wouldCreateCycle returns false for disconnected tokens", () => {
-      const a = createToken(db, {
+    it("wouldCreateCycle returns false for disconnected tokens", async () => {
+      const a = await createToken(db, {
         slug: "token-a",
         concept: "Concept A",
         domain: "test",
         bloom_level: 1,
       });
-      const b = createToken(db, {
+      const b = await createToken(db, {
         slug: "token-b",
         concept: "Concept B",
         domain: "test",
         bloom_level: 1,
       });
-      expect(wouldCreateCycle(db, a.id, b.id)).toBe(false);
+      expect(await wouldCreateCycle(db, a.id, b.id)).toBe(false);
     });
 
-    it("idempotent duplicate edge does not throw", () => {
-      const a = createToken(db, {
+    it("idempotent duplicate edge does not throw", async () => {
+      const a = await createToken(db, {
         slug: "token-a",
         concept: "Concept A",
         domain: "test",
         bloom_level: 1,
       });
-      const b = createToken(db, {
+      const b = await createToken(db, {
         slug: "token-b",
         concept: "Concept B",
         domain: "test",
         bloom_level: 1,
       });
 
-      addPrerequisite(db, a.id, b.id);
+      await addPrerequisite(db, a.id, b.id);
       // Adding the same edge again should be a no-op, not a cycle error
-      expect(() => addPrerequisite(db, a.id, b.id)).not.toThrow();
-      expect(getPrerequisites(db, a.id)).toHaveLength(1);
+      await expect(addPrerequisite(db, a.id, b.id)).resolves.not.toThrow();
+      expect(await getPrerequisites(db, a.id)).toHaveLength(1);
     });
   });
 
   // ── Fuzzy search ─────────────────────────────────────────────────────────
 
   describe("findTokens fuzzy search", () => {
-    beforeEach(() => {
-      createToken(db, {
+    beforeEach(async () => {
+      await createToken(db, {
         slug: "git-commit",
         concept: "git commit records staged changes to the repository",
         domain: "git",
         bloom_level: 2,
       });
-      createToken(db, {
+      await createToken(db, {
         slug: "git-branch",
         concept: "git branch lists, creates, or deletes branches",
         domain: "git",
         bloom_level: 1,
       });
-      createToken(db, {
+      await createToken(db, {
         slug: "docker-run",
         concept: "docker run starts a new container from an image",
         domain: "docker",
@@ -211,25 +210,25 @@ describe("integration: token → card → review flow", () => {
       });
     });
 
-    it("finds tokens by slug keyword", () => {
-      const results = findTokens(db, "branch");
+    it("finds tokens by slug keyword", async () => {
+      const results = await findTokens(db, "branch");
       expect(results).toHaveLength(1);
       expect(results[0].slug).toBe("git-branch");
     });
 
-    it("finds tokens by concept text", () => {
-      const results = findTokens(db, "container");
+    it("finds tokens by concept text", async () => {
+      const results = await findTokens(db, "container");
       expect(results).toHaveLength(1);
       expect(results[0].slug).toBe("docker-run");
     });
 
-    it("returns empty for no match", () => {
-      const results = findTokens(db, "nonexistent123");
+    it("returns empty for no match", async () => {
+      const results = await findTokens(db, "nonexistent123");
       expect(results).toHaveLength(0);
     });
 
-    it("ranks by word overlap score", () => {
-      const results = findTokens(db, "git branch");
+    it("ranks by word overlap score", async () => {
+      const results = await findTokens(db, "git branch");
       expect(results.length).toBeGreaterThanOrEqual(2);
       // "git-branch" should score higher than plain "git" tokens
       expect(results[0].slug).toBe("git-branch");
@@ -239,8 +238,8 @@ describe("integration: token → card → review flow", () => {
   // ── Token → Card → Review flow ───────────────────────────────────────────
 
   describe("token → card → review lifecycle", () => {
-    it("creates a token, ensures a card, rates it, and shows due cards", () => {
-      const token = createToken(db, {
+    it("creates a token, ensures a card, rates it, and shows due cards", async () => {
+      const token = await createToken(db, {
         slug: "test-concept",
         concept: "A test concept for integration testing",
         domain: "testing",
@@ -251,13 +250,13 @@ describe("integration: token → card → review flow", () => {
       expect(token.bloom_level).toBe(2);
 
       // Card does not exist yet
-      const card = ensureCard(db, token.id, "thomas");
+      const card = await ensureCard(db, token.id, "thomas");
       expect(card.token_id).toBe(token.id);
       expect(card.user_id).toBe("thomas");
       expect(card.state).toBe("new");
 
       // Rate the card
-      const result = evaluateRating(db, {
+      const result = await evaluateRating(db, {
         cardId: card.id,
         tokenId: token.id,
         userId: "thomas",
@@ -270,7 +269,8 @@ describe("integration: token → card → review flow", () => {
 
       // The card should now be in the due queue (scheduled for future)
       // Newly rated cards won't be "due" yet, but the queue building works
-      const queue = buildReviewQueue(db, "thomas", {
+      const queue = await buildReviewQueue(db, {
+        userId: "thomas",
         maxNew: 5,
         maxReviews: 10,
       });
@@ -279,26 +279,26 @@ describe("integration: token → card → review flow", () => {
       expect(queue.items.length).toBeGreaterThanOrEqual(0);
     });
 
-    it("full lifecycle: token → prerequisite chain → block → unblock", () => {
-      const prereq = createToken(db, {
+    it("full lifecycle: token → prerequisite chain → block → unblock", async () => {
+      const prereq = await createToken(db, {
         slug: "prerequisite-token",
         concept: "A prerequisite concept",
         domain: "testing",
         bloom_level: 1,
       });
-      const target = createToken(db, {
+      const target = await createToken(db, {
         slug: "target-token",
         concept: "A dependent concept",
         domain: "testing",
         bloom_level: 2,
       });
 
-      addPrerequisite(db, target.id, prereq.id);
+      await addPrerequisite(db, target.id, prereq.id);
 
-      const targetCard = ensureCard(db, target.id, "thomas");
+      const targetCard = await ensureCard(db, target.id, "thomas");
 
       // Rating 1 (forgot) on the target should cascade-block it and surface prerequisites
-      const result = executeReviewAction(db, {
+      const result = await executeReviewAction(db, {
         action: "rate",
         cardId: targetCard.id,
         userId: "thomas",
@@ -312,12 +312,12 @@ describe("integration: token → card → review flow", () => {
       expect(result.blocked?.prerequisites[0]?.slug).toBe(prereq.slug);
 
       // The target card should now be blocked
-      const blockedToken = getTokenBySlug(db, target.slug);
+      const blockedToken = await getTokenBySlug(db, target.slug);
       expect(blockedToken).toBeDefined();
 
       // Learn the prerequisite
-      const prereqCard = ensureCard(db, prereq.id, "thomas");
-      executeReviewAction(db, {
+      const prereqCard = await ensureCard(db, prereq.id, "thomas");
+      await executeReviewAction(db, {
         action: "rate",
         cardId: prereqCard.id,
         userId: "thomas",
@@ -325,7 +325,7 @@ describe("integration: token → card → review flow", () => {
       });
 
       // Now unblock — the target should become ready
-      const unblocked = unblockReady(db, "thomas");
+      const unblocked = await unblockReady(db, "thomas");
       expect(unblocked.unblocked.length).toBeGreaterThanOrEqual(1);
       expect(unblocked.unblocked.some((u) => u.slug === target.slug)).toBe(
         true,

--- a/tests/kernel/database-backend.test.ts
+++ b/tests/kernel/database-backend.test.ts
@@ -13,31 +13,33 @@ afterEach(() => {
 });
 
 describe("local database backend", () => {
-  it("opens and persists a local SQLite database without libsql features", () => {
+  it("opens and persists a local SQLite database without libsql features", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zam-local-sqlite-"));
     tempDirs.push(dir);
     const dbPath = join(dir, "zam.db");
 
-    const first = openDatabase({
+    const first = await openDatabase({
       dbPath,
       initialize: true,
       useConfiguredCloud: false,
     });
-    first
+    await first
       .prepare("INSERT INTO user_config (key, value) VALUES (?, ?)")
       .run("arm64.test", "ready");
-    first.close();
+    await first.close();
 
-    const second = openDatabase({
+    const second = await openDatabase({
       dbPath,
       useConfiguredCloud: false,
     });
-    const row = second
+    const row = (await second
       .prepare("SELECT value FROM user_config WHERE key = ?")
-      .get("arm64.test") as { value: string };
+      .get("arm64.test")) as { value: string };
 
     expect(row.value).toBe("ready");
-    expect(second.pragma("journal_mode")).toEqual([{ journal_mode: "wal" }]);
-    second.close();
+    expect(await second.pragma("journal_mode")).toEqual([
+      { journal_mode: "wal" },
+    ]);
+    await second.close();
   });
 });

--- a/tests/kernel/provider-contract.test.ts
+++ b/tests/kernel/provider-contract.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Runs the provider contract against every Database implementation and adds
+ * remote-transport-specific cases (auth, offline, timeout).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import BetterSqlite3 from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { toHttpUrl } from "../../src/kernel/db/remote/hrana.js";
+import { openRemoteDatabase } from "../../src/kernel/db/remote/provider.js";
+import { wrapSyncDatabase } from "../../src/kernel/db/sync-adapter.js";
+import type { SyncDatabase } from "../../src/kernel/db/types.js";
+import { describeDatabaseContract } from "../helpers/db-contract.js";
+import { startHranaStub } from "../helpers/hrana-stub.js";
+
+describeDatabaseContract("local SQLite (better-sqlite3)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "zam-contract-"));
+  const driver = new BetterSqlite3(
+    join(dir, "contract.db"),
+  ) as unknown as SyncDatabase;
+  const db = wrapSyncDatabase(driver);
+  return {
+    db,
+    async cleanup() {
+      await db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+});
+
+describeDatabaseContract("remote Turso over HTTP (hrana stub)", async () => {
+  const stub = await startHranaStub();
+  const db = openRemoteDatabase({ url: stub.url });
+  return {
+    db,
+    async cleanup() {
+      await db.close();
+      await stub.close();
+    },
+  };
+});
+
+describe("remote provider transport behavior", () => {
+  it("authenticates with the configured bearer token", async () => {
+    const stub = await startHranaStub({ authToken: "secret" });
+    try {
+      const db = openRemoteDatabase({ url: stub.url, authToken: "secret" });
+      expect(await db.prepare("SELECT 1 AS one").get()).toEqual({ one: 1 });
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("reports rejected credentials with an actionable message", async () => {
+    const stub = await startHranaStub({ authToken: "secret" });
+    try {
+      const db = openRemoteDatabase({ url: stub.url, authToken: "wrong" });
+      await expect(db.prepare("SELECT 1").get()).rejects.toThrow(
+        /zam connector setup turso/,
+      );
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("reports unreachable hosts with an actionable offline message", async () => {
+    const db = openRemoteDatabase({
+      url: "http://127.0.0.1:9",
+      maxAttempts: 2,
+    });
+    await expect(db.prepare("SELECT 1").get()).rejects.toThrow(
+      /Cannot reach the Turso database .* ZAM_DB_PROVIDER=local/s,
+    );
+  });
+
+  it("times out slow servers instead of hanging", async () => {
+    const stub = await startHranaStub({ delayMs: 500 });
+    try {
+      const db = openRemoteDatabase({ url: stub.url, timeoutMs: 50 });
+      await expect(db.prepare("SELECT 1").get()).rejects.toThrow(
+        /Cannot reach the Turso database/,
+      );
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("normalizes libsql:// and ws:// URLs to HTTP equivalents", () => {
+    expect(toHttpUrl("libsql://db.example.turso.io")).toBe(
+      "https://db.example.turso.io",
+    );
+    expect(toHttpUrl("wss://db.example.turso.io/")).toBe(
+      "https://db.example.turso.io",
+    );
+    expect(toHttpUrl("ws://127.0.0.1:8080")).toBe("http://127.0.0.1:8080");
+    expect(toHttpUrl("https://db.example.turso.io")).toBe(
+      "https://db.example.turso.io",
+    );
+  });
+});

--- a/tests/kernel/provider-contract.test.ts
+++ b/tests/kernel/provider-contract.test.ts
@@ -71,7 +71,7 @@ describe("remote provider transport behavior", () => {
       maxAttempts: 2,
     });
     await expect(db.prepare("SELECT 1").get()).rejects.toThrow(
-      /Cannot reach the Turso database .* ZAM_DB_PROVIDER=local/s,
+      /Cannot reach the Turso database .*ZAM_DB_PROVIDER=local/s,
     );
   });
 

--- a/tests/kernel/repos.test.ts
+++ b/tests/kernel/repos.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  type Database,
   getRepoPaths,
   openDatabase,
   resolveAllBeliefPaths,
@@ -13,9 +14,9 @@ import {
 const TEST_DIR = resolve("./temp-test-repos");
 
 describe("Multi-Repo Context Settings", () => {
-  let db: any;
+  let db: Database;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     // Create temporary folders for testing directory resolution
     mkdirSync(TEST_DIR, { recursive: true });
     mkdirSync(join(TEST_DIR, "personal", "beliefs"), { recursive: true });
@@ -23,79 +24,79 @@ describe("Multi-Repo Context Settings", () => {
     mkdirSync(join(TEST_DIR, "team", "beliefs"), { recursive: true });
     mkdirSync(join(TEST_DIR, "org", "goals"), { recursive: true });
 
-    db = openDatabase({
+    db = await openDatabase({
       dbPath: ":memory:",
       initialize: true,
       useConfiguredCloud: false,
     });
   });
 
-  afterAll(() => {
-    db.close();
+  afterAll(async () => {
+    await db.close();
     // Clean up temporary folders
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true, force: true });
     }
   });
 
-  it("should return null paths when nothing is configured", () => {
-    const paths = getRepoPaths(db);
+  it("should return null paths when nothing is configured", async () => {
+    const paths = await getRepoPaths(db);
     expect(paths.personal).toBeNull();
     expect(paths.team).toBeNull();
     expect(paths.org).toBeNull();
   });
 
-  it("should fall back to personal.workspace_dir for personal repo", () => {
+  it("should fall back to personal.workspace_dir for personal repo", async () => {
     const personalPath = join(TEST_DIR, "personal");
-    setSetting(db, "personal.workspace_dir", personalPath);
+    await setSetting(db, "personal.workspace_dir", personalPath);
 
-    const paths = getRepoPaths(db);
+    const paths = await getRepoPaths(db);
     expect(paths.personal).toBe(resolve(personalPath));
     expect(paths.team).toBeNull();
     expect(paths.org).toBeNull();
   });
 
-  it("should prefer repo.personal over personal.workspace_dir", () => {
+  it("should prefer repo.personal over personal.workspace_dir", async () => {
     const personalPath = join(TEST_DIR, "personal");
     const customPersonalPath = join(TEST_DIR, "custom-personal");
-    setSetting(db, "personal.workspace_dir", personalPath);
-    setSetting(db, "repo.personal", customPersonalPath);
+    await setSetting(db, "personal.workspace_dir", personalPath);
+    await setSetting(db, "repo.personal", customPersonalPath);
 
-    const paths = getRepoPaths(db);
+    const paths = await getRepoPaths(db);
     expect(paths.personal).toBe(resolve(customPersonalPath));
   });
 
-  it("should resolve team and org repos correctly", () => {
+  it("should resolve team and org repos correctly", async () => {
     const teamPath = join(TEST_DIR, "team");
     const orgPath = join(TEST_DIR, "org");
-    setSetting(db, "repo.team", teamPath);
-    setSetting(db, "repo.org", orgPath);
+    await setSetting(db, "repo.team", teamPath);
+    await setSetting(db, "repo.org", orgPath);
 
-    const paths = getRepoPaths(db);
+    const paths = await getRepoPaths(db);
     expect(paths.team).toBe(resolve(teamPath));
     expect(paths.org).toBe(resolve(orgPath));
   });
 
-  it("should resolve single repo path using resolveRepoPath", () => {
+  it("should resolve single repo path using resolveRepoPath", async () => {
     const personalPath = resolve(join(TEST_DIR, "custom-personal"));
-    const resolved = resolveRepoPath(db, "personal");
+    const resolved = await resolveRepoPath(db, "personal");
     expect(resolved).toBe(personalPath);
   });
 
-  it("should resolve all existing beliefs directories", () => {
+  it("should resolve all existing beliefs directories", async () => {
     // Set personal repo to the one with the beliefs folder
     const personalPath = join(TEST_DIR, "personal");
-    setSetting(db, "repo.personal", personalPath);
+    await setSetting(db, "repo.personal", personalPath);
 
-    const beliefDirs = resolveAllBeliefPaths(db);
+    const beliefDirs = await resolveAllBeliefPaths(db);
     // Personal and Team have beliefs folder, Org does not
     expect(beliefDirs.length).toBe(2);
     expect(beliefDirs[0]).toBe(resolve(personalPath, "beliefs"));
     expect(beliefDirs[1]).toBe(resolve(join(TEST_DIR, "team", "beliefs")));
   });
 
-  it("should resolve all existing goals directories", () => {
-    const goalDirs = resolveAllGoalPaths(db);
+  it("should resolve all existing goals directories", async () => {
+    const goalDirs = await resolveAllGoalPaths(db);
     // Personal and Org have goals folder, Team does not
     expect(goalDirs.length).toBe(2);
     expect(goalDirs[0]).toBe(resolve(join(TEST_DIR, "personal", "goals")));

--- a/tests/kernel/review-maintenance.test.ts
+++ b/tests/kernel/review-maintenance.test.ts
@@ -4,9 +4,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   addPrerequisite,
-  type Database,
   createAgentSkill,
   createToken,
+  type Database,
   deleteCardForUser,
   deleteToken,
   ensureCard,
@@ -29,16 +29,16 @@ describe("review maintenance primitives", () => {
   let db: Database;
   let tempDir: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), "zam-core-"));
-    db = openDatabase({
+    db = await openDatabase({
       dbPath: join(tempDir, "zam-test.db"),
       initialize: true,
     });
   });
 
-  afterEach(() => {
-    db.close();
+  afterEach(async () => {
+    await db.close();
     try {
       rmSync(tempDir, {
         recursive: true,
@@ -51,8 +51,8 @@ describe("review maintenance primitives", () => {
     }
   });
 
-  it("updates mutable token fields without changing the slug", () => {
-    const token = createToken(db, {
+  it("updates mutable token fields without changing the slug", async () => {
+    const token = await createToken(db, {
       slug: "git-current-branch",
       concept: "git branch shows branches",
       domain: "git",
@@ -62,7 +62,7 @@ describe("review maintenance primitives", () => {
 
     expect(token.source_link).toBe("src/git.ts#L10");
 
-    const updated = updateToken(db, token.slug, {
+    const updated = await updateToken(db, token.slug, {
       concept: "git branch marks the current branch with *",
       domain: "github",
       bloom_level: 2,
@@ -79,55 +79,55 @@ describe("review maintenance primitives", () => {
     expect(updated.symbiosis_mode).toBe("copilot");
     expect(updated.source_link).toBe("src/git.ts#L25");
 
-    const cleared = updateToken(db, token.slug, {
+    const cleared = await updateToken(db, token.slug, {
       source_link: null,
     });
     expect(cleared.source_link).toBeNull();
   });
 
-  it("previews and deletes a token with dependent learning data and skill references", () => {
-    const prerequisite = createToken(db, {
+  it("previews and deletes a token with dependent learning data and skill references", async () => {
+    const prerequisite = await createToken(db, {
       slug: "shell-start-dir",
       concept: "find starts from a directory",
       domain: "shell",
       bloom_level: 1,
     });
-    const target = createToken(db, {
+    const target = await createToken(db, {
       slug: "shell-find-command",
       concept: "find recursively searches directory trees",
       domain: "shell",
       bloom_level: 2,
     });
 
-    addPrerequisite(db, target.id, prerequisite.id);
+    await addPrerequisite(db, target.id, prerequisite.id);
 
-    const card = ensureCard(db, prerequisite.id, "thomas");
-    executeReviewAction(db, {
+    const card = await ensureCard(db, prerequisite.id, "thomas");
+    await executeReviewAction(db, {
       action: "rate",
       cardId: card.id,
       userId: "thomas",
       rating: 3,
     });
 
-    const session = startSession(db, {
+    const session = await startSession(db, {
       user_id: "thomas",
       task: "Review shell concepts",
     });
-    logStep(db, {
+    await logStep(db, {
       session_id: session.id,
       token_id: prerequisite.id,
       done_by: "user",
       rating: 3,
     });
 
-    createAgentSkill(db, {
+    await createAgentSkill(db, {
       slug: "shell-find-workflow",
       description: "Use find to scan a tree",
       steps: ["open terminal", "run find"],
       token_slugs: [prerequisite.slug, target.slug],
     });
 
-    const impact = getTokenDeleteImpact(db, prerequisite.slug);
+    const impact = await getTokenDeleteImpact(db, prerequisite.slug);
     expect(impact).toEqual({
       cards: 1,
       review_logs: 1,
@@ -138,72 +138,72 @@ describe("review maintenance primitives", () => {
       agent_skills: 1,
     });
 
-    const deleted = deleteToken(db, prerequisite.slug);
+    const deleted = await deleteToken(db, prerequisite.slug);
     expect(deleted.impact).toEqual(impact);
-    expect(getTokenBySlug(db, prerequisite.slug)).toBeUndefined();
-    expect(getCard(db, prerequisite.id, "thomas")).toBeUndefined();
-    expect(getReviewsForCard(db, card.id)).toHaveLength(0);
-    expect(getPrerequisites(db, target.id)).toEqual([]);
-    expect(listAgentSkills(db)[0].token_slugs).toEqual([target.slug]);
+    expect(await getTokenBySlug(db, prerequisite.slug)).toBeUndefined();
+    expect(await getCard(db, prerequisite.id, "thomas")).toBeUndefined();
+    expect(await getReviewsForCard(db, card.id)).toHaveLength(0);
+    expect(await getPrerequisites(db, target.id)).toEqual([]);
+    expect((await listAgentSkills(db))[0].token_slugs).toEqual([target.slug]);
   });
 
-  it("deletes one user's card while preserving the token and session history", () => {
-    const token = createToken(db, {
+  it("deletes one user's card while preserving the token and session history", async () => {
+    const token = await createToken(db, {
       slug: "zam-token-vs-card",
       concept: "tokens define concepts while cards track user state",
       domain: "zam",
       bloom_level: 2,
     });
 
-    const card = ensureCard(db, token.id, "thomas");
-    executeReviewAction(db, {
+    const card = await ensureCard(db, token.id, "thomas");
+    await executeReviewAction(db, {
       action: "rate",
       cardId: card.id,
       userId: "thomas",
       rating: 4,
     });
 
-    const session = startSession(db, {
+    const session = await startSession(db, {
       user_id: "thomas",
       task: "Review ZAM concepts",
     });
-    logStep(db, {
+    await logStep(db, {
       session_id: session.id,
       token_id: token.id,
       done_by: "user",
       rating: 4,
     });
 
-    expect(getCardDeletionImpact(db, token.id, "thomas")).toEqual({
+    expect(await getCardDeletionImpact(db, token.id, "thomas")).toEqual({
       review_logs: 1,
     });
 
-    const deleted = deleteCardForUser(db, token.id, "thomas");
+    const deleted = await deleteCardForUser(db, token.id, "thomas");
     expect(deleted.impact).toEqual({ review_logs: 1 });
-    expect(getTokenBySlug(db, token.slug)).toBeTruthy();
-    expect(getCard(db, token.id, "thomas")).toBeUndefined();
-    expect(getReviewsForCard(db, card.id)).toHaveLength(0);
-    expect(getSessionSummary(db, session.id).steps).toHaveLength(1);
+    expect(await getTokenBySlug(db, token.slug)).toBeTruthy();
+    expect(await getCard(db, token.id, "thomas")).toBeUndefined();
+    expect(await getReviewsForCard(db, card.id)).toHaveLength(0);
+    expect((await getSessionSummary(db, session.id)).steps).toHaveLength(1);
   });
 
-  it("routes rating=1 through prerequisite blocking in executeReviewAction", () => {
-    const prerequisite = createToken(db, {
+  it("routes rating=1 through prerequisite blocking in executeReviewAction", async () => {
+    const prerequisite = await createToken(db, {
       slug: "git-branches",
       concept: "branches isolate lines of work",
       domain: "git",
       bloom_level: 1,
     });
-    const target = createToken(db, {
+    const target = await createToken(db, {
       slug: "git-show-current",
       concept: "git branch --show-current prints the current branch",
       domain: "git",
       bloom_level: 2,
     });
 
-    addPrerequisite(db, target.id, prerequisite.id);
-    const card = ensureCard(db, target.id, "thomas");
+    await addPrerequisite(db, target.id, prerequisite.id);
+    const card = await ensureCard(db, target.id, "thomas");
 
-    const result = executeReviewAction(db, {
+    const result = await executeReviewAction(db, {
       action: "rate",
       cardId: card.id,
       userId: "thomas",
@@ -216,16 +216,16 @@ describe("review maintenance primitives", () => {
     expect(result.blocked?.prerequisites[0]?.slug).toBe(prerequisite.slug);
   });
 
-  it("edits and short-circuits review actions without mutating scheduling unexpectedly", () => {
-    const token = createToken(db, {
+  it("edits and short-circuits review actions without mutating scheduling unexpectedly", async () => {
+    const token = await createToken(db, {
       slug: "macos-brew-cask",
       concept: "brew install --cask installs GUI apps",
       domain: "macos",
       bloom_level: 2,
     });
-    const card = ensureCard(db, token.id, "thomas");
+    const card = await ensureCard(db, token.id, "thomas");
 
-    const edited = executeReviewAction(db, {
+    const edited = await executeReviewAction(db, {
       action: "edit-token",
       cardId: card.id,
       userId: "thomas",
@@ -235,14 +235,14 @@ describe("review maintenance primitives", () => {
       "brew install --cask installs GUI macOS apps",
     );
 
-    const skipped = executeReviewAction(db, {
+    const skipped = await executeReviewAction(db, {
       action: "skip",
       cardId: card.id,
       userId: "thomas",
     });
     expect(skipped.skipped).toBe(true);
 
-    const stopped = executeReviewAction(db, {
+    const stopped = await executeReviewAction(db, {
       action: "stop",
       cardId: card.id,
       userId: "thomas",


### PR DESCRIPTION
## Summary

Implements Increment 10 Phases 1–3 (`increments/10 - Async Database Providers & Turso Sync.md`).

**Phase 1 — Async contract.** The public `Database`/`Statement` types are now an async contract (`src/kernel/db/types.ts`); no kernel or public API type depends on a concrete database package. better-sqlite3 and the optional native libsql replica are lifted through a sync adapter (`sync-adapter.ts`) with serialized `BEGIN IMMEDIATE` transactions.

**Phase 2 — Kernel + CLI migration.** All models, scheduler, recall, analytics, settings, repos, every CLI command, the desktop bridge, and the LLM client converted to async; entrypoint uses `parseAsync`. `deleteToken`'s pre-existing manual BEGIN/COMMIT became a `db.transaction()`; all other flows keep their exact statement-by-statement behavior.

**Phase 3 — Remote Turso over HTTP.** A hand-rolled Hrana v3 HTTP transport (`db/remote/hrana.ts`, ~250 lines, zero new runtime dependencies, no native bindings) with per-request timeout, bounded retries only for provably-pre-response failures (ECONNREFUSED/DNS — never risks duplicate writes), actionable auth and offline errors, and baton-scoped interactive transactions. Provider selection is explicit: `ConnectionOptions.provider` > `ZAM_DB_PROVIDER` > credentials `mode` (set via `zam connector setup turso --mode native|remote`); defaults unchanged (local without creds, native libsql with creds).

**Tests.** A provider contract suite runs identically against local SQLite and the remote provider via an in-process hrana stub backed by real better-sqlite3 — covering round-trips (text/int/float/null/blob), errors, transactions (commit/rollback/serialization), pragma table_info, plus transport tests (401, offline, timeout, URL normalization). It runs on every CI platform including `windows-11-arm`, satisfying "test the provider on Windows ARM64 CI". 157 tests green; typecheck, biome, build green; CLI smoke (setup → whoami → stats → token register) verified against the built dist.

## Notes

- Native `libsql` stays optional and untouched for Thomas's existing native-mode machines (Phase 5 removal comes after migration).
- Windows ARM64 users can now use cloud Turso via `--mode remote` — previously impossible (no native binding).
- Phase 4 (local-to-cloud promotion) is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)