### PR TITLE
docs(adr): name ADRs by decision date (YYYY-MM-DD), drop sequential numbers

### DIFF
--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -326,7 +326,7 @@ The `capture-ui` command supports:
 
 On Windows, uses PowerShell/.NET for screen capture. On macOS, uses `screencapture`.
 
-**Observer permissions (Layer 2, ADR-0001).** `capture-ui` enforces a
+**Observer permissions (Layer 2).** `capture-ui` enforces a
 user-configurable policy resolved from `zam settings`: `observer.scope`
 (`off` | `window` | `fullscreen`), `observer.allowlist`, `observer.denylist`,
 `observer.consent`, `observer.retention`. Set them with e.g.

--- a/README.de.md
+++ b/README.de.md
@@ -78,7 +78,7 @@ Was `zam update` je nach Installationskanal tut:
 - **winget / Homebrew** — delegiert an `winget upgrade` / `brew upgrade`, damit eine paketverwaltete Installation nie selbst ersetzt wird.
 - **Direkt-Download / Desktop** — installiert ein signiertes In-place-Update über ZAM Desktop.
 
-`zam update` verweigert einen Developer-Checkout mit uncommitteten Änderungen; committe oder stashe sie zuerst, oder nutze `--force`. Design-Details: [ADR-0012](docs/adr/0012-approachable-setup-and-self-update.md).
+`zam update` verweigert einen Developer-Checkout mit uncommitteten Änderungen; committe oder stashe sie zuerst, oder nutze `--force`. Design-Details: [ADR „Approachable Setup and Self-Update“](docs/adr/2026-06-13b-approachable-setup-and-self-update.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ What `zam update` does per install channel:
 - **winget / Homebrew** — defers to `winget upgrade` / `brew upgrade`, so a package-managed install is never self-replaced.
 - **Direct download / desktop** — applies a signed in-place update through ZAM Desktop.
 
-`zam update` refuses to touch a developer checkout with uncommitted changes; commit or stash them first, or pass `--force`. See [ADR-0012](docs/adr/0012-approachable-setup-and-self-update.md) for the design.
+`zam update` refuses to touch a developer checkout with uncommitted changes; commit or stash them first, or pass `--force`. See the [“Approachable Setup and Self-Update” ADR](docs/adr/2026-06-13b-approachable-setup-and-self-update.md) for the design.
 
 ---
 

--- a/docs/adr/2026-03-23-kernel-and-shell-observation.md
+++ b/docs/adr/2026-03-23-kernel-and-shell-observation.md
@@ -1,7 +1,6 @@
-# ADR-0002: Kernel and Shell Observation
+# Kernel and Shell Observation
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-03-26-personal-workflow-foundations.md
+++ b/docs/adr/2026-03-26-personal-workflow-foundations.md
@@ -1,7 +1,6 @@
-# ADR-0003: Personal Workflow Foundations
+# Personal Workflow Foundations
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-03-27-stabilization-and-workflow-integrity.md
+++ b/docs/adr/2026-03-27-stabilization-and-workflow-integrity.md
@@ -1,7 +1,6 @@
-# ADR-0004: Stabilization and Workflow Integrity
+# Stabilization and Workflow Integrity
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-05-30a-standalone-learning-session.md
+++ b/docs/adr/2026-05-30a-standalone-learning-session.md
@@ -1,7 +1,6 @@
-# ADR-0005: Standalone Learning Session
+# Standalone Learning Session
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-05-30b-hardware-setup-and-agent-distribution.md
+++ b/docs/adr/2026-05-30b-hardware-setup-and-agent-distribution.md
@@ -1,7 +1,6 @@
-# ADR-0006: Hardware Setup and Agent Distribution
+# Hardware Setup and Agent Distribution
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-05-31a-locale-aware-active-recall.md
+++ b/docs/adr/2026-05-31a-locale-aware-active-recall.md
@@ -1,7 +1,6 @@
-# ADR-0007: Locale-Aware Active Recall
+# Locale-Aware Active Recall
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-05-31b-tauri-active-recall-studio.md
+++ b/docs/adr/2026-05-31b-tauri-active-recall-studio.md
@@ -1,7 +1,6 @@
-# ADR-0008: Tauri Active-Recall Studio
+# Tauri Active-Recall Studio
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-06-07-release-hardening.md
+++ b/docs/adr/2026-06-07-release-hardening.md
@@ -1,7 +1,6 @@
-# ADR-0009: Release Hardening
+# Release Hardening
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-06-09-async-database-providers.md
+++ b/docs/adr/2026-06-09-async-database-providers.md
@@ -1,7 +1,6 @@
-# ADR-0010: Async Database Providers
+# Async Database Providers
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-06-13a-automatic-session-synthesis.md
+++ b/docs/adr/2026-06-13a-automatic-session-synthesis.md
@@ -1,7 +1,6 @@
-# ADR-0011: Automatic Session Synthesis
+# Automatic Session Synthesis
 
 **Status:** Implemented
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-06-13b-approachable-setup-and-self-update.md
+++ b/docs/adr/2026-06-13b-approachable-setup-and-self-update.md
@@ -1,7 +1,6 @@
-# ADR-0012: Approachable Setup and Self-Update
+# Approachable Setup and Self-Update
 
 **Status:** Partially implemented
-**Date:** 2026-06-20 *(migrated to ADR; originally decided 2026-06-13)*
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-06-15-kernel-polish-and-performance.md
+++ b/docs/adr/2026-06-15-kernel-polish-and-performance.md
@@ -1,7 +1,6 @@
-# ADR-0013: Kernel Polish and Performance
+# Kernel Polish and Performance
 
 **Status:** Proposed
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 
 ---

--- a/docs/adr/2026-06-20-observer-permission-model.md
+++ b/docs/adr/2026-06-20-observer-permission-model.md
@@ -1,7 +1,6 @@
-# ADR-0001: Configurable Observer Permission Model (`ObserverPolicy`) and Two-Layer Consent
+# Configurable Observer Permission Model (`ObserverPolicy`) and Two-Layer Consent
 
 **Status:** Accepted
-**Date:** 2026-06-20
 **Deciders:** Thomas (project owner)
 **Related:**
 [windows-ui-observer-proposal.md](../windows-ui-observer-proposal.md) ·

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,21 +4,24 @@ Each ADR captures one significant decision: its context, the options weighed, an
 the consequences. ADRs are immutable once **Accepted** — supersede with a new ADR
 rather than rewriting history.
 
-Naming: `NNNN-kebab-title.md`, zero-padded sequential number.
-Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`) → (`Deprecated` | `Superseded by ADR-NNNN`).
+Naming: `YYYY-MM-DD-kebab-title.md`, using the **decision date**. If two decisions
+land on the same day, disambiguate with a chronological letter suffix
+(`YYYY-MM-DDa-…`, `YYYY-MM-DDb-…`). The filename date is canonical and never
+changes; git history records edits.
+Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`) → (`Deprecated` | `Superseded by a later ADR`).
 
