### PR TITLE
feat(llm): role-based provider resolution + Anthropic Messages vision adapter

### DIFF
--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -16,6 +16,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import type { Database, SupportedLocale } from "../../kernel/index.js";
 import {
+  getProviderApiKey,
   getSetting,
   getSystemProfile,
   hasCommand,
@@ -81,27 +82,187 @@ export function getCloudModelRecommendation(url: string): string | null {
   return null;
 }
 
-export async function getVisionConfig(db: Database): Promise<LlmConfig> {
-  const base = await getLlmConfig(db);
-  const maxFramesStr = await getSetting(db, "llm.vision.max_frames");
-  const maxFrames = maxFramesStr ? parseInt(maxFramesStr, 10) : 100;
+// ── Role-based provider resolution (ADR 2026-06-23) ──────────────────────────
 
-  const url = (await getSetting(db, "llm.vision.url")) || base.url;
-  let model = await getSetting(db, "llm.vision.model");
+export type LlmRole = "vision" | "recall" | "text";
+export type ApiFlavor = "chat-completions" | "anthropic-messages";
 
-  if (!model) {
-    // If not set explicitly, try to recommend a cheap cloud model based on URL, otherwise fall back to base
-    const cloudRec = getCloudModelRecommendation(url);
-    model = cloudRec || base.model;
+/** A resolved endpoint for one role, with an optional fallback to try next. */
+export interface ProviderConfig {
+  enabled: boolean;
+  url: string;
+  model: string;
+  apiKey: string;
+  apiFlavor: ApiFlavor;
+  locale: SupportedLocale;
+  /** Vision only: max frames to sample from a recording. */
+  maxFrames?: number;
+  /** Optional next endpoint to try when the primary is unusable. */
+  fallback?: ProviderConfig;
+}
+
+/** Infer the wire protocol from the endpoint host (anthropic.com → Messages API). */
+export function inferApiFlavor(url: string): ApiFlavor {
+  try {
+    return new URL(url).hostname.toLowerCase().endsWith("anthropic.com")
+      ? "anthropic-messages"
+      : "chat-completions";
+  } catch {
+    return "chat-completions";
+  }
+}
+
+interface ProviderRecord {
+  url?: string;
+  model?: string;
+  apiFlavor?: ApiFlavor;
+  apiKey?: string;
+  apiKeyRef?: string;
+}
+type ProvidersMap = Record<string, ProviderRecord>;
+interface RoleBinding {
+  primary?: string;
+  fallback?: string;
+}
+type RolesMap = Partial<Record<LlmRole, RoleBinding>>;
+
+async function readJsonSetting<T>(
+  db: Database,
+  key: string,
+): Promise<T | null> {
+  const raw = await getSetting(db, key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function resolveProviderApiKey(rec: ProviderRecord): string {
+  if (rec.apiKey) return rec.apiKey;
+  if (rec.apiKeyRef) {
+    const key = getProviderApiKey(rec.apiKeyRef);
+    if (key) return key;
+  }
+  return DEFAULT_LLM_API_KEY;
+}
+
+/**
+ * Resolve the configured provider for a role.
+ *
+ * New-style config: JSON `llm.providers` (named endpoint records) + `llm.roles`
+ * (role → {primary, fallback}). When either is absent, falls back to the legacy
+ * `llm.*` / `llm.vision.*` keys, so existing installs behave identically.
+ *
+ * Enablement stays on the existing gates — `llm.enabled` for recall/text,
+ * `llm.vision.enabled` for vision — so the vision consent/privacy semantics are
+ * preserved regardless of how providers are wired.
+ */
+export async function getProviderForRole(
+  db: Database,
+  role: LlmRole,
+): Promise<ProviderConfig> {
+  const enabled =
+    role === "vision"
+      ? (await getSetting(db, "llm.vision.enabled")) === "true"
+      : (await getSetting(db, "llm.enabled")) === "true";
+
+  const base = await getLegacyRoleConfig(db, role, enabled);
+
+  const providers = await readJsonSetting<ProvidersMap>(db, "llm.providers");
+  const roles = await readJsonSetting<RolesMap>(db, "llm.roles");
+  const binding = roles?.[role];
+
+  if (providers && binding?.primary && providers[binding.primary]) {
+    const primary = materializeProvider(providers[binding.primary], base, role);
+    const fallback =
+      binding.fallback && providers[binding.fallback]
+        ? materializeProvider(providers[binding.fallback], base, role)
+        : undefined;
+    return { ...primary, fallback };
   }
 
+  return base;
+}
+
+function materializeProvider(
+  rec: ProviderRecord,
+  base: ProviderConfig,
+  role: LlmRole,
+): ProviderConfig {
+  const url = rec.url || base.url;
   return {
-    enabled: (await getSetting(db, "llm.vision.enabled")) === "true",
+    enabled: base.enabled,
     url,
-    model,
-    apiKey: (await getSetting(db, "llm.vision.api_key")) || base.apiKey,
+    model: rec.model || base.model,
+    apiKey: resolveProviderApiKey(rec),
+    apiFlavor: rec.apiFlavor || inferApiFlavor(url),
     locale: base.locale,
-    maxFrames: Number.isNaN(maxFrames) ? 100 : maxFrames,
+    ...(role === "vision" ? { maxFrames: base.maxFrames } : {}),
+  };
+}
+
+/** Legacy `llm.*` / `llm.vision.*` resolution — the back-compat default. */
+async function getLegacyRoleConfig(
+  db: Database,
+  role: LlmRole,
+  enabled: boolean,
+): Promise<ProviderConfig> {
+  const base = await getLlmConfig(db);
+
+  if (role === "vision") {
+    const maxFramesStr = await getSetting(db, "llm.vision.max_frames");
+    const parsed = maxFramesStr ? parseInt(maxFramesStr, 10) : 100;
+    const url = (await getSetting(db, "llm.vision.url")) || base.url;
+    let model = await getSetting(db, "llm.vision.model");
+    if (!model) model = getCloudModelRecommendation(url) || base.model;
+    return {
+      enabled,
+      url,
+      model,
+      apiKey: (await getSetting(db, "llm.vision.api_key")) || base.apiKey,
+      apiFlavor: inferApiFlavor(url),
+      locale: base.locale,
+      maxFrames: Number.isNaN(parsed) ? 100 : parsed,
+    };
+  }
+
+  // recall / text both map to the base text endpoint today.
+  return {
+    enabled,
+    url: base.url,
+    model: base.model,
+    apiKey: base.apiKey,
+    apiFlavor: inferApiFlavor(base.url),
+    locale: base.locale,
+  };
+}
+
+/** Guard for paths that only speak chat-completions (recall text today). */
+function assertChatCompletions(cfg: ProviderConfig): void {
+  if (cfg.apiFlavor !== "chat-completions") {
+    throw new Error(
+      `This role is configured for a "${cfg.apiFlavor}" provider, which is not ` +
+        `supported here yet. Use a chat-completions provider for the recall role.`,
+    );
+  }
+}
+
+/**
+ * Vision/UI-observer config in the legacy `LlmConfig` shape, for callers that
+ * don't need flavor/fallback (e.g. `checkVisionReadiness`). Delegates to
+ * {@link getProviderForRole} so the role config stays the single source.
+ */
+export async function getVisionConfig(db: Database): Promise<LlmConfig> {
+  const p = await getProviderForRole(db, "vision");
+  return {
+    enabled: p.enabled,
+    url: p.url,
+    model: p.model,
+    apiKey: p.apiKey,
+    locale: p.locale,
+    maxFrames: p.maxFrames,
   };
 }
 
@@ -167,10 +328,11 @@ export async function generateQuestionViaLLM(
     sourceLinkContent?: string | null;
   },
 ): Promise<string> {
-  const cfg = await getLlmConfig(db);
+  const cfg = await getProviderForRole(db, "recall");
   if (!cfg.enabled) {
     throw new Error("LLM integration is disabled in settings (llm.enabled)");
   }
+  assertChatCompletions(cfg);
 
   const bloom = (
     input.bloomLevel >= 1 && input.bloomLevel <= 5 ? input.bloomLevel : 1
@@ -234,10 +396,11 @@ export async function evaluateAnswerViaLLM(
     sourceLinkContent?: string | null;
   },
 ): Promise<string> {
-  const cfg = await getLlmConfig(db);
+  const cfg = await getProviderForRole(db, "recall");
   if (!cfg.enabled) {
     throw new Error("LLM integration is disabled in settings (llm.enabled)");
   }
+  assertChatCompletions(cfg);
   const langName = LANGUAGE_NAMES[cfg.locale] || "English";
   const ratingPrefix =
     LOCALIZED_RATING_PREFIX[cfg.locale] || "Suggested rating";
@@ -298,10 +461,11 @@ export async function translateQuestionViaLLM(
   db: Database,
   question: string,
 ): Promise<string> {
-  const cfg = await getLlmConfig(db);
+  const cfg = await getProviderForRole(db, "recall");
   if (!cfg.enabled) {
     throw new Error("LLM integration is disabled in settings");
   }
+  assertChatCompletions(cfg);
   const targetLang = LANGUAGE_NAMES[cfg.locale] || "English";
 
   const systemPrompt = `You are a highly precise translator. Translate the given active-recall question into clear, natural ${targetLang}.

--- a/src/cli/llm/vision.ts
+++ b/src/cli/llm/vision.ts
@@ -17,9 +17,10 @@ import {
   UI_OBSERVATION_PROTOCOL_VERSION,
 } from "../../kernel/index.js";
 import {
+  type ApiFlavor,
   DEFAULT_LLM_API_KEY,
   fetchWithInteractiveTimeout,
-  getVisionConfig,
+  getProviderForRole,
 } from "./client.js";
 
 const LANGUAGE_NAMES: Record<SupportedLocale, string> = {
@@ -81,7 +82,7 @@ export async function observeUiSnapshotViaLLM(
   db: Database,
   input: UiSnapshotObservationInput,
 ): Promise<UiObservationReport> {
-  const cfg = await getVisionConfig(db);
+  const cfg = await getProviderForRole(db, "vision");
   if (!cfg.enabled) {
     throw new Error(
       "Vision observation is disabled in settings (llm.vision.enabled)",
@@ -160,6 +161,7 @@ export async function observeUiSnapshotViaLLM(
     url: cfg.url,
     apiKey: cfg.apiKey || DEFAULT_LLM_API_KEY,
     model,
+    apiFlavor: cfg.apiFlavor,
     locale: cfg.locale,
     imageUrls,
     input,
@@ -185,22 +187,54 @@ export async function observeUiSnapshotViaLLM(
   return report;
 }
 
-async function requestVisionDraft(args: {
+type VisionRequestArgs = {
   url: string;
   apiKey: string;
   model: string;
+  apiFlavor: ApiFlavor;
   locale: SupportedLocale;
   imageUrls: string[];
   input: UiSnapshotObservationInput;
-}): Promise<string> {
-  const language = LANGUAGE_NAMES[args.locale] ?? "English";
-  const schema = `{
+};
+
+const VISION_SYSTEM_PROMPT =
+  "You are ZAM's UI observer. Return only strict JSON. Do not include markdown, prose, or fields outside the requested schema.";
+
+function visionSchema(language: string): string {
+  return `{
   "kind": "progress | step-completed | error | help-seeking | uncertain",
   "summary": "short factual UI summary in ${language}",
   "actions": [{"type": "click | shortcut | typing | scroll | window-change", "target": "optional UI target", "result": "optional visible result"}],
   "candidateTokens": [{"slug": "optional-kebab-case-skill-token", "confidence": 0.0, "rationale": "why this token may matter"}],
   "confidence": 0.0
 }`;
+}
+
+function visionUserText(args: VisionRequestArgs, language: string): string {
+  const intro =
+    args.imageUrls.length > 1
+      ? "Observe this sequence of Windows/macOS application snapshots showing a task performed over time."
+      : "Observe this Windows/macOS application snapshot for a learning session.";
+  return `${intro}
+Application process: ${args.input.application.processName}
+Window title: ${args.input.application.windowTitle ?? "(unknown)"}
+
+Return this JSON draft only:
+${visionSchema(language)}`;
+}
+
+/** Dispatch to the configured wire protocol for the vision endpoint. */
+async function requestVisionDraft(args: VisionRequestArgs): Promise<string> {
+  if (args.apiFlavor === "anthropic-messages") {
+    return requestAnthropicVisionDraft(args);
+  }
+  return requestChatCompletionsVisionDraft(args);
+}
+
+async function requestChatCompletionsVisionDraft(
+  args: VisionRequestArgs,
+): Promise<string> {
+  const language = LANGUAGE_NAMES[args.locale] ?? "English";
 
   const res = await fetchWithInteractiveTimeout(
     `${args.url}/chat/completions`,
@@ -213,31 +247,11 @@ async function requestVisionDraft(args: {
       body: JSON.stringify({
         model: args.model,
         messages: [
-          {
-            role: "system",
-            content:
-              "You are ZAM's UI observer. Return only strict JSON. Do not include markdown, prose, or fields outside the requested schema.",
-          },
+          { role: "system", content: VISION_SYSTEM_PROMPT },
           {
             role: "user",
             content: [
-              {
-                type: "text",
-                text:
-                  args.imageUrls.length > 1
-                    ? `Observe this sequence of Windows/macOS application snapshots showing a task performed over time.
-Application process: ${args.input.application.processName}
-Window title: ${args.input.application.windowTitle ?? "(unknown)"}
-
-Return this JSON draft only:
-${schema}`
-                    : `Observe this Windows/macOS application snapshot for a learning session.
-Application process: ${args.input.application.processName}
-Window title: ${args.input.application.windowTitle ?? "(unknown)"}
-
-Return this JSON draft only:
-${schema}`,
-              },
+              { type: "text", text: visionUserText(args, language) },
               ...args.imageUrls.map((url) => ({
                 type: "image_url",
                 image_url: { url },
@@ -297,6 +311,87 @@ ${schema}`,
     throw new Error("Empty response from vision model");
   }
   return content.trim();
+}
+
+interface AnthropicImageBlock {
+  type: "image";
+  source: { type: "base64"; media_type: string; data: string };
+}
+
+interface AnthropicMessageResponse {
+  content?: Array<{ type?: string; text?: string }>;
+  stop_reason?: string;
+  error?: unknown;
+}
+
+function dataUrlToAnthropicImage(dataUrl: string): AnthropicImageBlock {
+  const match = dataUrl.match(/^data:(image\/[a-zA-Z]+);base64,(.+)$/);
+  if (!match) {
+    throw new Error("Unsupported image data for Anthropic vision request");
+  }
+  return {
+    type: "image",
+    source: { type: "base64", media_type: match[1], data: match[2] },
+  };
+}
+
+/**
+ * Anthropic Messages API vision request (ADR 2026-06-23 item 2). The Messages
+ * API is not OpenAI-shaped: keys go on `x-api-key`, images are base64 source
+ * blocks, and the reply is a content-block array.
+ */
+async function requestAnthropicVisionDraft(
+  args: VisionRequestArgs,
+): Promise<string> {
+  const language = LANGUAGE_NAMES[args.locale] ?? "English";
+  const base = args.url.replace(/\/+$/, "").replace(/\/v1$/, "");
+
+  const res = await fetchWithInteractiveTimeout(`${base}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": args.apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: args.model,
+      max_tokens: args.input.maxTokens ?? 450,
+      system: VISION_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: visionUserText(args, language) },
+            ...args.imageUrls.map(dataUrlToAnthropicImage),
+          ],
+        },
+      ],
+    }),
+    locale: args.locale,
+    hardTimeoutMs: args.input.hardTimeoutMs ?? 180000,
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => "");
+    throw new Error(
+      `Vision LLM request failed: ${res.statusText} (${res.status}) - ${errorText}`,
+    );
+  }
+
+  const data = (await res.json()) as AnthropicMessageResponse;
+  if (data.error !== undefined) {
+    throw new Error(`Vision model failed: ${formatModelError(data.error)}`);
+  }
+  if (data.stop_reason === "refusal") {
+    throw new Error("Vision model refused the request (safety classifier).");
+  }
+  const text = data.content?.find(
+    (b) => b.type === "text" && typeof b.text === "string",
+  )?.text;
+  if (!text) {
+    throw new Error("Empty response from vision model");
+  }
+  return text.trim();
 }
 
 function extractDraft(content: string): VisionObservationDraft {

--- a/src/kernel/credentials.ts
+++ b/src/kernel/credentials.ts
@@ -38,6 +38,12 @@ export interface ADOCredentials {
 export interface Credentials {
   turso?: Partial<TursoCredentials>;
   ado?: Partial<ADOCredentials>;
+  /**
+   * API keys for named LLM providers, keyed by the provider's reference name
+   * (the `apiKeyRef` in the `llm.providers` setting). Kept here — not in the
+   * database — so workspace exports / DB snapshots never carry provider keys.
+   */
+  llmProviders?: Record<string, { apiKey: string }>;
 }
 
 /** Load credentials from ~/.zam/credentials.json. Returns empty object if missing. */
@@ -136,5 +142,22 @@ export function setADOCredentials(
 export function clearADOCredentials(path?: string): void {
   const creds = loadCredentials(path);
   delete creds.ado;
+  saveCredentials(creds, path);
+}
+
+/** Get a named LLM provider's API key (by `apiKeyRef`), or null if unset. */
+export function getProviderApiKey(name: string, path?: string): string | null {
+  const key = loadCredentials(path).llmProviders?.[name]?.apiKey;
+  return key && key.length > 0 ? key : null;
+}
+
+/** Store a named LLM provider's API key (referenced by `apiKeyRef`). */
+export function setProviderApiKey(
+  name: string,
+  apiKey: string,
+  path?: string,
+): void {
+  const creds = loadCredentials(path);
+  creds.llmProviders = { ...creds.llmProviders, [name]: { apiKey } };
   saveCredentials(creds, path);
 }

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -24,10 +24,12 @@ export {
   clearADOCredentials,
   clearTursoCredentials,
   getADOCredentials,
+  getProviderApiKey,
   getTursoCredentials,
   loadCredentials,
   saveCredentials,
   setADOCredentials,
+  setProviderApiKey,
   setTursoCredentials,
 } from "./credentials.js";
 // Database

--- a/tests/cli/llm-providers.test.ts
+++ b/tests/cli/llm-providers.test.ts
@@ -1,0 +1,290 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getProviderForRole,
+  inferApiFlavor,
+} from "../../src/cli/llm/client.js";
+import { observeUiSnapshotViaLLM } from "../../src/cli/llm/vision.js";
+import {
+  getProviderApiKey,
+  openDatabase,
+  setProviderApiKey,
+  setSetting,
+} from "../../src/kernel/index.js";
+
+function openDb() {
+  return openDatabase({
+    dbPath: ":memory:",
+    initialize: true,
+    useConfiguredCloud: false,
+  });
+}
+
+const tempDirs: string[] = [];
+function makeSnapshot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "zam-providers-"));
+  tempDirs.push(dir);
+  const path = join(dir, "snapshot.png");
+  writeFileSync(path, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]));
+  return path;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("inferApiFlavor", () => {
+  it("maps anthropic.com to the Messages API, everything else to chat-completions", () => {
+    expect(inferApiFlavor("https://api.anthropic.com")).toBe(
+      "anthropic-messages",
+    );
+    expect(inferApiFlavor("https://api.deepseek.com/v1")).toBe(
+      "chat-completions",
+    );
+    expect(inferApiFlavor("http://localhost:8000/v1")).toBe("chat-completions");
+    expect(inferApiFlavor("not a url")).toBe("chat-completions");
+  });
+});
+
+describe("getProviderForRole", () => {
+  it("falls back to legacy llm.* keys for recall when no role config exists", async () => {
+    const db = await openDb();
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(db, "llm.url", "https://api.deepseek.com/v1");
+    await setSetting(db, "llm.model", "deepseek-v4-flash");
+    try {
+      const p = await getProviderForRole(db, "recall");
+      expect(p).toMatchObject({
+        enabled: true,
+        url: "https://api.deepseek.com/v1",
+        model: "deepseek-v4-flash",
+        apiFlavor: "chat-completions",
+      });
+      expect(p.fallback).toBeUndefined();
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("falls back to legacy llm.vision.* keys for vision", async () => {
+    const db = await openDb();
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(db, "llm.url", "http://localhost:8000/v1");
+    await setSetting(db, "llm.model", "gemma4-it:e4b");
+    await setSetting(db, "llm.vision.enabled", "true");
+    await setSetting(db, "llm.vision.url", "http://localhost:8000/v1");
+    await setSetting(db, "llm.vision.model", "mimo-vl");
+    try {
+      const p = await getProviderForRole(db, "vision");
+      expect(p).toMatchObject({
+        enabled: true,
+        url: "http://localhost:8000/v1",
+        model: "mimo-vl",
+        apiFlavor: "chat-completions",
+        maxFrames: 100,
+      });
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("resolves a role to its configured provider + fallback", async () => {
+    const db = await openDb();
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(
+      db,
+      "llm.providers",
+      JSON.stringify({
+        deepseek: {
+          url: "https://api.deepseek.com/v1",
+          model: "deepseek-v4-flash",
+          apiKey: "sk-ds",
+        },
+        mimo: {
+          url: "https://api.xiaomi.com/mimo/v1",
+          model: "mimo-v2.5",
+          apiKey: "sk-mimo",
+        },
+      }),
+    );
+    await setSetting(
+      db,
+      "llm.roles",
+      JSON.stringify({ recall: { primary: "deepseek", fallback: "mimo" } }),
+    );
+    try {
+      const p = await getProviderForRole(db, "recall");
+      expect(p).toMatchObject({
+        enabled: true,
+        url: "https://api.deepseek.com/v1",
+        model: "deepseek-v4-flash",
+        apiKey: "sk-ds",
+        apiFlavor: "chat-completions",
+      });
+      expect(p.fallback).toMatchObject({
+        model: "mimo-v2.5",
+        apiKey: "sk-mimo",
+      });
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("infers the anthropic-messages flavor from an anthropic provider URL", async () => {
+    const db = await openDb();
+    await setSetting(db, "llm.vision.enabled", "true");
+    await setSetting(
+      db,
+      "llm.providers",
+      JSON.stringify({
+        claude: {
+          url: "https://api.anthropic.com",
+          model: "claude-haiku-4-5",
+          apiKey: "sk-ant",
+        },
+      }),
+    );
+    await setSetting(
+      db,
+      "llm.roles",
+      JSON.stringify({ vision: { primary: "claude" } }),
+    );
+    try {
+      const p = await getProviderForRole(db, "vision");
+      expect(p).toMatchObject({
+        enabled: true,
+        url: "https://api.anthropic.com",
+        model: "claude-haiku-4-5",
+        apiFlavor: "anthropic-messages",
+      });
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("keeps the vision consent gate independent of provider wiring", async () => {
+    const db = await openDb();
+    // Providers/roles configured, but llm.vision.enabled is left off.
+    await setSetting(
+      db,
+      "llm.providers",
+      JSON.stringify({
+        claude: { url: "https://api.anthropic.com", model: "claude-haiku-4-5" },
+      }),
+    );
+    await setSetting(
+      db,
+      "llm.roles",
+      JSON.stringify({ vision: { primary: "claude" } }),
+    );
+    try {
+      const p = await getProviderForRole(db, "vision");
+      expect(p.enabled).toBe(false);
+    } finally {
+      await db.close();
+    }
+  });
+});
+
+describe("provider API key store (apiKeyRef)", () => {
+  it("round-trips a provider key via credentials.json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zam-creds-"));
+    const path = join(dir, "credentials.json");
+    try {
+      expect(getProviderApiKey("deepseek", path)).toBeNull();
+      setProviderApiKey("deepseek", "sk-secret", path);
+      expect(getProviderApiKey("deepseek", path)).toBe("sk-secret");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("anthropic-messages vision adapter", () => {
+  it("posts base64 image blocks to /v1/messages with x-api-key", async () => {
+    const db = await openDb();
+    await setSetting(db, "llm.vision.enabled", "true");
+    await setSetting(
+      db,
+      "llm.providers",
+      JSON.stringify({
+        claude: {
+          url: "https://api.anthropic.com",
+          model: "claude-haiku-4-5",
+          apiKey: "sk-ant-test",
+        },
+      }),
+    );
+    await setSetting(
+      db,
+      "llm.roles",
+      JSON.stringify({ vision: { primary: "claude" } }),
+    );
+    await setSetting(db, "system.locale", "de");
+
+    const imagePath = makeSnapshot();
+    const originalFetch = global.fetch;
+    let requestUrl: string | undefined;
+    let requestHeaders: Record<string, string> | undefined;
+    let requestBody: Record<string, unknown> | undefined;
+
+    global.fetch = (async (url, init) => {
+      requestUrl = String(url);
+      requestHeaders = init?.headers as Record<string, string>;
+      requestBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                kind: "progress",
+                summary: "Das Fenster zeigt eine einfache UI.",
+                actions: [],
+                candidateTokens: [],
+                confidence: 0.6,
+              }),
+            },
+          ],
+          stop_reason: "end_turn",
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const report = await observeUiSnapshotViaLLM(db, {
+        sessionId: "s1",
+        sequence: 1,
+        observedFrom: "2026-06-23T00:00:00.000Z",
+        observedTo: "2026-06-23T00:00:01.000Z",
+        imagePath,
+        application: { processName: "notepad.exe" },
+      });
+
+      expect(report).toMatchObject({
+        kind: "progress",
+        summary: "Das Fenster zeigt eine einfache UI.",
+        confidence: 0.6,
+      });
+      expect(requestUrl).toBe("https://api.anthropic.com/v1/messages");
+      expect(requestHeaders?.["x-api-key"]).toBe("sk-ant-test");
+      expect(requestHeaders?.["anthropic-version"]).toBe("2023-06-01");
+      expect(requestBody?.model).toBe("claude-haiku-4-5");
+      const messages = requestBody?.messages as Array<{
+        content: Array<Record<string, unknown>>;
+      }>;
+      expect(messages[0].content[0]).toMatchObject({ type: "text" });
+      expect(messages[0].content[1]).toMatchObject({
+        type: "image",
+        source: { type: "base64", media_type: "image/png" },
+      });
+    } finally {
+      global.fetch = originalFetch;
+      await db.close();
+    }
+  });
+});


### PR DESCRIPTION
Implements ADR 2026-06-23 items 1–3 (the provider-roles foundation).

## What
- **`getProviderForRole(db, role)`** — single resolver for `vision` / `recall` / `text`. Providers are named JSON records in `llm.providers`; roles bind to them via `llm.roles` (`{primary, fallback}`).
- **Back-compat:** when `llm.providers`/`llm.roles` are unset, resolution falls back to the legacy `llm.*` / `llm.vision.*` keys — existing installs behave identically (all prior LLM tests unchanged).
- **`apiFlavor`** (`chat-completions` | `anthropic-messages`), inferred from the endpoint host when not set.
- **`apiKeyRef` → `~/.zam/credentials.json`** (`getProviderApiKey`/`setProviderApiKey`) — provider keys never touch the DB, so workspace exports/snapshots carry no secrets.
- **Anthropic Messages vision adapter** in `vision.ts` (x-api-key, `anthropic-version`, base64 image blocks) beside the existing chat-completions path. `getVisionConfig` now delegates to the resolver; recall text functions route through role `recall`.
- The **vision consent gate** (`llm.vision.enabled`) stays independent of provider wiring — privacy semantics preserved.

## Verification
- `npm run build` ✓ · Biome clean on changed files ✓ · full suite **284 tests / 35 files** ✓
- New `tests/cli/llm-providers.test.ts`: flavor inference, legacy fallback (recall + vision), role→provider+fallback resolution, consent-gate independence, credentials round-trip, and the Anthropic vision request shape.
- Pre-existing `profiler.ts` Biome nit is untouched/out of scope.

## Deferred (follow-ups)
- Consume the resolved `{fallback}` chain in the vision loop — the reconciliation with the [2026-06-22](https://github.com/zam-os/zam/blob/main/docs/adr/2026-06-22-screen-recording-observer.md) frame-sampling path (ADR item 4; WIP on `wip/codex-observer-vision-and-learn-open`).
- Anthropic **text** path for recall (guarded today: a non-chat recall provider throws a clear error).
- A migration command + the Studio UI to edit providers/roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)