### PR TITLE
[codex] Support retroactive prerequisite blocking

### DIFF
--- a/.agent/skills/zam/SKILL.md
+++ b/.agent/skills/zam/SKILL.md
@@ -30,6 +30,7 @@ zam token deprecate --slug <slug>          # mark outdated knowledge
 # Card & review management
 zam card due --user <username>
 zam card update --user <username> --token <slug> --rating <1-4>
+zam card block --user <username> --token <slug>
 zam card unblock --user <username>
 
 # Sessions
@@ -412,16 +413,22 @@ zam token register \
 
 # 2. Wire it as a prerequisite of the high-level token
 zam token prereq --token <high-level-slug> --requires <parent-slug>-<gap-keyword>
+
+# 3. Block the high-level card after all new prerequisites are wired
+zam card block --user <username> --token <high-level-slug>
 ```
 
-### What happens next (automatic)
+### What happens next
 
-After wiring prerequisites:
-- The high-level token is **automatically blocked** because it was rated 1
-  and its prerequisites haven't been recalled yet (Blocking Rule)
+After wiring prerequisites and blocking the card:
+- The high-level token is removed from the review queue
 - The next review session will surface the *foundation tokens first*
 - Once all prerequisites reach `reps >= 1`, `zam card unblock` promotes the
   high-level token back into the review queue
+
+If prerequisites already existed when the token was rated 1, the rating command
+blocks it automatically. Use `zam card block` when the missing prerequisites were
+discovered and registered only after the rating.
 
 ### Example: High-school history
 
@@ -445,6 +452,7 @@ Agent wires them:
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-staende
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-begriffe
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-daten
+zam card block --user <username> --token ge-aufklaerung
 ```
 
 `ge-aufklaerung` is now blocked. Next session: foundations first. When they

--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -33,6 +33,7 @@ zam token deprecate --slug <slug>          # mark outdated knowledge
 # Card & review management
 zam card due --user <username>
 zam card update --user <username> --token <slug> --rating <1-4>
+zam card block --user <username> --token <slug>
 zam card unblock --user <username>
 
 # Sessions
@@ -416,16 +417,22 @@ zam token register \
 
 # 2. Wire it as a prerequisite of the high-level token
 zam token prereq --token <high-level-slug> --requires <parent-slug>-<gap-keyword>
+
+# 3. Block the high-level card after all new prerequisites are wired
+zam card block --user <username> --token <high-level-slug>
 ```
 
-### What happens next (automatic)
+### What happens next
 
-After wiring prerequisites:
-- The high-level token is **automatically blocked** because it was rated 1
-  and its prerequisites haven't been recalled yet (Blocking Rule)
+After wiring prerequisites and blocking the card:
+- The high-level token is removed from the review queue
 - The next review session will surface the *foundation tokens first*
 - Once all prerequisites reach `reps >= 1`, `zam card unblock` promotes the
   high-level token back into the review queue
+
+If prerequisites already existed when the token was rated 1, the rating command
+blocks it automatically. Use `zam card block` when the missing prerequisites were
+discovered and registered only after the rating.
 
 ### Example: High-school history
 
@@ -449,6 +456,7 @@ Agent wires them:
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-staende
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-begriffe
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-daten
+zam card block --user <username> --token ge-aufklaerung
 ```
 
 `ge-aufklaerung` is now blocked. Next session: foundations first. When they

--- a/.claude/skills/zam/SKILL.md
+++ b/.claude/skills/zam/SKILL.md
@@ -30,6 +30,7 @@ zam token deprecate --slug <slug>          # mark outdated knowledge
 # Card & review management
 zam card due --user <username>
 zam card update --user <username> --token <slug> --rating <1-4>
+zam card block --user <username> --token <slug>
 zam card unblock --user <username>
 
 # Sessions
@@ -412,16 +413,22 @@ zam token register \
 
 # 2. Wire it as a prerequisite of the high-level token
 zam token prereq --token <high-level-slug> --requires <parent-slug>-<gap-keyword>
