### PR TITLE
fix(monitor): run npm .cmd shim so PowerShell monitor captures commands

### DIFF
--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -253,16 +253,47 @@ monitorCommand
  * Resolve the `zam` invocation — built CLI if available, otherwise tsx source.
  * This ensures the spawned terminal uses the correct entrypoint.
  */
+/**
+ * Pick the path PowerShell/cmd can actually run from `where.exe` output.
+ *
+ * `where.exe zam` can return both an extensionless shim (the npm Unix shell
+ * wrapper at ...\npm\zam) and the Windows-executable variant (...\npm\zam.cmd).
+ * PowerShell and cmd can only run the latter — invoking the extensionless shim
+ * silently produces no output, which left the spawned monitor window with no
+ * hooks installed (#51). Prefer a result whose extension is in PATHEXT.
+ */
+export function selectWindowsExecutable(
+  results: string[],
+  pathext: string = process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+): string | null {
+  if (results.length === 0) return null;
+  const extensions = pathext
+    .split(";")
+    .map((ext) => ext.trim().toLowerCase())
+    .filter(Boolean);
+  const runnable = results.find((result) =>
+    extensions.some((ext) => result.toLowerCase().endsWith(ext)),
+  );
+  return runnable ?? results[0];
+}
+
 function findExecutable(command: string): string | null {
   try {
     const lookup =
       process.platform === "win32"
         ? `where.exe ${command}`
         : `command -v ${command}`;
-    const result = execSync(lookup, { encoding: "utf-8" })
-      .split(/\r?\n/)[0]
-      ?.trim();
-    return result || null;
+    const results = execSync(lookup, { encoding: "utf-8" })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (results.length === 0) return null;
+
+    if (process.platform === "win32") {
+      return selectWindowsExecutable(results);
+    }
+
+    return results[0];
   } catch {
     return null;
   }

--- a/tests/cli/monitor.test.ts
+++ b/tests/cli/monitor.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { selectWindowsExecutable } from "../../src/cli/commands/monitor.js";
+
+describe("selectWindowsExecutable", () => {
+  const pathext = ".COM;.EXE;.BAT;.CMD";
+
+  it("prefers the PATHEXT match over an extensionless npm shim (#51)", () => {
+    // `where.exe zam` lists the Unix shell shim first, then the .cmd wrapper.
+    // PowerShell can only run the .cmd, so the extensionless shim must lose.
+    const results = [
+      "C:\\Users\\me\\AppData\\Roaming\\npm\\zam",
+      "C:\\Users\\me\\AppData\\Roaming\\npm\\zam.cmd",
+    ];
+    expect(selectWindowsExecutable(results, pathext)).toBe(
+      "C:\\Users\\me\\AppData\\Roaming\\npm\\zam.cmd",
+    );
+  });
+
+  it("returns a .exe match directly", () => {
+    const results = ["C:\\Program Files\\PowerShell\\7\\pwsh.exe"];
+    expect(selectWindowsExecutable(results, pathext)).toBe(
+      "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+    );
+  });
+
+  it("matches PATHEXT case-insensitively", () => {
+    const results = ["C:\\tools\\foo.CMD"];
+    expect(selectWindowsExecutable(results, pathext)).toBe("C:\\tools\\foo.CMD");
+  });
+
+  it("falls back to the first result when none match PATHEXT", () => {
+    const results = ["C:\\weird\\zam", "C:\\weird\\zam.bak"];
+    expect(selectWindowsExecutable(results, pathext)).toBe("C:\\weird\\zam");
+  });
+
+  it("returns null for an empty list", () => {
+    expect(selectWindowsExecutable([], pathext)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem (#51)
`zam monitor open` opened a PowerShell window, but the monitor log stayed empty — commands run there were never captured.

## Root cause
`resolveZamInvocation` builds `& '<zam>'` from `findExecutable("zam")`, which returned the **first** `where.exe zam` line. On a machine with the npm global shim that is the extensionless **Unix** shim (`...\npm\zam`), not `...\npm\zam.cmd`. PowerShell cannot execute the extensionless shim — it silently produces no output — so `$__zamHook` was empty and `Invoke-Expression` installed no prompt hook. The window opened (`-NoExit`) but captured nothing.

Confirmed empirically: `& '...\npm\zam' --version` prints nothing in Windows PowerShell, while `& '...\npm\zam.cmd' --version` prints `0.3.13`.

## Fix
Pick the PATHEXT-runnable variant from `where.exe` output. Extracted into a pure, exported `selectWindowsExecutable()` with unit tests.

## Verification
- Reproduced the empty log via the exact spawned `shellSetup` string, then confirmed the fix records `command_start`/`command_end` with correct exit codes (0 and 1) end-to-end.
- `zam bridge get-monitor` and `zam monitor status` now report the captured commands (`Commands: 2, Errors: 1`).
- 5 new regression tests; full suite 221 passing; lint clean.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)