### PR TITLE
feat(cli): apply updates with `zam update`

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -63,6 +63,25 @@ Einstieg: `zam whoami --set <deine-id>`
 
 ---
 
+## 🔄 ZAM aktuell halten
+
+Prüfe, ob eine neuere Version vorliegt, und aktualisiere — ZAM wählt den passenden Mechanismus je nachdem, wie diese Kopie installiert wurde:
+
+```bash
+zam update          # neueste Version anwenden (fragt nach; -y überspringt)
+zam update check    # nur prüfen, ob ein Update verfügbar ist
+```
+
+Was `zam update` je nach Installationskanal tut:
+
+- **Developer** (Quell-Checkout, Standard für Mitwirkende) — holt den neuesten Quellcode, installiert Abhängigkeiten neu, baut die CLI und frischt die Skill-Dateien auf (`zam setup --force`). Danach den Agent-Client (z. B. Claude Code) neu starten, damit der aktualisierte `/zam`-Skill geladen wird.
+- **winget / Homebrew** — delegiert an `winget upgrade` / `brew upgrade`, damit eine paketverwaltete Installation nie selbst ersetzt wird.
+- **Direkt-Download / Desktop** — installiert ein signiertes In-place-Update über ZAM Desktop.
+
+`zam update` verweigert einen Developer-Checkout mit uncommitteten Änderungen; committe oder stashe sie zuerst, oder nutze `--force`. Design-Details: [ADR-0012](docs/adr/0012-approachable-setup-and-self-update.md).
+
+---
+
 ## 🏛 Vision: Eine paradiesische Zukunft
 
 ZAM ist das Werkzeug für den Übergang in eine Welt, in der Fürsorge und gemeinsames Wachstum die Währung sind.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,25 @@ Token deletion is global. Card deletion is per-user.
 
 ---
 
+## 🔄 Keeping ZAM up to date
+
+Check whether a newer release is out, then update — ZAM picks the right mechanism for how this copy was installed:
+
+```bash
+zam update          # apply the latest release (asks first; -y to skip)
+zam update check    # only report whether an update is available
+```
+
+What `zam update` does per install channel:
+
+- **Developer** (source checkout, the default for contributors) — pulls the latest source, reinstalls dependencies, rebuilds the CLI, and refreshes the skill files (`zam setup --force`) in the current instance. Restart your agent client (e.g. Claude Code) afterwards to load the refreshed `/zam` skill.
+- **winget / Homebrew** — defers to `winget upgrade` / `brew upgrade`, so a package-managed install is never self-replaced.
+- **Direct download / desktop** — applies a signed in-place update through ZAM Desktop.
+
+`zam update` refuses to touch a developer checkout with uncommitted changes; commit or stash them first, or pass `--force`. See [ADR-0012](docs/adr/0012-approachable-setup-and-self-update.md) for the design.
+
+---
+
 ## 🏛 Vision: A Flourishing Future
 
 ZAM is a tool for the transition to a world where care and shared growth are the common currency.

--- a/docs/adr/0012-approachable-setup-and-self-update.md
+++ b/docs/adr/0012-approachable-setup-and-self-update.md
@@ -1,8 +1,32 @@
 # ADR-0012: Approachable Setup and Self-Update
 
-**Status:** Proposed
-**Date:** 2026-06-20
+**Status:** Partially implemented
+**Date:** 2026-06-20 *(migrated to ADR; originally decided 2026-06-13)*
 **Deciders:** Thomas (project owner)
+
+---
+
+## Implementation status
+
+*As of 2026-06-21 (v0.4.0): the decision below is accepted; the consumer-facing
+rollout is in progress.*
+
+- ✅ **Install-channel model** — per-machine `~/.zam/config.json` records
+  developer vs default mode and the update channel.
+- ✅ **Channel-aware update check** — `zam update check` reports whether a newer
+  release exists and how this copy should update.
+- ✅ **Developer self-update** — `zam update` applies it for a source checkout
+  (pull → install → build → `zam setup --force`); see "Keeping ZAM up to date"
+  in the [README](../../README.md).
+- ⏳ **Default mode + signed installers** (`.dmg`/`.msi`/`.deb`), winget
+  manifest, Homebrew cask — not yet shipped.
+- ⏳ **Skills as program resources** — in Default mode, bundle the skill files
+  and have `zam setup` provision them from the program directory. Today
+  `copySkills` resolves them only from a source checkout
+  (`packageRoot/.claude/skills/…`), which end users will not have.
+- ⏳ **Desktop in-place self-update** — pending the Tauri updater keypair and
+  Apple signing identity.
+- ⏳ **Bundled open agent** (opencode) — not yet shipped.
 
 ---
 
