### PR TITLE
fix(bridge): agent-side UI observation with reliable window capture

### DIFF
--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -68,7 +68,35 @@ zam bridge submit --user <username> --card-id <id> --rating <1-4>
 zam bridge get-skill --slug <slug>
 zam bridge get-monitor --session <id>                 # read monitor log as JSON
 echo '{"patterns":[...]}' | zam bridge analyze-monitor --session <id>  # auto-rate from log
+zam bridge add-token --user <username>                # create token + user card from JSON stdin
+zam bridge capture-ui [--session <id>] [--output <path>] [--image <path>]  # screenshot for agent-side vision
 ```
+
+### Codex Execution Notes
+
+Use `npx zam ...` from the personal instance unless a linked `zam` binary is known
+to resolve correctly. The configured Turso database is remote; if a ZAM command
+fails with network sandbox errors such as `EACCES ...:443`, retry the same
+command with escalated permissions and a scoped prefix rule like `["npx","zam"]`.
+
+On Windows in Codex, prefer the classic Windows PowerShell executable for ZAM
+commands that contain quoted or multi-word arguments:
+
+```text
+C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+```
+
+The default `pwsh.exe` runner can fail with `CreateProcessAsUserW failed: 1312`,
+and `cmd` can split quoted arguments in surprising ways. `cmd` is fine for simple
+no-space commands such as `npx zam stats --user thomas`, but use Windows
+PowerShell for `--task`, `--concept`, `--question`, and multi-word `--query`
+values.
+
+For a concept that should immediately enter the user's learning queue, prefer
+`zam bridge add-token --user <username>` with JSON on stdin. `zam token register`
+creates the token only; it does not ensure the user's card exists. Do not use
+`bridge add-token` through `zam bridge serve --stdin`, because `add-token` reads
+raw stdin itself.
 
 ---
 
@@ -107,11 +135,11 @@ Always prefer observation over probing. Talking interrupts flow. The best ZAM se
 
 ## Observation Levels
 
-- **Level 1 — Shell** (current): Agent reads shell command history and output to infer success/failure
-- **Level 2 — Screen** (future): Agent observes full screen, guides UI interaction, auto-rates based on what it sees
+- **Level 1 — Shell**: Agent reads shell command history and output to infer success/failure
+- **Level 2 — Screen**: Agent captures screenshots via `zam bridge capture-ui` and analyzes them with Codex's multimodal capabilities or a vision-capable subagent
 - **Level 3 — Real life** (future): Voice + visual overlay on device (phone, AR). The agent is an overlay; the user lives in their world.
 
-The interface is pluggable — future observers replace Level 1 shell calls with their own primitives. Today: always Level 1.
+The interface is pluggable — future observers replace Level 1 shell calls with their own primitives.
 
 ---
 
@@ -158,6 +186,13 @@ zam token register --slug <slug> --concept "<one sentence>" --domain <d> --bloom
 zam token prereq --token <child> --requires <parent>
 ```
 
+If the token should be reviewed by this user, create the card in the same step:
+
+```bash
+printf '%s\n' '{"slug":"<slug>","concept":"<one sentence>","domain":"<d>","bloom_level":2,"question":"<concept-free recall question>"}' \
+  | zam bridge add-token --user <username>
+```
+
 ### STEP 3 — Start a session
 
 **For review/conceptual sessions**, load review data into a temp file so it stays out of the conversation, then start the session quietly:
@@ -195,7 +230,7 @@ Hand off to the user:
 
 Step back. Do not interrupt unless the user asks for help.
 
