### PR TITLE
chore(desktop): bump vite past GHSA-fx2h-pf6j-xcff

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -16,7 +16,7 @@
         "@tauri-apps/cli": "^2",
         "@types/three": "^0.175.0",
         "typescript": "~5.6.2",
-        "vite": "^6.0.3"
+        "vite": "^6.4.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1347,9 +1347,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
-    "vite": "^6.0.3",
+    "vite": "^6.4.3",
     "typescript": "~5.6.2",
     "@types/three": "^0.175.0"
   }


### PR DESCRIPTION
## What

Bump the desktop frontend's `vite` devDependency from `^6.0.3` (resolved **6.4.2**) to `^6.4.3` (resolved **6.4.3**), updating `desktop/package-lock.json` accordingly.

## Why

`npm audit` flags **GHSA-fx2h-pf6j-xcff** (high) — *"server.fs.deny bypass on Windows alternate paths"*, affecting vite `<=6.4.2`. The fix landed in **6.4.3**. The declared range floor is bumped to `^6.4.3` so a fresh install can't regress to a vulnerable version.

Vite is **dev-server-only** — it is not part of the shipped Tauri bundle — so real-world exposure is low, but the advisory is worth clearing.

## Scope

Minimal: only the vite bump and its transitive lockfile entry. No other deps or app code touched.

```
 desktop/package.json      | 2 +-
 desktop/package-lock.json | 8 ++++----
```

## Verification

- ✅ `npm --prefix desktop install` — lockfile resolves vite **6.4.3**
- ✅ `npm --prefix desktop run build` (`tsc && vite build`) — stays green, built with `vite v6.4.3`
- ✅ `npm --prefix desktop audit` — **0 vulnerabilities** (GHSA-fx2h-pf6j-xcff cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)