### PR TITLE
feat(desktop): gate the manual UI Observer panel behind a dev key

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -56,7 +56,7 @@
           <button id="btn-open-graph" class="btn secondary-btn btn-large">Wissensnetz / Knowledge Map (3D)</button>
         </div>
 
-        <div class="observer-panel frosted">
+        <div id="observer-panel" class="observer-panel frosted hidden">
           <div class="observer-panel-header">
             <div>
               <h2 id="lbl-observer-title">UI Observer</h2>

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1994,9 +1994,29 @@ function showCompletionState() {
 }
 
 // ── KEYBOARD SHORTCUTS & EVENT BINDINGS ──────────────────────────────────
+/**
+ * Dev-only gate for the manual "UI Observer" capture panel. Capture scope is
+ * normally decided by the Agent harness (ADR 2026-06-23), so this panel is
+ * hidden by default. Enable it for debugging from the devtools console:
+ *   localStorage.setItem("zam:dev-observer", "1")  // then reload
+ */
+function devObserverEnabled(): boolean {
+  try {
+    return localStorage.getItem("zam:dev-observer") === "1";
+  } catch {
+    return false;
+  }
+}
+
 window.addEventListener("DOMContentLoaded", () => {
   // Load initial dashboard state
   loadDashboard();
+
+  // The manual UI Observer is a developer-only affordance; reveal it only when
+  // the dev key is set (see devObserverEnabled).
+  if (devObserverEnabled()) {
+    document.getElementById("observer-panel")?.classList.remove("hidden");
+  }
 
   // Start Session Button
   document.getElementById("btn-start-session")!.addEventListener("click", () => {


### PR DESCRIPTION
Per ADR 2026-06-23: capture scope is decided by the Agent harness, so the manual window-capture panel in the Recall Studio is no longer a default feature. It's hidden by default and revealed only when a developer sets `localStorage.setItem("zam:dev-observer", "1")` and reloads.

Verified: `tsc && vite build` (desktop) passes. Desktop-frontend only; no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)