-| ADR | Title | Status |
-|-----|-------|--------|
-| [0001](0001-observer-permission-model.md) | Configurable Observer permission model (`ObserverPolicy`) and two-layer consent | Accepted |
-| [0002](0002-kernel-and-shell-observation.md) | Kernel and Shell Observation | Implemented |
-| [0003](0003-personal-workflow-foundations.md) | Personal Workflow Foundations | Implemented |
-| [0004](0004-stabilization-and-workflow-integrity.md) | Stabilization and Workflow Integrity | Implemented |
-| [0005](0005-standalone-learning-session.md) | Standalone Learning Session | Implemented |
-| [0006](0006-hardware-setup-and-agent-distribution.md) | Hardware Setup and Agent Distribution | Implemented |
-| [0007](0007-locale-aware-active-recall.md) | Locale-Aware Active Recall | Implemented |
-| [0008](0008-tauri-active-recall-studio.md) | Tauri Active-Recall Studio | Implemented |
-| [0009](0009-release-hardening.md) | Release Hardening | Implemented |
-| [0010](0010-async-database-providers.md) | Async Database Providers | Implemented |
-| [0011](0011-automatic-session-synthesis.md) | Automatic Session Synthesis | Implemented |
-| [0012](0012-approachable-setup-and-self-update.md) | Approachable Setup and Self-Update | Partially implemented |
-| [0013](0013-kernel-polish-and-performance.md) | Kernel Polish and Performance | Proposed |
+| Date | Title | Status |
+|------|-------|--------|
+| [2026-03-23](2026-03-23-kernel-and-shell-observation.md) | Kernel and Shell Observation | Implemented |
+| [2026-03-26](2026-03-26-personal-workflow-foundations.md) | Personal Workflow Foundations | Implemented |
+| [2026-03-27](2026-03-27-stabilization-and-workflow-integrity.md) | Stabilization and Workflow Integrity | Implemented |
+| [2026-05-30a](2026-05-30a-standalone-learning-session.md) | Standalone Learning Session | Implemented |
+| [2026-05-30b](2026-05-30b-hardware-setup-and-agent-distribution.md) | Hardware Setup and Agent Distribution | Implemented |
+| [2026-05-31a](2026-05-31a-locale-aware-active-recall.md) | Locale-Aware Active Recall | Implemented |
+| [2026-05-31b](2026-05-31b-tauri-active-recall-studio.md) | Tauri Active-Recall Studio | Implemented |
+| [2026-06-07](2026-06-07-release-hardening.md) | Release Hardening | Implemented |
+| [2026-06-09](2026-06-09-async-database-providers.md) | Async Database Providers | Implemented |
+| [2026-06-13a](2026-06-13a-automatic-session-synthesis.md) | Automatic Session Synthesis | Implemented |
+| [2026-06-13b](2026-06-13b-approachable-setup-and-self-update.md) | Approachable Setup and Self-Update | Partially implemented |
+| [2026-06-15](2026-06-15-kernel-polish-and-performance.md) | Kernel Polish and Performance | Proposed |
+| [2026-06-20](2026-06-20-observer-permission-model.md) | Configurable Observer permission model (`ObserverPolicy`) and two-layer consent | Accepted |

