### PR TITLE
docs(adr): add Code Signing and Trusted Installers ADR

### DIFF
--- a/docs/adr/2026-06-21-code-signing-and-trusted-installers.md
+++ b/docs/adr/2026-06-21-code-signing-and-trusted-installers.md
@@ -1,0 +1,65 @@
+# Code Signing and Trusted Installers
+
+**Status:** Proposed
+**Deciders:** Thomas (project owner)
+
+---
+
+## Context
+
+Release installers are currently unsigned, so every platform greets new users as
+an "unknown publisher":
+
+- **Windows** — Microsoft Defender SmartScreen blocks a downloaded `.msi`/`.exe`
+  with *"Windows protected your PC"*; the only way through is **More info → Run
+  anyway**. Downloaded files carry the Mark of the Web, and an unsigned (or
+  reputation-less) binary trips SmartScreen.
+- **macOS** — Gatekeeper blocks an unsigned, un-notarized app the same way, which
+  is why macOS targets are currently excluded from `release.yml`.
+
+This install-time friction directly undermines the approachable-install goal of
+[Approachable Setup and Self-Update](2026-06-13b-approachable-setup-and-self-update.md),
+which already lists code-signing/notarization identities as pending.
+
+**Not the same thing:** the existing `TAURI_SIGNING_PRIVATE_KEY` signs only the
+in-app updater's manifests (`latest.json` / `.sig`). It is unrelated to
+Authenticode/Apple signing and does nothing for SmartScreen or Gatekeeper — a
+separate certificate is required per OS.
+
+## Decision
+
+Sign release artifacts per platform so they install without "unknown publisher"
+warnings, wired into the existing `tauri-action` pipeline with credentials stored
+as repository secrets:
+
+- **Windows** — Authenticode-sign the installers/binaries
+  (`tauri.conf.json` → `bundle.windows.signCommand`, or a signing GitHub Action).
+- **macOS** — Apple Developer ID Application certificate + **notarization**
+  (`notarytool`) + stapling; this also unblocks re-adding the macOS targets to
+  `release.yml`.
+
+## Options weighed (Windows certificate)
+
+| Option | Trust | Cost / overhead |
+|--------|-------|-----------------|
+| OV certificate | SmartScreen reputation must accrue over downloads/time — early users still warned | low cost, reputation lag |
+| EV certificate | Instant SmartScreen reputation | pricier, hardware/cloud HSM, stricter vetting |
+| **Azure Trusted Signing** *(recommended)* | Good SmartScreen treatment, cloud-based, CI-friendly (no USB token) | low monthly cost; org-tenure requirement (individual options emerging) |
+
+Azure Trusted Signing is the recommended starting point for a small project; fall
+back to an EV certificate if the tenure/vetting requirement blocks it.
+
+## Consequences
+
+- Removes the install-time trust barrier on both OSes — the core win.
+- macOS signing + notarization unblocks shipping macOS installers (today excluded).
+- Adds certificate procurement and secret management, plus a small recurring cost;
+  EV/HSM paths add operational overhead.
+- Certificates and identities must be obtained by the project owner — they cannot
+  be provisioned from inside the repo.
+
+## Open
+
+- Final Windows path (Azure Trusted Signing vs EV) — chosen at procurement.
+- Apple Developer ID + notarization credentials to be set up.
+- Sequencing is intentionally left open.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-06-13b](2026-06-13b-approachable-setup-and-self-update.md) | Approachable Setup and Self-Update | Partially implemented |
 | [2026-06-15](2026-06-15-kernel-polish-and-performance.md) | Kernel Polish and Performance | Proposed |
 | [2026-06-20](2026-06-20-observer-permission-model.md) | Configurable Observer permission model (`ObserverPolicy`) and two-layer consent | Accepted |
+| [2026-06-21](2026-06-21-code-signing-and-trusted-installers.md) | Code Signing and Trusted Installers | Proposed |


### PR DESCRIPTION
## What

New ADR: **Code Signing and Trusted Installers** (`docs/adr/2026-06-21-code-signing-and-trusted-installers.md`).

Documents the plan to remove the "unknown publisher" install friction:
- **Windows** — Authenticode signing (SmartScreen).
- **macOS** — Developer ID + notarization (Gatekeeper; also unblocks the macOS release targets currently excluded from `release.yml`).

Options weighed for the Windows cert (OV / EV / **Azure Trusted Signing**, recommended). Clarifies that the existing Tauri *updater* key is separate from OS code signing. Sequencing intentionally left open (no target date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