-**Two ways to observe:**
+**Choose the observation approach:**
 
 Check the user's preference first:
 ```bash
@@ -246,7 +281,31 @@ diagnostic output is needed.
 
 When done, the user can simply close the monitored terminal window — hooks only live in that shell process. No cleanup command needed.
 
-**Rating scale (both approaches):**
+**Approach C — Agent-side UI observation (Level 2):** For GUI tasks where shell hooks can't see what's happening. The agent captures screenshots and analyzes them with Codex's multimodal capabilities, preferably a cost-efficient vision-capable subagent when one is available. Do not rely on the laptop's local LLM for rating unless the user explicitly wants that; it may be too weak for UI evidence.
+
+```bash
+zam session start --user <username> --task "<description>" --context ui --skip-review --json
+```
+
+Workflow:
+1. Tell the user: *"Perform the task in the app, leave the relevant window visible, and come back when you're done."*
+2. When the user returns, capture the screen:
+   ```bash
+   zam bridge capture-ui --session <session-id>
+   ```
+   Returns JSON with `imagePath` and `base64` (PNG screenshot).
+3. If Codex subagents are available, spawn a cheap vision-capable subagent (for example a mini model) and pass the screenshot as a local image plus the task, expected evidence, and candidate token slugs. Ask it for observed facts and suggested 1-4 ratings with brief evidence.
+4. Review the subagent's evidence yourself before writing ratings. If the screenshot is ambiguous, ask the user instead of guessing.
+5. Submit ratings and session logs for only the tokens the user actually exercised.
+
+The `capture-ui` command supports:
+- `--image <path>` — analyze an existing image instead of capturing
+- `--output <path>` — save the screenshot to a specific path
+- `--process-name <name>` or `--hwnd <handle>` — target a specific window when known
+
+On Windows, uses PowerShell/.NET for screen capture. On macOS, uses `screencapture`.
+
+**Rating scale (all observation approaches):**
 - Completed correctly, no hesitation, no help → **4**
 - Slight pause or looked something up → **3**
 - Made errors, corrected themselves → **2**

--- a/docs/ui-observation-protocol.md
+++ b/docs/ui-observation-protocol.md
@@ -25,6 +25,7 @@ zam bridge capture-ui --session <id> [--output <path>] [--image <path>]
   "imagePath": "C:\\Users\\...\\zam-capture-abc123.png",
   "base64": "<PNG base64>",
   "mimeType": "image/png",
+  "captureMethod": "printwindow",
   "capturedAt": "2026-06-20T04:43:27.592Z",
   "platform": "win32"
 }
@@ -46,9 +47,35 @@ zam bridge capture-ui --session <id> [--output <path>] [--image <path>]
 - `--image <path>` bypasses capture and returns an existing image
 - Token registration, session start/end with `--context ui` all work
 
+### Window targeting — DONE (via PrintWindow)
+`--hwnd` and `--process-name` now capture a specific window correctly, even when
+it is occluded or in the background. The first implementation used
+`SetForegroundWindow` + `CopyFromScreen`, but Windows blocks a background process
+from forcing a window to the foreground, so `CopyFromScreen` grabbed whatever sat
+on top at the target window's rectangle (e.g. the agent's own window). The capture
+now uses `PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT=0x2)`, which renders the
+target window directly regardless of z-order and does not steal focus. Verified
+against scientific Calculator (UWP, hosted by ApplicationFrameHost), Notepad,
+and Electron/Chromium windows (OpenCode, Claude desktop, Edge WebView2) — all
+captured correctly while in the background.
+
+A **black-frame guard** makes the capture self-healing: PrintWindow can return a
+near-black frame on some hardware-accelerated/DirectComposition surfaces, so the
+capture samples mean luminance and, if it is essentially black, falls back to a
+foreground `CopyFromScreen` grab. The JSON reports which method actually ran via
+`captureMethod`: `printwindow` | `copyfromscreen` | `fullscreen` | `provided`
+(or `screencapture-window` | `screencapture-full` on macOS). A harness can use
+this field to judge the evidence quality — `fullscreen` means no specific window
+was targeted, `copyfromscreen` means the window may have been occluded.
+
+> Scope of verification: confirmed on Windows 11 with classic `powershell.exe`
+> and this machine's GPU/driver. PrintWindow behavior on some
+> DirectComposition surfaces is driver-dependent; the guard exists precisely so
+> untested environments degrade gracefully instead of returning a black image.
+> The macOS path is unchanged and was not tested here.
+
 ### Doesn't Work Yet
-- **No vision analysis** — the agent (Mimo-V2.5 via Opencode) received the base64 but cannot analyze images (model limitation)
-- **No window targeting** — `capture-ui` captures the entire primary screen, not a specific window. When Calculator was open, the screenshot showed the Opencode window instead (foreground problem)
+- **No vision analysis in-model** — a text-only local LLM cannot analyze images. Use the agent harness's own multimodal model or a vision-capable subagent (see SKILL.md Approach C).
 - **No event-driven observation** — currently the agent asks "are you done?" and then takes one screenshot. No process launch detection, no UIA events, no delta detection
 
 ---
@@ -184,5 +211,7 @@ Compare two screenshots to detect meaningful changes:
 | PowerShell screenshot capture | ✅ Works, captures full primary screen |
 | macOS screencapture | Not tested (no macOS available) |
 | Vision analysis (local LLM) | ❌ Model doesn't support images |
-| Vision analysis (agent multimodal) | ❌ Mimo-V2.5-Pro is text-only; Mimo-V2.5 can but no image was re-sent |
-| Window targeting | ❌ Captures foreground, not target window |
+| Vision analysis (agent multimodal) | ✅ Multimodal harness / vision subagent reads the base64 PNG and identifies the app |
+| Window targeting (`--hwnd`) | ✅ PrintWindow captures the real target window even when occluded |
+| Window targeting (`--process-name`) | ✅ Resolves MainWindowHandle, then PrintWindow (Notepad verified) |
+| Background capture without focus steal | ✅ PrintWindow does not call SetForegroundWindow |

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -629,6 +629,7 @@ bridgeCommand
         context?: string;
         symbiosis_mode?: string | null;
         source_link?: string | null;
+        question?: string | null;
       };
 
       try {
@@ -657,6 +658,7 @@ bridgeCommand
           | null
           | undefined,
         source_link: data?.source_link ?? null,
+        question: data?.question ?? null,
       });
 
       const card = await ensureCard(db, token.id, userId);

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -913,7 +913,7 @@ function captureScreenshot(
   outputPath: string,
   hwnd?: string,
   processName?: string,
-): void {
+): string {
   const platform = process.platform;
   if (hwnd && !/^(0x)?[0-9a-fA-F]+$/.test(hwnd)) {
     throw new Error(`Invalid HWND format: ${hwnd}`);
@@ -923,7 +923,7 @@ function captureScreenshot(
   }
 
   if (platform === "win32") {
-    execFileSync(
+    const stdout = execFileSync(
       "powershell",
       [
         "-NoProfile",
@@ -948,6 +948,9 @@ public class Win32 {
 
     [DllImport("user32.dll")]
     public static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint nFlags);
 
     [StructLayout(LayoutKind.Sequential)]
     public struct RECT {
@@ -984,12 +987,10 @@ if ($targetHwnd -ne '') {
 
 if ($hwndVal -ne [IntPtr]::Zero) {
     if ([Win32]::IsIconic($hwndVal)) {
-        [Win32]::ShowWindow($hwndVal, 9) # SW_RESTORE = 9
+        [Win32]::ShowWindow($hwndVal, 9) | Out-Null # SW_RESTORE = 9
         Start-Sleep -Milliseconds 250
     }
-    [Win32]::SetForegroundWindow($hwndVal)
-    Start-Sleep -Milliseconds 250
-    
+
     $rect = New-Object Win32+RECT
     if ([Win32]::GetWindowRect($hwndVal, [ref]$rect)) {
         $width = $rect.Right - $rect.Left
@@ -997,10 +998,46 @@ if ($hwndVal -ne [IntPtr]::Zero) {
         if ($width -gt 0 -and $height -gt 0) {
             $bitmap = New-Object System.Drawing.Bitmap($width, $height)
             $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
-            $graphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, $bitmap.Size)
+            # PrintWindow renders the target window directly, regardless of
+            # z-order, so an occluded or background window is still captured
+            # correctly. SetForegroundWindow from a background process is
+            # blocked by Windows, so CopyFromScreen would grab whatever sits
+            # on top. PW_RENDERFULLCONTENT (0x2) handles modern/UWP windows.
+            $hdc = $graphics.GetHdc()
+            $printed = [Win32]::PrintWindow($hwndVal, $hdc, 2)
+            $graphics.ReleaseHdc($hdc)
+            $method = "printwindow"
+
+            # Black-frame guard: PrintWindow can return a near-black frame on
+            # some hardware-accelerated / DirectComposition surfaces. Sample a
+            # sparse grid; if it is essentially black, fall back to a foreground
+            # CopyFromScreen grab so the capture self-heals on those drivers.
+            $needFallback = -not $printed
+            if (-not $needFallback) {
+                $sum = 0.0
+                $cnt = 0
+                $stepX = [Math]::Max(1, [int]($width / 12))
+                $stepY = [Math]::Max(1, [int]($height / 12))
+                for ($sy = 0; $sy -lt $height; $sy += $stepY) {
+                    for ($sx = 0; $sx -lt $width; $sx += $stepX) {
+                        $px = $bitmap.GetPixel($sx, $sy)
+                        $sum += ($px.R + $px.G + $px.B) / 3.0
+                        $cnt++
+                    }
+                }
+                if ($cnt -gt 0 -and ($sum / $cnt) -lt 6) { $needFallback = $true }
+            }
+
+            if ($needFallback) {
+                [Win32]::SetForegroundWindow($hwndVal) | Out-Null
+                Start-Sleep -Milliseconds 250
+                $graphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, $bitmap.Size)
+                $method = "copyfromscreen"
+            }
             $bitmap.Save('${outputPath.replace(/\\/g, "\\\\")}', [System.Drawing.Imaging.ImageFormat]::Png)
             $graphics.Dispose()
             $bitmap.Dispose()
+            Write-Output "CAPTURE_METHOD:$method"
             exit 0
         }
     }
@@ -1014,10 +1051,13 @@ $graphics.CopyFromScreen($screen.Location, [System.Drawing.Point]::Empty, $scree
 $bitmap.Save('${outputPath.replace(/\\/g, "\\\\")}', [System.Drawing.Imaging.ImageFormat]::Png)
 $graphics.Dispose()
 $bitmap.Dispose()
+Write-Output "CAPTURE_METHOD:fullscreen"
         `.trim(),
       ],
