### PR TITLE
Release prep v0.4.4 — Studio version/update UI + workspace-publish hardening

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -124,6 +124,21 @@
             <span id="lbl-workspace">Workspace</span>:
             <code id="workspace-path">—</code>
           </p>
+          <div class="setup-meta-row">
+            <p class="sub-label setup-meta-item">
+              <span id="lbl-app-version">Version</span>:
+              <code id="app-version">—</code>
+            </p>
+            <div class="setup-update-actions">
+              <button id="btn-check-updates" class="btn secondary-btn btn-sm" type="button">
+                Check for updates
+              </button>
+              <button id="btn-open-releases" class="btn secondary-btn btn-sm" type="button">
+                Releases
+              </button>
+            </div>
+          </div>
+          <p id="update-status" class="sub-label"></p>
           <div class="action-row" style="margin-top: 8px; gap: 8px;">
             <button id="btn-choose-workspace" class="btn secondary-btn btn-sm" type="button">
               Choose workspace…

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "desktop",
-  "version": "0.1.0",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.1.0",
+      "version": "0.4.4",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "three": "^0.175.0"
       },
       "devDependencies": {
@@ -1055,6 +1056,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -13,12 +13,13 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "three": "^0.175.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
-    "vite": "^6.4.3",
+    "@types/three": "^0.175.0",
     "typescript": "~5.6.2",
-    "@types/three": "^0.175.0"
+    "vite": "^6.4.3"
   }
 }

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.0"
+version = "0.4.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.0"
+version = "0.4.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,7 +1,12 @@
+import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { appDataDir, join as joinPath } from "@tauri-apps/api/path";
 import { open as openFolderDialog } from "@tauri-apps/plugin-dialog";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { check as checkForUpdate } from "@tauri-apps/plugin-updater";
 import * as THREE from "three";
+
+const ZAM_RELEASES_URL = "https://github.com/zam-os/zam/releases";
 
 // ── LOCALIZATION DICTIONARIES ─────────────────────────────────────────────
 const TRANSLATIONS: Record<string, Record<string, string>> = {
@@ -104,6 +109,15 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     workspace_default_suffix: "(default)",
     workspace_set: "Workspace set to {path}",
     workspace_pick_failed: "Could not set workspace: {message}",
+    lbl_app_version: "Version",
+    btn_check_updates: "Check for updates",
+    btn_open_releases: "Releases",
+    version_unknown: "unknown",
+    update_checking: "Checking for updates...",
+    update_available: "Update available: {version}",
+    update_none: "You are on the latest version.",
+    update_failed: "Update check failed: {message}",
+    release_link_failed: "Could not open releases: {message}",
   },
   de: {
     ai_status_offline: "Lokale KI offline",
@@ -204,6 +218,15 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     workspace_default_suffix: "(Standard)",
     workspace_set: "Arbeitsbereich gesetzt: {path}",
     workspace_pick_failed: "Arbeitsbereich konnte nicht gesetzt werden: {message}",
+    lbl_app_version: "Version",
+    btn_check_updates: "Nach Updates suchen",
+    btn_open_releases: "Releases",
+    version_unknown: "unbekannt",
+    update_checking: "Suche nach Updates...",
+    update_available: "Update verfügbar: {version}",
+    update_none: "Du nutzt die aktuelle Version.",
+    update_failed: "Update-Prüfung fehlgeschlagen: {message}",
+    release_link_failed: "Releases konnten nicht geöffnet werden: {message}",
   }
 };
 
