### PR TITLE
feat(observer): unify sidecar privacy policy with the kernel ObserverPolicy (ADR-0001)

### DIFF
--- a/docs/adr/0001-observer-permission-model.md
+++ b/docs/adr/0001-observer-permission-model.md
@@ -260,7 +260,7 @@ and future agent.
 Ordered so a fresh agent with a token budget can pick up any item. File paths are
 load-bearing.
 
-> **Progress (2026-06-20):** Items 1–2 are done. The wire-contract half of item 3
+> **Progress (2026-06-20):** Items 1–2 and 4 are done. The wire-contract half of item 3
 > (`CaptureUiResponse` / `ObserverPermission` / `denialReason` / the denied
 > variant) shipped with them; the `GetObserverPolicyResponse` introspection
 > endpoint is still open. Item 8 is partly done (SKILL.md Approach C updated;
@@ -268,7 +268,13 @@ load-bearing.
 > (`observer.scope`, …), not `observer_*` — see item 5. Enforcement is two-phase
 > (pre-capture for scope/explicit target; post-resolution for the captured
 > window's process/title); the deny discriminator is `denialReason`, not the
-> originally sketched `kind: "privacy-pause"`.
+> originally sketched `kind: "privacy-pause"`. Item 4: the native Rust sidecar
+> now resolves `<observer-dir>/policy.json` (kernel-written;
+> `ZAM_OBSERVER_PRIVACY_POLICY` is a deprecated fallback), and the kernel writes
+> it via `zam bridge sync-observer-policy` and on every `observer.*` settings
+> change — one policy source for both capture paths. Caveat: if the desktop
+> launches the observer with a custom `ZAM_OBSERVER_DIR`, the sync must target
+> that dir.
 
 1. [x] **Define the policy.** Add `ObserverPolicy`, defaults, the built-in
    sensitive denylist, and `resolveObserverPolicy(db)` in
@@ -286,7 +292,7 @@ load-bearing.
    `CaptureUiResponse` (currently ad hoc), an exported `ObserverPolicy`, a
    `GetObserverPolicyResponse` (lets an agent ask "what may I capture?"), and the
    `denied` variant. Bump the policy/protocol version.
-4. [ ] **Unify the sidecar.** Replace the Rust observer's
+4. [x] **Unify the sidecar.** Replace the Rust observer's
    `ZAM_OBSERVER_PRIVACY_POLICY` env path with the resolved policy passed from the
    kernel (JSON on spawn or a resolved config file). Keep the env var as a
    deprecated fallback for one release.

--- a/observer/README.md
+++ b/observer/README.md
@@ -220,7 +220,13 @@ Custom privacy policy:
 }
 ```
 
-Set `ZAM_OBSERVER_PRIVACY_POLICY` to the JSON file path before starting the
-sidecar. `allowProcesses` bypasses only custom policy rules; built-in pauses for
-password managers, authentication/private-browsing, and financial contexts still
-win.
+The sidecar resolves this policy from, in order: the kernel-written
+`<observer-dir>/policy.json` (`<observer-dir>` is `ZAM_OBSERVER_DIR`, else
+`~/.zam/observer`); then the `ZAM_OBSERVER_PRIVACY_POLICY` env file (deprecated
+fallback); then the built-in default. The kernel derives that file from the
+user's `observer.*` settings — `zam bridge sync-observer-policy` writes it and
+`zam settings set observer.*` refreshes it — so the native sidecar and the
+headless `capture-ui` path share one policy source (see
+[ADR-0001](../docs/adr/0001-observer-permission-model.md)). `allowProcesses`
+bypasses only custom policy rules; built-in pauses for password managers,
+authentication/private-browsing, and financial contexts still win.

--- a/observer/src/lib.rs
+++ b/observer/src/lib.rs
@@ -33,7 +33,8 @@ pub use picker::{
 pub use privacy::{
     classify_window_privacy, classify_window_privacy_with_policy, ensure_capture_allowed,
     load_window_privacy_policy, load_window_privacy_policy_from_env, redact_window_title,
-    PrivacyAction, WindowPrivacy, WindowPrivacyPolicy, PRIVACY_POLICY_ENV, REDACTED_WINDOW_TITLE,
+    resolve_window_privacy_policy, PrivacyAction, WindowPrivacy, WindowPrivacyPolicy,
+    PRIVACY_POLICY_ENV, REDACTED_WINDOW_TITLE, RESOLVED_POLICY_FILE,
 };
 pub use raw_input::{watch_raw_input, watch_raw_input_continuous};
 pub use replay::{ReplayEngine, ReplayError, ReplaySummary};

--- a/observer/src/picker.rs
+++ b/observer/src/picker.rs
@@ -97,8 +97,8 @@ mod windows_picker {
 
     use super::{PickedWindow, WindowInfo, PROTOCOL_VERSION};
     use crate::privacy::{
-        classify_window_privacy_with_policy, ensure_capture_allowed,
-        load_window_privacy_policy_from_env, redact_window_title, WindowPrivacyPolicy,
+        classify_window_privacy_with_policy, ensure_capture_allowed, redact_window_title,
+        resolve_window_privacy_policy, WindowPrivacyPolicy,
     };
 
     const PICKER_TIMEOUT: Duration = Duration::from_secs(120);
@@ -108,7 +108,7 @@ mod windows_picker {
             RoInitialize(RO_INIT_SINGLETHREADED)
                 .map_err(|error| format!("failed to initialize WinRT: {error}"))?;
         }
-        let policy = load_window_privacy_policy_from_env()?;
+        let policy = resolve_window_privacy_policy()?;
 
         let picker = GraphicsCapturePicker::new()
             .map_err(|error| format!("failed to create capture picker: {error}"))?;
@@ -141,7 +141,7 @@ mod windows_picker {
             RoInitialize(RO_INIT_SINGLETHREADED)
                 .map_err(|error| format!("failed to initialize WinRT: {error}"))?;
         }
-        let policy = load_window_privacy_policy_from_env()?;
+        let policy = resolve_window_privacy_policy()?;
 
         let hwnd = hwnd_from_u64(raw_hwnd);
         if hwnd.is_invalid() {
@@ -172,7 +172,7 @@ mod windows_picker {
     }
 
     pub(crate) fn list_windows() -> Result<Vec<WindowInfo>, String> {
-        let policy = load_window_privacy_policy_from_env()?;
+        let policy = resolve_window_privacy_policy()?;
         let mut state = WindowEnumerationState {
             windows: Vec::new(),
             policy,
@@ -191,7 +191,7 @@ mod windows_picker {
     }
 
     pub(crate) fn foreground_window() -> Result<Option<WindowInfo>, String> {
-        let policy = load_window_privacy_policy_from_env()?;
+        let policy = resolve_window_privacy_policy()?;
         let hwnd = unsafe { GetForegroundWindow() };
         if hwnd.is_invalid() {
             return Ok(None);
@@ -201,7 +201,7 @@ mod windows_picker {
     }
 
     pub(crate) fn window_info(raw_hwnd: u64) -> Result<Option<WindowInfo>, String> {
-        let policy = load_window_privacy_policy_from_env()?;
+        let policy = resolve_window_privacy_policy()?;
         let hwnd = hwnd_from_u64(raw_hwnd);
         if hwnd.is_invalid() {
             return Err("invalid HWND 0".to_string());

--- a/observer/src/privacy.rs
+++ b/observer/src/privacy.rs
@@ -1,5 +1,6 @@
 use std::env;
-use std::path::Path;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -109,6 +110,60 @@ pub fn load_window_privacy_policy(path: &Path) -> Result<WindowPrivacyPolicy, St
         .map_err(|error| format!("failed to read privacy policy {}: {error}", path.display()))?;
     serde_json::from_str::<WindowPrivacyPolicy>(&raw)
         .map_err(|error| format!("failed to parse privacy policy {}: {error}", path.display()))
+}
+
+/// Filename, under the observer directory, of the policy the ZAM kernel writes
+/// from the user's `observer.*` settings.
+pub const RESOLVED_POLICY_FILE: &str = "policy.json";
+
+const OBSERVER_DIR_ENV: &str = "ZAM_OBSERVER_DIR";
+
+/// Resolve the active window-privacy policy from the unified ZAM source.
+///
+/// Precedence (Layer 2 of the two-layer consent model — see
+/// docs/adr/0001-observer-permission-model.md, item 4):
+/// 1. the kernel-written file at `<observer-dir>/policy.json` (primary);
+/// 2. the `ZAM_OBSERVER_PRIVACY_POLICY` env file (deprecated fallback);
+/// 3. the built-in default.
+///
+/// The observer directory mirrors the kernel's resolution: `ZAM_OBSERVER_DIR`,
+/// else `~/.zam/observer`. The built-in sensitive set is always enforced on top
+/// of whatever this returns; user config can only make the policy stricter.
+pub fn resolve_window_privacy_policy() -> Result<WindowPrivacyPolicy, String> {
+    resolve_window_privacy_policy_with(observer_dir(), env::var_os(PRIVACY_POLICY_ENV))
+}
+
+fn resolve_window_privacy_policy_with(
+    observer_dir: Option<PathBuf>,
+    env_policy_path: Option<OsString>,
+) -> Result<WindowPrivacyPolicy, String> {
+    if let Some(dir) = observer_dir {
+        let resolved = dir.join(RESOLVED_POLICY_FILE);
+        if resolved.is_file() {
+            return load_window_privacy_policy(&resolved);
+        }
+    }
+    if let Some(path) = env_policy_path {
+        if !path.is_empty() {
+            return load_window_privacy_policy(Path::new(&path));
+        }
+    }
+    Ok(WindowPrivacyPolicy::default())
+}
+
+fn observer_dir() -> Option<PathBuf> {
+    if let Some(dir) = env::var_os(OBSERVER_DIR_ENV) {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    let home = if cfg!(windows) {
+        env::var_os("USERPROFILE")
+    } else {
+        env::var_os("HOME")
+    };
+    home.filter(|value| !value.is_empty())
+        .map(|value| PathBuf::from(value).join(".zam").join("observer"))
 }
 
 pub fn redact_window_title(title: String, privacy: &WindowPrivacy) -> String {
@@ -305,5 +360,46 @@ mod tests {
         let built_in = classify_window_privacy_with_policy("chrome.exe", "Sign in", &policy);
         assert_eq!(built_in.action, PrivacyAction::PrivacyPause);
         assert_eq!(built_in.reasons, vec!["authentication"]);
+    }
+
+    #[test]
+    fn resolves_kernel_file_over_env_and_default() {
+        let dir = std::env::temp_dir().join(format!("zam-policy-file-{}", std::process::id()));
+        let observer_dir = dir.join("observer");
+        std::fs::create_dir_all(&observer_dir).expect("create observer dir");
+        std::fs::write(
+            observer_dir.join(RESOLVED_POLICY_FILE),
+            r#"{"denyProcesses":["slack"]}"#,
+        )
+        .expect("write policy");
+
+        let policy =
+            resolve_window_privacy_policy_with(Some(observer_dir), None).expect("resolve policy");
+        assert_eq!(policy.deny_processes, vec!["slack".to_string()]);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn falls_back_to_env_when_no_kernel_file() {
+        let dir = std::env::temp_dir().join(format!("zam-policy-env-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create dir");
+        let env_file = dir.join("env-policy.json");
+        std::fs::write(&env_file, r#"{"denyTitleMarkers":["payroll"]}"#).expect("write env policy");
+
+        let policy = resolve_window_privacy_policy_with(
+            Some(dir.join("missing-observer")),
+            Some(env_file.into_os_string()),
+        )
+        .expect("resolve policy");
+        assert_eq!(policy.deny_title_markers, vec!["payroll".to_string()]);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn defaults_when_neither_file_nor_env() {
+        let policy = resolve_window_privacy_policy_with(None, None).expect("resolve policy");
+        assert_eq!(policy, WindowPrivacyPolicy::default());
     }
 }

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -49,6 +49,7 @@ import {
   resolveObserverPolicy,
   resolveReviewContext,
   startSession,
+  syncObserverSidecarPolicy,
   uiObservationLogExists,
 } from "../../kernel/index.js";
 import {
@@ -1411,6 +1412,20 @@ bridgeCommand
         platform: process.platform,
         permission: { ...permission, granted: true },
       });
+    });
+  });
+
+// ── zam bridge sync-observer-policy ────────────────────────────────────────
+
+bridgeCommand
+  .command("sync-observer-policy")
+  .description(
+    "Write the resolved observer policy to the native sidecar file (JSON)",
+  )
+  .action(async () => {
+    await withDb(async (db) => {
+      const { path, policy } = await syncObserverSidecarPolicy(db);
+      jsonOut({ synced: true, path, policy });
     });
   });
 

--- a/src/cli/commands/settings.ts
+++ b/src/cli/commands/settings.ts
@@ -11,6 +11,7 @@ import {
   getRepoPaths,
   getSetting,
   setSetting,
+  syncObserverSidecarPolicy,
 } from "../../kernel/index.js";
 import { withDb } from "./shared/db.js";
 
@@ -106,6 +107,10 @@ settingsCommand
     await withDb(async (db) => {
       const parsedVal = normalizeSettingValue(key, value);
       await setSetting(db, key, parsedVal);
+      if (key.startsWith("observer.")) {
+        // Keep the native sidecar's policy file in sync with observer.* settings.
+        await syncObserverSidecarPolicy(db);
+      }
       if (!opts.quiet) {
         console.log(`Set ${key} = ${parsedVal}`);
       }
@@ -121,6 +126,10 @@ settingsCommand
   .action(async (key, opts) => {
     await withDb(async (db) => {
       const deleted = await deleteSetting(db, key);
+      if (key.startsWith("observer.")) {
+        // Regenerate the sidecar policy file after an observer.* change.
+        await syncObserverSidecarPolicy(db);
+      }
       if (!opts.quiet) {
         if (deleted) {
           console.log(`Deleted: ${key}`);

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -183,6 +183,12 @@ export {
   readMonitorLog,
   writeMonitorEvent,
 } from "./observation/monitor-io.js";
+export type { SidecarPrivacyPolicy } from "./observation/observer-sidecar-policy.js";
+export {
+  SIDECAR_POLICY_FILE,
+  syncObserverSidecarPolicy,
+  toSidecarPrivacyPolicy,
+} from "./observation/observer-sidecar-policy.js";
 export type {
   CaptureDecision,
   CaptureDenialReason,

--- a/src/kernel/observation/observer-sidecar-policy.ts
+++ b/src/kernel/observation/observer-sidecar-policy.ts
@@ -1,0 +1,62 @@
+/**
+ * Bridge between the ObserverPolicy (Layer 2) and the native Rust observer
+ * sidecar. The sidecar reads a kernel-written policy file at
+ * `<observer-dir>/policy.json` instead of its own `ZAM_OBSERVER_PRIVACY_POLICY`
+ * env var, so the headless `capture-ui` path and the live sidecar share one
+ * source of truth. See docs/adr/0001-observer-permission-model.md (item 4).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Database } from "../db/types.js";
+import { type ObserverPolicy, resolveObserverPolicy } from "./policy.js";
+import { getUiObserverDir } from "./ui-observer-io.js";
+
+/** Filename, under the observer dir, that the Rust sidecar reads. */
+export const SIDECAR_POLICY_FILE = "policy.json";
+
+/**
+ * The Rust observer's `WindowPrivacyPolicy` wire shape (serde camelCase). These
+ * are only the user-configurable lists; the sidecar enforces its own
+ * authoritative built-in sensitive set on top, exactly like the TS side.
+ */
+export interface SidecarPrivacyPolicy {
+  allowProcesses: string[];
+  denyProcesses: string[];
+  denyTitleMarkers: string[];
+}
+
+/**
+ * Pure mapping from an ObserverPolicy to the sidecar's `WindowPrivacyPolicy`.
+ * A denylist term should block on process OR title, so it feeds both the
+ * process and title-marker lists.
+ */
+export function toSidecarPrivacyPolicy(
+  policy: ObserverPolicy,
+): SidecarPrivacyPolicy {
+  return {
+    allowProcesses: [...policy.allowlist],
+    denyProcesses: [...policy.denylist],
+    denyTitleMarkers: [...policy.denylist],
+  };
+}
+
+/**
+ * Resolve the policy from settings and write the sidecar file. Returns the
+ * path written and the serialized policy. The directory mirrors
+ * `getUiObserverDir()`, which the Rust observer resolves identically
+ * (`ZAM_OBSERVER_DIR`, else `~/.zam/observer`).
+ */
+export async function syncObserverSidecarPolicy(
+  db: Database,
+  dir: string = getUiObserverDir(),
+): Promise<{ path: string; policy: SidecarPrivacyPolicy }> {
+  const policy = toSidecarPrivacyPolicy(await resolveObserverPolicy(db));
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = join(dir, SIDECAR_POLICY_FILE);
+  writeFileSync(path, `${JSON.stringify(policy, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  return { path, policy };
+}

--- a/tests/kernel/observation/observer-sidecar-policy.test.ts
+++ b/tests/kernel/observation/observer-sidecar-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { toSidecarPrivacyPolicy } from "../../../src/kernel/observation/observer-sidecar-policy.js";
+import {
+  DEFAULT_OBSERVER_POLICY,
+  type ObserverPolicy,
+} from "../../../src/kernel/observation/policy.js";
+
+function policy(overrides: Partial<ObserverPolicy> = {}): ObserverPolicy {
+  return { ...DEFAULT_OBSERVER_POLICY, ...overrides };
+}
+
+describe("toSidecarPrivacyPolicy", () => {
+  it("maps an empty policy to empty lists", () => {
+    expect(toSidecarPrivacyPolicy(policy())).toEqual({
+      allowProcesses: [],
+      denyProcesses: [],
+      denyTitleMarkers: [],
+    });
+  });
+
+  it("maps the allowlist to allowProcesses", () => {
+    const mapped = toSidecarPrivacyPolicy(
+      policy({ allowlist: ["calculator", "notepad"] }),
+    );
+    expect(mapped.allowProcesses).toEqual(["calculator", "notepad"]);
+  });
+
+  it("feeds a denylist term into both process and title-marker lists", () => {
+    const mapped = toSidecarPrivacyPolicy(policy({ denylist: ["signal"] }));
+    expect(mapped.denyProcesses).toEqual(["signal"]);
+    expect(mapped.denyTitleMarkers).toEqual(["signal"]);
+  });
+
+  it("does not alias the source policy arrays", () => {
+    const source = policy({ denylist: ["signal"] });
+    const mapped = toSidecarPrivacyPolicy(source);
+    mapped.denyProcesses.push("teams");
+    expect(source.denylist).toEqual(["signal"]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements [ADR-0001](docs/adr/0001-observer-permission-model.md) **Action Item 4** — the divergence the ADR was written to close. The native Rust observer and the headless `capture-ui` path now resolve **one** policy source instead of the sidecar's separate `ZAM_OBSERVER_PRIVACY_POLICY` env var.

## Mechanism — a kernel-written file at a well-known path

No desktop/Tauri spawn changes needed: whoever launches the observer (CLI or desktop) reads the same file the kernel writes.

**Rust** (`observer/`)
- `resolve_window_privacy_policy()` resolves with precedence: **`<observer-dir>/policy.json` (kernel-written, primary) → `ZAM_OBSERVER_PRIVACY_POLICY` env file (deprecated fallback) → built-in default.**
- `<observer-dir>` mirrors the kernel: `ZAM_OBSERVER_DIR`, else `~/.zam/observer`. `picker.rs`'s 5 call sites repointed off the env-only loader.
- The built-in sensitive set stays authoritative — user config can only make the policy stricter (unchanged invariant).

**TypeScript**
- `observer-sidecar-policy.ts` maps an `ObserverPolicy` → the sidecar's `WindowPrivacyPolicy` (`allowProcesses` / `denyProcesses` / `denyTitleMarkers`; a denylist term feeds both process and title lists) and writes `<observer-dir>/policy.json`.
- New `zam bridge sync-observer-policy` writes the file; `zam settings set` / `delete` auto-sync it whenever an `observer.*` key changes.

## Verification

- `cargo test` (observer) ✅ — incl. 3 new precedence tests (file > env > default).
- `typecheck` ✅ · `lint` ✅ · `build` ✅ · `test` ✅ (242 passed / 30 files, +4 mapping tests).
- Manual round-trip: `bridge sync-observer-policy` wrote `~/.zam/observer/policy.json` at **exactly** the path the Rust `observer_dir()` computes, in the camelCase shape `WindowPrivacyPolicy` deserializes.

## Notes

- `ZAM_OBSERVER_PRIVACY_POLICY` still works as a deprecated fallback (one-release migration); `observer/README.md` documents the new precedence.
- Caveat (noted in ADR): if the desktop launches the observer with a custom `ZAM_OBSERVER_DIR`, the sync must target that dir.
- Unrelated `cargo fmt` drift in `capture.rs`/`replay.rs`/`uia.rs` was deliberately reverted to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
