### PR TITLE
feat(cli): agent-harness registry + zam agent open/list (ADR item 5)

### DIFF
--- a/docs/adr/2026-06-23-pluggable-providers-and-agent-harnesses.md
+++ b/docs/adr/2026-06-23-pluggable-providers-and-agent-harnesses.md
@@ -254,14 +254,16 @@ over-captures known-app tasks; a global `window` cannot observe app discovery.
 
 Ordered so a fresh agent can pick up any item; file paths are load-bearing.
 
-> **Progress (2026-06-23):** Items 1–4 are done. #73 landed the resolver
+> **Progress (2026-06-23):** Items 1–5 are done. #73 landed the resolver
 > (`getProviderForRole`), the `anthropic-messages` vision adapter,
 > `apiKeyRef`→`credentials.json`, and the legacy back-compat fallback; #74 added
 > the vision primary→fallback loop, unified with the frame-sampling path. The
-> item-7 Studio capture-UI dev-flag gate shipped in #71. Deviations/remainder:
-> the adapter uses a strict-JSON system prompt + tolerant parse rather than
-> structured outputs; an Anthropic *text* path for recall is guarded (throws);
-> a migration command + Studio providers/roles editor are still open.
+> item-7 Studio capture-UI dev-flag gate shipped in #71. #75 landed the
+> agent-harness registry + `zam agent open` / `list` (item 5, CLI side).
+> Deviations/remainder: the adapter uses a strict-JSON system prompt + tolerant
+> parse rather than structured outputs; an Anthropic *text* path for recall is
+> guarded (throws); a migration command, the Studio "Open Agent" button, and the
+> Studio providers/roles editor are still open.
 
 1. [x] **Provider records + resolver.** Added the `providers`/`roles` schema and
    `getProviderForRole(db, role)` in [`src/cli/llm/client.ts`](../../src/cli/llm/client.ts);
