### PR TITLE
fix(desktop): repair GUI bridge spawn, window sizing, single-instance (v0.3.11)

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
 ]
 
@@ -3736,6 +3737,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -24,3 +24,6 @@ tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-single-instance = "2"
+

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -27,6 +27,32 @@ fn home_dir() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+/// Append a diagnostic line to ~/.zam/desktop-bridge.rust.log. A windowed app
+/// discards stdout/stderr, so this file is the only way to see how the bridge
+/// process is resolved and spawned when launched from the GUI. Best-effort.
+fn diag_log(msg: &str) {
+    if let Some(home) = home_dir() {
+        let dir = home.join(".zam");
+        let _ = fs::create_dir_all(&dir);
+        if let Ok(mut f) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join("desktop-bridge.rust.log"))
+        {
+            let _ = writeln!(f, "[{}] {}", chrono_now(), msg);
+        }
+    }
+}
+
+/// Minimal timestamp without pulling in a date crate.
+fn chrono_now() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 /// Locate the compiled ZAM CLI (`dist/cli/index.js`) independently of the
 /// process working directory, so the installed GUI works when launched from
 /// the Start menu / Program Files (where the cwd is NOT the repo).
@@ -65,8 +91,24 @@ fn resolve_dev_cli_path() -> Option<PathBuf> {
     None
 }
 
