### PR TITLE
feat(llm): consume vision provider fallback chain (ADR item 4)

### DIFF
--- a/docs/adr/2026-06-23-pluggable-providers-and-agent-harnesses.md
+++ b/docs/adr/2026-06-23-pluggable-providers-and-agent-harnesses.md
@@ -254,20 +254,29 @@ over-captures known-app tasks; a global `window` cannot observe app discovery.
 
 Ordered so a fresh agent can pick up any item; file paths are load-bearing.
 
-1. [ ] **Provider records + resolver.** Add the `providers`/`roles` schema and
+> **Progress (2026-06-23):** Items 1–4 are done. #73 landed the resolver
+> (`getProviderForRole`), the `anthropic-messages` vision adapter,
+> `apiKeyRef`→`credentials.json`, and the legacy back-compat fallback; #74 added
+> the vision primary→fallback loop, unified with the frame-sampling path. The
+> item-7 Studio capture-UI dev-flag gate shipped in #71. Deviations/remainder:
+> the adapter uses a strict-JSON system prompt + tolerant parse rather than
+> structured outputs; an Anthropic *text* path for recall is guarded (throws);
+> a migration command + Studio providers/roles editor are still open.
+
+1. [x] **Provider records + resolver.** Added the `providers`/`roles` schema and
    `getProviderForRole(db, role)` in [`src/cli/llm/client.ts`](../../src/cli/llm/client.ts);
-   route `getVisionConfig` → role `vision`, `getLlmConfig`/`evaluateAnswerViaLLM`
-   → role `recall`. Keep the `{primary, fallback}` shape.
-2. [ ] **`anthropic-messages` adapter.** Add the Messages-API request function in
+   `getVisionConfig` → role `vision`, the recall text functions → role `recall`.
+   Keeps the `{primary, fallback}` shape.
+2. [x] **`anthropic-messages` adapter.** Messages-API request function in
    [`src/cli/llm/vision.ts`](../../src/cli/llm/vision.ts) beside the
-   chat-completions / responses paths; use structured outputs for the report
-   schema; check `stop_reason === "refusal"` before reading content.
-3. [ ] **Back-compat shim + migration** from `llm.*` / `llm.vision.*`; `apiKeyRef`
-   → [`credentials.ts`](../../src/kernel/credentials.ts).
-4. [ ] **Reconcile with [2026-06-22](2026-06-22-screen-recording-observer.md):**
-   fold the frame-sampling (`ffmpeg`/`maxFrames`) loop and the role-based
-   per-endpoint flavor/fallback into one path (the WIP on
-   `wip/codex-observer-vision-and-learn-open` is the starting point).
+   chat-completions path; checks `stop_reason === "refusal"`. (Structured outputs
+   deferred — uses a strict-JSON prompt + tolerant parse.)
+3. [x] **Back-compat shim + `apiKeyRef`** → [`credentials.ts`](../../src/kernel/credentials.ts).
+   (Standalone migration command still open; the legacy fallback covers
+   unmigrated installs.)
+4. [x] **Reconciled with [2026-06-22](2026-06-22-screen-recording-observer.md):**
+   the frame-sampling (`ffmpeg`/`maxFrames`) loop and the role-based
+   primary→fallback now share one path in `observeUiSnapshotViaLLM` (#74).
 5. [ ] **Agent harness registry** generalizing
    [`terminal-open.ts`](../../src/cli/terminal-open.ts); detection à la
    [`installer.ts`](../../src/kernel/system/installer.ts); Studio "Open Agent"

--- a/src/cli/llm/vision.ts
+++ b/src/cli/llm/vision.ts
@@ -156,35 +156,77 @@ export async function observeUiSnapshotViaLLM(
     throw new Error("No image data available for vision analysis");
   }
 
-  const model = input.model ?? cfg.model;
-  const content = await requestVisionDraft({
-    url: cfg.url,
-    apiKey: cfg.apiKey || DEFAULT_LLM_API_KEY,
-    model,
-    apiFlavor: cfg.apiFlavor,
-    locale: cfg.locale,
-    imageUrls,
-    input,
-  });
-
-  let draft: VisionObservationDraft;
-  try {
-    draft = extractDraft(content);
-  } catch {
-    return uncertainReport(
-      input,
-      "Vision model returned output that could not be parsed as JSON.",
-    );
+  // Try the role's primary endpoint, then its configured fallback. The
+  // frame-sampled `imageUrls` are shared across endpoints; only the endpoint
+  // (url/key/model/flavor) changes. `input.model` overrides the primary only.
+  const endpoints: Array<
+    Pick<VisionRequestArgs, "url" | "apiKey" | "model" | "apiFlavor">
+  > = [
+    {
+      url: cfg.url,
+      apiKey: cfg.apiKey || DEFAULT_LLM_API_KEY,
+      model: input.model ?? cfg.model,
+      apiFlavor: cfg.apiFlavor,
+    },
+  ];
+  if (cfg.fallback) {
+    endpoints.push({
+      url: cfg.fallback.url,
+      apiKey: cfg.fallback.apiKey || DEFAULT_LLM_API_KEY,
+      model: cfg.fallback.model,
+      apiFlavor: cfg.fallback.apiFlavor,
+    });
   }
 
-  const report = buildReport(input, draft);
-  if (!isUiObservationReport(report)) {
+  let lastRequestError: Error | undefined;
+  let sawUnparseableDraft = false;
+  let sawInvalidDraft = false;
+
+  for (const endpoint of endpoints) {
+    let content: string;
+    try {
+      content = await requestVisionDraft({
+        ...endpoint,
+        locale: cfg.locale,
+        imageUrls,
+        input,
+      });
+    } catch (err) {
+      lastRequestError = err as Error;
+      continue;
+    }
+
+    let draft: VisionObservationDraft;
+    try {
+      draft = extractDraft(content);
+    } catch {
+      sawUnparseableDraft = true;
+      continue;
+    }
+
+    const report = buildReport(input, draft);
+    if (isUiObservationReport(report)) {
+      return report;
+    }
+    sawInvalidDraft = true;
+  }
+
+  // All endpoints exhausted. Surface a hard request error only when no endpoint
+  // produced any draft at all; otherwise return an uncertain report reflecting
+  // the most informative failure seen.
+  if (lastRequestError && !sawUnparseableDraft && !sawInvalidDraft) {
+    throw lastRequestError;
+  }
+  if (sawInvalidDraft) {
     return uncertainReport(
       input,
       "Vision model returned an invalid UI report draft.",
     );
   }
-  return report;
+  return uncertainReport(
+    input,
+    "Vision model returned output that could not be parsed as JSON.",
+  );
 }
 
 type VisionRequestArgs = {

--- a/tests/cli/llm-providers.test.ts
+++ b/tests/cli/llm-providers.test.ts
@@ -288,3 +288,82 @@ describe("anthropic-messages vision adapter", () => {
     }
   });
 });