@@ -277,10 +279,13 @@ Ordered so a fresh agent can pick up any item; file paths are load-bearing.
 4. [x] **Reconciled with [2026-06-22](2026-06-22-screen-recording-observer.md):**
    the frame-sampling (`ffmpeg`/`maxFrames`) loop and the role-based
    primary→fallback now share one path in `observeUiSnapshotViaLLM` (#74).
-5. [ ] **Agent harness registry** generalizing
-   [`terminal-open.ts`](../../src/cli/terminal-open.ts); detection à la
-   [`installer.ts`](../../src/kernel/system/installer.ts); Studio "Open Agent"
-   button + "Practice solo".
+5. [x] **Agent harness registry** in
+   [`agent-harness.ts`](../../src/cli/agent-harness.ts) (Claude Code / Codex /
+   opencode / Cursor / Copilot / Antigravity), detection à la
+   [`installer.ts`](../../src/kernel/system/installer.ts), plus `zam agent open`
+   / `list` built on [`terminal-open.ts`](../../src/cli/terminal-open.ts) (#75).
+   The Studio "Open Agent" button is deferred to the Studio frontend (item 6);
+   "Practice solo" is `zam learn open` (#69).
 6. [ ] **Studio setup**: workspace picker (default `~/Documents/ZAM`), "Open data
    folder" reveal, DB backup/export into the workspace.
 7. [ ] **Harness-driven capture scope** in the session/observer flow (the Agent

--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -1,0 +1,159 @@
+/**
+ * Agent-harness registry (ADR 2026-06-23 §Decision 2 / action item 5).
+ *
+ * A *harness* is the external AI the learner works *with* — it drives ZAM via
+ * `zam bridge`. This is the "Open Agent" axis, deliberately separate from the
+ * providers ZAM calls itself (see `llm/client.ts` `getProviderForRole`).
+ *
+ * CLI harnesses open in a terminal in the workspace (reusing `terminal-open.ts`);
+ * app harnesses are launched as a detached process with the workspace as an
+ * argument. Commands/paths are best-effort and overridable per harness via the
+ * `agent.<id>.command` setting, since these tools churn and install paths vary.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  buildShellSetupCommand,
+  findExecutable,
+  isPowerShellShell,
+  openTerminalWindow,
+  psSingleQuoted,
+  type TerminalShell,
+} from "./terminal-open.js";
+
+export type AgentHarnessId =
+  | "claude-code"
+  | "codex"
+  | "opencode"
+  | "cursor"
+  | "copilot"
+  | "antigravity";
+
+export interface AgentHarness {
+  id: AgentHarnessId;
+  label: string;
+  kind: "cli" | "app";
+  /** Default executable / CLI command; override via `agent.<id>.command`. */
+  command: string;
+  /** Best-effort absolute paths to probe for app harnesses, per platform. */
+  candidatePaths?: Partial<Record<NodeJS.Platform, string[]>>;
+}
+
+/**
+ * Known harnesses. CLI-first ones (Claude Code, Codex, opencode) launch in a
+ * terminal; GUI apps (Cursor, Copilot, Antigravity) launch as a process. The
+ * commands are sensible defaults — when a tool isn't on PATH under that name,
+ * the user points us at it with `zam settings set agent.<id>.command <path>`.
+ */
+export const AGENT_HARNESSES: AgentHarness[] = [
+  { id: "claude-code", label: "Claude Code", kind: "cli", command: "claude" },
+  { id: "codex", label: "Codex", kind: "cli", command: "codex" },
+  { id: "opencode", label: "opencode", kind: "cli", command: "opencode" },
+  {
+    id: "cursor",
+    label: "Cursor",
+    kind: "app",
+    command: "cursor",
+    candidatePaths: {
+      win32: [
+        join(homedir(), "AppData", "Local", "Programs", "cursor", "Cursor.exe"),
+      ],
+      darwin: ["/Applications/Cursor.app/Contents/MacOS/Cursor"],
+    },
+  },
+  { id: "copilot", label: "GitHub Copilot", kind: "app", command: "copilot" },
+  {
+    id: "antigravity",
+    label: "Antigravity",
+    kind: "app",
+    command: "antigravity",
+  },
+];
+
+export function getHarness(id: string): AgentHarness | undefined {
+  return AGENT_HARNESSES.find((h) => h.id === id);
+}
+
+export interface ResolveDeps {
+  find?: (command: string) => string | null;
+  exists?: (path: string) => boolean;
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Resolve the runnable executable for a harness, or null if not detected.
+ * Tries the (possibly overridden) command on PATH first, then — for app
+ * harnesses — the per-platform candidate paths. Dependencies are injectable so
+ * the resolution logic is unit-testable without touching the real system.
+ */
+export function resolveHarnessExecutable(
+  harness: AgentHarness,
+  overrideCommand?: string,
+  deps: ResolveDeps = {},
+): string | null {
+  const find = deps.find ?? findExecutable;
+  const exists = deps.exists ?? existsSync;
+  const platform = deps.platform ?? process.platform;
+
+  const found = find(overrideCommand || harness.command);
+  if (found) return found;
+
+  if (harness.kind === "app") {
+    for (const candidate of harness.candidatePaths?.[platform] ?? []) {
+      if (exists(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+export type AgentLaunchPlan =
+  | { kind: "cli"; shellSetup: string; shell: TerminalShell }
+  | { kind: "app"; executable: string; args: string[] };
+
+/** Pure: build the launch plan for a resolved harness (no side effects). */
+export function planHarnessLaunch(
+  harness: AgentHarness,
+  opts: { executable: string; workspace: string; shell: TerminalShell },
+): AgentLaunchPlan {
+  if (harness.kind === "cli") {
+    const invocation = isPowerShellShell(opts.shell)
+      ? `& ${psSingleQuoted(opts.executable)}`
+      : JSON.stringify(opts.executable);
+    return {
+      kind: "cli",
+      shell: opts.shell,
+      shellSetup: buildShellSetupCommand(
+        opts.workspace,
+        opts.shell,
+        invocation,
+      ),
+    };
+  }
+  return { kind: "app", executable: opts.executable, args: [opts.workspace] };
+}
+
+/** Launch the harness: a terminal window for CLI, a detached process for app. */
+export function launchHarness(
+  harness: AgentHarness,
+  opts: { executable: string; workspace: string; shell: TerminalShell },
+): void {
+  const plan = planHarnessLaunch(harness, opts);
+  if (plan.kind === "cli") {
+    openTerminalWindow({
+      shellSetup: plan.shellSetup,
+      label: `agent-${harness.id}`,
+      dir: opts.workspace,
+      shell: plan.shell,
+    });
+    return;
+  }
+  spawn(plan.executable, plan.args, {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  }).unref();
+  console.log(`Launched ${harness.label} in ${opts.workspace}`);
+}

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -11,7 +11,20 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { Command } from "commander";
-import { hasCommand, installOpenCode } from "../../kernel/index.js";
+import type { Database } from "../../kernel/index.js";
+import {
+  getSetting,
+  hasCommand,
+  installOpenCode,
+  openDatabase,
+} from "../../kernel/index.js";
+import {
+  AGENT_HARNESSES,
+  getHarness,
+  launchHarness,
+  resolveHarnessExecutable,
+} from "../agent-harness.js";
+import { normalizeShell } from "../terminal-open.js";
 
 const C = {
   reset: "\x1b[0m",
@@ -83,8 +96,93 @@ const statusCmd = new Command("status")
   .description("Show whether the agent is installed and wired to ZAM")
   .action(printStatus);
 
+const listCmd = new Command("list")
+  .description("List known agent harnesses and whether each is detected")
+  .action(() => {
+    console.log(`${C.bold}Agent harnesses${C.reset}`);
+    for (const h of AGENT_HARNESSES) {
+      const status = resolveHarnessExecutable(h)
+        ? `${C.green}detected${C.reset}`
+        : `${C.yellow}not found${C.reset}`;
+      console.log(
+        `  ${h.id.padEnd(13)} ${status}  ${C.dim}${h.label} (${h.kind})${C.reset}`,
+      );
+    }
+    console.log(`\n  ${C.dim}Open one: zam agent open --id <id>${C.reset}`);
+    console.log(
+      `  ${C.dim}Point ZAM at a custom path: zam settings set agent.<id>.command <path>${C.reset}`,
+    );
+  });
+
+const openCmd = new Command("open")
+  .description("Open an agent harness in the workspace, ready to drive ZAM")
+  .option(
+    "--id <id>",
+    "Harness id (default: agent.default setting, else first detected)",
+  )
+  .option("--dir <path>", "Workspace directory (defaults to cwd)")
+  .option(
+    "--shell <type>",
+    "Shell type: zsh | bash | pwsh | powershell (auto-detected)",
+  )
+  .action(async (opts: { id?: string; dir?: string; shell?: string }) => {
+    let shell: ReturnType<typeof normalizeShell>;
+    try {
+      shell = normalizeShell(opts.shell);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    let id = opts.id;
+    let override: string | undefined;
+    let db: Database | undefined;
+    try {
+      db = await openDatabase();
+      if (!id) {
+        id = (await getSetting(db, "agent.default")) || undefined;
+      }
+      if (!id) {
+        id = AGENT_HARNESSES.find((h) => resolveHarnessExecutable(h))?.id;
+      }
+      if (id) {
+        override = (await getSetting(db, `agent.${id}.command`)) || undefined;
+      }
+    } finally {
+      await db?.close();
+    }
+
+    if (!id) {
+      console.error(
+        "No agent harness configured or detected. Install one (e.g. zam agent install), then set a default: zam settings set agent.default <id>.",
+      );
+      process.exit(1);
+    }
+
+    const harness = getHarness(id);
+    if (!harness) {
+      console.error(
+        `Unknown harness: ${id}. Known: ${AGENT_HARNESSES.map((h) => h.id).join(", ")}.`,
+      );
+      process.exit(1);
+    }
+
+    const executable = resolveHarnessExecutable(harness, override);
+    if (!executable) {
+      console.error(
+        `${harness.label} was not detected. Install it, or point ZAM at it: zam settings set agent.${harness.id}.command <path>.`,
+      );
+      process.exit(1);
+    }
+
+    const workspace = opts.dir ?? process.cwd();
+    launchHarness(harness, { executable, workspace, shell });
+  });
+
 export const agentCommand = new Command("agent")
   .description("Provision and inspect the agent that drives ZAM sessions")
   .addCommand(installCmd)
   .addCommand(statusCmd)
+  .addCommand(openCmd)
+  .addCommand(listCmd)
   .action(printStatus);

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AgentHarness,
+  AGENT_HARNESSES,
+  getHarness,
+  planHarnessLaunch,
+  resolveHarnessExecutable,
+} from "../../src/cli/agent-harness.js";
+
+describe("agent harness registry", () => {
+  it("includes the documented harnesses (ADR 2026-06-23)", () => {
+    const ids = AGENT_HARNESSES.map((h) => h.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "claude-code",
+        "codex",
+        "opencode",
+        "cursor",
+        "copilot",
+        "antigravity",
+      ]),
+    );
+  });
+
+  it("resolves a harness by id", () => {
+    expect(getHarness("claude-code")?.kind).toBe("cli");
+    expect(getHarness("cursor")?.kind).toBe("app");
+    expect(getHarness("nope")).toBeUndefined();
+  });
+});
+
+describe("resolveHarnessExecutable", () => {
+  const claude = getHarness("claude-code") as AgentHarness;
+
+  it("returns the resolved command for a CLI harness on PATH", () => {
+    expect(
+      resolveHarnessExecutable(claude, undefined, {
+        find: () => "/usr/bin/claude",
+      }),
+    ).toBe("/usr/bin/claude");
+  });
+
+  it("returns null for a CLI harness that isn't on PATH", () => {
+    expect(
+      resolveHarnessExecutable(claude, undefined, { find: () => null }),
+    ).toBeNull();
+  });
+
+  it("honors an override command", () => {
+    const probed: string[] = [];
+    resolveHarnessExecutable(claude, "/opt/claude", {
+      find: (c) => {
+        probed.push(c);
+        return null;
+      },
+    });
+    expect(probed).toEqual(["/opt/claude"]);
+  });
+
+  it("falls back to a candidate app path when the command isn't on PATH", () => {
+    const app: AgentHarness = {
+      id: "cursor",
+      label: "X",
+      kind: "app",
+      command: "x",
+      candidatePaths: { linux: ["/opt/x/x"] },
+    };
+    expect(
+      resolveHarnessExecutable(app, undefined, {
+        find: () => null,
+        exists: (p) => p === "/opt/x/x",
+        platform: "linux",
+      }),
+    ).toBe("/opt/x/x");
+  });
+
+  it("does not probe candidate paths for CLI harnesses", () => {
+    expect(
+      resolveHarnessExecutable(claude, undefined, {
+        find: () => null,
+        exists: () => true,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("planHarnessLaunch", () => {
+  const claude = getHarness("claude-code") as AgentHarness;
+  const cursor = getHarness("cursor") as AgentHarness;
+
+  it("builds a PowerShell terminal setup for a CLI harness", () => {
+    expect(
+      planHarnessLaunch(claude, {
+        executable: "C:/bin/claude.cmd",
+        workspace: "C:/work",
+        shell: "pwsh",
+      }),
+    ).toEqual({
+      kind: "cli",
+      shell: "pwsh",
+      shellSetup: "Set-Location -LiteralPath 'C:/work'; & 'C:/bin/claude.cmd'",
+    });
+  });
+
+  it("builds a POSIX terminal setup for a CLI harness", () => {
+    expect(
+      planHarnessLaunch(claude, {
+        executable: "/usr/bin/claude",
+        workspace: "/home/me/work",
+        shell: "bash",
+      }),
+    ).toEqual({
+      kind: "cli",
+      shell: "bash",
+      shellSetup: 'cd "/home/me/work" && "/usr/bin/claude"',
+    });
+  });
+
+  it("launches an app harness with the workspace as an argument", () => {
+    expect(
+      planHarnessLaunch(cursor, {
+        executable: "/Applications/Cursor.app/Contents/MacOS/Cursor",
+        workspace: "/home/me/work",
+        shell: "bash",
+      }),
+    ).toEqual({
+      kind: "app",
+      executable: "/Applications/Cursor.app/Contents/MacOS/Cursor",
+      args: ["/home/me/work"],
+    });
+  });
+});


### PR DESCRIPTION
Implements ADR 2026-06-23 item 5 (CLI side) — the agent-harness axis (the AI you *work with*, distinct from the providers ZAM calls itself).

## What
- **`src/cli/agent-harness.ts`** — a registry of harnesses (Claude Code, Codex, opencode, Cursor, GitHub Copilot, Antigravity) with:
  - **detection** via `findExecutable` + per-platform candidate paths (à la `installer.ts`), overridable per harness with `agent.<id>.command` since these tools churn;
  - **launch** — CLI harnesses open a terminal in the workspace (reusing `terminal-open.ts`); app harnesses spawn detached with the workspace as an argument. `planHarnessLaunch` is a pure, unit-tested function.
- **`zam agent open [--id] [--dir] [--shell]`** — launches the configured (`agent.default`) or first-detected harness in the workspace.
- **`zam agent list`** — shows each harness + detection status.
- The existing opencode `install`/`status` is **unchanged**; opencode is just one entry in the registry now.

## Verification
- `npm run build` ✓ · Biome clean ✓ · full suite **295 tests / 36 files** ✓ (10 new: registry lookup, detection with injected deps, CLI/app launch plans).

## Deferred
- The Studio **"Open Agent" button** (desktop frontend) — folds into the Studio-setup work (item 6). "Practice solo" already exists as `zam learn open` (#69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)