-      { stdio: "pipe" },
+      { stdio: "pipe", encoding: "utf8" },
     );
+    const match = /CAPTURE_METHOD:(\w+)/.exec(stdout ?? "");
+    return match ? match[1] : "unknown";
   } else if (platform === "darwin") {
     if (hwnd) {
       const parsedHwnd = hwnd.startsWith("0x")
@@ -1026,6 +1066,7 @@ $bitmap.Dispose()
       execFileSync("screencapture", ["-l", String(parsedHwnd), outputPath], {
         stdio: "pipe",
       });
+      return "screencapture-window";
     } else if (processName) {
       try {
         const windowId = execFileSync(
@@ -1040,14 +1081,16 @@ $bitmap.Dispose()
           execFileSync("screencapture", ["-l", windowId, outputPath], {
             stdio: "pipe",
           });
-          return;
+          return "screencapture-window";
         }
       } catch {
         // Fallback if AppleScript fails
       }
       execFileSync("screencapture", ["-x", outputPath], { stdio: "pipe" });
+      return "screencapture-full";
     } else {
       execFileSync("screencapture", ["-x", outputPath], { stdio: "pipe" });
+      return "screencapture-full";
     }
   } else {
     throw new Error(
@@ -1071,9 +1114,9 @@ bridgeCommand
         opts.output ??
         join(tmpdir(), `zam-capture-${randomBytes(4).toString("hex")}.png`);
 
-      if (!opts.image) {
-        captureScreenshot(outputPath, opts.hwnd, opts.processName);
-      }
+      const captureMethod = opts.image
+        ? "provided"
+        : captureScreenshot(outputPath, opts.hwnd, opts.processName);
 
       const imageBytes = readFileSync(outputPath);
       const base64 = imageBytes.toString("base64");
@@ -1083,6 +1126,7 @@ bridgeCommand
         imagePath: outputPath,
         base64,
         mimeType: "image/png",
+        captureMethod,
         capturedAt: new Date().toISOString(),
         platform: process.platform,
       });

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -54,4 +54,17 @@ describe("setup command helpers", () => {
       expect(frontmatter?.[1]).toMatch(/^description:\s+.+/m);
     }
   });
