### PR TITLE
chore: publish zam-core to npm on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'Publish ZAM Desktop Release'
+name: 'Publish ZAM Release'
 
 on:
   push:
@@ -6,6 +6,46 @@ on:
       - 'v*'
 
 jobs:
+  publish-npm:
+    name: 'Publish zam-core to npm'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      # Required for npm publish --provenance to mint a signed attestation.
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Guard tag/package version match
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-tauri:
     permissions:
       contents: write


### PR DESCRIPTION
## Why

The release workflow (`release.yml`) only built Tauri desktop bundles and a GitHub draft release — it never ran `npm publish`. As a result the npm package silently drifted: `latest` was stuck at **0.3.7** while git tags and `package.json` reached **0.3.11** (the 0.3.8–0.3.11 desktop releases bumped the version but never reached npm).

`zam-core@0.3.11` has now been published manually to close the existing gap. This PR prevents the drift from recurring.

## What

Adds a `publish-npm` job to `release.yml`, triggered on `v*` tags (same as the desktop job, runs independently):

- `npm ci` → `npm run build` → `npm test`
- **Tag/version guard** — fails if `package.json` version ≠ the pushed tag
- `npm publish --provenance --access public`

## Requirements

- **`NPM_TOKEN` repo secret** — already configured.
- The token must be **2FA-bypassing** (Granular with "Bypass 2FA", or Classic *Automation*); a standard login/granular token will fail the publish step with `EOTP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)