+
+describe("vision endpoint fallback", () => {
+  it("falls back to the configured fallback endpoint when the primary fails", async () => {
+    const db = await openDb();
+    await setSetting(db, "llm.vision.enabled", "true");
+    await setSetting(
+      db,
+      "llm.providers",
+      JSON.stringify({
+        local: {
+          url: "http://local/v1",
+          model: "text-only",
+          apiKey: "sk-local",
+        },
+        cloud: {
+          url: "https://api.deepseek.com/v1",
+          model: "deepseek-v4-flash",
+          apiKey: "sk-cloud",
+        },
+      }),
+    );
+    await setSetting(
+      db,
+      "llm.roles",
+      JSON.stringify({ vision: { primary: "local", fallback: "cloud" } }),
+    );
+
+    const imagePath = makeSnapshot();
+    const originalFetch = global.fetch;
+    const urls: string[] = [];
+    global.fetch = (async (url) => {
+      urls.push(String(url));
+      if (String(url) === "http://local/v1/chat/completions") {
+        // Primary (local, text-only) rejects image input → request throws.
+        return new Response("image input unsupported", { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  kind: "help-seeking",
+                  summary: "Cloud-Fallback lief.",
+                  actions: [],
+                  candidateTokens: [],
+                  confidence: 0.7,
+                }),
+              },
+            },
+          ],
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const report = await observeUiSnapshotViaLLM(db, {
+        sessionId: "s2",
+        sequence: 2,
+        observedFrom: "2026-06-23T00:00:00.000Z",
+        observedTo: "2026-06-23T00:00:01.000Z",
+        imagePath,
+        application: { processName: "explorer.exe" },
+      });
+
+      expect(urls).toEqual([
+        "http://local/v1/chat/completions",
+        "https://api.deepseek.com/v1/chat/completions",
+      ]);
+      expect(report).toMatchObject({
+        kind: "help-seeking",
+        summary: "Cloud-Fallback lief.",
+      });
+    } finally {
+      global.fetch = originalFetch;
+      await db.close();
+    }
+  });
+});


### PR DESCRIPTION
Completes ADR 2026-06-23 item 4 — folds the frame-sampling path and the role-based primary→fallback into one vision path.

## What
`observeUiSnapshotViaLLM` now builds an endpoint list `[primary, fallback?]` from the resolved vision `ProviderConfig` (from #73) and tries each in order, sharing the frame-sampled `imageUrls` across endpoints (`input.model` overrides the primary only). Semantics preserved:
- A hard request error is surfaced only when **no** endpoint produced a draft.
- Otherwise the most informative uncertain report is returned (invalid draft vs. unparseable output).

This unifies the `ffmpeg`/`maxFrames` frame sampling (already on main from [2026-06-22](https://github.com/zam-os/zam/blob/main/docs/adr/2026-06-22-screen-recording-observer.md)) with the role-based fallback — superseding the parallel vision work on `wip/codex-observer-vision-and-learn-open`.

## Verification
- `npm run build` ✓ · Biome clean ✓ · full suite **285 tests / 35 files** ✓
- New test: primary (text-only) rejects images → request throws → the configured fallback endpoint serves the report.
- ADR action items 1–4 marked done with a progress note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)