### PR TITLE
chore(release): bump version to 0.4.1

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # ZAM Architecture Handbook
 *The Complete System Reference Manual for the Symbiotic Learning Kernel*
 
-> Last updated: 2026-06-20 · Version 0.4.0 (Phase 1: Individual Symbiosis)
+> Last updated: 2026-06-21 · Version 0.4.1 (Phase 1: Individual Symbiosis)
 >
 > Related Documentation:
 > - [TEMPLATES.md](TEMPLATES.md) — template/instance model, repo families, setup protocol

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What

Bumps `zam-core` to **0.4.1** (package.json, lockfile, ARCHITECTURE handbook).

Rolls up since 0.4.0:
- #64 — `zam update` applies updates
- #65 — ADRs named by decision date
- #66 — agent skills bundled for Default-mode setup

## Release

Tagging `v0.4.1` after merge triggers `release.yml`: publishes `zam-core@0.4.1` to npm and builds a **draft** desktop release with Windows (x64/ARM) + Linux (deb/rpm) installers. macOS desktop is excluded (Apple signing not set up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
