### PR TITLE
test: raise getSystemProfile timeout for cold CI runners

### DIFF
--- a/tests/kernel/system.test.ts
+++ b/tests/kernel/system.test.ts
@@ -18,7 +18,9 @@ import {
 
 describe("System Profiling & Tool Detections", () => {
   describe("getSystemProfile", () => {
-    it("returns a valid profile matching OS structure", () => {
+    // Hardware probing shells out (WMI on Windows); cold CI runners can take
+    // well over the default 5s — seen at 7s on the windows-11-arm runner.
+    it("returns a valid profile matching OS structure", { timeout: 30_000 }, () => {
       const profile = getSystemProfile();
       expect(profile).toHaveProperty("os");
       expect(profile).toHaveProperty("arch");


### PR DESCRIPTION
Flaked on the windows-11-arm runner in the PR #32 run (7s actual vs 5s default, docs-only diff). Per-test 30s timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)