@@ -37,7 +61,7 @@ Make ZAM installable and updatable like any consumer application, while keeping 
 
 - Default vs Developer mode selection and the Default-mode application/data directory layout.
 - Signed installers + winget manifest + Homebrew cask, validated on clean machines (no Node, no source) before release.
-- A self-contained desktop bundle: the compiled CLI bridge ships as a Tauri resource (extends `scripts/prepare-desktop-bridge.mjs`) so the app runs with no repo and no Node.
+- A self-contained desktop bundle: the compiled CLI bridge **and the agent skill files** ship as Tauri resources (extends `scripts/prepare-desktop-bridge.mjs`) so the app runs with no repo and no Node. In Default mode `zam setup` provisions skills from the bundled program directory — not from a git checkout, which end users do not have. Prefer pointing a configurable-skill-path agent straight at the program directory; otherwise copy on install/update (symlinks are avoided because they need elevated rights on Windows).
 - Personal-folder chooser (local or any synced directory) plus verified DB snapshot export/import.
 - Channel-aware in-app update detection and apply/notify flow.
 - Optional download + configuration of one default open agent.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,7 +5,7 @@ the consequences. ADRs are immutable once **Accepted** — supersede with a new 
 rather than rewriting history.
 
 Naming: `NNNN-kebab-title.md`, zero-padded sequential number.
