### PR TITLE
feat(desktop): Studio workspace picker (ADR item 6)

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -120,7 +120,14 @@
 
         <div class="card frosted" id="setup-card">
           <h2 id="lbl-setup-title">Setup &amp; Data</h2>
+          <p class="sub-label" style="margin-top: 8px;">
+            <span id="lbl-workspace">Workspace</span>:
+            <code id="workspace-path">—</code>
+          </p>
           <div class="action-row" style="margin-top: 8px; gap: 8px;">
+            <button id="btn-choose-workspace" class="btn secondary-btn btn-sm" type="button">
+              Choose workspace…
+            </button>
             <button id="btn-open-data-folder" class="btn secondary-btn btn-sm" type="button">
               Open data folder
             </button>

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "three": "^0.175.0"
       },
@@ -1036,6 +1037,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "three": "^0.175.0"
   },

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
@@ -2884,6 +2885,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,6 +3741,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "dialog:allow-open",
     "opener:default",
     "updater:default"
   ]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1275,6 +1275,7 @@ pub fn run() {
     }));
 
     builder
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { appDataDir, join as joinPath } from "@tauri-apps/api/path";
+import { open as openFolderDialog } from "@tauri-apps/plugin-dialog";
 import * as THREE from "three";
 
 // ── LOCALIZATION DICTIONARIES ─────────────────────────────────────────────
@@ -98,6 +99,11 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     setup_backup_failed: "Backup failed: {message}",
     setup_backup_failed_generic: "Backup failed.",
     setup_open_folder_failed: "Could not open the data folder: {message}",
+    lbl_workspace: "Workspace",
+    btn_choose_workspace: "Choose workspace…",
+    workspace_default_suffix: "(default)",
+    workspace_set: "Workspace set to {path}",
+    workspace_pick_failed: "Could not set workspace: {message}",
   },
   de: {
     ai_status_offline: "Lokale KI offline",
@@ -193,6 +199,11 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     setup_backup_failed: "Sicherung fehlgeschlagen: {message}",
     setup_backup_failed_generic: "Sicherung fehlgeschlagen.",
     setup_open_folder_failed: "Datenordner konnte nicht geöffnet werden: {message}",
+    lbl_workspace: "Arbeitsbereich",
+    btn_choose_workspace: "Arbeitsbereich wählen…",
+    workspace_default_suffix: "(Standard)",
+    workspace_set: "Arbeitsbereich gesetzt: {path}",
+    workspace_pick_failed: "Arbeitsbereich konnte nicht gesetzt werden: {message}",
   }
 };
 
@@ -488,9 +499,30 @@ function initializeTranslations() {
   document.getElementById("lbl-setup-title")!.textContent = t("setup_title");
   document.getElementById("btn-open-data-folder")!.textContent = t("btn_open_data_folder");
   document.getElementById("btn-backup-db")!.textContent = t("btn_backup_db");
+  document.getElementById("lbl-workspace")!.textContent = t("lbl_workspace");
+  document.getElementById("btn-choose-workspace")!.textContent =
+    t("btn_choose_workspace");
 
   // Locale badge
   document.getElementById("locale-badge")!.textContent = currentLocale.toUpperCase();
+}
+
+/** Show the configured workspace dir (or the default, marked as such). */
+async function loadWorkspaceInfo(): Promise<void> {
+  const pathEl = document.getElementById("workspace-path");
+  if (!pathEl) return;
+  try {
+    const info = await runBridge<{
+      workspaceDir: string | null;
+      defaultWorkspaceDir: string;
+    }>("workspace-info");
+    const dir = info.workspaceDir ?? info.defaultWorkspaceDir;
+    pathEl.textContent = info.workspaceDir
+      ? dir
+      : `${dir} ${t("workspace_default_suffix")}`;
+  } catch {
+    // Leave the placeholder in place if the bridge is unavailable.
+  }
 }
 
 async function listObserverWindows(): Promise<void> {
@@ -1632,6 +1664,7 @@ async function loadDashboard() {
     isLlmEnabled = settings.llm?.enabled || false;
     
     initializeTranslations();
+    void loadWorkspaceInfo();
 
     // 2. Check due cards count and active domains
     const dueInfo = await runBridge<{ dueCount: number; domains: string[] }>("check-due");
@@ -2102,6 +2135,41 @@ window.addEventListener("DOMContentLoaded", () => {
       }
     })();
   });
