### PR TITLE
feat(bridge): add get-observer-policy introspection endpoint (ADR-0001)

### DIFF
--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -329,7 +329,8 @@ user-configurable policy resolved from `zam settings`: `observer.scope`
 set (password managers, auth/UAC dialogs, banking) is always refused and
 cannot be allowlisted — those return `denied: true` with
 `denialReason: "sensitive"`. Treat any `denied` response as final: do not
-retry to work around it; tell the user which surface was blocked.
+retry to work around it; tell the user which surface was blocked. To check the
+active scope/allow/denylist up front, call `zam bridge get-observer-policy`.
 
 **Rating scale (all observation approaches):**
 - Completed correctly, no hesitation, no help → **4**

--- a/docs/adr/0001-observer-permission-model.md
+++ b/docs/adr/0001-observer-permission-model.md
@@ -260,10 +260,10 @@ and future agent.
 Ordered so a fresh agent with a token budget can pick up any item. File paths are
 load-bearing.
 
-> **Progress (2026-06-20):** Items 1–2 and 4 are done. The wire-contract half of item 3
+> **Progress (2026-06-20):** Items 1–4 are done. The wire-contract half of item 3
 > (`CaptureUiResponse` / `ObserverPermission` / `denialReason` / the denied
 > variant) shipped with them; the `GetObserverPolicyResponse` introspection
-> endpoint is still open. Item 8 is partly done (SKILL.md Approach C updated;
+> endpoint (`zam bridge get-observer-policy`) completes it. Item 8 is partly done (SKILL.md Approach C updated;
 > ARCHITECTURE.md + proposal note still TODO). Settings keys are dotted
 > (`observer.scope`, …), not `observer_*` — see item 5. Enforcement is two-phase
 > (pre-capture for scope/explicit target; post-resolution for the captured
@@ -287,7 +287,7 @@ load-bearing.
    denylisted or the frontmost window is sensitive, return a typed
    `{ denied: true, reason, kind: "privacy-pause" }` instead of pixels; honor
    `consent` and `retention`.
-3. [ ] **Extend the contract.** In
+3. [x] **Extend the contract.** In
    [`src/bridge/protocol.ts`](../../src/bridge/protocol.ts) add a typed
    `CaptureUiResponse` (currently ad hoc), an exported `ObserverPolicy`, a
    `GetObserverPolicyResponse` (lets an agent ask "what may I capture?"), and the

--- a/src/bridge/protocol.ts
+++ b/src/bridge/protocol.ts
@@ -357,3 +357,21 @@ export interface CaptureUiDeniedResponse {
   platform: string;
   permission: ObserverPermission;
 }
+
+/**
+ * Reported by `bridge get-observer-policy` so an agent can check the rules
+ * before attempting a capture (the check-before-acting / list-granted pattern).
+ * `denylist` is the user's configured list; the surfaces in
+ * `builtInSensitiveMatchers` are always refused regardless of `allowlist`.
+ */
+export interface GetObserverPolicyResponse {
+  scope: ObserverScope;
+  consent: ObserverConsent;
+  retention: ObserverRetention;
+  allowlist: string[];
+  denylist: string[];
+  redactWindowTitles: boolean;
+  audioOptIn: boolean;
+  builtInSensitiveAlwaysRefused: true;
+  builtInSensitiveMatchers: string[];
+}

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -23,6 +23,7 @@ import type {
 import {
   analyzeObservation,
   appendUiObservationReport,
+  BUILT_IN_SENSITIVE_MATCHERS,
   buildReviewQueue,
   createToken,
   decidePostCapture,
@@ -1411,6 +1412,30 @@ bridgeCommand
         capturedAt: new Date().toISOString(),
         platform: process.platform,
         permission: { ...permission, granted: true },
+      });
+    });
+  });
+
+// ── zam bridge get-observer-policy ─────────────────────────────────────────
+
+bridgeCommand
+  .command("get-observer-policy")
+  .description(
+    "Report the resolved observer policy so an agent can check before capturing (JSON)",
+  )
+  .action(async () => {
+    await withDb(async (db) => {
+      const policy = await resolveObserverPolicy(db);
+      jsonOut({
+        scope: policy.scope,
+        consent: policy.consent,
+        retention: policy.retention,
+        allowlist: policy.allowlist,
+        denylist: policy.denylist,
+        redactWindowTitles: policy.redactWindowTitles,
+        audioOptIn: policy.audioOptIn,
+        builtInSensitiveAlwaysRefused: true,
+        builtInSensitiveMatchers: [...BUILT_IN_SENSITIVE_MATCHERS],
       });
     });
   });


### PR DESCRIPTION
## Summary

Completes [ADR-0001](docs/adr/0001-observer-permission-model.md) **Action Item 3**. Adds `zam bridge get-observer-policy`, which reports the resolved observer policy so an agent can check the rules **before** attempting a capture — the check-before-acting / `list_granted_applications` pattern — instead of learning them reactively from a `denied` response.

Returns: `scope`, `consent`, `retention`, the user `allowlist`/`denylist`, `redactWindowTitles`, `audioOptIn`, and the always-enforced `builtInSensitiveMatchers` (with `builtInSensitiveAlwaysRefused: true`).

- `protocol.ts`: `GetObserverPolicyResponse` (the wire contract).
- `SKILL.md` Approach C documents the introspection call.

## Verification

`typecheck` ✅ · `lint` ✅ · `build` ✅ · `test` ✅ (242 passed). Manual smoke test returns the resolved policy + the built-in sensitive set:
```json
{ "scope": "window", "consent": "per-session", "retention": "none",
  "allowlist": [], "denylist": [], "builtInSensitiveAlwaysRefused": true,
  "builtInSensitiveMatchers": ["1password", "bitwarden", "...", "onlinebanking"] }
```

ADR-0001 now has items **1–4** complete; remaining: 5 (`zam observer` UX + first-run prompt), 6 (mode presets), 7 (`zam mcp serve`), 8-rest (ARCHITECTURE.md/proposal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
