### PR TITLE
feat(desktop): polish Studio setup card — i18n, backup message, tighter opener

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -6,7 +6,6 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "opener:allow-open-path",
     "updater:default"
   ]
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use tauri::Manager;
+use tauri_plugin_opener::OpenerExt;
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -1242,6 +1243,22 @@ fn cancel_zam_bridge(state: tauri::State<'_, Arc<BridgeState>>) -> Result<bool, 
     }
 }
 
+/// Open the ZAM data folder (`~/.zam`) in the OS file manager. A dedicated
+/// command so the webview never passes arbitrary paths to the opener plugin —
+/// tighter than granting the broad `opener:allow-open-path` capability to JS.
+#[tauri::command]
+fn open_data_folder(app: tauri::AppHandle) -> Result<(), String> {
+    let dir = home_dir()
+        .ok_or_else(|| "Could not resolve home directory".to_string())?
+        .join(".zam");
+    fs::create_dir_all(&dir).map_err(|e| {
+        format!("Failed to create data directory {}: {e}", dir.display())
+    })?;
+    app.opener()
+        .open_path(dir.to_string_lossy().to_string(), None::<&str>)
+        .map_err(|e| format!("Failed to open data folder: {e}"))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = tauri::Builder::default();
@@ -1279,7 +1296,8 @@ pub fn run() {
             capture_zam_observer_once,
             capture_zam_observer_window,
             sample_zam_observer_window,
-            snapshot_zam_observer_window
+            snapshot_zam_observer_window,
+            open_data_folder
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,6 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { appDataDir, homeDir, join as joinPath } from "@tauri-apps/api/path";
-import { openPath } from "@tauri-apps/plugin-opener";
+import { appDataDir, join as joinPath } from "@tauri-apps/api/path";
 import * as THREE from "three";
 
 // ── LOCALIZATION DICTIONARIES ─────────────────────────────────────────────
@@ -89,6 +88,16 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     graph_prereqs: "Bases (Prerequisites)",
     graph_dependents: "Higher Abilities (Dependents)",
     graph_no_card: "no personal card yet",
+    setup_title: "Setup & Data",
+    btn_open_data_folder: "Open data folder",
+    btn_backup_db: "Back up database",
+    setup_backing_up: "Backing up database…",
+    setup_backed_up: "Backed up to {path}",
+    setup_remote_no_backup:
+      "Your database syncs to the cloud ({target}) — no separate local backup needed.",
+    setup_backup_failed: "Backup failed: {message}",
+    setup_backup_failed_generic: "Backup failed.",
+    setup_open_folder_failed: "Could not open the data folder: {message}",
   },
   de: {
     ai_status_offline: "Lokale KI offline",
@@ -174,6 +183,16 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     graph_prereqs: "Basis (Voraussetzungen)",
     graph_dependents: "Höhere Fähigkeiten (Darauf aufbauend)",
     graph_no_card: "noch keine persönliche Karte",
+    setup_title: "Einrichtung & Daten",
+    btn_open_data_folder: "Datenordner öffnen",
+    btn_backup_db: "Datenbank sichern",
+    setup_backing_up: "Datenbank wird gesichert…",
+    setup_backed_up: "Gesichert nach {path}",
+    setup_remote_no_backup:
+      "Deine Datenbank synchronisiert in die Cloud ({target}) — kein separates lokales Backup nötig.",
+    setup_backup_failed: "Sicherung fehlgeschlagen: {message}",
+    setup_backup_failed_generic: "Sicherung fehlgeschlagen.",
+    setup_open_folder_failed: "Datenordner konnte nicht geöffnet werden: {message}",
   }
 };
 
