### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # ZAM Architecture Handbook
 *The Complete System Reference Manual for the Symbiotic Learning Kernel*
 
-> Last updated: 2026-06-20 · Version 0.3.13 (Phase 1: Individual Symbiosis)
+> Last updated: 2026-06-20 · Version 0.4.0 (Phase 1: Individual Symbiosis)
 >
 > Related Documentation:
 > - [TEMPLATES.md](TEMPLATES.md) — template/instance model, repo families, setup protocol

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.3.13",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump zam-core from 0.3.13 to 0.4.0
- Keep package-lock.json in sync for the npm release guard
- Update the architecture handbook version marker

## Why 0.4.0
This release collects the new observer/UI automation capability set: targeted UI capture, observer policy enforcement, observer settings UX, policy introspection, and the setup output fix for Turso-vs-local database clarity.

## Verification
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run build
- npm.cmd test
- npm.cmd pack --dry-run