-Status: `Proposed` → `Accepted` → (`Deprecated` | `Superseded by ADR-NNNN`).
+Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`) → (`Deprecated` | `Superseded by ADR-NNNN`).
 
 | ADR | Title | Status |
 |-----|-------|--------|
@@ -20,5 +20,5 @@ Status: `Proposed` → `Accepted` → (`Deprecated` | `Superseded by ADR-NNNN`).
 | [0009](0009-release-hardening.md) | Release Hardening | Implemented |
 | [0010](0010-async-database-providers.md) | Async Database Providers | Implemented |
 | [0011](0011-automatic-session-synthesis.md) | Automatic Session Synthesis | Implemented |
-| [0012](0012-approachable-setup-and-self-update.md) | Approachable Setup and Self-Update | Proposed |
+| [0012](0012-approachable-setup-and-self-update.md) | Approachable Setup and Self-Update | Partially implemented |
 | [0013](0013-kernel-polish-and-performance.md) | Kernel Polish and Performance | Proposed |

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,21 +1,26 @@
 /**
- * `zam update check` — has a newer ZAM been released, and how should this
- * install update? (Increment 12, Phase 5.)
+ * `zam update` — apply the latest ZAM release; `zam update check` — only report
+ * whether one is available. (Increment 12, Phase 5.)
  *
- * The decision (self-update vs defer to a package manager vs inform a developer
- * install) lives in the kernel; this command supplies the current version, the
- * latest version (fetched from GitHub releases unless `--latest` is given), and
- * the detected install channel.
+ * The decision (self-update vs defer to a package manager vs update a developer
+ * checkout) lives in the kernel (`decideUpdate`/`planUpdate`, pure and
+ * unit-tested); this command supplies the current version, the latest version
+ * (fetched from GitHub releases unless `--latest` is given), the detected
+ * install channel, and the side effects that carry the plan out.
  */
 
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { confirm } from "@inquirer/prompts";
 import { Command } from "commander";
 import {
   decideUpdate,
   getInstallChannel,
+  hasCommand,
   type InstallChannel,
+  planUpdate,
   type UpdateDecision,
 } from "../../kernel/index.js";
 
@@ -33,6 +38,7 @@ const C = {
   cyan: "\x1b[36m",
   dim: "\x1b[2m",
   green: "\x1b[32m",
+  red: "\x1b[31m",
   yellow: "\x1b[33m",
 };
 
@@ -50,6 +56,18 @@ function currentVersion(): string {
     }
   }
   return "0.0.0";
+}
+
+/** Read the version recorded in a specific checkout's package.json. */
+function versionAt(dir: string): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(dir, "package.json"), "utf-8"),
+    ) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 async function fetchLatestVersion(repo: string): Promise<string> {
@@ -138,6 +156,188 @@ const checkCmd = new Command("check")
     },
   );
 
+/** Locate the ZAM source checkout by walking up from this module to a .git. */
+function findSourceRepo(): string | null {
+  let dir = realpathSync(dirname(fileURLToPath(import.meta.url)));
+  let parent = dirname(dir);
+  while (parent !== dir) {
+    if (existsSync(join(dir, ".git"))) return dir;
+    dir = parent;
+    parent = dirname(dir);
+  }
+  return existsSync(join(dir, ".git")) ? dir : null;
+}
+
+function runGit(
+  cwd: string,
+  args: string[],
+  capture: boolean,
+): { ok: boolean; out: string } {
+  const res = spawnSync("git", args, {
+    cwd,
+    stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    encoding: "utf8",
+  });
+  return { ok: res.status === 0, out: (res.stdout ?? "").trim() };
+}
+
+/** npm is npm.cmd on Windows, so child processes need a shell there. */
+function runNpm(args: string[], cwd: string): number {
+  const res = spawnSync("npm", args, {
+    cwd,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  return res.status ?? 1;
+}
+
+/** Run a package-manager command (winget/brew) through the shell. */
+function runShell(command: string): boolean {
+  const res = spawnSync(command, { stdio: "inherit", shell: true });
+  return res.status === 0;
+}
+
+/**
+ * Developer channel: pull, install, and rebuild the linked source checkout,
+ * then refresh this instance's skill files with the freshly built CLI so the
+ * new /zam skill lands in .claude/.agent/.agents.
+ */
+function applyDeveloperUpdate(force: boolean): void {
+  if (!hasCommand("git")) {
+    console.error(`${C.red}✗${C.reset} git was not found on PATH.`);
+    process.exit(1);
+  }
+
+  const src = findSourceRepo();
+  if (!src) {
+    console.error(
+      `${C.red}✗${C.reset} Could not locate the ZAM source checkout to update.`,
+    );
+    process.exit(1);
+  }
+
+  // Never clobber uncommitted work in the source checkout.
+  const status = runGit(src, ["status", "--porcelain"], true);
+  if (status.ok && status.out && !force) {
+    console.error(
+      `${C.red}✗${C.reset} The source checkout has uncommitted changes:\n${status.out}\n` +
+        `Commit or stash them, or re-run with ${C.cyan}--force${C.reset}.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `${C.dim}→ git pull --ff-only${C.reset}  ${C.dim}(${src})${C.reset}`,
+  );
+  if (!runGit(src, ["pull", "--ff-only"], false).ok) {
+    console.error(
+      `${C.red}✗${C.reset} git pull failed — the branch may have diverged or you are offline. Resolve it manually, then retry.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`${C.dim}→ npm install${C.reset}`);
+  if (runNpm(["install"], src) !== 0) {
+    console.error(`${C.red}✗${C.reset} npm install failed.`);
+    process.exit(1);
+  }
+
+  console.log(`${C.dim}→ npm run build${C.reset}`);
+  if (runNpm(["run", "build"], src) !== 0) {
+    console.error(`${C.red}✗${C.reset} Build failed.`);
+    process.exit(1);
+  }
+
+  console.log(`${C.dim}→ zam setup --force${C.reset}`);
+  const setup = spawnSync(
+    process.execPath,
+    [join(src, "dist", "cli", "index.js"), "setup", "--force"],
+    { cwd: process.cwd(), stdio: "inherit" },
+  );
+  if (setup.status !== 0) {
+    console.warn(
+      `${C.yellow}⚠${C.reset} Skill refresh reported a problem — run '${C.cyan}zam setup --force${C.reset}' here manually.`,
+    );
+  }
+
+  console.log(
+    `\n${C.green}✓${C.reset} Updated to ${C.cyan}${versionAt(src)}${C.reset}. ` +
+      `Restart your agent client (e.g. Claude Code) to load the refreshed ${C.cyan}/zam${C.reset} skill.`,
+  );
+}
+
+async function applyUpdate(opts: {
+  yes?: boolean;
+  force?: boolean;
+}): Promise<void> {
+  try {
+    const current = currentVersion();
+    const latest = await fetchLatestVersion(GITHUB_REPO);
+    const channel = getInstallChannel();
+    const decision = decideUpdate({
+      currentVersion: current,
+      latestVersion: latest,
+      channel,
+    });
+
+    if (!decision.updateAvailable) {
+      console.log(
+        `${C.green}✓${C.reset} ZAM is up to date (${C.cyan}${current}${C.reset}).`,
+      );
+      return;
+    }
+
+    console.log(
+      `${C.yellow}↑${C.reset} ${C.bold}Update available${C.reset}: ` +
+        `${C.dim}${current}${C.reset} → ${C.cyan}${latest}${C.reset} ${C.dim}(${channel} install)${C.reset}`,
+    );
+    for (const step of planUpdate(decision)) {
+      console.log(`  ${C.dim}•${C.reset} ${step.label}`);
+    }
+
+    // The CLI cannot apply a signed in-place update; that is the desktop app.
+    if (channel === "direct") {
+      console.log(
+        `\n${C.dim}This install updates through the desktop app's signed updater — open ZAM Desktop to install ${latest}.${C.reset}`,
+      );
+      return;
+    }
+
+    if (!opts.yes) {
+      const ok = await confirm({
+        message: "Apply this update?",
+        default: true,
+      });
+      if (!ok) {
+        console.log("Aborted.");
+        return;
+      }
+    }
+
+    console.log();
+
+    if (channel === "winget" || channel === "homebrew") {
+      if (!decision.command || !runShell(decision.command)) process.exit(1);
+      return;
+    }
+
+    applyDeveloperUpdate(opts.force ?? false);
+  } catch (err) {
+    console.error("Error:", (err as Error).message);
+    process.exit(1);
+  }
+}
+
 export const updateCommand = new Command("update")
