### PR TITLE
feat(cli): zam workspace data-dir + backup (ADR item 6 plumbing)

### DIFF
--- a/docs/adr/2026-06-23-pluggable-providers-and-agent-harnesses.md
+++ b/docs/adr/2026-06-23-pluggable-providers-and-agent-harnesses.md
@@ -259,7 +259,9 @@ Ordered so a fresh agent can pick up any item; file paths are load-bearing.
 > `apiKeyRef`→`credentials.json`, and the legacy back-compat fallback; #74 added
 > the vision primary→fallback loop, unified with the frame-sampling path. The
 > item-7 Studio capture-UI dev-flag gate shipped in #71. #75 landed the
-> agent-harness registry + `zam agent open` / `list` (item 5, CLI side).
+> agent-harness registry + `zam agent open` / `list` (item 5, CLI side). #76
+> added the CLI workspace plumbing for item 6 (`zam workspace data-dir` /
+> `backup`, SQLite `VACUUM INTO`).
 > Deviations/remainder: the adapter uses a strict-JSON system prompt + tolerant
 > parse rather than structured outputs; an Anthropic *text* path for recall is
 > guarded (throws); a migration command, the Studio "Open Agent" button, and the
@@ -286,8 +288,11 @@ Ordered so a fresh agent can pick up any item; file paths are load-bearing.
    / `list` built on [`terminal-open.ts`](../../src/cli/terminal-open.ts) (#75).
    The Studio "Open Agent" button is deferred to the Studio frontend (item 6);
    "Practice solo" is `zam learn open` (#69).
-6. [ ] **Studio setup**: workspace picker (default `~/Documents/ZAM`), "Open data
-   folder" reveal, DB backup/export into the workspace.
+6. [ ] **Studio setup**: workspace picker (default `~/Documents/zam`), "Open data
+   folder" reveal, DB backup/export into the workspace. CLI plumbing landed in
+   #76 — `zam workspace data-dir` and `zam workspace backup` (SQLite
+   `VACUUM INTO`, local DB only); the Tauri Studio UI that calls it (picker,
+   reveal, backup + "Open Agent" buttons) is the remainder.
 7. [ ] **Harness-driven capture scope** in the session/observer flow (the Agent
    harness selects fullscreen vs. window from task context and passes it to
    `capture-ui` / the recorder); **gate the existing Recall Studio window-capture

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -7,11 +7,18 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { confirm, input } from "@inquirer/prompts";
 import { Command } from "commander";
-import { getSetting, hasCommand, openDatabase } from "../../kernel/index.js";
+import type { Database } from "../../kernel/index.js";
+import {
+  getDatabaseTargetInfo,
+  getSetting,
+  hasCommand,
+  openDatabase,
+} from "../../kernel/index.js";
 
 /**
  * Execute a shell command inside a specific directory.
@@ -188,5 +195,77 @@ workspaceCommand
           "You can push manually later using: git push -u origin main",
         );
       }
+    }
+  });
+
+/**
+ * Consistent single-file backup of the open database into
+ * `<targetDir>/zam-backups/`. Uses SQLite `VACUUM INTO`, which writes a clean
+ * snapshot even in WAL mode with a live connection. Returns the backup path.
+ */
+export async function backupDatabaseTo(
+  db: Database,
+  targetDir: string,
+): Promise<string> {
+  const backupDir = join(targetDir, "zam-backups");
+  mkdirSync(backupDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const dest = join(backupDir, `zam-${stamp}.db`);
+  await db.exec(`VACUUM INTO '${dest.replace(/'/g, "''")}'`);
+  return dest;
+}
+
+workspaceCommand
+  .command("data-dir")
+  .description("Print the ZAM data directory (database, credentials, config)")
+  .option("--json", "Output as JSON")
+  .action((opts: { json?: boolean }) => {
+    const dir = join(homedir(), ".zam");
+    console.log(opts.json ? JSON.stringify({ dataDir: dir }) : dir);
+  });
+
+workspaceCommand
+  .command("backup")
+  .description("Back up the local ZAM database into your workspace")
+  .option(
+    "--dir <path>",
+    "Target directory (default: workspace dir, else ~/Documents/zam)",
+  )
+  .option("--json", "Output as JSON")
+  .action(async (opts: { dir?: string; json?: boolean }) => {
+    const target = getDatabaseTargetInfo();
+    if (target.kind !== "local") {
+      const reason = `The database is ${target.kind} (${target.location}); file backup applies only to a local database — your Turso remote is already the cloud backup.`;
+      if (opts.json) {
+        console.log(JSON.stringify({ ok: false, reason }));
+        return;
+      }
+      console.error(`\x1b[33m⚠ ${reason}\x1b[0m`);
+      process.exit(1);
+    }
+
+    let db: Database | undefined;
+    try {
+      db = await openDatabase();
+      const workspaceDir =
+        opts.dir ||
+        (await getSetting(db, "personal.workspace_dir")) ||
+        join(homedir(), "Documents", "zam");
+      const dest = await backupDatabaseTo(db, workspaceDir);
+      if (opts.json) {
+        console.log(JSON.stringify({ ok: true, path: dest }));
+      } else {
+        console.log(`\x1b[32m✓ Database backed up to ${dest}\x1b[0m`);
+      }
+    } catch (err) {
+      const reason = (err as Error).message;
+      if (opts.json) {
+        console.log(JSON.stringify({ ok: false, reason }));
+      } else {
+        console.error(`\x1b[31m✗ Backup failed: ${reason}\x1b[0m`);
+      }
+      process.exit(1);
+    } finally {
+      await db?.close();
     }
   });

--- a/tests/cli/workspace-backup.test.ts
+++ b/tests/cli/workspace-backup.test.ts
@@ -1,0 +1,61 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { backupDatabaseTo } from "../../src/cli/commands/workspace.js";
+import {
+  createToken,
+  getTokenBySlug,
+  openDatabase,
+} from "../../src/kernel/index.js";
+
+const dirs: string[] = [];
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("workspace database backup", () => {
+  it("writes a VACUUM INTO snapshot in zam-backups/ that contains the data", async () => {
+    const srcDir = tmp("zam-bk-src-");
+    const wsDir = tmp("zam-bk-ws-");
+
+    const db = await openDatabase({
+      dbPath: join(srcDir, "zam.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    const slug = `bk-${Date.now()}`;
+    await createToken(db, {
+      slug,
+      concept: "Backup test concept",
+      domain: "ops",
+      bloom_level: 2,
+    });
+
+    const dest = await backupDatabaseTo(db, wsDir);
+    await db.close();
+
+    expect(dest.startsWith(join(wsDir, "zam-backups"))).toBe(true);
+    expect(existsSync(dest)).toBe(true);
+
+    // The backup is a standalone, valid SQLite DB holding the seeded token.
+    const restored = await openDatabase({
+      dbPath: dest,
+      useConfiguredCloud: false,
+    });
+    try {
+      const token = await getTokenBySlug(restored, slug);
+      expect(token?.concept).toBe("Backup test concept");
+    } finally {
+      await restored.close();
+    }
+  });
+});


### PR DESCRIPTION
The DRY, testable CLI foundation for ADR 2026-06-23 item 6 (Studio setup). The desktop is "100% DRY" (calls the CLI bridge), so the backup/data-dir logic lives here; the Studio buttons will call it.

## What
- **`zam workspace data-dir [--json]`** — prints the ZAM data directory (`~/.zam`), i.e. what the Studio "Open data folder" button reveals.
- **`zam workspace backup [--dir] [--json]`** — writes a consistent SQLite snapshot via **`VACUUM INTO`** (clean even in WAL mode with a live connection) into `<workspace>/zam-backups/zam-<timestamp>.db`. **Local DB only** — for a Turso remote it declines (the remote *is* the cloud backup). Target defaults to `personal.workspace_dir` (set by `zam init`), else `~/Documents/zam`.
- `backupDatabaseTo()` exported and unit-tested.

The live DB stays at `~/.zam` (ADR decision #3) — this exports a *copy* into the visible workspace, never relocating the live WAL file into a cloud-synced folder.

## Verification
- `npm run build` ✓ · Biome clean ✓ · full suite **296 tests / 37 files** ✓ (new test seeds a token, backs up, reopens the snapshot, and confirms the data survived).

## Deferred (the rest of item 6)
The **Tauri Studio UI** that calls this — workspace picker, "Open data folder" reveal, "Back up database", and the "Open Agent" button (→ `zam agent open`) — is GUI work best verified by running the app, so it's a follow-up rather than unverified frontend code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)