--- a/docs/windows-ui-observer-proposal.md
+++ b/docs/windows-ui-observer-proposal.md
@@ -635,7 +635,7 @@ help-seeking, and privacy-sensitive intervals. Compare models on:
 
 1. When should ZAM escalate from single-window observation to full-display
    observation?
-   *Note: Partially resolved in ADR-0001: The default scope is `window` (restricting capture to a targeted application process or HWND). The user can explicitly escalate to `fullscreen` by setting `observer.scope = "fullscreen"` in user config, which is also the default for autonomy mode.*
+   *Note: Partially resolved in [the Observer permission model ADR](adr/2026-06-20-observer-permission-model.md): The default scope is `window` (restricting capture to a targeted application process or HWND). The user can explicitly escalate to `fullscreen` by setting `observer.scope = "fullscreen"` in user config, which is also the default for autonomy mode.*
 2. How long may derived keyframes survive after the session?
 3. Which cloud regions and provider contracts are acceptable for personal and
    organizational deployments?

--- a/observer/README.md
+++ b/observer/README.md
@@ -227,6 +227,6 @@ fallback); then the built-in default. The kernel derives that file from the
 user's `observer.*` settings — `zam bridge sync-observer-policy` writes it and
 `zam settings set observer.*` refreshes it — so the native sidecar and the
 headless `capture-ui` path share one policy source (see
-[ADR-0001](../docs/adr/0001-observer-permission-model.md)). `allowProcesses`
+[the Observer permission model ADR](../docs/adr/2026-06-20-observer-permission-model.md)). `allowProcesses`
 bypasses only custom policy rules; built-in pauses for password managers,
 authentication/private-browsing, and financial contexts still win.


### PR DESCRIPTION
## What

Renames all 13 ADRs from `NNNN-slug.md` to `YYYY-MM-DD-slug.md`, using each decision's **date** (recovered from git history). Sequential numbers are dropped.

- **Collision suffix** only where a day has >1 decision: `2026-05-30a/b`, `2026-05-31a/b`, `2026-06-13a/b` (chronological).
- **`# ADR-NNNN:` heading prefix removed**; the in-file `**Date:**` field removed — the filename is now the canonical, immutable decision date, and git history records edits.
- The few `ADR-NNNN` references (`observer/README.md`, the Codex skill, the windows-ui proposal, both top-level READMEs' update links) now reference ADRs by name.
- `docs/adr/README.md`: date-based naming convention (incl. same-day suffix rule) + chronological `Date | Title | Status` table.

## Why

Decisions get navigated by topic and chronology, not by a number nobody remembers. A date prefix shows *when* at a glance. Notably the old numbers were **not** chronological — old `0001` (observer permission) is the *newest* decision (2026-06-20) — so this also fixes the ordering. Putting the decision date in the immutable filename also resolves the earlier ambiguity of the in-file `Date:` field.

Renames use `git mv` (history preserved). Markdown only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