+
+# 3. Block the high-level card after all new prerequisites are wired
+zam card block --user <username> --token <high-level-slug>
 ```
 
-### What happens next (automatic)
+### What happens next
 
-After wiring prerequisites:
-- The high-level token is **automatically blocked** because it was rated 1
-  and its prerequisites haven't been recalled yet (Blocking Rule)
+After wiring prerequisites and blocking the card:
+- The high-level token is removed from the review queue
 - The next `/zam` session will surface the *foundation tokens first*
 - Once all prerequisites reach `reps >= 1`, `zam card unblock` promotes the
   high-level token back into the review queue
+
+If prerequisites already existed when the token was rated 1, the rating command
+blocks it automatically. Use `zam card block` when the missing prerequisites were
+discovered and registered only after the rating.
 
 ### Example: High-school history
 
@@ -445,6 +452,7 @@ Agent wires them:
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-staende
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-begriffe
 zam token prereq --token ge-aufklaerung --requires ge-aufklaerung-daten
+zam card block --user <username> --token ge-aufklaerung
 ```
 
 `ge-aufklaerung` is now blocked. Next session: foundations first. When they

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,6 +161,8 @@ These are template-based (not LLM-generated). The AI skill layer uses them as st
 6. Return result (next due date, stability, state)
 
 Blocking logic is **not** in the evaluator. Callers invoke `cascadeBlock()` separately after a rating of 1.
+If prerequisites are discovered and added only after the rating, run
+`zam card block --user <id> --token <slug>` to invoke the same blocking path.
 
 ---
 
@@ -275,7 +277,7 @@ src/
 │   └── commands/
 │       ├── init.ts               ← zam init
 │       ├── token.ts              ← zam token register/find/list/prereq/deprecate/status
-│       ├── card.ts               ← zam card due/update/unblock
+│       ├── card.ts               ← zam card due/update/block/unblock
 │       ├── review.ts             ← zam review (interactive)
 │       ├── session.ts            ← zam session start/log/end
 │       ├── stats.ts              ← zam stats

--- a/src/cli/commands/card.ts
+++ b/src/cli/commands/card.ts
@@ -165,6 +165,47 @@ cardCommand
     });
   });
 
+// ── zam card block ────────────────────────────────────────────────────────
+
+cardCommand
+  .command("block")
+  .description("Block a card and surface its prerequisites")
+  .option("--user <id>", "User ID (default: whoami)")
+  .requiredOption("--token <slug>", "Token slug")
+  .option("--json", "Output as JSON")
+  .option("--quiet", "Suppress output (exit code only)")
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await resolveUser(opts, db);
+      const token = await getTokenBySlug(db, opts.token);
+      if (!token) {
+        console.error(`Token not found: ${opts.token}`);
+        process.exit(1);
+      }
+
+      const prereqs = await getPrerequisites(db, token.id);
+      if (prereqs.length === 0) {
+        console.error(
+          `Cannot block ${opts.token}: token has no prerequisites.`,
+        );
+        process.exit(1);
+      }
+
+      const result = await cascadeBlock(db, userId, token.slug);
+
+      if (opts.quiet) return;
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      console.log(`Blocked ${result.blockedSlug}. Prerequisites surfaced:`);
+      for (const prerequisite of result.prerequisites) {
+        console.log(`  - ${prerequisite.slug}: ${prerequisite.concept}`);
+      }
+    });
+  });
+
 // ── zam card unblock ──────────────────────────────────────────────────────
 
 cardCommand

--- a/src/kernel/scheduler/blocker.ts
+++ b/src/kernel/scheduler/blocker.ts
@@ -49,6 +49,11 @@ export async function cascadeBlock(
     throw new Error(`Unknown token slug: ${tokenSlug}`);
   }
 
+  const prereqs = await getPrerequisites(db, token.id);
+  if (prereqs.length === 0) {
+    throw new Error(`Cannot block ${tokenSlug}: token has no prerequisites`);
+  }
+
   // Ensure a card exists, then block it
   await ensureCard(db, token.id, userId);
   await db
