### PR TITLE
chore(lint): bump Biome to 2.5.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "zam": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.8",
+        "@biomejs/biome": "2.5.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.5.0",
         "tsup": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "esbuild": "0.28.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.8",
+    "@biomejs/biome": "2.5.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.5.0",
     "tsup": "^8.5.1",


### PR DESCRIPTION
Aligns the biome.json schema + `@biomejs/biome` devDependency + lockfile to **2.5.0** — the version the repo was already formatted with. Fixes the local `profiler.ts` format false-positive (a 2.4.8 CLI flagging 2.5.0-formatted code). `npm run lint` is clean across 81 files; lockfile delta is a single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)