### PR TITLE
[codex] Stabilize Linux release v0.3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ jobs:
   publish-tauri:
     permissions:
       contents: write
+    env:
+      NPM_CONFIG_FETCH_RETRIES: '5'
+      NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '20000'
+      NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
     strategy:
       fail-fast: false
       matrix:
@@ -19,7 +23,10 @@ jobs:
         include:
           - platform: 'ubuntu-22.04'
             target: 'x86_64-unknown-linux-gnu'
-            args: '--target x86_64-unknown-linux-gnu'
+            # AppImage's linuxdeploy currently fails when it scans the bundled
+            # native libsql module. Keep libsql support and ship deb/rpm until
+            # upstream AppImage packaging can handle that resource.
+            args: '--target x86_64-unknown-linux-gnu --bundles deb,rpm'
           - platform: 'windows-latest'
             target: 'x86_64-pc-windows-msvc'
             args: '--target x86_64-pc-windows-msvc'

--- a/README.de.md
+++ b/README.de.md
@@ -98,7 +98,7 @@ Dies kompiliert das Rust-Backend im Hintergrund, startet den Vite-Entwicklungsse
 
 ### 📦 Automatische GitHub Releases & Native Installer
 
-Wir haben eine **GitHub Actions CI/CD-Pipeline** integriert, die derzeit native Installationsdateien für Windows (`.msi`/`.exe`) und Linux (`.deb`/`.rpm`/`.AppImage`) kompiliert und verpackt, sobald ein neuer Git-Tag gepusht wird. macOS kann weiterhin aus dem Quellcode gebaut werden; signierte und notarisierte macOS-Release-Artefakte folgen, sobald der Apple-Signing-Account verfügbar ist.
+Wir haben eine **GitHub Actions CI/CD-Pipeline** integriert, die derzeit native Installationsdateien für Windows (`.msi`/`.exe`) und Linux (`.deb`/`.rpm`) kompiliert und verpackt, sobald ein neuer Git-Tag gepusht wird. AppImage-Pakete sind vorläufig ausgesetzt, weil `linuxdeploy` das mitgelieferte native `libsql`-Modul noch nicht zuverlässig verarbeiten kann. macOS kann weiterhin aus dem Quellcode gebaut werden; signierte und notarisierte macOS-Release-Artefakte folgen, sobald der Apple-Signing-Account verfügbar ist.
 
 Um eine neue Version zu veröffentlichen (z.B. `v0.1.0`):
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This will compile the secure Rust backend, spin up the Vite development server, 
 
 ### 📦 Automated GitHub Releases & Native Installers
 
-We have integrated a **GitHub Actions CI/CD workflow** that currently compiles and packages native installers for Windows (`.msi`/`.exe`) and Linux (`.deb`/`.rpm`/`.AppImage`) when a new git tag is pushed. macOS builds remain supported from source, but signed/notarized macOS release artifacts are deferred until the Apple signing account is available.
+We have integrated a **GitHub Actions CI/CD workflow** that currently compiles and packages native installers for Windows (`.msi`/`.exe`) and Linux (`.deb`/`.rpm`) when a new git tag is pushed. AppImage packaging is temporarily deferred because `linuxdeploy` cannot process the bundled native `libsql` module reliably. macOS builds remain supported from source, but signed/notarized macOS release artifacts are deferred until the Apple signing account is available.
 
 To release a new version (e.g., `v0.1.0`):
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the **ZAM Cross-Platform Desktop GUI**! This native desktop application co-exists with the ZAM CLI, utilizing a **100% DRY architecture** by executing the compiled ZAM CLI bridge directly via a secure Rust backend. This enables native execution across **Windows, macOS, and Linux**, securely sharing the local SQLite database at `~/.zam/zam.db`.
 
-Published release installers currently target Windows and Linux. macOS source builds are supported, while signed/notarized macOS release artifacts are deferred until Apple signing is configured.
+Published release installers currently target Windows and Linux. Linux AppImage packaging is temporarily deferred because `linuxdeploy` cannot process the bundled native `libsql` module reliably. macOS source builds are supported, while signed/notarized macOS release artifacts are deferred until Apple signing is configured.
 
 ---
 
@@ -113,7 +113,7 @@ To verify the bundle and package a standalone native binary for your platform:
 # Verify TypeScript & Vite compilation inside desktop/
 npm run build
 
-# Package locally (Windows: .msi/.exe, macOS source build: .dmg/.app, Linux: .deb/.rpm/.AppImage)
+# Package locally (Windows: .msi/.exe, macOS source build: .dmg/.app, Linux: .deb/.rpm)
 npm run tauri build
 ```
 The compiled release binary will be packaged inside `desktop/src-tauri/target/release/bundle/`!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- Publish Linux `.deb` and `.rpm` bundles without invoking AppImage's `linuxdeploy`.
- Keep the native `libsql` module in the self-contained desktop bridge.
- Add npm network retries to all release matrix jobs.
- Document the temporary AppImage limitation.
- Bump the release version to 0.3.10.

## Root cause

The v0.3.9 release built Windows x64 and Windows ARM64 successfully. Linux compiled the application and produced `.deb` and `.rpm`, but failed twice when `linuxdeploy` scanned the AppDir containing the newly bundled native `libsql` module.

The earlier v0.3.8 AppImage build succeeded only because the desktop bridge packaging script omitted optional dependencies, which also omitted `libsql`. Restoring that omission would reintroduce the release-audit defect.

## Validation

- `npm ci` in root and desktop workspaces
- `npm test` (196 tests)
- `npm run lint`
- `npm run typecheck`
- desktop production build
- `cargo metadata --locked --format-version 1 --no-deps`
- `git diff --check`