-  .description("Check for ZAM updates")
+  .description(
+    "Update ZAM to the latest release (use `update check` to only check)",
+  )
+  .option("-y, --yes", "Apply without confirmation")
+  .option(
+    "--force",
+    "Update even if the source checkout has uncommitted changes",
+  )
+  .action(async (opts: { yes?: boolean; force?: boolean }) => {
+    await applyUpdate(opts);
+  })
   .addCommand(checkCmd);

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -359,10 +359,13 @@ export type {
   InstallChannel,
   UpdateActionKind,
   UpdateDecision,
+  UpdateStep,
+  UpdateStepKind,
 } from "./system/update-check.js";
 export {
   compareVersions,
   decideUpdate,
   HOMEBREW_CASK,
+  planUpdate,
   WINGET_PACKAGE_ID,
 } from "./system/update-check.js";

--- a/src/kernel/system/update-check.ts
+++ b/src/kernel/system/update-check.ts
@@ -141,3 +141,59 @@ export function decideUpdate(input: {
       };
   }
 }
+
+/** A single step an executor runs to APPLY an update, in order. */
+export type UpdateStepKind =
+  | "git-pull"
+  | "npm-install"
+  | "npm-build"
+  | "distribute-skills"
+  | "run-command"
+  | "self-update";
+
+export interface UpdateStep {
+  kind: UpdateStepKind;
+  /** Human-readable description of the step. */
+  label: string;
+  /** For "run-command": the exact command to run. */
+  command?: string;
+}
+
+/**
+ * Turn a decision into the ordered steps that APPLY it — the counterpart to
+ * `decideUpdate`, which only decides whether and how. Pure and side-effect
+ * free, so the sequencing is unit-tested; the CLI resolves paths and runs each
+ * step. Empty when no update is available.
+ */
+export function planUpdate(decision: UpdateDecision): UpdateStep[] {
+  if (!decision.updateAvailable) return [];
+
+  switch (decision.channel) {
+    case "developer":
+      return [
+        { kind: "git-pull", label: "Pull the latest source" },
+        { kind: "npm-install", label: "Install dependencies" },
+        { kind: "npm-build", label: "Rebuild the CLI" },
+        {
+          kind: "distribute-skills",
+          label: "Refresh skill files (zam setup --force)",
+        },
+      ];
+    case "winget":
+    case "homebrew":
+      return [
+        {
+          kind: "run-command",
+          label: `Update via ${decision.channel}`,
+          command: decision.command,
+        },
+      ];
+    case "direct":
+      return [
+        {
+          kind: "self-update",
+          label: "Apply the signed update via the desktop app",
+        },
+      ];
+  }
+}

