### PR TITLE
feat(desktop): bundle agent skills so Default-mode setup provisions them

### DIFF
--- a/docs/adr/2026-06-13b-approachable-setup-and-self-update.md
+++ b/docs/adr/2026-06-13b-approachable-setup-and-self-update.md
@@ -19,10 +19,11 @@ rollout is in progress.*
   in the [README](../../README.md).
 - ⏳ **Default mode + signed installers** (`.dmg`/`.msi`/`.deb`), winget
   manifest, Homebrew cask — not yet shipped.
-- ⏳ **Skills as program resources** — in Default mode, bundle the skill files
-  and have `zam setup` provision them from the program directory. Today
-  `copySkills` resolves them only from a source checkout
-  (`packageRoot/.claude/skills/…`), which end users will not have.
+- ✅ **Skills as program resources** — `prepare-desktop-bridge.mjs` bundles the
+  skill files into the app resources, so the desktop app's `zam setup` provisions
+  them from the program directory (its self-located `packageRoot`) — no git
+  checkout needed. The end-to-end Default-mode install still depends on the
+  installer work above.
 - ⏳ **Desktop in-place self-update** — pending the Tauri updater keypair and
   Apple signing identity.
 - ⏳ **Bundled open agent** (opencode) — not yet shipped.

--- a/scripts/prepare-desktop-bridge.mjs
+++ b/scripts/prepare-desktop-bridge.mjs
@@ -57,6 +57,20 @@ cpSync(join(repoRoot, "dist"), join(resourceRoot, "dist"), {
   recursive: true,
 });
 
+// Bundle the agent skill files alongside the CLI so the desktop app's `zam
+// setup` can provision them from the installed program directory in Default
+// mode — end users have no git checkout to copy them from. `copySkills`
+// resolves them relative to its own (self-located) packageRoot, which in the
+// bundle is this resource root.
+for (const agentDir of [".claude", ".agent", ".agents"]) {
+  const skillsSrc = join(repoRoot, agentDir, "skills");
+  if (existsSync(skillsSrc)) {
+    cpSync(skillsSrc, join(resourceRoot, agentDir, "skills"), {
+      recursive: true,
+    });
+  }
+}
+
 writeFileSync(
   join(resourceRoot, "package.json"),
   `${JSON.stringify(


### PR DESCRIPTION
## What

`scripts/prepare-desktop-bridge.mjs` now copies the agent skill files (`.claude` / `.agent` / `.agents` → `skills/`) into the desktop resource bundle, next to the bundled CLI.

## Why

In Default mode (installed app, **no git checkout**), `zam setup` had nothing to copy skills *from* — `copySkills` only resolved them from a source checkout. Now the skills ship as program resources, and the bundled `zam setup` provisions them from the program directory via its existing self-located `packageRoot`. No `setup.ts` change needed.

## Verified

End-to-end: built the bundle, then ran the **bundled** CLI's `zam setup` (from `resources/zam-cli/`, no checkout) into a fresh temp dir — it copied all three skill files (`.claude` / `.agent` / `.agents`).

ADR *Approachable Setup and Self-Update*: "skills as program resources" marked implemented (the end-to-end Default-mode install still depends on the installer work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