@@ -502,6 +525,9 @@ function initializeTranslations() {
   document.getElementById("lbl-workspace")!.textContent = t("lbl_workspace");
   document.getElementById("btn-choose-workspace")!.textContent =
     t("btn_choose_workspace");
+  document.getElementById("lbl-app-version")!.textContent = t("lbl_app_version");
+  document.getElementById("btn-check-updates")!.textContent = t("btn_check_updates");
+  document.getElementById("btn-open-releases")!.textContent = t("btn_open_releases");
 
   // Locale badge
   document.getElementById("locale-badge")!.textContent = currentLocale.toUpperCase();
@@ -522,6 +548,48 @@ async function loadWorkspaceInfo(): Promise<void> {
       : `${dir} ${t("workspace_default_suffix")}`;
   } catch {
     // Leave the placeholder in place if the bridge is unavailable.
+  }
+}
+
+async function loadAppVersion(): Promise<void> {
+  const versionEl = document.getElementById("app-version");
+  if (!versionEl) return;
+  try {
+    versionEl.textContent = `v${await getVersion()}`;
+  } catch {
+    versionEl.textContent = t("version_unknown");
+  }
+}
+
+async function checkDesktopUpdates(): Promise<void> {
+  const status = document.getElementById("update-status");
+  const button = document.getElementById("btn-check-updates") as HTMLButtonElement | null;
+  if (status) status.textContent = t("update_checking");
+  if (button) button.disabled = true;
+  try {
+    const update = await checkForUpdate();
+    if (status) {
+      status.textContent = update
+        ? tf("update_available", { version: update.version })
+        : t("update_none");
+    }
+  } catch (err) {
+    if (status) {
+      status.textContent = tf("update_failed", { message: errorMessage(err) });
+    }
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+async function openReleasesPage(): Promise<void> {
+  try {
+    await openUrl(ZAM_RELEASES_URL);
+  } catch (err) {
+    const status = document.getElementById("update-status");
+    if (status) {
+      status.textContent = tf("release_link_failed", { message: errorMessage(err) });
+    }
   }
 }
 
@@ -2069,6 +2137,7 @@ function devObserverEnabled(): boolean {
 window.addEventListener("DOMContentLoaded", () => {
   // Load initial dashboard state
   loadDashboard();
+  void loadAppVersion();
 
   // The manual UI Observer is a developer-only affordance; reveal it only when
   // the dev key is set (see devObserverEnabled).
@@ -2134,6 +2203,14 @@ window.addEventListener("DOMContentLoaded", () => {
         }
       }
     })();
+  });
+
+  document.getElementById("btn-check-updates")?.addEventListener("click", () => {
+    void checkDesktopUpdates();
+  });
+
+  document.getElementById("btn-open-releases")?.addEventListener("click", () => {
+    void openReleasesPage();
   });
 
   // Setup & Data: choose the workspace directory (native folder picker).

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -360,6 +360,40 @@ body {
   margin-top: 15px;
 }
 
+.setup-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px 12px;
+  margin-top: 10px;
+}
+
+.setup-meta-item,
+#setup-status,
+#update-status {
+  line-height: 1.4;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+#setup-card code {
+  color: var(--clr-text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.setup-update-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+#update-status {
+  min-height: 18px;
+  margin-top: 6px;
+}
+
 .observer-panel {
   margin-top: 16px;
   padding: 16px 20px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -6,7 +6,7 @@
  * and change-managed team workflow.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -23,9 +23,9 @@ import {
 /**
  * Execute a shell command inside a specific directory.
  */
-function runGit(cwd: string, args: string): string {
+function runGit(cwd: string, args: string[]): string {
   try {
-    return execSync(`git ${args}`, {
+    return execFileSync("git", args, {
       cwd,
       stdio: "pipe",
       encoding: "utf8",
@@ -33,6 +33,19 @@ function runGit(cwd: string, args: string): string {
   } catch (err) {
     throw new Error(`Git command failed: ${(err as Error).message}`);
   }
+}
+
+export function ghRepoCreateArgs(
+  repoName: string,
+  repoVisibility: "--private" | "--public",
+): string[] {
+  return ["repo", "create", repoName, repoVisibility, "--source=.", "--push"];
+}
+
+export function gitRemoteArgs(githubUrl: string, hasOrigin: boolean): string[] {
+  return hasOrigin
+    ? ["remote", "set-url", "origin", githubUrl]
+    : ["remote", "add", "origin", githubUrl];
 }
 
 export const workspaceCommand = new Command("workspace").description(
@@ -93,12 +106,13 @@ workspaceCommand
     const hasGitRepo = existsSync(join(workspaceDir, ".git"));
     if (!hasGitRepo) {
       console.log("Initializing local Git repository...");
-      runGit(workspaceDir, "init -b main");
-      runGit(workspaceDir, "add .");
-      runGit(
-        workspaceDir,
-        'commit -m "chore: initial workspace sandbox bootstrap"',
-      );
+      runGit(workspaceDir, ["init", "-b", "main"]);
+      runGit(workspaceDir, ["add", "."]);
+      runGit(workspaceDir, [
+        "commit",
+        "-m",
+        "chore: initial workspace sandbox bootstrap",
+      ]);
       console.log("\x1b[32m✓ Local Git repository initialized.\x1b[0m");
     } else {
       console.log("Git repository is already initialized.");
@@ -129,13 +143,10 @@ workspaceCommand
       if (proceedGh) {
         try {
           console.log(`Creating GitHub repository ${repoName}...`);
-          execSync(
-            `gh repo create ${repoName} ${repoVisibility} --source=. --push`,
-            {
-              cwd: workspaceDir,
-              stdio: "inherit",
-            },
-          );
+          execFileSync("gh", ghRepoCreateArgs(repoName, repoVisibility), {
+            cwd: workspaceDir,
+            stdio: "inherit",
+          });
           console.log(
             "\n\x1b[32m✓ Successfully published workspace to GitHub!\x1b[0m",
           );
@@ -173,17 +184,13 @@ workspaceCommand
         // Check if origin already exists
         let hasOrigin = false;
         try {
-          runGit(workspaceDir, "remote get-url origin");
+          runGit(workspaceDir, ["remote", "get-url", "origin"]);
           hasOrigin = true;
         } catch {}
 
-        if (hasOrigin) {
-          runGit(workspaceDir, `remote set-url origin ${githubUrl}`);
-        } else {
-          runGit(workspaceDir, `remote add origin ${githubUrl}`);
-        }
+        runGit(workspaceDir, gitRemoteArgs(githubUrl, hasOrigin));
 
-        runGit(workspaceDir, "push -u origin main");
+        runGit(workspaceDir, ["push", "-u", "origin", "main"]);
         console.log(
           "\x1b[32m✓ Successfully linked and pushed to GitHub!\x1b[0m",
         );

--- a/tests/cli/workspace-backup.test.ts
+++ b/tests/cli/workspace-backup.test.ts
@@ -2,7 +2,11 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { backupDatabaseTo } from "../../src/cli/commands/workspace.js";
+import {
+  backupDatabaseTo,
+  ghRepoCreateArgs,
+  gitRemoteArgs,
+} from "../../src/cli/commands/workspace.js";
 import {
   createToken,
   getTokenBySlug,
@@ -20,6 +24,36 @@ afterEach(() => {
   for (const dir of dirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe("workspace publish command arguments", () => {
+  it("passes gh repo creation inputs as argv segments", () => {
+    expect(ghRepoCreateArgs("name; touch nope", "--private")).toEqual([
+      "repo",
+      "create",
+      "name; touch nope",
+      "--private",
+      "--source=.",
+      "--push",
+    ]);
+  });
+
+  it("passes remote URLs as a single git argv segment", () => {
+    expect(
+      gitRemoteArgs("git@github.com:user/repo.git; touch nope", false),
+    ).toEqual([
+      "remote",
+      "add",
+      "origin",
+      "git@github.com:user/repo.git; touch nope",
+    ]);
+    expect(gitRemoteArgs("git@github.com:user/repo.git", true)).toEqual([
+      "remote",
+      "set-url",
+      "origin",
+      "git@github.com:user/repo.git",
+    ]);
+  });
 });
 
 describe("workspace database backup", () => {


### PR DESCRIPTION
Prepares the **v0.4.4** release. Reviews and lands Codex's local WIP (he adjusted a few things, then ran out of credits), with `main.ts` slimmed of incidental formatting churn.

### Changes
1. **`fix(cli)` — harden `zam workspace publish` against shell injection.** `runGit`/`gh repo create` no longer interpolate user input (repo name, GitHub URL) into a shell string; they use `execFileSync` with argv arrays. Pure `ghRepoCreateArgs` / `gitRemoteArgs` helpers + injection tests. *(Codex)*
2. **`feat(desktop)` — app version + update check in the Studio.** Setup & Data card shows the running version and offers "Check for updates" (`tauri-plugin-updater`) and a "Releases" link (opener → GitHub releases). Localized (en + de) + styles. *(Codex; reuses existing `updater:default` / `opener:default` capabilities)*
3. **`chore(release)` — bump to 0.4.4** (zam-core, desktop app, Tauri crate).

### main.ts slimming
Codex's local change to `desktop/src/main.ts` was ~819 lines, mostly an incidental ~80-col re-wrap of long string literals. This PR keeps **only the functional additions (+77 lines, 0 deletions)** in the original single-line style — verified the new feature symbols match Codex's version 1:1.

### Verification
- biome lint ✓ · CLI build ✓ · desktop `tsc && vite build` ✓ · `cargo check` (v0.4.4) ✓
- full suite — **315 tests** ✓ (+2 injection tests)
- Live UI smoke test via computer-use: _in progress, results to follow._

Release publish (tag → signed build → draft) is **not** triggered here — that's a separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
