### PR TITLE
[codex] Harden desktop release v0.3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,11 @@ jobs:
       - name: Prepare bundled desktop bridge
         run: npm run desktop:prepare -- --bundle-node
 
-      - name: Smoke-test bundled desktop bridge
-        run: desktop/src-tauri/resources/zam-cli/runtime/node desktop/src-tauri/resources/zam-cli/dist/cli/index.js bridge --help
+      - name: Smoke-test bundled desktop bridge on a clean machine
+        run: |
+          export HOME="$RUNNER_TEMP/zam-first-run"
+          desktop/src-tauri/resources/zam-cli/runtime/node desktop/src-tauri/resources/zam-cli/dist/cli/index.js bridge desktop-bootstrap
+          desktop/src-tauri/resources/zam-cli/runtime/node desktop/src-tauri/resources/zam-cli/dist/cli/index.js bridge check-due
 
       - name: Install desktop dependencies
         working-directory: desktop
@@ -81,7 +84,7 @@ jobs:
 
       - name: Check Tauri backend
         working-directory: desktop/src-tauri
-        run: cargo check
+        run: cargo check --locked
 
   windows-arm64:
     runs-on: windows-11-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,25 @@ jobs:
       - name: Prepare Self-Contained Desktop Bridge
         run: npm run desktop:prepare -- --bundle-node
 
