### PR TITLE
feat(observer): enforce configurable ObserverPolicy on capture-ui (ADR-0001)

### DIFF
--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -291,12 +291,18 @@ Workflow:
 1. Tell the user: *"Perform the task in the app, leave the relevant window visible, and come back when you're done."*
 2. When the user returns, capture the screen:
    ```bash
-   zam bridge capture-ui --session <session-id>
+   zam bridge capture-ui --session <session-id> --process-name <app>
    ```
-   Returns JSON with `imagePath`, `base64` (PNG screenshot), `captureMethod`,
-   and `captureTarget` metadata when a target window was resolved. Save to a
-   stable file with `--output <path>` whenever you will pass the image to a
-   subagent.
+   Under the default observer policy (`observer.scope=window`) a capture must
+   target a window: pass `--process-name <app>` or `--hwnd <handle>`. An
+   untargeted call is refused with `{ "granted": false, "denied": true,
+   "denialReason": "scope-requires-target", ... }` — retry with a target, or
+   for a deliberate whole-screen grab set `observer.scope=fullscreen`.
+
+   A granted response is JSON with `granted: true`, `imagePath`, `base64`
+   (PNG screenshot), `captureMethod`, `captureTarget` metadata, and a
+   `permission` block. Save to a stable file with `--output <path>` whenever
+   you will pass the image to a subagent.
 3. If Codex subagents are available, spawn a cheap vision-capable subagent (for example a mini model) and pass the screenshot as a local image plus the task, expected evidence, and candidate token slugs. Ask it for observed facts and suggested 1-4 ratings with brief evidence.
 4. Review `captureTarget` and the visual evidence yourself before writing
    ratings. If `captureMethod` is `fullscreen`, the target is missing, the
@@ -314,6 +320,16 @@ The `capture-ui` command supports:
 - `--process-name <name>` or `--hwnd <handle>` — target a specific window when known
 
 On Windows, uses PowerShell/.NET for screen capture. On macOS, uses `screencapture`.
+
+**Observer permissions (Layer 2, ADR-0001).** `capture-ui` enforces a
+user-configurable policy resolved from `zam settings`: `observer.scope`
+(`off` | `window` | `fullscreen`), `observer.allowlist`, `observer.denylist`,
+`observer.consent`, `observer.retention`. Set them with e.g.
+`zam settings set --key observer.scope --value window`. A built-in sensitive
+set (password managers, auth/UAC dialogs, banking) is always refused and
+cannot be allowlisted — those return `denied: true` with
+`denialReason: "sensitive"`. Treat any `denied` response as final: do not
+retry to work around it; tell the user which surface was blocked.
 
 **Rating scale (all observation approaches):**
 - Completed correctly, no hesitation, no help → **4**

--- a/docs/adr/0001-observer-permission-model.md
+++ b/docs/adr/0001-observer-permission-model.md
@@ -260,12 +260,22 @@ and future agent.
 Ordered so a fresh agent with a token budget can pick up any item. File paths are
 load-bearing.
 
