### PR TITLE
chore(cli): prefer pwsh 7+ over Windows PowerShell 5.1 internally

### DIFF
--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -909,6 +909,21 @@ bridgeCommand
 
 // ── zam bridge capture-ui ──────────────────────────────────────────────────
 
+/**
+ * Resolve the PowerShell executable, preferring PowerShell 7+ (`pwsh`) over
+ * the legacy Windows PowerShell 5.1 (`powershell`). pwsh 7 still ships the
+ * Windows Desktop assemblies the screen-capture script needs, so it is the
+ * default; `powershell` remains a fallback for machines without pwsh.
+ */
+function resolveWindowsPowerShell(): string {
+  try {
+    execFileSync("where.exe", ["pwsh.exe"], { stdio: "ignore" });
+    return "pwsh";
+  } catch {
+    return "powershell";
+  }
+}
+
 function captureScreenshot(
   outputPath: string,
   hwnd?: string,
@@ -924,7 +939,7 @@ function captureScreenshot(
 
   if (platform === "win32") {
     const stdout = execFileSync(
-      "powershell",
+      resolveWindowsPowerShell(),
       [
         "-NoProfile",
         "-Command",

--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -478,9 +478,12 @@ function openWindowsPowerShell(
     `-ArgumentList @('-NoExit','-NoProfile','-Command',${psSingleQuoted(shellSetup)})`,
   ].join(" ");
 
+  // Prefer pwsh 7+ as the launcher too; fall back to Windows PowerShell 5.1.
+  const launcher = findExecutable("pwsh.exe") ? "pwsh.exe" : "powershell.exe";
+
   try {
     execFileSync(
-      "powershell.exe",
+      launcher,
       ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", startCommand],
       {
         stdio: "ignore",


### PR DESCRIPTION
Standardize ZAM's internal PowerShell usage on pwsh 7+, falling back to Windows PowerShell 5.1 (`powershell.exe`) only when pwsh is not installed.

## Changes
- `bridge capture-ui`: screen capture resolves `pwsh` first via `resolveWindowsPowerShell()`
- `monitor open`: the launcher process prefers `pwsh.exe`
- The detected/opened monitor shell already preferred pwsh (`detectShell`)

## Why it's safe
pwsh 7.6 still provides the Windows Desktop assemblies (`System.Windows.Forms`, `System.Drawing`) the capture script relies on. Verified end-to-end: inline-C# `PrintWindow` window capture produces a correct image under pwsh 7, and `capture-ui` full-screen capture works via the resolved pwsh.

## Out of scope (intentionally)
The Codex-runner guidance in `.agents/skills/zam/SKILL.md` still recommends classic Windows PowerShell, because `pwsh.exe` can fail in that sandbox with `CreateProcessAsUserW failed: 1312`. That is an external harness constraint, not a ZAM internal choice, so it is left unchanged.

Lint clean, full suite (221 tests) passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)