+
+  // Setup & Data: choose the workspace directory (native folder picker).
+  document
+    .getElementById("btn-choose-workspace")
+    ?.addEventListener("click", () => {
+      void (async () => {
+        const status = document.getElementById("setup-status");
+        try {
+          const selected = await openFolderDialog({
+            directory: true,
+            multiple: false,
+            title: t("btn_choose_workspace"),
+          });
+          if (typeof selected !== "string") return; // cancelled
+          const res = await runBridge<{ ok?: boolean; workspaceDir?: string }>(
+            "set-workspace-dir",
+            ["--dir", selected],
+          );
+          if (res.workspaceDir) {
+            await loadWorkspaceInfo();
+            if (status) {
+              status.textContent = tf("workspace_set", {
+                path: res.workspaceDir,
+              });
+            }
+          }
+        } catch (err) {
+          if (status) {
+            status.textContent = tf("workspace_pick_failed", {
+              message: errorMessage(err),
+            });
+          }
+        }
+      })();
+    });
 
   // Open 3D Graph (experimental)
   const openGraphBtn = document.getElementById("btn-open-graph") as HTMLButtonElement | null;

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -9,7 +9,7 @@ import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { readdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { Command } from "commander";
 import type {
   BloomLevel,
@@ -52,6 +52,7 @@ import {
   readUiObservationLog,
   resolveObserverPolicy,
   resolveReviewContext,
+  setSetting,
   startSession,
   syncObserverSidecarPolicy,
   uiObservationLogExists,
@@ -243,6 +244,37 @@ bridgeCommand
         join(homedir(), "Documents", "zam");
       const path = await backupDatabaseTo(db, workspaceDir);
       jsonOut({ ok: true, path });
+    });
+  });
+
+// ── zam bridge workspace-info / set-workspace-dir ──────────────────────────
+
+bridgeCommand
+  .command("workspace-info")
+  .description("Report the workspace dir, its default, and the data dir (JSON)")
+  .action(async () => {
+    await withDb(async (db) => {
+      const workspaceDir =
+        (await getSetting(db, "personal.workspace_dir")) || null;
+      jsonOut({
+        workspaceDir,
+        defaultWorkspaceDir: join(homedir(), "Documents", "zam"),
+        dataDir: join(homedir(), ".zam"),
+      });
+    });
+  });
+
+bridgeCommand
+  .command("set-workspace-dir")
+  .description("Set the personal workspace directory (JSON)")
+  .requiredOption("--dir <path>", "Path to the workspace directory")
+  .action(async (opts) => {
+    const raw = String(opts.dir ?? "").trim();
+    if (!raw) jsonError("A non-empty --dir is required");
+    const dir = resolve(raw);
+    await withDb(async (db) => {
+      await setSetting(db, "personal.workspace_dir", dir);
+      jsonOut({ ok: true, workspaceDir: dir });
     });
   });
 


### PR DESCRIPTION
Completes the remaining Studio half of **ADR item 6**: a native folder picker that sets `personal.workspace_dir` — the DB backup target and personal-content root (read by `workspace backup`, `repos`, `snapshot`, `profile`).

### What's new
- **Tauri dialog plugin** (`tauri-plugin-dialog` + `@tauri-apps/plugin-dialog`), gated by the narrow **`dialog:allow-open`** capability (not the broad default set — consistent with the opener tightening in #79).
- **Setup & Data card → Workspace row**: shows the current dir (or the default, marked `(default)`) and a **"Choose workspace…"** button that opens the OS folder picker and persists the choice. Localized (en + de).
- **Two JSON bridge commands**: `workspace-info` (workspace/default/data dirs) and `set-workspace-dir --dir <path>` (resolves + stores `personal.workspace_dir`).

### Verification
- biome lint (`src/`) ✓ · CLI build ✓ · desktop `tsc && vite build` ✓
- `cargo check` ✓ — dialog plugin compiles, capability validates
- full Vitest suite — **313 tests** ✓
- **isolated end-to-end** run of both bridge commands (`info → set → info → empty-dir error`) against a throwaway `HOME`, so the real (Turso) DB was never touched ✓

The native dialog itself (`open({ directory: true })` → returns the picked path) is standard plugin behavior; everything from the picked path onward is covered above. The one un-automatable bit is the literal folder-picker click in the running app.

### Notes / follow-ups
- Pre-existing dev-only advisory surfaced during install: `vite` `server.fs.deny` bypass (GHSA-fx2h-pf6j-xcff) — not introduced here, dev-server only. Worth a separate `vite` bump.
- Remaining Studio pieces: the **"Open Agent" button** and a **provider/roles editor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