+/// Strip the Windows `\\?\` verbatim (extended-length) path prefix.
+/// Tauri's `resource_dir()` can return verbatim paths, but Node's module loader
+/// cannot resolve a main script whose path starts with `\\?\` — it fails with
+/// `EISDIR: illegal operation on a directory, lstat 'C:'`, crashing the spawned
+/// bridge before any CLI code runs. Returning a normal path keeps it loadable.
+fn strip_verbatim(p: PathBuf) -> PathBuf {
+    let s = p.to_string_lossy();
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{}", rest));
+    }
+    if let Some(rest) = s.strip_prefix(r"\\?\") {
+        return PathBuf::from(rest.to_string());
+    }
+    p
+}
+
 fn bundled_runtime(app: &tauri::AppHandle) -> Option<BridgeRuntime> {
-    let resource_dir = app.path().resource_dir().ok()?;
+    let resource_dir = strip_verbatim(app.path().resource_dir().ok()?);
     let roots = [
         resource_dir.join("resources").join("zam-cli"),
         resource_dir.join("zam-cli"),
@@ -200,11 +242,26 @@ fn execute_zam_bridge_blocking(
             let _ = bridge.child.kill();
         }
 
-        let runtime = resolve_bridge_runtime(&app).ok_or_else(|| {
-            "Could not locate the ZAM CLI. Reinstall the desktop app, or set \
-             ZAM_HOME to a source checkout for development."
-                .to_string()
-        })?;
+        diag_log(&format!(
+            "spawning bridge | home={:?} | cwd={:?}",
+            home_dir(),
+            env::current_dir().ok()
+        ));
+
+        let runtime = match resolve_bridge_runtime(&app) {
+            Some(r) => r,
+            None => {
+                diag_log("resolve_bridge_runtime returned None — CLI not found");
+                return Err("Could not locate the ZAM CLI. Reinstall the desktop \
+                    app, or set ZAM_HOME to a source checkout for development."
+                    .to_string());
+            }
+        };
+
+        diag_log(&format!(
+            "runtime resolved | node={:?} | cli={:?} | working_dir={:?}",
+            runtime.node_path, runtime.cli_path, runtime.working_dir
+        ));
 
         let mut command = Command::new(&runtime.node_path);
         #[cfg(target_os = "windows")]
@@ -219,9 +276,27 @@ fn execute_zam_bridge_blocking(
         command.stdin(std::process::Stdio::piped());
         command.stdout(std::process::Stdio::piped());
 
-        let mut child = command
-            .spawn()
-            .map_err(|e| format!("Failed to spawn ZAM CLI: {}", e))?;
+        // A windowed app discards the child's inherited stderr, so a node crash
+        // on startup would be invisible. Capture it to a log file so bridge
+        // failures that only happen under the GUI are diagnosable.
+        if let Some(home) = home_dir() {
+            let log_dir = home.join(".zam");
+            let _ = fs::create_dir_all(&log_dir);
+            if let Ok(file) = fs::File::create(log_dir.join("desktop-bridge.stderr.log")) {
+                command.stderr(std::process::Stdio::from(file));
+            }
+        }
+
+        let mut child = match command.spawn() {
+            Ok(c) => {
+                diag_log(&format!("spawn OK | pid={}", c.id()));
+                c
+            }
+            Err(e) => {
+                diag_log(&format!("spawn FAILED: {}", e));
+                return Err(format!("Failed to spawn ZAM CLI: {}", e));
+            }
+        };
         let stdin = child
             .stdin
             .take()
@@ -333,7 +408,20 @@ fn cancel_zam_bridge(state: tauri::State<'_, Arc<BridgeState>>) -> Result<bool, 
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default();
+
+    // Enforce a single running instance. A second launch focuses the existing
+    // window instead of opening another GUI (and another bridge daemon).
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.unminimize();
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    }));
+
+    builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -10,6 +10,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     ai_status_model_missing: "Local AI: model not found",
     lbl_due_reviews: "Due Reviews",
     lbl_caught_up: "You're all caught up!",
+    dashboard_error: "Could not load your data",
     lbl_domains: "Active Domains",
     btn_start_session: "Start Learning Session",
     lbl_translating: "Translating dynamically...",
@@ -56,6 +57,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     ai_status_model_missing: "Lokale KI: Modell fehlt",
     lbl_due_reviews: "Anstehende Wiederholungen",
     lbl_caught_up: "Du bist voll auf dem Laufenden!",
+    dashboard_error: "Deine Daten konnten nicht geladen werden",
     lbl_domains: "Aktive Wissensbereiche",
     btn_start_session: "Lernsitzung starten",
     lbl_translating: "Übersetze dynamisch...",
@@ -798,6 +800,7 @@ async function initOrShowGraph() {
 // ── DASHBOARD LOADING ─────────────────────────────────────────────────────
 async function loadDashboard() {
   try {
+    clearDashboardError();
     // 1. Initialize first-run state, then apply settings and translations.
     const settings = await runBridge<{ locale: string; llm: { enabled: boolean } }>("desktop-bootstrap");
     currentLocale = settings.locale || "en";
@@ -871,7 +874,32 @@ async function loadDashboard() {
       });
   } catch (err) {
     console.error("Failed to load dashboard:", err);
+    showDashboardError(err);
   }
+}
+
+/**
+ * Surface a bridge/data error directly in the dashboard. Previously these were
+ * only logged to the (invisible) console, so a failing bridge looked like an
+ * empty "no tokens" dashboard with no explanation.
+ */
+function showDashboardError(err: unknown): void {
+  const view = document.getElementById("dashboard-view");
+  if (!view) return;
+  let banner = document.getElementById("dashboard-error");
+  if (!banner) {
+    banner = document.createElement("div");
+    banner.id = "dashboard-error";
+    banner.className = "error-banner";
+    view.prepend(banner);
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  banner.textContent = `⚠ ${t("dashboard_error")}: ${msg}`;
+  banner.classList.remove("hidden");
+}
+
+function clearDashboardError(): void {
+  document.getElementById("dashboard-error")?.classList.add("hidden");
 }
 
 // ── ACTIVE STUDY FLOW ─────────────────────────────────────────────────────

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -43,16 +43,20 @@
   padding: 0;
 }
 
+html {
+  height: 100vh;
+}
+
 body {
   font-family: var(--font-family);
   background-color: var(--bg-deep-space);
   color: var(--clr-text-primary);
-  min-height: 100vh;
-  overflow-x: hidden;
+  height: 100vh;
+  overflow: hidden;
   position: relative;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -93,7 +97,10 @@ body {
 .container {
   width: 100%;
   max-width: 950px;
-  min-height: 720px;
+  height: 100vh;
+  max-height: 100vh;
+  min-height: 0;
+  overflow-y: auto;
   padding: 30px;
   display: flex;
   flex-direction: column;
@@ -105,7 +112,7 @@ body {
   max-width: 100%;
   width: 100%;
   padding: 8px 12px;
-  min-height: 100vh;
+  overflow: hidden;
 }
 
 /* ── HEADER BAR ──────────────────────────────────────────────────────────── */
@@ -831,6 +838,20 @@ textarea::placeholder {
 
 .hidden {
   display: none !important;
+}
+
+/* Visible error banner (e.g. bridge/data failures) */
+.error-banner {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #fecaca;
+  border-radius: 12px;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 /* ==========================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -1017,6 +1017,33 @@ bridgeCommand
   .action(async (_opts) => {
     isServeMode = true;
 
+    // Diagnostic log. A windowed GUI swallows the daemon's stderr, so failures
+    // that only happen when the bridge is spawned by the desktop app are
+    // otherwise invisible. Logging the resolved environment makes a wrong
+    // home directory (→ missing credentials → empty database) obvious.
+    const {
+      appendFileSync,
+      existsSync: fileExists,
+      mkdirSync: makeDir,
+    } = await import("node:fs");
+    const nodeOs = await import("node:os");
+    const nodePath = await import("node:path");
+    const logDir = nodePath.join(nodeOs.homedir(), ".zam");
+    const logPath = nodePath.join(logDir, "desktop-bridge.log");
+    const logDiag = (msg: string): void => {
+      try {
+        if (!fileExists(logDir)) makeDir(logDir, { recursive: true });
+        appendFileSync(logPath, `[${new Date().toISOString()}] ${msg}\n`);
+      } catch {
+        // best-effort only — never let logging break the bridge
+      }
+    };
+    logDiag(
+      `serve start | homedir=${nodeOs.homedir()} | USERPROFILE=${
+        process.env.USERPROFILE ?? ""
+      } | HOME=${process.env.HOME ?? ""} | cwd=${process.cwd()}`,
+    );
+
     // Configure exitOverride so commander doesn't process.exit on parsing errors
     bridgeCommand.exitOverride();
     for (const cmd of bridgeCommand.commands) {
@@ -1118,9 +1145,16 @@ bridgeCommand
       terminal: false,
     });
 
-    rl.on("line", async (line) => {
+    // Process requests strictly one at a time. processRequest() relies on a
+    // shared output buffer and temporarily swaps the global console methods, so
+    // overlapping executions would corrupt each other's responses. Chaining on
+    // a single promise serialises them regardless of how fast lines arrive.
+    let pending: Promise<void> = Promise.resolve();
+    rl.on("line", (line) => {
       if (!line.trim()) return;
-      const response = await processRequest(line);
-      process.stdout.write(`${response}\n`);
+      pending = pending.then(async () => {
+        const response = await processRequest(line);
+        process.stdout.write(`${response}\n`);
+      });
     });
   });

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -2,7 +2,6 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import BetterSqlite3 from "better-sqlite3";
 import { getTursoCredentials } from "../credentials.js";
 import { openRemoteDatabase } from "./remote/provider.js";
 import { SCHEMA } from "./schema.js";
@@ -49,6 +48,18 @@ function isDatabaseProvider(value: unknown): value is DatabaseProvider {
 }
 
 function openLocalSqlite(dbPath: string): SyncDatabase {
+  // Loaded lazily (not as a top-level import) so that remote/HTTP Turso users
+  // never trigger the native better-sqlite3 binding. A failure to load that
+  // binding inside the packaged desktop app would otherwise crash the whole
+  // CLI at startup — before any provider selection or error handling runs.
+  const mod = require("better-sqlite3") as
+    | (new (
+        path: string,
+      ) => unknown)
+    | { default: new (path: string) => unknown };
+  const BetterSqlite3 = ("default" in mod ? mod.default : mod) as new (
+    path: string,
+  ) => unknown;
   return new BetterSqlite3(dbPath) as unknown as SyncDatabase;
 }
 
@@ -176,21 +187,42 @@ export async function openDatabase(
 
   let driver: SyncDatabase;
   if (isRemote || isEmbeddedReplica) {
-    const LibsqlDatabase = loadLibsql();
     try {
-      driver = new LibsqlDatabase(dbPath, dbOpts);
-    } catch (err) {
-      const msg = (err as Error).message;
-      if (msg.includes("InvalidLocalState") && options.syncUrl) {
-        // Last-ditch recovery: metadata is corrupt or mismatched
-        const metaPath = `${dbPath}.meta`;
-        const infoPath = `${dbPath}-info`;
-        if (existsSync(metaPath)) rmSync(metaPath);
-        if (existsSync(infoPath)) rmSync(infoPath);
+      const LibsqlDatabase = loadLibsql();
+      try {
         driver = new LibsqlDatabase(dbPath, dbOpts);
-      } else {
-        throw err;
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg.includes("InvalidLocalState") && options.syncUrl) {
+          // Last-ditch recovery: metadata is corrupt or mismatched
+          const metaPath = `${dbPath}.meta`;
+          const infoPath = `${dbPath}-info`;
+          if (existsSync(metaPath)) rmSync(metaPath);
+          if (existsSync(infoPath)) rmSync(infoPath);
+          driver = new LibsqlDatabase(dbPath, dbOpts);
+        } else {
+          throw err;
+        }
       }
+    } catch (nativeErr) {
+      // The native libsql driver is unavailable or failed to initialise — a
+      // failure mode that can occur inside the packaged desktop app. For a pure
+      // remote database we transparently fall back to the HTTP provider, which
+      // needs no native bindings. Embedded replicas require the native driver,
+      // so those still surface the original error.
+      const fallbackUrl = isRemote ? dbPath : options.syncUrl;
+      if (isRemote && !isEmbeddedReplica && fallbackUrl) {
+        const db = openRemoteDatabase({
+          url: fallbackUrl,
+          authToken: configuredCloud?.token ?? options.authToken,
+        });
+        if (options.initialize) {
+          await db.exec(SCHEMA);
+        }
+        await runMigrations(db);
+        return db;
+      }
+      throw nativeErr;
     }
   } else {
     driver = openLocalSqlite(dbPath);


### PR DESCRIPTION
## Summary

Fixes the showstopper where the **installed desktop app showed no tokens** plus the window/scrollbar and multi-instance issues found while testing v0.3.10.

### Root cause (no tokens)
Tauri's `resource_dir()` returns Windows `\?\` verbatim paths. Node's module loader can't load a main script with that prefix — it crashes with `EISDIR: lstat 'C:'` **before any CLI code runs**. So the bridge daemon died on spawn, the dashboard's bridge calls failed (silently), and it looked like a lost Turso connection. Diagnosed via new spawn + stderr logging; fixed by stripping the verbatim prefix before spawning.

### Also fixed
- **Window/scroll:** dropped the fixed `min-height:720px`; the shell now binds to the viewport (no permanent vertical scrollbar).
- **Single instance:** a second launch focuses the existing window instead of opening another GUI + bridge daemon (`tauri-plugin-single-instance`).
- **DB robustness:** `better-sqlite3` loaded lazily (a native-load failure no longer crashes remote users at startup); native libsql → HTTP provider fallback for pure-remote Turso.
- **Bridge daemon:** serialised serve-mode requests (concurrent requests corrupted the shared output buffer); bridge errors now surface in the dashboard instead of being swallowed; spawn decisions + daemon stderr logged to `~/.zam/desktop-bridge.*`.

Verified by a local installer build: tokens load (dueCount 8), window fits, second launch focuses existing window. Lint/typecheck/build/196 tests green; `cargo build --release` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)