@@ -464,6 +483,11 @@ function initializeTranslations() {
   if (answerInput) {
     answerInput.placeholder = t("placeholder_answer");
   }
+
+  // Setup & Data card
+  document.getElementById("lbl-setup-title")!.textContent = t("setup_title");
+  document.getElementById("btn-open-data-folder")!.textContent = t("btn_open_data_folder");
+  document.getElementById("btn-backup-db")!.textContent = t("btn_backup_db");
 
   // Locale badge
   document.getElementById("locale-badge")!.textContent = currentLocale.toUpperCase();
@@ -2033,12 +2057,17 @@ window.addEventListener("DOMContentLoaded", () => {
     .getElementById("btn-open-data-folder")
     ?.addEventListener("click", () => {
       void (async () => {
-        const dir = await joinPath(await homeDir(), ".zam");
         const status = document.getElementById("setup-status");
         try {
-          await openPath(dir);
+          // Dedicated command resolves ~/.zam server-side, so the webview never
+          // passes arbitrary paths to the opener (tighter than allow-open-path).
+          await invoke("open_data_folder");
         } catch (err) {
-          if (status) status.textContent = `Could not open ${dir}: ${err}`;
+          if (status) {
+            status.textContent = tf("setup_open_folder_failed", {
+              message: errorMessage(err),
+            });
+          }
         }
       })();
     });
@@ -2046,20 +2075,30 @@ window.addEventListener("DOMContentLoaded", () => {
   document.getElementById("btn-backup-db")?.addEventListener("click", () => {
     void (async () => {
       const status = document.getElementById("setup-status");
-      if (status) status.textContent = "Backing up database…";
+      if (status) status.textContent = t("setup_backing_up");
       try {
         const res = await runBridge<{
           ok?: boolean;
           path?: string;
-          error?: string;
+          reason?: string;
+          target?: string;
         }>("backup-db");
-        if (status) {
-          status.textContent = res.path
-            ? `Backed up to ${res.path}`
-            : (res.error ?? "Backup failed.");
+        if (!status) return;
+        if (res.ok && res.path) {
+          status.textContent = tf("setup_backed_up", { path: res.path });
+        } else if (res.reason === "remote") {
+          status.textContent = tf("setup_remote_no_backup", {
+            target: res.target ?? "remote",
+          });
+        } else {
+          status.textContent = t("setup_backup_failed_generic");
         }
       } catch (err) {
-        if (status) status.textContent = `Backup failed: ${err}`;
+        if (status) {
+          status.textContent = tf("setup_backup_failed", {
+            message: errorMessage(err),
+          });
+        }
       }
     })();
   });

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -225,9 +225,16 @@ bridgeCommand
   .action(async (opts) => {
     const target = getDatabaseTargetInfo();
     if (target.kind !== "local") {
-      jsonError(
-        `Database is ${target.kind} (${target.location}); file backup applies only to a local database — your Turso remote is already the cloud backup.`,
-      );
+      // Not an error: a Turso-backed database already lives in the cloud, so a
+      // local file backup does not apply. Return a structured result the caller
+      // (e.g. the Studio) can present as an informational, localized message.
+      jsonOut({
+        ok: false,
+        reason: "remote",
+        target: target.kind,
+        location: target.location,
+      });
+      return;
     }
     await withDb(async (db) => {
       const workspaceDir =


### PR DESCRIPTION
Three leftover polish items for the Studio **Setup & Data** card (ADR item 6 follow-up):

### 1. Localize the card (i18n)
The title, both buttons, and all status messages now resolve through the existing `TRANSLATIONS` dictionary (en + de) and `initializeTranslations()`, instead of being hard-coded English.

### 2. Friendlier remote-backup message
`bridge backup-db` now returns a **structured result** for Turso-backed databases:
```json
{ "ok": false, "reason": "remote", "target": "turso-remote", "location": "libsql://…" }
```
instead of a JSON error. The Studio presents this as an informational *"your database syncs to the cloud — no separate local backup needed"* message rather than a red "Backup failed". A real local backup still returns `{ ok: true, path }`.

### 3. Tighten the opener
Replace the broad `opener:allow-open-path` capability with a dedicated **`open_data_folder`** Tauri command that resolves `~/.zam` server-side and opens it via the opener plugin from Rust. The webview no longer passes arbitrary paths to the opener — least-privilege.

### Verification
- biome lint (`src/`) ✓
- CLI build (tsup) ✓
- desktop `tsc && vite build` ✓
- `cargo check` (Rust backend + capability validation) ✓
- full Vitest suite — **300 tests** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
