### PR TITLE
fix(setup): report active database target

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -11,7 +11,11 @@ import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
-import { getDefaultDbPath, openDatabaseWithSync } from "../../kernel/index.js";
+import {
+  type DatabaseTargetInfo,
+  getDatabaseTargetInfo,
+  openDatabaseWithSync,
+} from "../../kernel/index.js";
 
 // The bundled CLI resolves from dist/cli/index.js; source tests resolve from
 // src/cli/commands/setup.ts. Select the first candidate containing package.json.
@@ -66,14 +70,27 @@ export function copySkills(force: boolean, cwd: string = process.cwd()): void {
   }
 }
 
+export function formatDatabaseInitTarget(target: DatabaseTargetInfo): string {
+  switch (target.kind) {
+    case "local":
+      return `ZAM database at ${target.location} (local SQLite)`;
+    case "turso-remote":
+      return `ZAM database via Turso remote at ${target.location}`;
+    case "turso-native":
+      return `ZAM database via Turso native driver at ${target.location}`;
+    case "turso-replica":
+      return `ZAM database replica at ${target.location} syncing from ${target.syncUrl}`;
+  }
+}
+
 async function initDatabase(skipInit: boolean): Promise<void> {
   if (skipInit) return;
 
   try {
-    const dbPath = getDefaultDbPath();
+    const target = getDatabaseTargetInfo();
     const db = await openDatabaseWithSync({ initialize: true });
     await db.close();
-    console.log(`  init  ZAM database at ${dbPath}`);
+    console.log(`  init  ${formatDatabaseInitTarget(target)}`);
   } catch (err) {
     // Database may already exist â€” not an error during setup.
     const msg = (err as Error).message;

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -39,12 +39,113 @@ export interface ConnectionOptions {
   provider?: DatabaseProvider;
 }
 
+export interface DatabaseTargetInfo {
+  /** User-facing category of database target selected for this connection. */
+  kind: "local" | "turso-native" | "turso-remote" | "turso-replica";
+  /** Driver/provider that will be used for the selected target. */
+  provider: DatabaseProvider;
+  /** Local filesystem path or remote URL selected as the database target. */
+  location: string;
+  /** Turso primary URL when the selected target is an embedded replica. */
+  syncUrl?: string;
+}
+
+interface ResolvedDatabaseTarget {
+  dbPath: string;
+  provider: DatabaseProvider;
+  isRemote: boolean;
+  isEmbeddedReplica: boolean;
+  configuredCloud: ReturnType<typeof getTursoCredentials>;
+}
+
 function isRemoteDatabasePath(dbPath: string): boolean {
   return /^(libsql|https?|wss?):\/\//i.test(dbPath);
 }
 
 function isDatabaseProvider(value: unknown): value is DatabaseProvider {
   return value === "local" || value === "native" || value === "remote";
+}
+
+function cwdRequiresTursoCredentials(): boolean {
+  try {
+    const configPath = join(process.cwd(), ".zam", "config.yaml");
+    if (existsSync(configPath)) {
+      const configText = readFileSync(configPath, "utf-8");
+      return /[\s\S]*turso:[\s\S]*url:/m.test(configText);
+    }
+  } catch (_e) {}
+  return false;
+}
+
+function resolveDatabaseTarget(
+  options: ConnectionOptions = {},
+): ResolvedDatabaseTarget {
+  const configuredCloud =
+    options.useConfiguredCloud !== false && !options.dbPath && !options.syncUrl
+      ? getTursoCredentials()
+      : null;
+
+  if (
+    cwdRequiresTursoCredentials() &&
+    !configuredCloud &&
+    options.useConfiguredCloud !== false &&
+    !options.dbPath &&
+    !options.syncUrl
+  ) {
+    throw new Error(
+      "Turso cloud database is configured in .zam/config.yaml but missing local credentials. Run: zam connector setup turso",
+    );
+  }
+
+  const dbPath = configuredCloud?.url ?? options.dbPath ?? DEFAULT_DB_PATH;
+  const isRemote = isRemoteDatabasePath(dbPath);
+  const isEmbeddedReplica = Boolean(options.syncUrl);
+  const provider = resolveProvider(options, configuredCloud?.mode, isRemote);
+
+  return {
+    dbPath,
+    provider,
+    isRemote,
+    isEmbeddedReplica,
+    configuredCloud,
+  };
+}
+
+export function getDatabaseTargetInfo(
+  options: ConnectionOptions = {},
+): DatabaseTargetInfo {
+  const target = resolveDatabaseTarget(options);
+
+  if (target.isEmbeddedReplica) {
+    return {
+      kind: "turso-replica",
+      provider: target.provider,
+      location: target.dbPath,
+      syncUrl: options.syncUrl,
+    };
+  }
+
+  if (target.provider === "remote" && target.isRemote) {
+    return {
+      kind: "turso-remote",
+      provider: target.provider,
+      location: target.dbPath,
+    };
+  }
+
+  if (target.isRemote) {
+    return {
+      kind: "turso-native",
+      provider: target.provider,
+      location: target.dbPath,
+    };
+  }
+
+  return {
+    kind: "local",
+    provider: target.provider,
+    location: target.dbPath,
+  };
 }
 
 function openLocalSqlite(dbPath: string): SyncDatabase {
@@ -89,37 +190,8 @@ function loadLibsql(): LibsqlConstructor {
 export async function openDatabase(
   options: ConnectionOptions = {},
 ): Promise<Database> {
-  const configuredCloud =
-    options.useConfiguredCloud !== false && !options.dbPath && !options.syncUrl
-      ? getTursoCredentials()
-      : null;
-
-  let requiresTurso = false;
-  try {
-    const configPath = join(process.cwd(), ".zam", "config.yaml");
-    if (existsSync(configPath)) {
-      const configText = readFileSync(configPath, "utf-8");
-      if (/[\s\S]*turso:[\s\S]*url:/m.test(configText)) {
-        requiresTurso = true;
-      }
-    }
-  } catch (_e) {}
-
-  if (
-    requiresTurso &&
-    !configuredCloud &&
-    options.useConfiguredCloud !== false &&
-    !options.dbPath &&
-    !options.syncUrl
-  ) {
-    throw new Error(
-      "Turso cloud database is configured in .zam/config.yaml but missing local credentials. Run: zam connector setup turso",
-    );
-  }
-  const dbPath = configuredCloud?.url ?? options.dbPath ?? DEFAULT_DB_PATH;
-  const isRemote = isRemoteDatabasePath(dbPath);
-  const isEmbeddedReplica = Boolean(options.syncUrl);
-  const provider = resolveProvider(options, configuredCloud?.mode, isRemote);
+  const { dbPath, provider, isRemote, isEmbeddedReplica, configuredCloud } =
+    resolveDatabaseTarget(options);
   const shouldInitialize =
     options.initialize === true ||
     (!isRemote && !isEmbeddedReplica && !existsSync(dbPath));

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -34,8 +34,10 @@ export {
 export type {
   ConnectionOptions,
   DatabaseProvider,
+  DatabaseTargetInfo,
 } from "./db/connection.js";
 export {
+  getDatabaseTargetInfo,
   getDefaultDbPath,
   openDatabase,
   openDatabaseWithSync,

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -2,7 +2,11 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { copySkills, writeAgentsMd } from "../../src/cli/commands/setup.js";
+import {
+  copySkills,
+  formatDatabaseInitTarget,
+  writeAgentsMd,
+} from "../../src/cli/commands/setup.js";
 
 describe("setup command helpers", () => {
   it("copies ZAM skills for Claude, shared agents, and Codex", () => {
@@ -39,6 +43,30 @@ describe("setup command helpers", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("formats local database initialization clearly", () => {
+    expect(
+      formatDatabaseInitTarget({
+        kind: "local",
+        provider: "local",
+        location: "C:\\Users\\example\\.zam\\zam.db",
+      }),
+    ).toBe(
+      "ZAM database at C:\\Users\\example\\.zam\\zam.db (local SQLite)",
+    );
+  });
+
+  it("formats Turso remote database initialization without implying local state", () => {
+    expect(
+      formatDatabaseInitTarget({
+        kind: "turso-remote",
+        provider: "remote",
+        location: "libsql://zam-example.turso.io",
+      }),
+    ).toBe(
+      "ZAM database via Turso remote at libsql://zam-example.turso.io",
+    );
   });
 
   it("ships valid frontmatter for every packaged ZAM skill", () => {

--- a/tests/kernel/connection-target.test.ts
+++ b/tests/kernel/connection-target.test.ts
@@ -1,0 +1,50 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { getDatabaseTargetInfo } from "../../src/kernel/db/connection.js";
+
+describe("database target description", () => {
+  it("describes explicit local SQLite targets", () => {
+    const location = join("tmp", "zam.db");
+
+    expect(
+      getDatabaseTargetInfo({
+        dbPath: location,
+        useConfiguredCloud: false,
+      }),
+    ).toEqual({
+      kind: "local",
+      provider: "local",
+      location,
+    });
+  });
+
+  it("describes explicit Turso HTTP targets", () => {
+    expect(
+      getDatabaseTargetInfo({
+        dbPath: "libsql://zam-example.turso.io",
+        provider: "remote",
+        useConfiguredCloud: false,
+      }),
+    ).toEqual({
+      kind: "turso-remote",
+      provider: "remote",
+      location: "libsql://zam-example.turso.io",
+    });
+  });
+
+  it("describes embedded replica targets", () => {
+    expect(
+      getDatabaseTargetInfo({
+        dbPath: join("tmp", "replica.db"),
+        syncUrl: "libsql://zam-example.turso.io",
+        provider: "native",
+        useConfiguredCloud: false,
+      }),
+    ).toEqual({
+      kind: "turso-replica",
+      provider: "native",
+      location: join("tmp", "replica.db"),
+      syncUrl: "libsql://zam-example.turso.io",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add database target introspection so setup can report the actual selected backend
- Change zam setup output to distinguish local SQLite, Turso remote, native Turso, and embedded replica targets
- Add regression tests for local and Turso remote setup messaging

## Verification
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd test
- node C:\src\zam\dist\cli\index.js setup --skip-claude-md --skip-agents-md from C:\src\zam-Thomas reports ZAM database via Turso remote at libsql://zam-josefczak.aws-eu-west-1.turso.io