+      - name: Verify locked Rust dependency graph
+        working-directory: desktop/src-tauri
+        run: cargo metadata --locked --format-version 1 --no-deps
+
+      - name: Smoke-test first launch (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          export HOME="$RUNNER_TEMP/zam-first-run"
+          desktop/src-tauri/resources/zam-cli/runtime/node desktop/src-tauri/resources/zam-cli/dist/cli/index.js bridge desktop-bootstrap
+          desktop/src-tauri/resources/zam-cli/runtime/node desktop/src-tauri/resources/zam-cli/dist/cli/index.js bridge check-due
+
+      - name: Smoke-test first launch (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: pwsh
+        run: |
+          $env:USERPROFILE = Join-Path $env:RUNNER_TEMP "zam-first-run"
+          & ".\desktop\src-tauri\resources\zam-cli\runtime\node.exe" ".\desktop\src-tauri\resources\zam-cli\dist\cli\index.js" bridge desktop-bootstrap
+          & ".\desktop\src-tauri\resources\zam-cli\runtime\node.exe" ".\desktop\src-tauri\resources\zam-cli\dist\cli\index.js" bridge check-due
+
       - name: Install dependencies (Desktop Application)
         working-directory: desktop
         run: npm ci

--- a/README.de.md
+++ b/README.de.md
@@ -77,7 +77,7 @@ ZAM ist das Werkzeug für den Übergang in eine Welt, in der Fürsorge und gemei
 
 ZAM enthält nun eine plattformübergreifende Desktop-Anwendung im Verzeichnis [`desktop/`](desktop/). Entwickelt mit **Tauri v2**, **Vite**, **TypeScript** und **Vanilla CSS**, bietet sie ein hochmodernes Dark-Mode-Lernstudio, das dieselbe SQLite-Datenbank wie das CLI nutzt.
 
-### Starten unter Windows oder macOS:
+### Starten unter Windows, macOS oder Linux:
 
 1. **CLI Bridge kompilieren**:
    Stelle sicher, dass der neueste CLI-Code im Hauptverzeichnis kompiliert ist:
@@ -98,7 +98,7 @@ Dies kompiliert das Rust-Backend im Hintergrund, startet den Vite-Entwicklungsse
 
 ### 📦 Automatische GitHub Releases & Native Installer
 
-Wir haben eine **GitHub Actions CI/CD-Pipeline** integriert, die automatisch native Installationsdateien (Windows `.msi`/`.exe`, macOS `.dmg` und Linux `.deb`/`.AppImage`) kompiliert und verpackt, sobald ein neuer Git-Tag gepusht wird.
+Wir haben eine **GitHub Actions CI/CD-Pipeline** integriert, die derzeit native Installationsdateien für Windows (`.msi`/`.exe`) und Linux (`.deb`/`.rpm`/`.AppImage`) kompiliert und verpackt, sobald ein neuer Git-Tag gepusht wird. macOS kann weiterhin aus dem Quellcode gebaut werden; signierte und notarisierte macOS-Release-Artefakte folgen, sobald der Apple-Signing-Account verfügbar ist.
 
 Um eine neue Version zu veröffentlichen (z.B. `v0.1.0`):
 
@@ -110,7 +110,7 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
-Dies startet automatisch die Build-Umgebungen auf GitHub-Runnern und erstellt einen Entwurf (Draft) für ein GitHub Release, das alle kompilierten Installationsdateien enthält!
+Dies startet automatisch die Windows- und Linux-Builds auf GitHub-Runnern und erstellt einen Entwurf (Draft) mit den kompilierten Installationsdateien.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ ZAM is a tool for the transition to a world where care and shared growth are the
 
 ZAM now includes a cross-platform desktop application inside the [`desktop/`](desktop/) directory. Built with **Tauri v2**, **Vite**, **TypeScript**, and **Vanilla CSS**, it provides a premium dark-mode dashboard and active-recall learning studio that securely shares the same SQLite database as the CLI.
 
-### How to Run on Windows or macOS:
+### How to Run on Windows, macOS, or Linux:
 
 1. **Build the CLI Bridge**:
    Ensure you have compiled the latest CLI code in the repository root:
@@ -118,7 +118,7 @@ This will compile the secure Rust backend, spin up the Vite development server, 
 
 ### 📦 Automated GitHub Releases & Native Installers
 
-We have integrated a **GitHub Actions CI/CD workflow** that automatically compiles and packages native installers (Windows `.msi`/`.exe`, macOS Intel/Silicon `.dmg`, and Linux `.deb`/`.AppImage`) when a new git tag is pushed.
+We have integrated a **GitHub Actions CI/CD workflow** that currently compiles and packages native installers for Windows (`.msi`/`.exe`) and Linux (`.deb`/`.rpm`/`.AppImage`) when a new git tag is pushed. macOS builds remain supported from source, but signed/notarized macOS release artifacts are deferred until the Apple signing account is available.
 
 To release a new version (e.g., `v0.1.0`):
 
@@ -130,7 +130,7 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
-This automatically spins up the multi-platform compiler environments on GitHub and creates a drafted GitHub Release containing the native redistributables for all platforms!
+This automatically spins up the Windows and Linux compiler environments on GitHub and creates a drafted GitHub Release containing their native redistributables.
 
 ---
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the **ZAM Cross-Platform Desktop GUI**! This native desktop application co-exists with the ZAM CLI, utilizing a **100% DRY architecture** by executing the compiled ZAM CLI bridge directly via a secure Rust backend. This enables native execution across **Windows, macOS, and Linux**, securely sharing the local SQLite database at `~/.zam/zam.db`.
 
+Published release installers currently target Windows and Linux. macOS source builds are supported, while signed/notarized macOS release artifacts are deferred until Apple signing is configured.
+
 ---
 
 ## ⚡ Quick start: `zam ui`
@@ -111,7 +113,7 @@ To verify the bundle and package a standalone native binary for your platform:
 # Verify TypeScript & Vite compilation inside desktop/
 npm run build
 
-# Package into a native production installer/executable (Windows: .msi/.exe, macOS: .dmg/.app, Linux: .deb/.AppImage)
+# Package locally (Windows: .msi/.exe, macOS source build: .dmg/.app, Linux: .deb/.rpm/.AppImage)
 npm run tauri build
 ```
 The compiled release binary will be packaged inside `desktop/src-tauri/target/release/bundle/`!

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +721,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -964,6 +985,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1528,6 +1559,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +1848,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,6 +2072,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2229,6 +2311,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2242,6 +2325,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2320,6 +2415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,6 +2434,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2742,15 +2857,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2760,6 +2880,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2791,6 +2925,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,6 +3010,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2861,6 +3077,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3083,6 +3322,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,6 +3450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,7 +3538,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3311,6 +3572,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,7 +3605,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3468,6 +3740,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,7 +3782,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3500,7 +3805,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3698,6 +4003,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4020,6 +4335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4312,6 +4633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,11 +4873,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4583,11 +4931,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4621,6 +4986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4631,6 +5002,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4645,10 +5022,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4663,6 +5052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4673,6 +5068,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4687,6 +5088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,6 +5104,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4850,7 +5263,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -4895,6 +5308,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5003,6 +5426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,6 +5462,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -4,7 +4,8 @@ use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 use tauri::Manager;
 
 #[cfg(target_os = "windows")]
@@ -125,6 +126,28 @@ struct PersistentBridge {
     request_counter: u64,
 }
 
+struct BridgeState {
+    bridge: Mutex<Option<PersistentBridge>>,
+    active_pid: AtomicU32,
+}
+
+impl BridgeState {
+    fn new() -> Self {
+        Self {
+            bridge: Mutex::new(None),
+            active_pid: AtomicU32::new(0),
+        }
+    }
+}
+
+struct ActiveRequestGuard<'a>(&'a AtomicU32);
+
+impl Drop for ActiveRequestGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(0, Ordering::SeqCst);
+    }
+}
+
 #[derive(serde::Serialize)]
 struct BridgeRequest {
     id: u64,
@@ -140,13 +163,27 @@ struct BridgeResponse {
 }
 
 #[tauri::command]
-fn execute_zam_bridge(
+async fn execute_zam_bridge(
     app: tauri::AppHandle,
-    state: tauri::State<'_, Mutex<Option<PersistentBridge>>>,
+    state: tauri::State<'_, Arc<BridgeState>>,
     cmd: String,
     args: Vec<String>,
 ) -> Result<String, String> {
-    let mut lock = state.lock().map_err(|e| e.to_string())?;
+    let state = Arc::clone(state.inner());
+    tauri::async_runtime::spawn_blocking(move || {
+        execute_zam_bridge_blocking(&app, &state, cmd, args)
+    })
+    .await
+    .map_err(|e| format!("Bridge task failed: {}", e))?
+}
+
+fn execute_zam_bridge_blocking(
+    app: &tauri::AppHandle,
+    state: &BridgeState,
+    cmd: String,
+    args: Vec<String>,
+) -> Result<String, String> {
+    let mut lock = state.bridge.lock().map_err(|e| e.to_string())?;
 
     // 1. Ensure the persistent bridge process is running.
     let is_alive = if let Some(ref mut bridge) = *lock {
@@ -178,13 +215,21 @@ fn execute_zam_bridge(
         command.arg("bridge");
         command.arg("serve");
         command.arg("--stdin");
-        
+
         command.stdin(std::process::Stdio::piped());
         command.stdout(std::process::Stdio::piped());
 
-        let mut child = command.spawn().map_err(|e| format!("Failed to spawn ZAM CLI: {}", e))?;
-        let stdin = child.stdin.take().ok_or_else(|| "Failed to open stdin".to_string())?;
-        let stdout = child.stdout.take().ok_or_else(|| "Failed to open stdout".to_string())?;
+        let mut child = command
+            .spawn()
+            .map_err(|e| format!("Failed to spawn ZAM CLI: {}", e))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Failed to open stdin".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Failed to open stdout".to_string())?;
         let stdout_reader = BufReader::new(stdout);
 
         *lock = Some(PersistentBridge {
@@ -197,6 +242,8 @@ fn execute_zam_bridge(
 
     // 2. Perform the request-response transaction.
     let bridge = lock.as_mut().unwrap();
+    state.active_pid.store(bridge.child.id(), Ordering::SeqCst);
+    let _active_request = ActiveRequestGuard(&state.active_pid);
     bridge.request_counter += 1;
     let req_id = bridge.request_counter;
 
@@ -237,7 +284,8 @@ fn execute_zam_bridge(
                             return Err(err_msg);
                         }
                         if let Some(res_val) = resp.result {
-                            let serialized = serde_json::to_string(&res_val).map_err(|e| e.to_string())?;
+                            let serialized =
+                                serde_json::to_string(&res_val).map_err(|e| e.to_string())?;
                             return Ok(serialized);
                         }
                         return Ok("".to_string());
@@ -254,16 +302,48 @@ fn execute_zam_bridge(
     }
 }
 
+#[tauri::command]
+fn cancel_zam_bridge(state: tauri::State<'_, Arc<BridgeState>>) -> Result<bool, String> {
+    let pid = state.active_pid.swap(0, Ordering::SeqCst);
+    if pid == 0 {
+        return Ok(false);
+    }
+
+    #[cfg(target_os = "windows")]
+    let status = {
+        let mut command = Command::new("taskkill");
+        command.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        command.args(["/PID", &pid.to_string(), "/F"]).status()
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let status = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status();
+
+    match status {
+        Ok(result) if result.success() => Ok(true),
+        Ok(result) => Err(format!(
+            "Failed to cancel bridge process {} (status {})",
+            pid, result
+        )),
+        Err(err) => Err(format!("Failed to cancel bridge process {}: {}", pid, err)),
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
-            app.manage(Mutex::new(None::<PersistentBridge>));
+            app.manage(Arc::new(BridgeState::new()));
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![execute_zam_bridge])
+        .invoke_handler(tauri::generate_handler![
+            execute_zam_bridge,
+            cancel_zam_bridge
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -156,6 +156,7 @@ let isWaitingForAi = false;
 let waitTimeoutId: number | null = null;
 let evaluationRequestId = 0;
 let revealInProgress = false;
+let ratingSubmitInProgress = false;
 
 // ── BRIDGE COMMAND RUNNER ────────────────────────────────────────────────
 async function runBridge<T = any>(cmd: string, args: string[] = []): Promise<T> {
@@ -209,6 +210,7 @@ function initializeTranslations() {
 function switchView(viewId: "dashboard-view" | "study-view" | "graph-view") {
   if (viewId === "dashboard-view" && studySessionActive) {
     evaluationRequestId++;
+    if (revealInProgress) cancelActiveBridgeRequest();
     revealInProgress = false;
     finishAiWait();
   }
@@ -796,8 +798,8 @@ async function initOrShowGraph() {
 // ── DASHBOARD LOADING ─────────────────────────────────────────────────────
 async function loadDashboard() {
   try {
-    // 1. Get settings and apply translations
-    const settings = await runBridge<{ locale: string; llm: { enabled: boolean } }>("get-settings");
+    // 1. Initialize first-run state, then apply settings and translations.
+    const settings = await runBridge<{ locale: string; llm: { enabled: boolean } }>("desktop-bootstrap");
     currentLocale = settings.locale || "en";
     isLlmEnabled = settings.llm?.enabled || false;
     
@@ -1105,9 +1107,16 @@ function finishAiWait() {
   document.getElementById("npu-loading")!.classList.add("hidden");
 }
 
+function cancelActiveBridgeRequest() {
+  void invoke<boolean>("cancel_zam_bridge").catch((err) => {
+    console.warn("Failed to cancel active bridge request:", err);
+  });
+}
+
 function skipAiWaitingAndReveal() {
   if (!revealInProgress) return;
   evaluationRequestId++;
+  cancelActiveBridgeRequest();
   finishAiWait();
   renderReveal("", false);
   revealInProgress = false;
@@ -1115,7 +1124,11 @@ function skipAiWaitingAndReveal() {
 
 // ── RATING ACTION SUBMIT ─────────────────────────────────────────────────
 async function submitRating(ratingVal: number) {
-  if (!activeCard) return;
+  if (!activeCard || ratingSubmitInProgress) return;
+  ratingSubmitInProgress = true;
+  document.querySelectorAll<HTMLButtonElement>(".rating-btn").forEach((button) => {
+    button.disabled = true;
+  });
 
   try {
     await runBridge("submit", [
@@ -1127,6 +1140,11 @@ async function submitRating(ratingVal: number) {
     await loadNextCard();
   } catch (err) {
     console.error("Failed to submit rating:", err);
+  } finally {
+    ratingSubmitInProgress = false;
+    document.querySelectorAll<HTMLButtonElement>(".rating-btn").forEach((button) => {
+      button.disabled = false;
+    });
   }
 }
 

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -683,6 +683,12 @@ textarea::placeholder {
   color: var(--clr-text-primary);
 }
 
+.rating-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* Dynamic Hover Glow styles per FSRS rating button */
 .rating-btn.again:hover {
   background: rgba(239, 68, 68, 0.06);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/scripts/prepare-desktop-bridge.mjs
+++ b/scripts/prepare-desktop-bridge.mjs
@@ -36,6 +36,10 @@ if (!existsSync(cliEntry)) {
 const packageJson = JSON.parse(
   readFileSync(join(repoRoot, "package.json"), "utf8"),
 );
+const packageLock = join(repoRoot, "package-lock.json");
+if (!existsSync(packageLock)) {
+  throw new Error("Root package-lock.json is required for desktop packaging.");
+}
 const requestedNode = optionValue("--node");
 const nodeSource = requestedNode
   ? resolve(requestedNode)
@@ -57,19 +61,31 @@ writeFileSync(
   join(resourceRoot, "package.json"),
   `${JSON.stringify(
     {
-      name: "zam-desktop-bridge",
+      name: packageJson.name,
       version: packageJson.version,
       private: true,
       type: "module",
+      license: packageJson.license,
+      engines: packageJson.engines,
+      bin: packageJson.bin,
       dependencies: packageJson.dependencies,
+      optionalDependencies: packageJson.optionalDependencies,
+      devDependencies: packageJson.devDependencies,
     },
     null,
     2,
   )}\n`,
   "utf8",
 );
+cpSync(packageLock, join(resourceRoot, "package-lock.json"));
 
-const npmArgs = ["install", "--omit=dev", "--no-audit", "--no-fund"];
+const npmArgs = [
+  "ci",
+  "--omit=dev",
+  "--include=optional",
+  "--no-audit",
+  "--no-fund",
+];
 const npmExecPath = process.env.npm_execpath;
 const install = npmExecPath
   ? spawnSync(process.execPath, [npmExecPath, ...npmArgs], {

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -50,7 +50,7 @@ import {
   isLlmOnline,
   translateQuestionViaLLM,
 } from "../llm/client.js";
-import { resolveUser } from "./resolve-user.js";
+import { ensureDefaultUser, resolveUser } from "./resolve-user.js";
 import { withDb as sharedWithDb } from "./shared/db.js";
 
 let isServeMode = false;
@@ -840,7 +840,23 @@ bridgeCommand
     });
   });
 
-// ── zam bridge get-settings ───────────────────────────────────────────────
+// ── zam bridge desktop-bootstrap / get-settings ───────────────────────────
+
+bridgeCommand
+  .command("desktop-bootstrap")
+  .description("Initialize first-run desktop state (JSON)")
+  .option("--user <id>", "Preferred user ID when none is configured")
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      const userId = await ensureDefaultUser(db, opts.user);
+      const { enabled, url, model, locale } = await getLlmConfig(db);
+      jsonOut({
+        userId,
+        locale,
+        llm: { enabled, url, model },
+      });
+    });
+  });
 
 bridgeCommand
   .command("get-settings")

--- a/src/cli/commands/resolve-user.ts
+++ b/src/cli/commands/resolve-user.ts
@@ -3,11 +3,32 @@
  */
 
 import type { Database } from "../../kernel/index.js";
-import { getSetting } from "../../kernel/index.js";
+import { getSetting, setSetting } from "../../kernel/index.js";
 
 export interface ResolveUserOptions {
   /** If true, output JSON error instead of console.error (for bridge commands). */
   json?: boolean;
+}
+
+/**
+ * Ensure the desktop has a usable local identity on first launch.
+ * Existing explicit configuration always wins.
+ */
+export async function ensureDefaultUser(
+  db: Database,
+  preferredUserId?: string,
+): Promise<string> {
+  const stored = await getSetting(db, "user.id");
+  if (stored) return stored;
+
+  const userId =
+    preferredUserId?.trim() ||
+    process.env.ZAM_USER?.trim() ||
+    process.env.USERNAME?.trim() ||
+    process.env.USER?.trim() ||
+    "default";
+  await setSetting(db, "user.id", userId);
+  return userId;
 }
 
 /**

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -619,13 +619,23 @@ export async function ensureLlmReadyHeadless(
 /**
  * Wraps a fetch call in an interactive wait loop with progress dots.
  * Every `timeoutMs`, prompts the user (in their locale) to keep waiting or skip.
- * In non-TTY / bridge contexts it degrades to a plain fetch.
+ * In non-TTY / bridge contexts the timeout is a hard deadline because there
+ * is no interactive prompt that can ask whether to keep waiting.
  */
 export async function fetchWithInteractiveTimeout(
   url: string,
-  options: RequestInit & { timeoutMs?: number; locale?: SupportedLocale } = {},
+  options: RequestInit & {
+    timeoutMs?: number;
+    hardTimeoutMs?: number;
+    locale?: SupportedLocale;
+  } = {},
 ): Promise<Response> {
-  const { timeoutMs = 20000, locale = "en", ...fetchOptions } = options;
+  const {
+    timeoutMs = 20000,
+    hardTimeoutMs = 120000,
+    locale = "en",
+    ...fetchOptions
+  } = options;
   const controller = new AbortController();
   const fetchPromise = fetch(url, {
     ...fetchOptions,
@@ -633,7 +643,18 @@ export async function fetchWithInteractiveTimeout(
   });
 
   if (!process.stdout.isTTY || process.env.ZAM_BRIDGE === "true") {
-    return fetchPromise;
+    let timeoutId: NodeJS.Timeout | undefined;
+    const hardTimeout = new Promise<never>((_resolve, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new Error(`LLM request timed out after ${hardTimeoutMs}ms`));
+        controller.abort();
+      }, hardTimeoutMs);
+    });
+    try {
+      return await Promise.race([fetchPromise, hardTimeout]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
 
   let attempts = 0;

--- a/src/kernel/credentials.ts
+++ b/src/kernel/credentials.ts
@@ -7,7 +7,13 @@
  * replica (Turso cloud sync).
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -49,10 +55,24 @@ export function loadCredentials(path?: string): Credentials {
 export function saveCredentials(creds: Credentials, path?: string): void {
   const p = path ?? DEFAULT_CREDENTIALS_PATH;
   const dir = dirname(p);
+  let createdDirectory = false;
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    createdDirectory = true;
   }
-  writeFileSync(p, `${JSON.stringify(creds, null, 2)}\n`, "utf-8");
+  if (
+    process.platform !== "win32" &&
+    (path === undefined || createdDirectory)
+  ) {
+    chmodSync(dir, 0o700);
+  }
+  writeFileSync(p, `${JSON.stringify(creds, null, 2)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  if (process.platform !== "win32") {
+    chmodSync(p, 0o600);
+  }
 }
 
 /** Get complete Turso credentials, or null if incomplete. */

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -28,7 +28,7 @@ export type DatabaseProvider = "local" | "native" | "remote";
 export interface ConnectionOptions {
   /** Path to the SQLite database file. Defaults to ~/.zam/zam.db */
   dbPath?: string;
-  /** If true, create the directory and run schema migrations on open */
+  /** If true, run the schema even when the database already exists. */
   initialize?: boolean;
   /** Turso sync URL for embedded replica mode (e.g. libsql://db-name.turso.io) */
   syncUrl?: string;
@@ -109,6 +109,9 @@ export async function openDatabase(
   const isRemote = isRemoteDatabasePath(dbPath);
   const isEmbeddedReplica = Boolean(options.syncUrl);
   const provider = resolveProvider(options, configuredCloud?.mode, isRemote);
+  const shouldInitialize =
+    options.initialize === true ||
+    (!isRemote && !isEmbeddedReplica && !existsSync(dbPath));
 
   if (provider === "remote") {
     const url = isRemote ? dbPath : options.syncUrl;
@@ -129,7 +132,7 @@ export async function openDatabase(
     return db;
   }
 
-  if (options.initialize && !isRemote) {
+  if (shouldInitialize && !isRemote) {
     const dir = dirname(dbPath);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
@@ -211,7 +214,7 @@ export async function openDatabase(
     await db.sync?.();
   }
 
-  if (options.initialize) {
+  if (shouldInitialize) {
     await db.exec(SCHEMA);
   }
 

--- a/src/kernel/observation/session-synthesis.ts
+++ b/src/kernel/observation/session-synthesis.ts
@@ -15,7 +15,7 @@ import type { Session } from "../models/session.js";
 import { logStep } from "../models/session.js";
 import type { Token } from "../models/token.js";
 import { getTokenBySlug } from "../models/token.js";
-import { evaluateRating } from "../recall/evaluator.js";
+import { evaluateRatingWithinTransaction } from "../recall/evaluator.js";
 import { cascadeBlock } from "../scheduler/blocker.js";
 import type { Rating } from "../scheduler/fsrs.js";
 import type {
@@ -271,7 +271,7 @@ export async function applySessionSynthesis(
 
     const card = await ensureCard(tx, token.id, session.user_id);
     const reviewLogId = ulid();
-    await evaluateRating(tx, {
+    await evaluateRatingWithinTransaction(tx, {
       cardId: card.id,
       tokenId: token.id,
       userId: session.user_id,

--- a/src/kernel/recall/actions.ts
+++ b/src/kernel/recall/actions.ts
@@ -17,7 +17,7 @@ import type { CascadeBlockResult } from "../scheduler/blocker.js";
 import { cascadeBlock } from "../scheduler/blocker.js";
 import type { Rating } from "../scheduler/fsrs.js";
 import type { EvaluateResult } from "./evaluator.js";
-import { evaluateRating } from "./evaluator.js";
+import { evaluateRatingWithinTransaction } from "./evaluator.js";
 
 export type ReviewActionType =
   | "rate"
@@ -73,26 +73,27 @@ export async function executeReviewAction(
   db: Database,
   input: ExecuteReviewActionInput,
 ): Promise<ReviewActionResult> {
-  const target = await getReviewTarget(db, input.cardId, input.userId);
+  if (input.action === "rate") {
+    if (input.rating == null) {
+      throw new Error("rating is required for action=rate");
+    }
+    const rating = input.rating;
 
-  switch (input.action) {
-    case "rate": {
-      if (input.rating == null) {
-        throw new Error("rating is required for action=rate");
-      }
+    return db.transaction(async (tx) => {
+      const target = await getReviewTarget(tx, input.cardId, input.userId);
 
-      const evaluation = await evaluateRating(db, {
+      const evaluation = await evaluateRatingWithinTransaction(tx, {
         cardId: target.cardId,
         tokenId: target.token.id,
         userId: input.userId,
-        rating: input.rating,
+        rating,
       });
 
       let blocked: CascadeBlockResult | undefined;
-      if (input.rating === 1) {
-        const prereqs = await getPrerequisites(db, target.token.id);
+      if (rating === 1) {
+        const prereqs = await getPrerequisites(tx, target.token.id);
         if (prereqs.length > 0) {
-          blocked = await cascadeBlock(db, input.userId, target.token.slug);
+          blocked = await cascadeBlock(tx, input.userId, target.token.slug);
         }
       }
 
@@ -102,8 +103,12 @@ export async function executeReviewAction(
         evaluation,
         blocked,
       };
-    }
+    });
+  }
 
+  const target = await getReviewTarget(db, input.cardId, input.userId);
+
+  switch (input.action) {
     case "skip":
       return { action: input.action, token: target.token, skipped: true };
 

--- a/src/kernel/recall/evaluator.ts
+++ b/src/kernel/recall/evaluator.ts
@@ -42,6 +42,17 @@ export async function evaluateRating(
   db: Database,
   input: EvaluateInput,
 ): Promise<EvaluateResult> {
+  return db.transaction((tx) => evaluateRatingWithinTransaction(tx, input));
+}
+
+/**
+ * Apply a rating using a transaction already owned by the caller.
+ * This is used when prerequisite blocking must commit with the review.
+ */
+export async function evaluateRatingWithinTransaction(
+  db: Database,
+  input: EvaluateInput,
+): Promise<EvaluateResult> {
   // Get current card state
   const card = (await db
     .prepare("SELECT * FROM cards WHERE id = ?")

--- a/tests/cli/llm.test.ts
+++ b/tests/cli/llm.test.ts
@@ -71,6 +71,34 @@ describe("LLM client utilities (CLI layer)", () => {
     }
   });
 
+  it("fetchWithInteractiveTimeout aborts hung bridge requests at the hard deadline", async () => {
+    const originalFetch = global.fetch;
+    const originalBridge = process.env.ZAM_BRIDGE;
+    let aborted = false;
+    global.fetch = ((_url, options) =>
+      new Promise<Response>((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      })) as typeof fetch;
+    process.env.ZAM_BRIDGE = "true";
+
+    try {
+      await expect(
+        fetchWithInteractiveTimeout("http://dummy", { hardTimeoutMs: 10 }),
+      ).rejects.toThrow("LLM request timed out after 10ms");
+      expect(aborted).toBe(true);
+    } finally {
+      global.fetch = originalFetch;
+      if (originalBridge === undefined) {
+        delete process.env.ZAM_BRIDGE;
+      } else {
+        process.env.ZAM_BRIDGE = originalBridge;
+      }
+    }
+  });
+
   it("ensureHighQualityQuestion dynamically generates and self-heals a missing question when LLM is enabled", async () => {
     const db = await openDatabase({
       dbPath: ":memory:",
@@ -80,7 +108,7 @@ describe("LLM client utilities (CLI layer)", () => {
     await setSetting(db, "llm.enabled", "true");
     await setSetting(db, "llm.url", "http://dummy/v1");
 
-    const slug = "test-self-heal-" + Date.now();
+    const slug = `test-self-heal-${Date.now()}`;
     const token = await createToken(db, {
       slug,
       concept: "Azure DevOps secure HTTPS credential storage on macOS Keychain",

--- a/tests/cli/resolve-user.test.ts
+++ b/tests/cli/resolve-user.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ensureDefaultUser } from "../../src/cli/commands/resolve-user.js";
+import {
+  getSetting,
+  openDatabase,
+  setSetting,
+} from "../../src/kernel/index.js";
+
+describe("desktop first-run identity", () => {
+  it("persists the preferred identity when no user is configured", async () => {
+    const db = await openDatabase({
+      dbPath: ":memory:",
+      useConfiguredCloud: false,
+    });
+
+    expect(await ensureDefaultUser(db, "first-user")).toBe("first-user");
+    expect(await getSetting(db, "user.id")).toBe("first-user");
+    await db.close();
+  });
+
+  it("preserves an existing explicit identity", async () => {
+    const db = await openDatabase({
+      dbPath: ":memory:",
+      useConfiguredCloud: false,
+    });
+    await setSetting(db, "user.id", "configured-user");
+
+    expect(await ensureDefaultUser(db, "replacement")).toBe("configured-user");
+    await db.close();
+  });
+});

--- a/tests/integration/token-card-review.test.ts
+++ b/tests/integration/token-card-review.test.ts
@@ -282,6 +282,36 @@ describe("integration: token → card → review flow", () => {
       expect(queue.items.length).toBeGreaterThanOrEqual(0);
     });
 
+    it("rolls back the card update when immutable review logging fails", async () => {
+      const token = await createToken(db, {
+        slug: "review-log-rollback",
+        concept: "A review must update scheduling and history atomically",
+        domain: "testing",
+        bloom_level: 2,
+      });
+      const card = await ensureCard(db, token.id, "thomas");
+      await db.exec(`
+        CREATE TRIGGER fail_review_log
+        BEFORE INSERT ON review_logs
+        BEGIN
+          SELECT RAISE(ABORT, 'simulated review log failure');
+        END;
+      `);
+
+      await expect(
+        evaluateRating(db, {
+          cardId: card.id,
+          tokenId: token.id,
+          userId: "thomas",
+          rating: 3,
+        }),
+      ).rejects.toThrow("simulated review log failure");
+
+      const unchanged = await getCard(db, token.id, "thomas");
+      expect(unchanged?.reps).toBe(0);
+      expect(unchanged?.last_review_at).toBeNull();
+    });
+
     it("full lifecycle: token → prerequisite chain → block → unblock", async () => {
       const prereq = await createToken(db, {
         slug: "prerequisite-token",
@@ -335,6 +365,51 @@ describe("integration: token → card → review flow", () => {
       );
     });
 
+    it("rolls back rating, review log, and cascade blocking together", async () => {
+      const prereq = await createToken(db, {
+        slug: "transaction-prerequisite",
+        concept: "A prerequisite surfaced by a failed rating",
+        domain: "testing",
+        bloom_level: 1,
+      });
+      const target = await createToken(db, {
+        slug: "transaction-target",
+        concept: "A target whose review must be atomic",
+        domain: "testing",
+        bloom_level: 2,
+      });
+      await addPrerequisite(db, target.id, prereq.id);
+      const targetCard = await ensureCard(db, target.id, "thomas");
+
+      await db.exec(`
+        CREATE TRIGGER fail_review_block
+        BEFORE UPDATE OF blocked ON cards
+        WHEN NEW.blocked = 1
+        BEGIN
+          SELECT RAISE(ABORT, 'simulated block failure');
+        END;
+      `);
+
+      await expect(
+        executeReviewAction(db, {
+          action: "rate",
+          cardId: targetCard.id,
+          userId: "thomas",
+          rating: 1,
+        }),
+      ).rejects.toThrow("simulated block failure");
+
+      const cardAfterFailure = await getCard(db, target.id, "thomas");
+      expect(cardAfterFailure?.reps).toBe(0);
+      expect(cardAfterFailure?.blocked).toBe(0);
+      expect(
+        await db
+          .prepare("SELECT id FROM review_logs WHERE card_id = ?")
+          .all(targetCard.id),
+      ).toHaveLength(0);
+      expect(await getCard(db, prereq.id, "thomas")).toBeUndefined();
+    });
+
     it("blocks retroactively after missing prerequisites are discovered", async () => {
       const target = await createToken(db, {
         slug: "analyze-enlightenment",
@@ -356,7 +431,8 @@ describe("integration: token → card → review flow", () => {
 
       const prerequisite = await createToken(db, {
         slug: "define-popular-sovereignty",
-        concept: "Popular sovereignty means political authority comes from the people",
+        concept:
+          "Popular sovereignty means political authority comes from the people",
         domain: "history",
         bloom_level: 1,
       });
@@ -373,11 +449,7 @@ describe("integration: token → card → review flow", () => {
       ]);
       expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(1);
 
-      const prerequisiteCard = await getCard(
-        db,
-        prerequisite.id,
-        "thomas",
-      );
+      const prerequisiteCard = await getCard(db, prerequisite.id, "thomas");
       expect(prerequisiteCard).toBeDefined();
       expect(prerequisiteCard?.blocked).toBe(0);
 

--- a/tests/kernel/credentials.test.ts
+++ b/tests/kernel/credentials.test.ts
@@ -1,0 +1,31 @@
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadCredentials, saveCredentials } from "../../src/kernel/index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("credential storage", () => {
+  it("writes credentials and tightens Unix permissions", () => {
+    const root = mkdtempSync(join(tmpdir(), "zam-credentials-"));
+    tempDirs.push(root);
+    const path = join(root, ".zam", "credentials.json");
+
+    saveCredentials({ turso: { url: "libsql://db", token: "secret" } }, path);
+
+    expect(loadCredentials(path)).toEqual({
+      turso: { url: "libsql://db", token: "secret" },
+    });
+    if (process.platform !== "win32") {
+      expect(statSync(dirname(path)).mode & 0o777).toBe(0o700);
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/tests/kernel/database-backend.test.ts
+++ b/tests/kernel/database-backend.test.ts
@@ -13,6 +13,25 @@ afterEach(() => {
 });
 
 describe("local database backend", () => {
+  it("initializes a brand-new local database and parent directory automatically", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zam-local-first-run-"));
+    tempDirs.push(dir);
+    const dbPath = join(dir, "nested", ".zam", "zam.db");
+
+    const db = await openDatabase({
+      dbPath,
+      useConfiguredCloud: false,
+    });
+    const tables = (await db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'user_config'",
+      )
+      .all()) as Array<{ name: string }>;
+
+    expect(tables).toEqual([{ name: "user_config" }]);
+    await db.close();
+  });
+
   it("opens and persists a local SQLite database without libsql features", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zam-local-sqlite-"));
     tempDirs.push(dir);


### PR DESCRIPTION
## What changed

- Make the desktop app initialize a fresh local database and default user on first launch.
- Add hard LLM timeouts, process cancellation, duplicate-rating protection, and atomic review transactions.
- Harden credential file permissions.
- Make desktop bridge packaging reproducible with locked optional dependencies.
- Add clean-machine release smoke tests and locked Rust dependency checks.
- Correct platform documentation and bump the release version to 0.3.9.

## Why

The first public desktop release audit found several issues that could require an immediate follow-up release: fresh installs could fail before initialization, hung LLM requests could not be cancelled reliably, review writes were not fully atomic, credentials needed stricter permissions, and release artifacts were not completely reproducible.

## Impact

Fresh Windows and Linux installations now bootstrap correctly, failed or cancelled study requests recover cleanly, ratings cannot be duplicated or partially persisted, and the release workflow validates the same self-contained artifact users receive.

## Validation

- `npm test` (196 tests)
- `npm run lint`
- `npm run typecheck`
- Root and desktop production builds
- `cargo check --locked`
- Self-contained desktop bridge preparation
- `npm pack --dry-run` for `zam-core@0.3.9`
- Isolated clean-home desktop bridge smoke test