-1. [ ] **Define the policy.** Add `ObserverPolicy`, defaults, the built-in
+> **Progress (2026-06-20):** Items 1–2 are done. The wire-contract half of item 3
+> (`CaptureUiResponse` / `ObserverPermission` / `denialReason` / the denied
+> variant) shipped with them; the `GetObserverPolicyResponse` introspection
+> endpoint is still open. Item 8 is partly done (SKILL.md Approach C updated;
+> ARCHITECTURE.md + proposal note still TODO). Settings keys are dotted
+> (`observer.scope`, …), not `observer_*` — see item 5. Enforcement is two-phase
+> (pre-capture for scope/explicit target; post-resolution for the captured
+> window's process/title); the deny discriminator is `denialReason`, not the
+> originally sketched `kind: "privacy-pause"`.
+
+1. [x] **Define the policy.** Add `ObserverPolicy`, defaults, the built-in
    sensitive denylist, and `resolveObserverPolicy(db)` in
    `src/kernel/observation/policy.ts`. Unit tests in
-   `tests/kernel/observer-policy.test.ts` (built-in denylist must win over
-   user allowlist; default = `window`/`per-session`/`none`).
-2. [ ] **Enforce on the bridge path.** In
+   `tests/kernel/observation/observer-policy.test.ts` (built-in denylist must win
+   over user allowlist; default = `window`/`per-session`/`none`).
+2. [x] **Enforce on the bridge path.** In
    [`src/cli/commands/bridge.ts`](../../src/cli/commands/bridge.ts) `capture-ui`:
    before `captureScreenshot()`, resolve policy → if `scope: "off"` or target is
    denylisted or the frontmost window is sensitive, return a typed
@@ -280,7 +290,7 @@ load-bearing.
    `ZAM_OBSERVER_PRIVACY_POLICY` env path with the resolved policy passed from the
    kernel (JSON on spawn or a resolved config file). Keep the env var as a
    deprecated fallback for one release.
-5. [ ] **Expose settings.** Wire the `observer_*` keys through `zam settings`; add
+5. [ ] **Expose settings.** Wire the `observer.*` keys through `zam settings`; add
    optional `zam observer grant|revoke|status` sugar over the picker. Surface an
    unset-policy prompt at the first `--context ui` session (per
    [user-settings.md](../concepts/user-settings.md) discoverability).

--- a/src/bridge/protocol.ts
+++ b/src/bridge/protocol.ts
@@ -288,3 +288,72 @@ export interface GetNeighborhoodResponse {
 export interface ListTokensResponse {
   tokens: GraphToken[];
 }
+
+// ── Observer Policy / UI Capture ─────────────────────────────────────────────
+//
+// Layer 2 of the two-layer consent model (docs/adr/0001-observer-permission-model.md).
+// Every `bridge capture-ui` response echoes the resolved permission summary and
+// is either granted (pixels returned) or denied (refused by policy).
+
+export type ObserverScope = "off" | "window" | "fullscreen";
+export type ObserverConsent = "per-capture" | "per-session" | "standing";
+export type ObserverRetention = "none" | "session" | "persist";
+
+/** The permission summary echoed back on every capture-ui response. */
+export interface ObserverPermission {
+  scope: ObserverScope;
+  consent: ObserverConsent;
+  retention: ObserverRetention;
+  granted: boolean;
+}
+
+export type CaptureDenialReason =
+  | "scope-off"
+  | "scope-requires-target"
+  | "denylisted"
+  | "not-allowlisted"
+  | "sensitive";
+
+export interface CaptureUiTarget {
+  requestedHwnd: string | null;
+  requestedProcessName: string | null;
+  matchedBy: string;
+  hwnd: number | null;
+  processId: number | null;
+  processName: string | null;
+  windowTitle: string | null;
+  bounds: {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+  } | null;
+}
+
+/** Granted capture (or a caller-provided `--image`). */
+export interface CaptureUiResponse {
+  sessionId: string | null;
+  granted: true;
+  imagePath: string;
+  base64: string;
+  mimeType: "image/png";
+  captureMethod: string;
+  captureTarget: CaptureUiTarget | null;
+  capturedAt: string;
+  platform: string;
+  permission: ObserverPermission;
+}
+
+/** Capture refused by the observer policy; no pixels are returned. */
+export interface CaptureUiDeniedResponse {
+  sessionId: string | null;
+  granted: false;
+  denied: true;
+  denialReason: CaptureDenialReason;
+  reason: string;
+  capturedAt: string;
+  platform: string;
+  permission: ObserverPermission;
+}

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
@@ -25,6 +25,8 @@ import {
   appendUiObservationReport,
   buildReviewQueue,
   createToken,
+  decidePostCapture,
+  decidePreCapture,
   discoverSkills,
   endSession,
   ensureCard,
@@ -44,6 +46,7 @@ import {
   pairCommands,
   readMonitorLog,
   readUiObservationLog,
+  resolveObserverPolicy,
   resolveReviewContext,
   startSession,
   uiObservationLogExists,
@@ -1321,21 +1324,84 @@ bridgeCommand
   .option("--hwnd <hwnd>", "Window handle (decimal or hex) to capture")
   .option("--process-name <name>", "Process name to capture")
   .action(async (opts) => {
-    try {
+    await withDb(async (db) => {
+      const policy = await resolveObserverPolicy(db);
+      const permission = {
+        scope: policy.scope,
+        consent: policy.consent,
+        retention: policy.retention,
+      };
+      const isProvided = Boolean(opts.image);
+
+      // A caller-provided --image is "analyze this file", not a capture: ZAM
+      // is not holding the camera, so scope/target policy does not apply.
+      // Live captures are gated below.
+      if (!isProvided) {
+        const pre = decidePreCapture(policy, {
+          hasExplicitTarget: Boolean(opts.hwnd || opts.processName),
+          requestedProcessName: opts.processName ?? null,
+        });
+        if (!pre.allowed) {
+          jsonOut({
+            sessionId: opts.session ?? null,
+            granted: false,
+            denied: true,
+            denialReason: pre.denialReason,
+            reason: pre.reason,
+            capturedAt: new Date().toISOString(),
+            platform: process.platform,
+            permission: { ...permission, granted: false },
+          });
+          return;
+        }
+      }
+
       const outputPath =
         opts.image ??
         opts.output ??
         join(tmpdir(), `zam-capture-${randomBytes(4).toString("hex")}.png`);
 
-      const captureResult = opts.image
+      const captureResult = isProvided
         ? ({ method: "provided", target: null } satisfies CaptureResult)
         : captureScreenshot(outputPath, opts.hwnd, opts.processName);
+
+      // Post-resolution gate: the real process/title are only known now, so
+      // the sensitive/denylist check runs against the window actually
+      // captured. If it fails, discard the pixels before they leave.
+      if (!isProvided) {
+        const post = decidePostCapture(policy, {
+          method: captureResult.method,
+          processName: captureResult.target?.processName ?? null,
+          windowTitle: captureResult.target?.windowTitle ?? null,
+        });
+        if (!post.allowed) {
+          if (!opts.output) {
+            try {
+              rmSync(outputPath, { force: true });
+            } catch {
+              // best-effort discard
+            }
+          }
+          jsonOut({
+            sessionId: opts.session ?? null,
+            granted: false,
+            denied: true,
+            denialReason: post.denialReason,
+            reason: post.reason,
+            capturedAt: new Date().toISOString(),
+            platform: process.platform,
+            permission: { ...permission, granted: false },
+          });
+          return;
+        }
+      }
 
       const imageBytes = readFileSync(outputPath);
       const base64 = imageBytes.toString("base64");
 
       jsonOut({
         sessionId: opts.session ?? null,
+        granted: true,
         imagePath: outputPath,
         base64,
         mimeType: "image/png",
@@ -1343,10 +1409,9 @@ bridgeCommand
         captureTarget: captureResult.target,
         capturedAt: new Date().toISOString(),
         platform: process.platform,
+        permission: { ...permission, granted: true },
       });
-    } catch (err) {
-      jsonError((err as Error).message);
-    }
+    });
   });
 
 // ── zam bridge check-llm ──────────────────────────────────────────────────

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -184,6 +184,28 @@ export {
   writeMonitorEvent,
 } from "./observation/monitor-io.js";
 export type {
+  CaptureDecision,
+  CaptureDenialReason,
+  CaptureRequest,
+  ObserverConsent,
+  ObserverPolicy,
+  ObserverRetention,
+  ObserverScope,
+  ObserverSettingKey,
+  ResolvedCaptureTarget,
+} from "./observation/policy.js";
+export {
+  BUILT_IN_SENSITIVE_MATCHERS,
+  DEFAULT_OBSERVER_POLICY,
+  decidePostCapture,
+  decidePreCapture,
+  matchBuiltInSensitive,
+  matchDenylist,
+  OBSERVER_POLICY_VERSION,
+  parseObserverPolicy,
+  resolveObserverPolicy,
+} from "./observation/policy.js";
+export type {
   ApplySessionSynthesisInput,
   ApplySessionSynthesisResult,
   PrepareSessionSynthesisInput,

--- a/src/kernel/observation/policy.ts
+++ b/src/kernel/observation/policy.ts
@@ -1,0 +1,313 @@
+/**
+ * Observer permission policy — Layer 2 of the two-layer consent model
+ * (see docs/adr/0001-observer-permission-model.md).
+ *
+ * A host (the CLI permission system today, MCP tool-consent later) decides
+ * WHETHER an agent may invoke the observer. This module decides WHAT a given
+ * capture is then allowed to see — enforced by ZAM, because ZAM holds the
+ * camera. The policy is user-configurable through `zam settings` (the
+ * `observer.*` keys in `user_config`) and resolved here into a typed value with
+ * safe defaults.
+ *
+ * The decision functions are pure so they can be unit-tested without a DB or a
+ * live screen, and reused unchanged under a future `zam mcp serve`.
+ */
+
+import type { Database } from "../db/types.js";
+import { getSetting } from "../models/settings.js";
+
+export const OBSERVER_POLICY_VERSION = 1 as const;
+
+export type ObserverScope = "off" | "window" | "fullscreen";
+export type ObserverConsent = "per-capture" | "per-session" | "standing";
+export type ObserverRetention = "none" | "session" | "persist";
+
+export interface ObserverPolicy {
+  version: typeof OBSERVER_POLICY_VERSION;
+  /** "off" disables capture; "window" requires a target; "fullscreen" permits an untargeted grab. */
+  scope: ObserverScope;
+  /** Lower-cased process names permitted under window scope (empty = any non-denied window). */
+  allowlist: string[];
+  /** Lower-cased process/title fragments the user never wants captured (added to the built-in set). */
+  denylist: string[];
+  consent: ObserverConsent;
+  retention: ObserverRetention;
+  redactWindowTitles: boolean;
+  audioOptIn: boolean;
+}
+
+export const DEFAULT_OBSERVER_POLICY: ObserverPolicy = {
+  version: OBSERVER_POLICY_VERSION,
+  scope: "window",
+  allowlist: [],
+  denylist: [],
+  consent: "per-session",
+  retention: "none",
+  redactWindowTitles: true,
+  audioOptIn: false,
+};
+
+/**
+ * Built-in sensitive process/title fragments that are ALWAYS non-observable.
+ * User config may extend the effective denylist but can never re-enable capture
+ * of these — a user `allowlist` cannot override the built-in floor. Matching is
+ * case-insensitive substring against process name and window title. This mirrors
+ * a conservative subset of the native Rust observer's sensitive-context set.
+ */
+export const BUILT_IN_SENSITIVE_MATCHERS: readonly string[] = [
+  // Password managers
+  "1password",
+  "bitwarden",
+  "keepass",
+  "lastpass",
+  "dashlane",
+  "nordpass",
+  "enpass",
+  "proton pass",
+  // Authentication / credential / UAC surfaces
+  "credentialuibroker",
+  "consentux",
+  "logonui",
+  "windowssecurity",
+  "authenticator",
+  // Conservative banking/title hints
+  "online banking",
+  "onlinebanking",
+];
+
+export type ObserverSettingKey =
+  | "observer.scope"
+  | "observer.allowlist"
+  | "observer.denylist"
+  | "observer.consent"
+  | "observer.retention"
+  | "observer.redact_titles"
+  | "observer.audio";
+
+function parseList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
+function parseScope(raw: string | undefined): ObserverScope {
+  return raw === "off" || raw === "window" || raw === "fullscreen"
+    ? raw
+    : DEFAULT_OBSERVER_POLICY.scope;
+}
+
+function parseConsent(raw: string | undefined): ObserverConsent {
+  return raw === "per-capture" || raw === "per-session" || raw === "standing"
+    ? raw
+    : DEFAULT_OBSERVER_POLICY.consent;
+}
+
+function parseRetention(raw: string | undefined): ObserverRetention {
+  return raw === "none" || raw === "session" || raw === "persist"
+    ? raw
+    : DEFAULT_OBSERVER_POLICY.retention;
+}
+
+function parseBool(raw: string | undefined, fallback: boolean): boolean {
+  if (raw === undefined) return fallback;
+  return raw === "true";
+}
+
+/** Pure: build a policy from raw setting strings (no DB access). */
+export function parseObserverPolicy(
+  raw: Partial<Record<ObserverSettingKey, string>>,
+): ObserverPolicy {
+  return {
+    version: OBSERVER_POLICY_VERSION,
+    scope: parseScope(raw["observer.scope"]),
+    allowlist: parseList(raw["observer.allowlist"]),
+    denylist: parseList(raw["observer.denylist"]),
+    consent: parseConsent(raw["observer.consent"]),
+    retention: parseRetention(raw["observer.retention"]),
+    redactWindowTitles: parseBool(
+      raw["observer.redact_titles"],
+      DEFAULT_OBSERVER_POLICY.redactWindowTitles,
+    ),
+    audioOptIn: parseBool(
+      raw["observer.audio"],
+      DEFAULT_OBSERVER_POLICY.audioOptIn,
+    ),
+  };
+}
+
+/** Read the policy from `user_config`, falling back to safe defaults. */
+export async function resolveObserverPolicy(
+  db: Database,
+): Promise<ObserverPolicy> {
+  const [scope, allowlist, denylist, consent, retention, redactTitles, audio] =
+    await Promise.all([
+      getSetting(db, "observer.scope"),
+      getSetting(db, "observer.allowlist"),
+      getSetting(db, "observer.denylist"),
+      getSetting(db, "observer.consent"),
+      getSetting(db, "observer.retention"),
+      getSetting(db, "observer.redact_titles"),
+      getSetting(db, "observer.audio"),
+    ]);
+  return parseObserverPolicy({
+    "observer.scope": scope,
+    "observer.allowlist": allowlist,
+    "observer.denylist": denylist,
+    "observer.consent": consent,
+    "observer.retention": retention,
+    "observer.redact_titles": redactTitles,
+    "observer.audio": audio,
+  });
+}
+
+// ── Capture decisions (pure) ────────────────────────────────────────────────
+
+export type CaptureDenialReason =
+  | "scope-off"
+  | "scope-requires-target"
+  | "denylisted"
+  | "not-allowlisted"
+  | "sensitive";
+
+export type CaptureDecision =
+  | { allowed: true }
+  | { allowed: false; reason: string; denialReason: CaptureDenialReason };
+
+export interface CaptureRequest {
+  /** Whether the caller specified a concrete window target (--hwnd or --process-name). */
+  hasExplicitTarget: boolean;
+  /** The requested process name, if any (comparison is case-insensitive). */
+  requestedProcessName: string | null;
+}
+
+export interface ResolvedCaptureTarget {
+  /** printwindow | copyfromscreen | fullscreen | provided | screencapture-* */
+  method: string;
+  processName: string | null;
+  windowTitle: string | null;
+}
+
+function haystacks(...values: Array<string | null | undefined>): string[] {
+  return values
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
+    .map((v) => v.toLowerCase());
+}
+
+function deny(
+  reason: string,
+  denialReason: CaptureDenialReason,
+): CaptureDecision {
+  return { allowed: false, reason, denialReason };
+}
+
+/** Built-in sensitive match (authoritative — user config cannot override). */
+export function matchBuiltInSensitive(
+  processName: string | null,
+  windowTitle: string | null,
+): string | null {
+  const fields = haystacks(processName, windowTitle);
+  for (const matcher of BUILT_IN_SENSITIVE_MATCHERS) {
+    if (fields.some((field) => field.includes(matcher))) return matcher;
+  }
+  return null;
+}
+
+/** User-denylist match. */
+export function matchDenylist(
+  policy: ObserverPolicy,
+  processName: string | null,
+  windowTitle: string | null,
+): string | null {
+  const fields = haystacks(processName, windowTitle);
+  for (const matcher of policy.denylist) {
+    if (fields.some((field) => field.includes(matcher))) return matcher;
+  }
+  return null;
+}
+
+function inAllowlist(
+  policy: ObserverPolicy,
+  processName: string | null,
+): boolean {
+  if (policy.allowlist.length === 0) return true;
+  if (!processName) return false;
+  const name = processName.toLowerCase();
+  return policy.allowlist.some((entry) => name.includes(entry));
+}
+
+/**
+ * Phase 1 — decide before any pixels are grabbed, from scope plus the requested
+ * target. Cheap denials (disabled observer, missing target, an explicitly named
+ * sensitive/denied process) happen here so no screenshot is taken at all.
+ */
+export function decidePreCapture(
+  policy: ObserverPolicy,
+  request: CaptureRequest,
+): CaptureDecision {
+  if (policy.scope === "off") {
+    return deny("observer is disabled (observer.scope=off)", "scope-off");
+  }
+  if (policy.scope === "window" && !request.hasExplicitTarget) {
+    return deny(
+      "window scope requires a target: pass --process-name or --hwnd, or set observer.scope=fullscreen",
+      "scope-requires-target",
+    );
+  }
+  const requested = request.requestedProcessName;
+  if (requested) {
+    const sensitive = matchBuiltInSensitive(requested, null);
+    if (sensitive) {
+      return deny(`refusing sensitive surface (${sensitive})`, "sensitive");
+    }
+    const denied = matchDenylist(policy, requested, null);
+    if (denied) {
+      return deny(`process is denylisted (${denied})`, "denylisted");
+    }
+    if (!inAllowlist(policy, requested)) {
+      return deny(
+        `process not in observer.allowlist (${requested.toLowerCase()})`,
+        "not-allowlisted",
+      );
+    }
+  }
+  return { allowed: true };
+}
+
+/**
+ * Phase 2 — decide after the window was resolved into a concrete target. This
+ * is the first point where the real process/title are known, so the
+ * sensitive/denylist check against the *actual* captured window happens here;
+ * the caller discards the pixels if it fails.
+ */
+export function decidePostCapture(
+  policy: ObserverPolicy,
+  target: ResolvedCaptureTarget,
+): CaptureDecision {
+  const isFullscreen = target.method.toLowerCase().includes("fullscreen");
+  if (policy.scope === "window" && isFullscreen) {
+    return deny(
+      "window scope but capture fell back to fullscreen (target window not resolved)",
+      "scope-requires-target",
+    );
+  }
+  const sensitive = matchBuiltInSensitive(
+    target.processName,
+    target.windowTitle,
+  );
+  if (sensitive) {
+    return deny(`refusing sensitive surface (${sensitive})`, "sensitive");
+  }
+  const denied = matchDenylist(policy, target.processName, target.windowTitle);
+  if (denied) {
+    return deny(`captured window is denylisted (${denied})`, "denylisted");
+  }
+  if (policy.scope === "window" && !inAllowlist(policy, target.processName)) {
+    return deny(
+      `captured window not in observer.allowlist (${target.processName ?? "unknown"})`,
+      "not-allowlisted",
+    );
+  }
+  return { allowed: true };
+}

--- a/tests/kernel/observation/observer-policy.test.ts
+++ b/tests/kernel/observation/observer-policy.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_OBSERVER_POLICY,
+  decidePostCapture,
+  decidePreCapture,
+  matchBuiltInSensitive,
+  type ObserverPolicy,
+  OBSERVER_POLICY_VERSION,
+  parseObserverPolicy,
+} from "../../../src/kernel/observation/policy.js";
+
+function policy(overrides: Partial<ObserverPolicy> = {}): ObserverPolicy {
+  return { ...DEFAULT_OBSERVER_POLICY, ...overrides };
+}
+
+describe("parseObserverPolicy", () => {
+  it("returns safe defaults for empty input", () => {
+    expect(parseObserverPolicy({})).toEqual(DEFAULT_OBSERVER_POLICY);
+  });
+
+  it("parses configured values", () => {
+    const parsed = parseObserverPolicy({
+      "observer.scope": "fullscreen",
+      "observer.allowlist": "Calculator, notepad",
+      "observer.denylist": "Signal,  Telegram ",
+      "observer.consent": "standing",
+      "observer.retention": "session",
+      "observer.redact_titles": "false",
+      "observer.audio": "true",
+    });
+    expect(parsed.version).toBe(OBSERVER_POLICY_VERSION);
+    expect(parsed.scope).toBe("fullscreen");
+    expect(parsed.allowlist).toEqual(["calculator", "notepad"]);
+    expect(parsed.denylist).toEqual(["signal", "telegram"]);
+    expect(parsed.consent).toBe("standing");
+    expect(parsed.retention).toBe("session");
+    expect(parsed.redactWindowTitles).toBe(false);
+    expect(parsed.audioOptIn).toBe(true);
+  });
+
+  it("falls back to defaults for invalid enum values", () => {
+    const parsed = parseObserverPolicy({
+      "observer.scope": "everything",
+      "observer.consent": "whenever",
+      "observer.retention": "forever",
+    });
+    expect(parsed.scope).toBe(DEFAULT_OBSERVER_POLICY.scope);
+    expect(parsed.consent).toBe(DEFAULT_OBSERVER_POLICY.consent);
+    expect(parsed.retention).toBe(DEFAULT_OBSERVER_POLICY.retention);
+  });
+});
+
+describe("decidePreCapture", () => {
+  it("denies when the observer is disabled", () => {
+    const d = decidePreCapture(policy({ scope: "off" }), {
+      hasExplicitTarget: true,
+      requestedProcessName: "notepad",
+    });
+    expect(d).toMatchObject({ allowed: false, denialReason: "scope-off" });
+  });
+
+  it("requires a target under window scope", () => {
+    const d = decidePreCapture(policy({ scope: "window" }), {
+      hasExplicitTarget: false,
+      requestedProcessName: null,
+    });
+    expect(d).toMatchObject({
+      allowed: false,
+      denialReason: "scope-requires-target",
+    });
+  });
+
+  it("allows a targeted window capture", () => {
+    const d = decidePreCapture(policy({ scope: "window" }), {
+      hasExplicitTarget: true,
+      requestedProcessName: "notepad",
+    });
+    expect(d.allowed).toBe(true);
+  });
+
+  it("allows an untargeted fullscreen capture", () => {
+    const d = decidePreCapture(policy({ scope: "fullscreen" }), {
+      hasExplicitTarget: false,
+      requestedProcessName: null,
+    });
+    expect(d.allowed).toBe(true);
+  });
+
+  it("refuses an explicitly requested sensitive process", () => {
+    const d = decidePreCapture(policy({ scope: "window" }), {
+      hasExplicitTarget: true,
+      requestedProcessName: "1Password",
+    });
+    expect(d).toMatchObject({ allowed: false, denialReason: "sensitive" });
+  });
+
+  it("refuses a user-denylisted process", () => {
+    const d = decidePreCapture(
+      policy({ scope: "window", denylist: ["signal"] }),
+      { hasExplicitTarget: true, requestedProcessName: "Signal" },
+    );
+    expect(d).toMatchObject({ allowed: false, denialReason: "denylisted" });
+  });
+
+  it("enforces a non-empty allowlist", () => {
+    const d = decidePreCapture(
+      policy({ scope: "window", allowlist: ["calculator"] }),
+      { hasExplicitTarget: true, requestedProcessName: "notepad" },
+    );
+    expect(d).toMatchObject({
+      allowed: false,
+      denialReason: "not-allowlisted",
+    });
+  });
+});
+
+describe("decidePostCapture", () => {
+  it("denies a window-scope capture that fell back to fullscreen", () => {
+    const d = decidePostCapture(policy({ scope: "window" }), {
+      method: "fullscreen",
+      processName: null,
+      windowTitle: null,
+    });
+    expect(d).toMatchObject({
+      allowed: false,
+      denialReason: "scope-requires-target",
+    });
+  });
+
+  it("refuses a resolved sensitive window", () => {
+    const d = decidePostCapture(policy({ scope: "window" }), {
+      method: "printwindow",
+      processName: "Bitwarden",
+      windowTitle: "Vault",
+    });
+    expect(d).toMatchObject({ allowed: false, denialReason: "sensitive" });
+  });
+
+  it("detects sensitive surfaces by window title too", () => {
+    const d = decidePostCapture(policy({ scope: "fullscreen" }), {
+      method: "fullscreen",
+      processName: "chrome",
+      windowTitle: "My Bank — Online Banking",
+    });
+    expect(d).toMatchObject({ allowed: false, denialReason: "sensitive" });
+  });
+
+  it("allows a permitted resolved window", () => {
+    const d = decidePostCapture(
+      policy({ scope: "window", allowlist: ["calculator"] }),
+      {
+        method: "printwindow",
+        processName: "Calculator",
+        windowTitle: "Calculator",
+      },
+    );
+    expect(d.allowed).toBe(true);
+  });
+
+  it("built-in sensitive set wins even when the user allowlists it", () => {
+    // The load-bearing invariant: a user allowlist can never re-enable capture
+    // of a built-in sensitive surface.
+    const d = decidePostCapture(
+      policy({ scope: "window", allowlist: ["1password"] }),
+      {
+        method: "printwindow",
+        processName: "1Password",
+        windowTitle: "1Password",
+      },
+    );
+    expect(d).toMatchObject({ allowed: false, denialReason: "sensitive" });
+  });
+});
+
+describe("matchBuiltInSensitive", () => {
+  it("matches a known password manager", () => {
+    expect(matchBuiltInSensitive("KeePassXC", null)).toBe("keepass");
+  });
+
+  it("returns null for an ordinary app", () => {
+    expect(matchBuiltInSensitive("notepad", "Untitled")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implements [ADR-0001](docs/adr/0001-observer-permission-model.md) Action Items **1 + 2** — the ZAM-owned **Layer 2** of the two-layer consent model. `capture-ui` now enforces a user-configurable permission policy instead of always grabbing the screen.

## What landed

- **New kernel module** `src/kernel/observation/policy.ts`
  - Typed `ObserverPolicy` resolved from `observer.*` settings, safe defaults: **`window` / `per-session` / `none`**.
  - A **built-in sensitive denylist** (password managers, auth/UAC dialogs, banking) that a user `allowlist` can **never** override — the load-bearing invariant, unit-tested.
  - Pure, two-phase decision functions: `decidePreCapture` (scope + explicitly requested target) and `decidePostCapture` (the *actually resolved* window's process/title).
- **Enforcement in `capture-ui`** (`src/cli/commands/bridge.ts`): pre-capture gate, then a post-resolution gate that **discards the captured pixels** before they leave the process if the resolved window is sensitive/denylisted. Responses are a typed granted/denied union with a `permission` summary + `denialReason`.
- **Wire contract** (`src/bridge/protocol.ts`): `ObserverPermission`, `CaptureDenialReason`, `CaptureUiResponse`, `CaptureUiDeniedResponse`.
- **Docs**: SKILL.md Approach C updated; ADR action items ticked (1–2 done, 3 partial, 8 partial).

## ⚠️ Behavior change

The default scope is **`window`**, so an **untargeted** `capture-ui` call is now **refused** (`denialReason: "scope-requires-target"`) — pass `--process-name` / `--hwnd`, or set `observer.scope=fullscreen` for a deliberate whole-screen grab. This is safe-by-default per the [Windows UI observer proposal](docs/windows-ui-observer-proposal.md), and `window` is the only scope under which the denylist is meaningful (a fullscreen grab can't be window-filtered).

## Verification

`typecheck` ✅ · `lint` ✅ (77 files) · `build` ✅ · `test` ✅ (238 passed / 29 files, +17 new)

Manual deny-path smoke test (no screenshot taken):
```json
{ "granted": false, "denied": true, "denialReason": "scope-requires-target",
  "permission": { "scope": "window", "consent": "per-session", "retention": "none", "granted": false } }
```

## Deferred (tracked in ADR-0001)

`GetObserverPolicyResponse` introspection (rest of item 3), Rust-sidecar unification (4), `zam settings` sugar + `zam observer grant` (5), mode presets (6), `zam mcp serve` (7), ARCHITECTURE.md/proposal docs (rest of 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