@@ -56,7 +61,6 @@ export async function cascadeBlock(
     .run(token.id, userId);
 
   // Surface all direct prerequisites — ensure cards exist (unblocked, due now)
-  const prereqs = await getPrerequisites(db, token.id);
   const surfaced: Array<{ slug: string; concept: string; bloomLevel: number }> =
     [];
 

--- a/tests/integration/token-card-review.test.ts
+++ b/tests/integration/token-card-review.test.ts
@@ -10,13 +10,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   addPrerequisite,
   buildReviewQueue,
+  cascadeBlock,
   createToken,
   type Database,
   ensureCard,
   evaluateRating,
   executeReviewAction,
   findTokens,
+  getCard,
   getDependents,
+  getDueCards,
   getPrerequisites,
   getTokenBySlug,
   openDatabase,
@@ -330,6 +333,87 @@ describe("integration: token → card → review flow", () => {
       expect(unblocked.unblocked.some((u) => u.slug === target.slug)).toBe(
         true,
       );
+    });
+
+    it("blocks retroactively after missing prerequisites are discovered", async () => {
+      const target = await createToken(db, {
+        slug: "analyze-enlightenment",
+        concept: "Analyze how Enlightenment ideas shaped political change",
+        domain: "history",
+        bloom_level: 4,
+      });
+      const targetCard = await ensureCard(db, target.id, "thomas");
+
+      const rating = await executeReviewAction(db, {
+        action: "rate",
+        cardId: targetCard.id,
+        userId: "thomas",
+        rating: 1,
+      });
+
+      expect(rating.blocked).toBeUndefined();
+      expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(0);
+
+      const prerequisite = await createToken(db, {
+        slug: "define-popular-sovereignty",
+        concept: "Popular sovereignty means political authority comes from the people",
+        domain: "history",
+        bloom_level: 1,
+      });
+      await addPrerequisite(db, target.id, prerequisite.id);
+
+      const blocked = await cascadeBlock(db, "thomas", target.slug);
+      expect(blocked.blockedSlug).toBe(target.slug);
+      expect(blocked.prerequisites).toEqual([
+        {
+          slug: prerequisite.slug,
+          concept: prerequisite.concept,
+          bloomLevel: prerequisite.bloom_level,
+        },
+      ]);
+      expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(1);
+
+      const prerequisiteCard = await getCard(
+        db,
+        prerequisite.id,
+        "thomas",
+      );
+      expect(prerequisiteCard).toBeDefined();
+      expect(prerequisiteCard?.blocked).toBe(0);
+
+      const dueSlugs = (await getDueCards(db, "thomas")).map(
+        (card) => card.slug,
+      );
+      expect(dueSlugs).toContain(prerequisite.slug);
+      expect(dueSlugs).not.toContain(target.slug);
+
+      await executeReviewAction(db, {
+        action: "rate",
+        cardId: prerequisiteCard!.id,
+        userId: "thomas",
+        rating: 3,
+      });
+
+      const unblocked = await unblockReady(db, "thomas");
+      expect(unblocked.unblocked).toContainEqual({
+        slug: target.slug,
+        concept: target.concept,
+      });
+      expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(0);
+    });
+
+    it("refuses to block a token without prerequisites", async () => {
+      const token = await createToken(db, {
+        slug: "standalone-token",
+        concept: "A token without prerequisites",
+        domain: "testing",
+        bloom_level: 2,
+      });
+
+      await expect(cascadeBlock(db, "thomas", token.slug)).rejects.toThrow(
+        "Cannot block standalone-token: token has no prerequisites",
+      );
+      expect(await getCard(db, token.id, "thomas")).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Collaboration

This follow-up was designed jointly with Thomas Josefczak after reviewing the dynamic token decomposition workflow in PR #34. Thomas is the commit author, with OpenAI Codex recorded as co-author.

## What changed

- Add `zam card block --user <id> --token <slug>` with JSON and quiet output modes.
- Reuse the existing prerequisite cascade to block the high-level card and surface direct prerequisite cards.
- Reject explicit blocking when the token has no prerequisites.
- Update all bundled ZAM skill variants and the architecture reference with the post-hoc decomposition workflow.
- Add integration coverage for rating first, discovering prerequisites later, blocking, learning the foundation, and unblocking.

## Why

Dynamic token decomposition can discover missing foundation knowledge only after a high-level token has already been rated. The existing automatic path checks prerequisites at rating time, so prerequisites added afterward did not block the high-level card. This command exposes the existing cascade explicitly for that post-hoc case.

## Impact

Agents can now register newly discovered foundation tokens, wire them as prerequisites, and immediately remove the high-level token from the review queue until those foundations have been recalled.

## Validation

- `npm run test` (159 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm pack --dry-run`
- CLI smoke test against a temporary local database for both successful blocking and the no-prerequisite error path