--- a/tests/kernel/update-check.test.ts
+++ b/tests/kernel/update-check.test.ts
@@ -3,6 +3,7 @@ import {
   compareVersions,
   decideUpdate,
   type InstallChannel,
+  planUpdate,
 } from "../../src/kernel/index.js";
 
 describe("compareVersions", () => {
@@ -93,5 +94,48 @@ describe("decideUpdate", () => {
     });
     expect(d.action).toBe("inform");
     expect(d.command).toContain("git pull");
+  });
+});
+
+describe("planUpdate", () => {
+  const upgrade = (channel: InstallChannel) =>
+    decideUpdate({
+      currentVersion: "0.3.7",
+      latestVersion: "0.4.0",
+      channel,
+    });
+
+  it("returns no steps when no update is available", () => {
+    const d = decideUpdate({
+      currentVersion: "0.4.0",
+      latestVersion: "0.4.0",
+      channel: "developer",
+    });
+    expect(planUpdate(d)).toEqual([]);
+  });
+
+  it("plans pull → install → build → skills for a developer install", () => {
+    expect(planUpdate(upgrade("developer")).map((s) => s.kind)).toEqual([
+      "git-pull",
+      "npm-install",
+      "npm-build",
+      "distribute-skills",
+    ]);
+  });
+
+  it("defers winget/homebrew to a single package-manager command", () => {
+    for (const channel of ["winget", "homebrew"] as const) {
+      const decision = upgrade(channel);
+      const steps = planUpdate(decision);
+      expect(steps).toHaveLength(1);
+      expect(steps[0]?.kind).toBe("run-command");
+      expect(steps[0]?.command).toBe(decision.command);
+    }
+  });
+
+  it("routes a direct install to the desktop self-updater", () => {
+    expect(planUpdate(upgrade("direct")).map((s) => s.kind)).toEqual([
+      "self-update",
+    ]);
   });
 });


### PR DESCRIPTION
## What

`zam update` now **applies** an update (previously it only reported one). `zam update check` remains the read-only check.

Per detected install channel:
- **developer** — `git pull --ff-only` → `npm install` → `npm run build` → `zam setup --force` (refresh skills), then restart your agent client
- **winget / homebrew** — defer to the package manager's upgrade command
- **direct** — defer to the desktop app's signed in-place updater

Safety: refuses a developer checkout with uncommitted changes (unless `--force`), uses `--ff-only`, confirms before applying (`-y` to skip), and self-locates the source repo from the running CLI.

## Why

Closes the gap where a developer install was told *how* to update but had to do it by hand — and the advised steps were easy to get wrong (e.g. running them outside the source checkout).

## Design

Pure, unit-tested `planUpdate()` in the kernel decides the ordered steps; the CLI executes them — matching the existing `decideUpdate` split. 4 new kernel tests; full suite green (268).

## Docs
- "Keeping ZAM up to date" section in `README.md` + `README.de.md`
- ADR-0012 → **Partially implemented** + implementation checklist; records that Default mode must provision skills from the bundled **program directory**, not a git clone (end users have no checkout)
- ADR status vocabulary extended (`Implemented` / `Partially implemented`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