+
+  it("ships Codex-specific UI observation and Windows execution guidance", () => {
+    const content = readFileSync(
+      join(process.cwd(), ".agents", "skills", "zam", "SKILL.md"),
+      "utf8",
+    );
+
+    expect(content).toContain("Codex Execution Notes");
+    expect(content).toContain("WindowsPowerShell");
+    expect(content).toContain("zam bridge add-token --user <username>");
+    expect(content).toContain("zam bridge capture-ui");
+    expect(content).toContain("vision-capable subagent");
+  });
 });


### PR DESCRIPTION
Completes the agent-side UI observation feature: `zam bridge capture-ui` captures a screenshot and returns it as base64 + file path in JSON, so an agent harness's own multimodal model (Claude Code, Codex, Opencode, Antigravity, Copilot, Grok, goose, hermes) can analyze the UI and rate knowledge tokens — no weak local vision model required.

## What's in this branch
- `capture-ui` command returning `{imagePath, base64, captureMethod, ...}` (Windows + macOS)
- `--hwnd` / `--process-name` window targeting
- **Window-capture fix**: switched from `SetForegroundWindow` + `CopyFromScreen` (Windows blocks background foreground-stealing, so it grabbed whatever was on top) to `PrintWindow(PW_RENDERFULLCONTENT)`, which renders the target window directly regardless of z-order and without stealing focus
- **Black-frame guard**: PrintWindow can return near-black on some hardware-accelerated surfaces, so the capture samples mean luminance and self-heals by falling back to a foreground grab; `captureMethod` in the JSON reports which path ran
- SKILL.md Approach C + protocol doc

## Verification (Windows 11, classic powershell.exe)
- UWP Calculator, Notepad, and Electron/Chromium windows (OpenCode, Claude desktop, Edge WebView2) all captured correctly while in the background
- captureMethod correct across printwindow / fullscreen / provided / fallback paths
- Lint clean, 216 tests pass

macOS path is implemented but untested here. Scope of verification noted in `docs/ui-observation-protocol.md`.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)