### PR TITLE
feat: prepare ZAM 0.5.0 Studio release

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="/src/styles.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="ZAM Active-Recall Studio for learning sessions, knowledge maps, local AI status, and workspace settings."
+    />
     <title>ZAM — Active-Recall Studio</title>
     <script type="module" src="/src/main.ts" defer></script>
   </head>
@@ -20,9 +24,13 @@
           <span class="logo-accent">ZAM</span>
           <span class="logo-sub">Recall Studio</span>
         </div>
+        <nav class="top-nav" aria-label="Main navigation">
+          <button id="nav-dashboard" class="nav-btn active" type="button">Dashboard</button>
+          <button id="nav-settings" class="nav-btn" type="button">Settings</button>
+        </nav>
         <div class="status-area" id="system-status">
           <div class="status-indicator">
-            <span class="pulse-dot green"></span>
+            <span class="pulse-dot gray" role="img" aria-label="Local AI Offline"></span>
             <span class="status-text" id="ai-status-label">Local AI Offline</span>
           </div>
           <span class="locale-badge" id="locale-badge">EN</span>
@@ -31,11 +39,28 @@
 
       <!-- VIEW 1: DASHBOARD OVERVIEW -->
       <section id="dashboard-view" class="view active">
+        <div class="dashboard-hero frosted">
+          <div class="dashboard-copy">
+            <p id="lbl-dashboard-kicker" class="eyebrow">Today in ZAM</p>
+            <h1 id="lbl-dashboard-title">Learn deliberately.</h1>
+            <p id="lbl-dashboard-subtitle">
+              Review what is due, open your knowledge map, or configure local AI and workspaces in Settings.
+            </p>
+          </div>
+          <div class="hero-actions">
+            <button id="btn-start-session" class="btn primary-btn btn-large glow-btn" disabled>
+              Start Learning Session
+            </button>
+            <button id="btn-open-graph" class="btn secondary-btn btn-large">Knowledge Map (3D)</button>
+            <button id="btn-open-settings" class="btn secondary-btn btn-large" type="button">Settings</button>
+          </div>
+        </div>
+
         <div class="dashboard-grid">
           <div class="card stat-card frosted">
             <h2 id="lbl-due-reviews">Due Reviews</h2>
             <div class="large-number" id="due-count">0</div>
-            <p id="lbl-caught-up" class="sub-label">You're all caught up!</p>
+            <p id="lbl-caught-up" class="sub-label" aria-live="polite">You're all caught up!</p>
           </div>
 
           <div class="card stat-card frosted">
@@ -44,16 +69,6 @@
               <span class="empty-tag">—</span>
             </div>
           </div>
-        </div>
-
-        <div class="action-row">
-          <button id="btn-start-session" class="btn primary-btn btn-large glow-btn" disabled>
-            Start Learning Session
-          </button>
-        </div>
-
-        <div class="action-row" style="margin-top: 12px;">
-          <button id="btn-open-graph" class="btn secondary-btn btn-large">Wissensnetz / Knowledge Map (3D)</button>
         </div>
 
         <div id="observer-panel" class="observer-panel frosted hidden">
@@ -117,19 +132,29 @@
             </div>
           </div>
         </div>
+      </section>
 
-        <div class="card frosted" id="setup-card">
-          <h2 id="lbl-setup-title">Setup &amp; Data</h2>
-          <p class="sub-label" style="margin-top: 8px;">
-            <span id="lbl-workspace">Workspace</span>:
-            <code id="workspace-path">—</code>
-          </p>
-          <div class="setup-meta-row">
-            <p class="sub-label setup-meta-item">
-              <span id="lbl-app-version">Version</span>:
-              <code id="app-version">—</code>
+      <!-- VIEW 2: SETTINGS -->
+      <section id="settings-view" class="view">
+        <div class="settings-hero frosted">
+          <div>
+            <p id="lbl-settings-kicker" class="eyebrow">Local configuration</p>
+            <h1 id="lbl-settings-title">Settings</h1>
+            <p id="lbl-settings-subtitle" class="settings-subtitle">
+              Configure this machine without forcing the same choices onto every workspace or device.
             </p>
-            <div class="setup-update-actions">
+          </div>
+          <button id="btn-settings-back" class="btn secondary-btn btn-sm" type="button">Back to dashboard</button>
+        </div>
+
+        <div class="settings-list" id="setup-card">
+          <article class="card frosted settings-card">
+            <h2 id="lbl-settings-system-title">System</h2>
+            <div class="settings-row">
+              <span id="lbl-app-version">Version</span>
+              <code id="app-version">—</code>
+            </div>
+            <div class="settings-actions">
               <button id="btn-check-updates" class="btn secondary-btn btn-sm" type="button">
                 Check for updates
               </button>
@@ -137,24 +162,69 @@
                 Releases
               </button>
             </div>
+            <p id="update-status" class="sub-label" aria-live="polite"></p>
+          </article>
+
+          <article class="card frosted settings-card">
+            <h2 id="lbl-settings-ai-title">AI models</h2>
+            <div class="settings-row">
+              <span id="lbl-learning-model">Learning model</span>
+              <code id="learning-model-status">—</code>
+            </div>
+            <div class="settings-row">
+              <span id="lbl-observer-model">Observer model</span>
+              <code id="observer-model-status">—</code>
+            </div>
+          </article>
+
+          <article class="card frosted settings-card">
+            <div class="settings-card-header">
+              <div>
+                <h2 id="lbl-settings-workspace-title">Workspace &amp; agents</h2>
+                <p id="lbl-workspaces-help" class="settings-card-help">Register personal, team, family, or community work directories for this machine.</p>
+              </div>
+            </div>
+            <div id="workspace-list" class="workspace-list" aria-live="polite"></div>
+            <div class="settings-actions">
+              <button id="btn-choose-workspace" class="btn secondary-btn btn-sm" type="button">
+                Choose workspace…
+              </button>
+              <button id="btn-open-terminal" class="btn primary-btn btn-sm" type="button">
+                Open Terminal
+              </button>
+            </div>
+          </article>
+
+          <article class="card frosted settings-card">
+            <h2 id="lbl-settings-appearance-title">Appearance</h2>
+            <label class="settings-field" for="theme-select">
+              <span id="lbl-settings-theme">Theme</span>
+              <select id="theme-select">
+                <option value="light" id="theme-light-option">Light</option>
+                <option value="dark" id="theme-dark-option">Dark</option>
+              </select>
+            </label>
+          </article>
+
+          <article class="card frosted settings-card">
+            <h2 id="lbl-settings-data-title">Data</h2>
+            <div class="settings-actions">
+              <button id="btn-open-data-folder" class="btn secondary-btn btn-sm" type="button">
+                Open data folder
+              </button>
+              <button id="btn-backup-db" class="btn secondary-btn btn-sm" type="button">
+                Back up database
+              </button>
+            </div>
+          </article>
+
+          <div class="settings-status-row">
+            <p id="setup-status" class="sub-label" aria-live="polite"></p>
           </div>
-          <p id="update-status" class="sub-label"></p>
-          <div class="action-row" style="margin-top: 8px; gap: 8px;">
-            <button id="btn-choose-workspace" class="btn secondary-btn btn-sm" type="button">
-              Choose workspace…
-            </button>
-            <button id="btn-open-data-folder" class="btn secondary-btn btn-sm" type="button">
-              Open data folder
-            </button>
-            <button id="btn-backup-db" class="btn secondary-btn btn-sm" type="button">
-              Back up database
-            </button>
-          </div>
-          <p id="setup-status" class="sub-label"></p>
         </div>
       </section>
 
-      <!-- VIEW 2: STUDY SESSION CARD -->
+      <!-- VIEW 3: STUDY SESSION CARD -->
       <section id="study-view" class="view">
         <div class="study-card frosted">
           <!-- CARD HEADER -->
@@ -261,50 +331,50 @@
         </div>
       </section>
 
-      <!-- VIEW 3: 3D KNOWLEDGE GRAPH (experimental focus + direct prereqs/dependents) -->
+      <!-- VIEW 4: 3D KNOWLEDGE GRAPH (experimental focus + direct prereqs/dependents) -->
       <section id="graph-view" class="view">
         <div class="graph-container frosted">
           <div class="graph-header">
             <div>
-              <span class="graph-title">Wissensnetz (3D)</span>
+              <span id="graph-title" class="graph-title">Knowledge Graph (3D)</span>
               <span id="graph-focus-label" class="focus-label"></span>
             </div>
             <div id="graph-domain-selector" class="domain-selector">
               <!-- JS populated: "All" + domain pills for filtering independent knowledge areas -->
             </div>
             <div class="graph-actions">
-              <button id="btn-graph-back" class="btn secondary-btn btn-sm">Zurück zum Dashboard</button>
-              <button id="btn-graph-refresh" class="btn secondary-btn btn-sm">Neu laden</button>
+              <button id="btn-graph-back" class="btn secondary-btn btn-sm">Back to Dashboard</button>
+              <button id="btn-graph-refresh" class="btn secondary-btn btn-sm">Refresh</button>
             </div>
           </div>
 
           <div class="graph-main">
             <!-- Three.js canvas container -->
             <div id="graph-canvas-container" class="graph-canvas-wrap">
-              <canvas id="graph-canvas" width="800" height="600"></canvas>
+              <canvas id="graph-canvas" width="800" height="600" tabindex="0"></canvas>
             </div>
 
             <!-- Side panel: focus details + quick neighbors -->
             <div class="graph-side frosted">
               <div id="graph-focus-info">
-                <div class="side-title">Fokus</div>
+                <div id="graph-focus-title" class="side-title">Focus</div>
                 <div id="focus-slug" class="focus-slug"></div>
                 <div id="focus-concept" class="focus-concept"></div>
                 <div id="focus-meta" class="focus-meta"></div>
               </div>
 
               <div class="side-section">
-                <div class="side-title">Basis (Prereqs)</div>
+                <div id="graph-prereqs-title" class="side-title">Bases (Prerequisites)</div>
                 <div id="prereq-list" class="neighbor-list"></div>
               </div>
 
               <div class="side-section">
-                <div class="side-title">Höhere Fähigkeiten (Dependents)</div>
+                <div id="graph-dependents-title" class="side-title">Higher Abilities (Dependents)</div>
                 <div id="dependent-list" class="neighbor-list"></div>
               </div>
 
-              <div class="graph-hint">
-                Ziehen zum Drehen • Klicken auf Knoten = neuer Fokus • Scroll = Zoomen
+              <div id="graph-hint" class="graph-hint" role="note">
+                Drag to rotate • Click nodes to focus • Scroll to zoom
               </div>
             </div>
           </div>

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -713,20 +713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "desktop"
-version = "0.4.4"
-dependencies = [
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
- "tauri-plugin-opener",
- "tauri-plugin-single-instance",
- "tauri-plugin-updater",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5424,6 +5410,20 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zam-app"
+version = "0.5.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "desktop"
-version = "0.4.4"
-description = "A Tauri App"
-authors = ["you"]
+name = "zam-app"
+version = "0.5.0"
+description = "ZAM Active-Recall Studio"
+authors = ["ZAM Contributors"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "desktop_lib"
+name = "zam_app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
@@ -27,4 +27,3 @@ serde_json = "1"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
-

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1259,6 +1259,51 @@ fn open_data_folder(app: tauri::AppHandle) -> Result<(), String> {
         .map_err(|e| format!("Failed to open data folder: {e}"))
 }
 
+#[tauri::command]
+fn open_terminal_in_dir(dir: String) -> Result<(), String> {
+    let path = PathBuf::from(dir);
+    if !path.exists() {
+        return Err(format!("Workspace path does not exist: {}", path.display()));
+    }
+    if !path.is_dir() {
+        return Err(format!("Workspace path is not a directory: {}", path.display()));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if Command::new("wt.exe").arg("-d").arg(&path).spawn().is_ok() {
+            return Ok(());
+        }
+        Command::new("powershell.exe")
+            .current_dir(&path)
+            .args(["-NoExit", "-NoProfile"])
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| format!("Failed to open PowerShell in {}: {e}", path.display()))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open")
+            .args(["-a", "Terminal"])
+            .arg(&path)
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| format!("Failed to open Terminal in {}: {e}", path.display()))
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let candidates = ["x-terminal-emulator", "gnome-terminal", "konsole", "xfce4-terminal"];
+        for candidate in candidates {
+            if Command::new(candidate).current_dir(&path).spawn().is_ok() {
+                return Ok(());
+            }
+        }
+        Err(format!("No supported terminal emulator found for {}", path.display()))
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = tauri::Builder::default();
@@ -1298,7 +1343,8 @@ pub fn run() {
             capture_zam_observer_window,
             sample_zam_observer_window,
             snapshot_zam_observer_window,
-            open_data_folder
+            open_data_folder,
+            open_terminal_in_dir
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    desktop_lib::run()
+    zam_app_lib::run()
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -15,7 +15,10 @@
       {
         "title": "ZAM",
         "width": 950,
-        "height": 720
+        "height": 720,
+        "minWidth": 720,
+        "minHeight": 580,
+        "theme": "Light"
       }
     ],
     "security": {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,6 +1,7 @@
 import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { appDataDir, join as joinPath } from "@tauri-apps/api/path";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open as openFolderDialog } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { check as checkForUpdate } from "@tauri-apps/plugin-updater";
@@ -15,6 +16,12 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     ai_status_online: "Local AI Online",
     ai_status_starting: "Starting Local AI...",
     ai_status_model_missing: "Local AI: model not found",
+    nav_dashboard: "Dashboard",
+    nav_settings: "Settings",
+    dashboard_kicker: "Today in ZAM",
+    dashboard_title: "Learn deliberately.",
+    dashboard_subtitle:
+      "Review what is due, open your knowledge map, or configure local AI and workspaces in Settings.",
     lbl_due_reviews: "Due Reviews",
     lbl_caught_up: "You're all caught up!",
     dashboard_error: "Could not load your data",
@@ -50,6 +57,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     session_completed_sub: "Great job completing this session! Your memory traces have been updated.",
     btn_back_to_dashboard: "Back to Dashboard",
     btn_open_graph: "Knowledge Map (3D)",
+    btn_open_settings: "Settings",
     observer_title: "UI Observer",
     observer_idle: "Load windows and choose one application window to observe.",
     observer_loading: "Loading observable windows...",
@@ -94,7 +102,24 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     graph_prereqs: "Bases (Prerequisites)",
     graph_dependents: "Higher Abilities (Dependents)",
     graph_no_card: "no personal card yet",
+    graph_refresh: "Refresh",
+    graph_domain_token_list_title: "All tokens in this domain",
     setup_title: "Setup & Data",
+    settings_kicker: "Local configuration",
+    settings_title: "Settings",
+    settings_subtitle:
+      "Configure this machine without forcing the same choices onto every workspace or device.",
+    settings_back: "Back to dashboard",
+    settings_system_title: "System",
+    settings_ai_title: "AI models",
+    settings_workspace_title: "Workspaces",
+    workspaces_help:
+      "Register personal, team, family, or community work directories for this machine.",
+    settings_appearance_title: "Appearance",
+    settings_data_title: "Data",
+    settings_theme: "Theme",
+    theme_light: "Light",
+    theme_dark: "Dark",
     btn_open_data_folder: "Open data folder",
     btn_backup_db: "Back up database",
     setup_backing_up: "Backing up database…",
@@ -106,10 +131,38 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     setup_open_folder_failed: "Could not open the data folder: {message}",
     lbl_workspace: "Workspace",
     btn_choose_workspace: "Choose workspace…",
+    btn_open_terminal: "Open Terminal",
+    terminal_opening: "Opening terminal...",
+    terminal_opened: "Opened terminal in {workspace}",
+    terminal_open_failed: "Could not open terminal: {message}",
+    workspace_active: "active",
+    workspace_default_label: "Default workspace",
+    workspace_empty: "No workspace registered yet.",
+    workspace_kind: "{kind} workspace",
+    workspace_kind_personal: "Personal workspace",
+    workspace_kind_team: "Team workspace",
+    workspace_kind_family: "Family workspace",
+    workspace_kind_community: "Community workspace",
+    workspace_kind_organization: "Organization workspace",
+    workspace_kind_custom: "Custom workspace",
+    workspace_more: "{count} more workspace(s) hidden. Use the CLI for the full list.",
+    workspace_use: "Use",
+    workspace_open: "Terminal",
     workspace_default_suffix: "(default)",
     workspace_set: "Workspace set to {path}",
+    workspace_added: "Workspace added: {path}",
     workspace_pick_failed: "Could not set workspace: {message}",
     lbl_app_version: "Version",
+    lbl_learning_model: "Learning model",
+    lbl_observer_model: "Observer model",
+    provider_ready: "ready",
+    provider_disabled: "disabled",
+    provider_offline: "offline",
+    provider_model_missing: "model missing",
+    provider_unsupported: "unsupported provider",
+    provider_local: "local",
+    provider_cloud: "cloud",
+    provider_unknown: "unknown",
     btn_check_updates: "Check for updates",
     btn_open_releases: "Releases",
     version_unknown: "unknown",
@@ -124,6 +177,12 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     ai_status_online: "Lokale KI online",
     ai_status_starting: "Starte lokale KI...",
     ai_status_model_missing: "Lokale KI: Modell fehlt",
+    nav_dashboard: "Übersicht",
+    nav_settings: "Einstellungen",
+    dashboard_kicker: "Heute in ZAM",
+    dashboard_title: "Bewusst lernen.",
+    dashboard_subtitle:
+      "Wiederhole, was fällig ist, öffne dein Wissensnetz oder konfiguriere lokale KI und Arbeitsbereiche in den Einstellungen.",
     lbl_due_reviews: "Anstehende Wiederholungen",
     lbl_caught_up: "Du bist voll auf dem Laufenden!",
     dashboard_error: "Deine Daten konnten nicht geladen werden",
@@ -159,6 +218,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     session_completed_sub: "Hervorragende Arbeit! Deine Gedächtnispfade wurden aktualisiert.",
     btn_back_to_dashboard: "Zurück zur Übersicht",
     btn_open_graph: "Wissensnetz (3D)",
+    btn_open_settings: "Einstellungen",
     observer_title: "UI Observer",
     observer_idle: "Fenster laden und ein Anwendungsfenster zur Beobachtung auswählen.",
     observer_loading: "Beobachtbare Fenster werden geladen...",
@@ -203,7 +263,24 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     graph_prereqs: "Basis (Voraussetzungen)",
     graph_dependents: "Höhere Fähigkeiten (Darauf aufbauend)",
     graph_no_card: "noch keine persönliche Karte",
+    graph_refresh: "Neu laden",
+    graph_domain_token_list_title: "Alle Tokens in diesem Bereich",
     setup_title: "Einrichtung & Daten",
+    settings_kicker: "Lokale Konfiguration",
+    settings_title: "Einstellungen",
+    settings_subtitle:
+      "Konfiguriere diesen Rechner, ohne dieselben Entscheidungen auf jeden Arbeitsbereich oder jedes Gerät zu übertragen.",
+    settings_back: "Zurück zur Übersicht",
+    settings_system_title: "System",
+    settings_ai_title: "KI-Modelle",
+    settings_workspace_title: "Arbeitsbereiche",
+    workspaces_help:
+      "Registriere persönliche, Team-, Familien- oder Community-Arbeitsverzeichnisse für diesen Rechner.",
+    settings_appearance_title: "Darstellung",
+    settings_data_title: "Daten",
+    settings_theme: "Theme",
+    theme_light: "Hell",
+    theme_dark: "Dunkel",
     btn_open_data_folder: "Datenordner öffnen",
     btn_backup_db: "Datenbank sichern",
     setup_backing_up: "Datenbank wird gesichert…",
@@ -213,12 +290,39 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     setup_backup_failed: "Sicherung fehlgeschlagen: {message}",
     setup_backup_failed_generic: "Sicherung fehlgeschlagen.",
     setup_open_folder_failed: "Datenordner konnte nicht geöffnet werden: {message}",
-    lbl_workspace: "Arbeitsbereich",
     btn_choose_workspace: "Arbeitsbereich wählen…",
+    btn_open_terminal: "Terminal öffnen",
+    terminal_opening: "Terminal wird geöffnet...",
+    terminal_opened: "Terminal in {workspace} geöffnet",
+    terminal_open_failed: "Terminal konnte nicht geöffnet werden: {message}",
+    workspace_active: "aktiv",
+    workspace_default_label: "Standard-Arbeitsbereich",
+    workspace_empty: "Noch kein Arbeitsbereich registriert.",
+    workspace_kind: "{kind}-Arbeitsbereich",
+    workspace_kind_personal: "Persönlicher Arbeitsbereich",
+    workspace_kind_team: "Team-Arbeitsbereich",
+    workspace_kind_family: "Familien-Arbeitsbereich",
+    workspace_kind_community: "Community-Arbeitsbereich",
+    workspace_kind_organization: "Organisations-Arbeitsbereich",
+    workspace_kind_custom: "Benutzerdefinierter Arbeitsbereich",
+    workspace_more: "{count} weitere Arbeitsbereiche ausgeblendet. Die vollständige Liste ist in der CLI.",
+    workspace_use: "Nutzen",
+    workspace_open: "Terminal",
     workspace_default_suffix: "(Standard)",
     workspace_set: "Arbeitsbereich gesetzt: {path}",
+    workspace_added: "Arbeitsbereich hinzugefügt: {path}",
     workspace_pick_failed: "Arbeitsbereich konnte nicht gesetzt werden: {message}",
     lbl_app_version: "Version",
+    lbl_learning_model: "Lernmodell",
+    lbl_observer_model: "Observer-Modell",
+    provider_ready: "bereit",
+    provider_disabled: "deaktiviert",
+    provider_offline: "offline",
+    provider_model_missing: "Modell fehlt",
+    provider_unsupported: "Provider nicht unterstützt",
+    provider_local: "lokal",
+    provider_cloud: "Cloud",
+    provider_unknown: "unbekannt",
     btn_check_updates: "Nach Updates suchen",
     btn_open_releases: "Releases",
     version_unknown: "unbekannt",
@@ -248,10 +352,49 @@ const BLOOM_LEVEL_NAMES: Record<string, Record<number, string>> = {
 };
 
 // ── STATE MANAGEMENT ──────────────────────────────────────────────────────
+type AppView = "dashboard-view" | "settings-view" | "study-view" | "graph-view";
+type ThemePreference = "light" | "dark";
+
 let currentLocale = "en";
 let isLlmEnabled = false;
 let totalDue = 0;
 let cardsReviewedThisSession = 0;
+
+interface ProviderRoleStatus {
+  enabled: boolean;
+  providerName?: string;
+  label?: string;
+  source: "legacy" | "shared" | "machine";
+  model: string;
+  apiFlavor: string;
+  local: boolean;
+  usable: boolean;
+  reason?: "disabled" | "offline" | "model-not-found" | "unsupported-provider";
+}
+
+interface ProviderStatusResponse {
+  roles: {
+    recall: ProviderRoleStatus;
+    vision: ProviderRoleStatus;
+  };
+}
+
+interface WorkspaceConfig {
+  id: string;
+  label?: string;
+  kind: string;
+  path: string;
+  sourceControl?: string;
+  knowledgeScopes?: string[];
+  defaultAgent?: string;
+}
+
+interface WorkspaceListResponse {
+  workspaces: WorkspaceConfig[];
+  workspaceDir: string | null;
+  defaultWorkspaceDir: string;
+  dataDir: string;
+}
 
 interface BridgeCard {
   cardId: string;
@@ -309,6 +452,8 @@ const OBSERVER_HISTORY_LIMIT = 100;
 const OBSERVER_LOOP_DELAY_MS = 60000;
 let desktopUserId: string | null = null;
 let zamUiSessionId: string | null = null;
+let activeWorkspaceDir: string | null = null;
+const MAX_VISIBLE_WORKSPACES = 5;
 
 interface ObserverWindowInfo {
   version: number;
@@ -472,11 +617,57 @@ function tf(key: string, values: Record<string, string | number>): string {
   );
 }
 
+function loadThemePreference(): ThemePreference {
+  try {
+    return localStorage.getItem("zam:theme") === "dark" ? "dark" : "light";
+  } catch {
+    return "light";
+  }
+}
+
+function applyTheme(theme: ThemePreference): void {
+  document.documentElement.dataset.theme = theme;
+  const select = document.getElementById("theme-select") as HTMLSelectElement | null;
+  if (select) select.value = theme;
+  try {
+    void getCurrentWindow()
+      .setTheme(theme)
+      .catch(() => {
+        // Browser preview has no native Tauri window; CSS theme still applies.
+      });
+  } catch {
+    // Browser preview has no native Tauri window; CSS theme still applies.
+  }
+  if (graphScene) {
+    graphScene.fog = new THREE.Fog(cssColorHex("--bg-deep-space", "#f5f7fb"), 12, 28);
+  }
+}
+
+function saveThemePreference(theme: ThemePreference): void {
+  try {
+    localStorage.setItem("zam:theme", theme);
+  } catch {
+    // The visual preference is non-critical; keep the current page theme.
+  }
+  applyTheme(theme);
+}
+
 // ── STATIC TRANSLATIONS INITIALIZER ──────────────────────────────────────
 function initializeTranslations() {
+  document.getElementById("nav-dashboard")!.textContent = t("nav_dashboard");
+  document.getElementById("nav-settings")!.textContent = t("nav_settings");
+  document.getElementById("lbl-dashboard-kicker")!.textContent =
+    t("dashboard_kicker");
+  document.getElementById("lbl-dashboard-title")!.textContent =
+    t("dashboard_title");
+  document.getElementById("lbl-dashboard-subtitle")!.textContent =
+    t("dashboard_subtitle");
   document.getElementById("lbl-due-reviews")!.textContent = t("lbl_due_reviews");
   document.getElementById("lbl-domains")!.textContent = t("lbl_domains");
   document.getElementById("btn-start-session")!.textContent = t("btn_start_session");
+  document.getElementById("btn-open-graph")!.textContent = t("btn_open_graph");
+  document.getElementById("btn-open-settings")!.textContent =
+    t("btn_open_settings");
   document.getElementById("lbl-translating")!.textContent = t("lbl_translating");
   document.getElementById("lbl-ai-evaluating")!.textContent = t("lbl_ai_evaluating");
   document.getElementById("lbl-ai-working")!.textContent = t("lbl_ai_working");
@@ -519,35 +710,233 @@ function initializeTranslations() {
   }
 
   // Setup & Data card
-  document.getElementById("lbl-setup-title")!.textContent = t("setup_title");
+  document.getElementById("lbl-settings-kicker")!.textContent =
+    t("settings_kicker");
+  document.getElementById("lbl-settings-title")!.textContent =
+    t("settings_title");
+  document.getElementById("lbl-settings-subtitle")!.textContent =
+    t("settings_subtitle");
+  document.getElementById("btn-settings-back")!.textContent =
+    t("settings_back");
+  document.getElementById("lbl-settings-system-title")!.textContent =
+    t("settings_system_title");
+  document.getElementById("lbl-settings-ai-title")!.textContent =
+    t("settings_ai_title");
+  document.getElementById("lbl-settings-workspace-title")!.textContent =
+    t("settings_workspace_title");
+  document.getElementById("lbl-workspaces-help")!.textContent =
+    t("workspaces_help");
+  document.getElementById("lbl-settings-appearance-title")!.textContent =
+    t("settings_appearance_title");
+  document.getElementById("lbl-settings-data-title")!.textContent =
+    t("settings_data_title");
+  document.getElementById("lbl-settings-theme")!.textContent =
+    t("settings_theme");
+  document.getElementById("theme-light-option")!.textContent = t("theme_light");
+  document.getElementById("theme-dark-option")!.textContent = t("theme_dark");
   document.getElementById("btn-open-data-folder")!.textContent = t("btn_open_data_folder");
   document.getElementById("btn-backup-db")!.textContent = t("btn_backup_db");
-  document.getElementById("lbl-workspace")!.textContent = t("lbl_workspace");
   document.getElementById("btn-choose-workspace")!.textContent =
     t("btn_choose_workspace");
+  document.getElementById("btn-open-terminal")!.textContent =
+    t("btn_open_terminal");
   document.getElementById("lbl-app-version")!.textContent = t("lbl_app_version");
+  document.getElementById("lbl-learning-model")!.textContent =
+    t("lbl_learning_model");
+  document.getElementById("lbl-observer-model")!.textContent =
+    t("lbl_observer_model");
   document.getElementById("btn-check-updates")!.textContent = t("btn_check_updates");
   document.getElementById("btn-open-releases")!.textContent = t("btn_open_releases");
+  document.getElementById("graph-title")!.textContent = t("graph_title");
+  document.getElementById("btn-graph-back")!.textContent =
+    t("btn_back_to_dashboard");
+  document.getElementById("btn-graph-refresh")!.textContent =
+    t("graph_refresh");
+  document.getElementById("graph-focus-title")!.textContent = t("graph_focus");
+  document.getElementById("graph-prereqs-title")!.textContent =
+    t("graph_prereqs");
+  document.getElementById("graph-dependents-title")!.textContent =
+    t("graph_dependents");
+  document.getElementById("graph-hint")!.textContent = t("graph_hint");
 
   // Locale badge
   document.getElementById("locale-badge")!.textContent = currentLocale.toUpperCase();
+  applyTheme(loadThemePreference());
 }
 
-/** Show the configured workspace dir (or the default, marked as such). */
-async function loadWorkspaceInfo(): Promise<void> {
-  const pathEl = document.getElementById("workspace-path");
-  if (!pathEl) return;
+function comparablePath(path: string): string {
+  return path.replace(/[\\/]+$/, "").toLowerCase();
+}
+
+function isActiveWorkspacePath(path: string): boolean {
+  return Boolean(activeWorkspaceDir && comparablePath(path) === comparablePath(activeWorkspaceDir));
+}
+
+function workspaceKindLabel(kind: string): string {
+  switch (kind) {
+    case "personal":
+      return t("workspace_kind_personal");
+    case "team":
+      return t("workspace_kind_team");
+    case "family":
+      return t("workspace_kind_family");
+    case "community":
+      return t("workspace_kind_community");
+    case "organization":
+      return t("workspace_kind_organization");
+    case "custom":
+      return t("workspace_kind_custom");
+    default:
+      return tf("workspace_kind", { kind });
+  }
+}
+
+function workspaceMeta(workspace: WorkspaceConfig): string {
+  const parts = [workspaceKindLabel(workspace.kind)];
+  if (workspace.sourceControl) parts.push(workspace.sourceControl);
+  if (workspace.knowledgeScopes?.length) {
+    parts.push(workspace.knowledgeScopes.slice(0, 3).join(", "));
+  }
+  return parts.join(" · ");
+}
+
+function buildVisibleWorkspaces(info: WorkspaceListResponse): WorkspaceConfig[] {
+  const activeDir = info.workspaceDir ?? info.defaultWorkspaceDir;
+  activeWorkspaceDir = activeDir;
+  const workspaces = [...info.workspaces];
+  const activeRegistered = workspaces.some((workspace) =>
+    comparablePath(workspace.path) === comparablePath(activeDir),
+  );
+  if (!activeRegistered) {
+    workspaces.unshift({
+      id: "current",
+      label: info.workspaceDir ? t("lbl_workspace") : t("workspace_default_label"),
+      kind: "personal",
+      path: activeDir,
+    });
+  }
+  return workspaces.sort((left, right) => {
+    const leftActive = isActiveWorkspacePath(left.path) ? 1 : 0;
+    const rightActive = isActiveWorkspacePath(right.path) ? 1 : 0;
+    return rightActive - leftActive;
+  });
+}
+
+function renderWorkspaceList(info: WorkspaceListResponse): void {
+  const list = document.getElementById("workspace-list");
+  if (!list) return;
+  list.replaceChildren();
+
+  const workspaces = buildVisibleWorkspaces(info);
+  const visible = workspaces.slice(0, MAX_VISIBLE_WORKSPACES);
+
+  for (const workspace of visible) {
+    const row = document.createElement("div");
+    row.className = "workspace-row";
+    row.dataset.active = String(isActiveWorkspacePath(workspace.path));
+
+    const main = document.createElement("div");
+    main.className = "workspace-main";
+
+    const titleRow = document.createElement("div");
+    titleRow.className = "workspace-title-row";
+    const title = document.createElement("span");
+    title.className = "workspace-title";
+    title.textContent = workspace.label || workspace.id;
+    titleRow.appendChild(title);
+    if (isActiveWorkspacePath(workspace.path)) {
+      const badge = document.createElement("span");
+      badge.className = "workspace-badge";
+      badge.textContent = t("workspace_active");
+      titleRow.appendChild(badge);
+    }
+
+    const path = document.createElement("code");
+    path.textContent = workspace.path;
+
+    const meta = document.createElement("span");
+    meta.className = "workspace-meta";
+    meta.textContent = workspaceMeta(workspace);
+
+    main.append(titleRow, path, meta);
+
+    const actions = document.createElement("div");
+    actions.className = "workspace-actions";
+
+    const useButton = document.createElement("button");
+    useButton.className = "btn secondary-btn btn-sm";
+    useButton.type = "button";
+    useButton.textContent = t("workspace_use");
+    useButton.disabled = isActiveWorkspacePath(workspace.path);
+    useButton.addEventListener("click", () => {
+      void setActiveWorkspace(workspace.path);
+    });
+
+    const terminalButton = document.createElement("button");
+    terminalButton.className = "btn primary-btn btn-sm";
+    terminalButton.type = "button";
+    terminalButton.textContent = t("workspace_open");
+    terminalButton.addEventListener("click", () => {
+      void openWorkspaceTerminal(workspace.path);
+    });
+
+    actions.append(useButton, terminalButton);
+    row.append(main, actions);
+    list.appendChild(row);
+  }
+
+  const hiddenCount = workspaces.length - visible.length;
+  if (hiddenCount > 0) {
+    const more = document.createElement("p");
+    more.className = "workspace-more";
+    more.textContent = tf("workspace_more", { count: hiddenCount });
+    list.appendChild(more);
+  }
+}
+
+async function loadWorkspaceList(): Promise<void> {
   try {
-    const info = await runBridge<{
-      workspaceDir: string | null;
-      defaultWorkspaceDir: string;
-    }>("workspace-info");
-    const dir = info.workspaceDir ?? info.defaultWorkspaceDir;
-    pathEl.textContent = info.workspaceDir
-      ? dir
-      : `${dir} ${t("workspace_default_suffix")}`;
+    const info = await runBridge<WorkspaceListResponse>("workspace-list");
+    renderWorkspaceList(info);
   } catch {
     // Leave the placeholder in place if the bridge is unavailable.
+  }
+}
+
+async function setActiveWorkspace(dir: string): Promise<void> {
+  const status = document.getElementById("setup-status");
+  const res = await runBridge<{ ok?: boolean; workspaceDir?: string }>(
+    "set-workspace-dir",
+    ["--dir", dir],
+  );
+  if (res.workspaceDir) {
+    activeWorkspaceDir = res.workspaceDir;
+    await loadWorkspaceList();
+    if (status) {
+      status.textContent = tf("workspace_set", { path: res.workspaceDir });
+    }
+  }
+}
+
+async function openWorkspaceTerminal(dir?: string | null): Promise<void> {
+  const workspace = dir ?? activeWorkspaceDir;
+  const status = document.getElementById("setup-status");
+  if (!workspace) {
+    if (status) status.textContent = t("workspace_empty");
+    return;
+  }
+  if (status) status.textContent = t("terminal_opening");
+  try {
+    await invoke("open_terminal_in_dir", { dir: workspace });
+    if (status) {
+      status.textContent = tf("terminal_opened", { workspace });
+    }
+  } catch (err) {
+    if (status) {
+      status.textContent = tf("terminal_open_failed", {
+        message: errorMessage(err),
+      });
+    }
   }
 }
 
@@ -558,6 +947,57 @@ async function loadAppVersion(): Promise<void> {
     versionEl.textContent = `v${await getVersion()}`;
   } catch {
     versionEl.textContent = t("version_unknown");
+  }
+}
+
+function providerReasonText(status: ProviderRoleStatus): string {
+  if (!status.enabled) return t("provider_disabled");
+  if (status.usable) return t("provider_ready");
+  switch (status.reason) {
+    case "model-not-found":
+      return t("provider_model_missing");
+    case "unsupported-provider":
+      return t("provider_unsupported");
+    case "offline":
+      return t("provider_offline");
+    case "disabled":
+      return t("provider_disabled");
+    default:
+      return t("provider_unknown");
+  }
+}
+
+function formatProviderStatus(status: ProviderRoleStatus): string {
+  const name =
+    status.label ||
+    status.providerName ||
+    (status.source === "legacy" ? "legacy" : status.source);
+  const location = status.local ? t("provider_local") : t("provider_cloud");
+  return `${name}: ${status.model} · ${location} · ${providerReasonText(status)}`;
+}
+
+function setAiStatus(label: string, dotClass: "green" | "amber" | "gray"): void {
+  const aiStatusLabel = document.getElementById("ai-status-label");
+  const pulseDot = document.querySelector(".pulse-dot");
+  if (aiStatusLabel) aiStatusLabel.textContent = label;
+  if (pulseDot) {
+    pulseDot.className = `pulse-dot ${dotClass}`;
+    pulseDot.setAttribute("aria-label", label);
+  }
+}
+
+async function loadProviderStatus(): Promise<void> {
+  const recallEl = document.getElementById("learning-model-status");
+  const visionEl = document.getElementById("observer-model-status");
+  if (!recallEl || !visionEl) return;
+
+  try {
+    const status = await runBridge<ProviderStatusResponse>("provider-status");
+    recallEl.textContent = formatProviderStatus(status.roles.recall);
+    visionEl.textContent = formatProviderStatus(status.roles.vision);
+  } catch {
+    recallEl.textContent = t("provider_unknown");
+    visionEl.textContent = t("provider_unknown");
   }
 }
 
@@ -1129,8 +1569,26 @@ function errorMessage(err: unknown): string {
 }
 
 // ── VIEW ROUTING ──────────────────────────────────────────────────────────
-function switchView(viewId: "dashboard-view" | "study-view" | "graph-view") {
-  if (viewId === "dashboard-view" && studySessionActive) {
+function setActiveNav(viewId: AppView): void {
+  const navByView: Partial<Record<AppView, string>> = {
+    "dashboard-view": "nav-dashboard",
+    "settings-view": "nav-settings",
+  };
+  for (const button of document.querySelectorAll<HTMLButtonElement>(".nav-btn")) {
+    const active = button.id === navByView[viewId];
+    button.classList.toggle("active", active);
+    button.setAttribute("aria-current", active ? "page" : "false");
+  }
+}
+
+function refreshSettingsData(): void {
+  void loadAppVersion();
+  void loadWorkspaceList();
+  void loadProviderStatus();
+}
+
+function switchView(viewId: AppView) {
+  if (viewId !== "study-view" && studySessionActive) {
     evaluationRequestId++;
     if (revealInProgress) cancelActiveBridgeRequest();
     revealInProgress = false;
@@ -1139,6 +1597,7 @@ function switchView(viewId: "dashboard-view" | "study-view" | "graph-view") {
   document.querySelectorAll(".view").forEach((el) => el.classList.remove("active"));
   document.getElementById(viewId)?.classList.add("active");
   studySessionActive = viewId === "study-view";
+  setActiveNav(viewId);
 
   const mainContainer = document.querySelector('main.container');
   if (viewId === "graph-view") {
@@ -1147,6 +1606,10 @@ function switchView(viewId: "dashboard-view" | "study-view" | "graph-view") {
     requestAnimationFrame(() => initOrShowGraph());
   } else {
     mainContainer?.classList.remove('graph-full');
+  }
+
+  if (viewId === "settings-view") {
+    refreshSettingsData();
   }
 }
 
@@ -1205,6 +1668,13 @@ function updateGraphCamera() {
   graphCamera.lookAt(0, 0, 0);
 }
 
+function cssColorHex(variableName: string, fallback: string): number {
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(variableName)
+    .trim();
+  return new THREE.Color(value || fallback).getHex();
+}
+
 function buildGraphScene(nb: any) {
   if (!graphScene) return;
   // clear previous
@@ -1234,11 +1704,12 @@ function buildGraphScene(nb: any) {
 
   // helper to make clickable pill
   const makePill = (gt: any, container: HTMLElement) => {
-    const pill = document.createElement("div");
+    const pill = document.createElement("button");
+    pill.type = "button";
     pill.className = "neighbor-pill";
     pill.textContent = gt.slug;
     pill.title = gt.concept;
-    pill.onclick = () => loadGraphFocus(gt.slug);
+    pill.addEventListener("click", () => loadGraphFocus(gt.slug));
     container.appendChild(pill);
   };
 
@@ -1557,7 +2028,7 @@ function populateDomainTokenList(tokens: any[]) {
     listSection.className = "side-section";
     const title = document.createElement("div");
     title.className = "side-title";
-    title.textContent = "Alle Tokens in Bereich (klickbar)";
+    title.textContent = t("graph_domain_token_list_title");
     listSection.appendChild(title);
     const listEl = document.createElement("div");
     listEl.id = "domain-full-list";
@@ -1570,11 +2041,12 @@ function populateDomainTokenList(tokens: any[]) {
   listEl.innerHTML = "";
 
   tokens.forEach((t: any) => {
-    const pill = document.createElement("div");
+    const pill = document.createElement("button");
+    pill.type = "button";
     pill.className = "neighbor-pill";
     pill.textContent = t.slug;
     pill.title = t.concept || "";
-    pill.onclick = () => loadGraphFocus(t.slug);
+    pill.addEventListener("click", () => loadGraphFocus(t.slug));
     listEl.appendChild(pill);
   });
 }
@@ -1611,7 +2083,7 @@ async function initOrShowGraph() {
     updateGraphCamera();
 
     // initial empty scene with soft fog
-    graphScene.fog = new THREE.Fog(0x07080d, 12, 28);
+    graphScene.fog = new THREE.Fog(cssColorHex("--bg-deep-space", "#f5f7fb"), 12, 28);
 
     // resize observer
     const ro = new ResizeObserver(() => {
@@ -1644,6 +2116,23 @@ async function initOrShowGraph() {
       graphDist = Math.max(2.5, Math.min(22, graphDist + e.deltaY * 0.012));
       updateGraphCamera();
     }, { passive: false });
+
+    canvas.addEventListener("keydown", (e) => {
+      const step = e.shiftKey ? 0.12 : 0.06;
+      if (e.key === "ArrowLeft") {
+        graphYaw -= step;
+      } else if (e.key === "ArrowRight") {
+        graphYaw += step;
+      } else if (e.key === "ArrowUp") {
+        graphPitch = Math.max(0.15, graphPitch - step);
+      } else if (e.key === "ArrowDown") {
+        graphPitch = Math.min(1.35, graphPitch + step);
+      } else {
+        return;
+      }
+      e.preventDefault();
+      updateGraphCamera();
+    });
 
     // click to focus (after possible drag)
     let clickStart = 0;
@@ -1732,7 +2221,8 @@ async function loadDashboard() {
     isLlmEnabled = settings.llm?.enabled || false;
     
     initializeTranslations();
-    void loadWorkspaceInfo();
+    void loadWorkspaceList();
+    void loadProviderStatus();
 
     // 2. Check due cards count and active domains
     const dueInfo = await runBridge<{ dueCount: number; domains: string[] }>("check-due");
@@ -1773,10 +2263,7 @@ async function loadDashboard() {
     // 3. Bring the local LLM online (auto-starts the server like `zam learn`)
     //    and reflect status. Don't block the dashboard on model load — show a
     //    "starting" state and update the badge once it resolves.
-    const aiStatusLabel = document.getElementById("ai-status-label")!;
-    const pulseDot = document.querySelector(".pulse-dot")!;
-    aiStatusLabel.textContent = t("ai_status_starting");
-    pulseDot.className = "pulse-dot amber";
+    setAiStatus(t("ai_status_starting"), "amber");
 
     runBridge<{ usable: boolean; online: boolean; reason?: string }>("ensure-llm", [
       "--timeout",
@@ -1784,19 +2271,15 @@ async function loadDashboard() {
     ])
       .then((llm) => {
         if (llm.usable) {
-          aiStatusLabel.textContent = t("ai_status_online");
-          pulseDot.className = "pulse-dot green";
+          setAiStatus(t("ai_status_online"), "green");
         } else if (llm.reason === "model-not-found") {
-          aiStatusLabel.textContent = t("ai_status_model_missing");
-          pulseDot.className = "pulse-dot gray";
+          setAiStatus(t("ai_status_model_missing"), "gray");
         } else {
-          aiStatusLabel.textContent = t("ai_status_offline");
-          pulseDot.className = "pulse-dot gray";
+          setAiStatus(t("ai_status_offline"), "gray");
         }
       })
       .catch(() => {
-        aiStatusLabel.textContent = t("ai_status_offline");
-        pulseDot.className = "pulse-dot gray";
+        setAiStatus(t("ai_status_offline"), "gray");
       });
   } catch (err) {
     console.error("Failed to load dashboard:", err);
@@ -2105,18 +2588,30 @@ async function submitRating(ratingVal: number) {
 // ── SESSION COMPLETION SCREEN ────────────────────────────────────────────
 function showCompletionState() {
   const studyView = document.getElementById("study-view")!;
-  studyView.innerHTML = `
-    <div class="study-card frosted" style="text-align: center; justify-content: center; align-items: center; gap: 20px; padding: 50px 30px;">
-      <div class="large-number" style="font-size: 60px; filter: drop-shadow(0 0 15px rgba(34, 197, 94, 0.4));">✓</div>
-      <h2 style="font-size: 24px; font-weight: 700; margin-bottom: 10px;">${t("session_completed")}</h2>
-      <p style="color: var(--clr-text-secondary); max-width: 500px; line-height: 1.6; margin-bottom: 25px;">${t("session_completed_sub")}</p>
-      <button id="btn-back-to-dashboard" class="btn primary-btn btn-large glow-btn">${t("btn_back_to_dashboard")}</button>
-    </div>
-  `;
+  studyView.textContent = "";
+  const card = document.createElement("div");
+  card.className = "study-card frosted completion-card";
 
-  document.getElementById("btn-back-to-dashboard")!.addEventListener("click", () => {
+  const mark = document.createElement("div");
+  mark.className = "completion-mark";
+  mark.textContent = "✓";
+
+  const title = document.createElement("h2");
+  title.textContent = t("session_completed");
+
+  const subtitle = document.createElement("p");
+  subtitle.textContent = t("session_completed_sub");
+
+  const button = document.createElement("button");
+  button.id = "btn-back-to-dashboard";
+  button.className = "btn primary-btn btn-large glow-btn";
+  button.textContent = t("btn_back_to_dashboard");
+  button.addEventListener("click", () => {
     window.location.reload();
   });
+
+  card.append(mark, title, subtitle, button);
+  studyView.appendChild(card);
 }
 
 // ── KEYBOARD SHORTCUTS & EVENT BINDINGS ──────────────────────────────────
@@ -2135,6 +2630,9 @@ function devObserverEnabled(): boolean {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
+  applyTheme(loadThemePreference());
+  initializeTranslations();
+
   // Load initial dashboard state
   loadDashboard();
   void loadAppVersion();
@@ -2152,6 +2650,27 @@ window.addEventListener("DOMContentLoaded", () => {
       switchView("study-view");
       loadNextCard();
     })();
+  });
+
+  document.getElementById("nav-dashboard")?.addEventListener("click", () => {
+    switchView("dashboard-view");
+  });
+
+  document.getElementById("nav-settings")?.addEventListener("click", () => {
+    switchView("settings-view");
+  });
+
+  document.getElementById("btn-open-settings")?.addEventListener("click", () => {
+    switchView("settings-view");
+  });
+
+  document.getElementById("btn-settings-back")?.addEventListener("click", () => {
+    switchView("dashboard-view");
+  });
+
+  document.getElementById("theme-select")?.addEventListener("change", (event) => {
+    const value = (event.target as HTMLSelectElement).value;
+    saveThemePreference(value === "dark" ? "dark" : "light");
   });
 
   // Setup & Data: reveal the data folder, back up the database.
@@ -2173,6 +2692,12 @@ window.addEventListener("DOMContentLoaded", () => {
         }
       })();
     });
+
+  document.getElementById("btn-open-terminal")?.addEventListener("click", () => {
+    void (async () => {
+      await openWorkspaceTerminal();
+    })();
+  });
 
   document.getElementById("btn-backup-db")?.addEventListener("click", () => {
     void (async () => {
@@ -2226,14 +2751,16 @@ window.addEventListener("DOMContentLoaded", () => {
             title: t("btn_choose_workspace"),
           });
           if (typeof selected !== "string") return; // cancelled
-          const res = await runBridge<{ ok?: boolean; workspaceDir?: string }>(
-            "set-workspace-dir",
-            ["--dir", selected],
-          );
+          const res = await runBridge<{
+            ok?: boolean;
+            workspace?: WorkspaceConfig;
+            workspaceDir?: string;
+          }>("workspace-add", ["--path", selected]);
           if (res.workspaceDir) {
-            await loadWorkspaceInfo();
+            activeWorkspaceDir = res.workspaceDir;
+            await loadWorkspaceList();
             if (status) {
-              status.textContent = tf("workspace_set", {
+              status.textContent = tf("workspace_added", {
                 path: res.workspaceDir,
               });
             }

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1,26 +1,37 @@
 /* ==========================================================================
-   ZAM Active-Recall Studio — Premium Glassmorphic Dark Mode Theme
+   ZAM Active-Recall Studio — calm light-first theme
    ========================================================================== */
 
 /* ── DESIGN SYSTEM VARIABLES ────────────────────────────────────────────── */
 :root {
   --font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  
-  /* Primary Gradients & Glow Accents */
-  --bg-deep-space: #07080d;
-  --bg-card-frosted: rgba(18, 22, 33, 0.45);
-  --border-card-frosted: rgba(255, 255, 255, 0.07);
-  --border-card-hover: rgba(255, 255, 255, 0.15);
-  
-  /* Color Palette (Tailored HSL) */
-  --primary-glow: linear-gradient(135deg, hsl(265, 90%, 65%), hsl(190, 95%, 55%));
-  
-  --clr-text-primary: #f1f3f9;
-  --clr-text-secondary: #9aa5b8;
-  --clr-text-muted: #626d7f;
-  
-  --clr-accent-purple: hsl(265, 90%, 65%);
-  --clr-accent-cyan: hsl(190, 95%, 55%);
+
+  color-scheme: light;
+
+  /* Primary surfaces */
+  --bg-deep-space: #f5f7fb;
+  --bg-page-wash:
+    radial-gradient(circle at 12% -12%, rgba(91, 95, 239, 0.15), transparent 32%),
+    radial-gradient(circle at 90% 10%, rgba(8, 145, 178, 0.12), transparent 30%),
+    linear-gradient(180deg, #fbfcff 0%, #f2f6fb 100%);
+  --bg-card-frosted: rgba(255, 255, 255, 0.82);
+  --bg-card-subtle: rgba(248, 250, 252, 0.86);
+  --bg-field: rgba(255, 255, 255, 0.84);
+  --border-card-frosted: rgba(15, 23, 42, 0.1);
+  --border-card-hover: rgba(37, 99, 235, 0.24);
+  --border-soft: rgba(15, 23, 42, 0.1);
+  --shadow-card: 0 18px 48px rgba(15, 23, 42, 0.1);
+  --shadow-card-hover: 0 24px 58px rgba(15, 23, 42, 0.14);
+
+  /* Color Palette */
+  --primary-glow: linear-gradient(135deg, hsl(246, 83%, 60%), hsl(190, 84%, 38%));
+
+  --clr-text-primary: #111827;
+  --clr-text-secondary: #334155;
+  --clr-text-muted: #4b5563;
+
+  --clr-accent-purple: hsl(246, 83%, 60%);
+  --clr-accent-cyan: hsl(190, 84%, 38%);
   
   /* FSRS Self-Rating Button Color Schemes */
   --clr-again: hsl(355, 85%, 60%);
@@ -36,6 +47,29 @@
   --bloom-5: hsl(340, 85%, 60%); /* Synthesize */
 }
 
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg-deep-space: #07080d;
+  --bg-page-wash:
+    radial-gradient(circle at 10% -10%, rgba(139, 92, 246, 0.16), transparent 36%),
+    radial-gradient(circle at 94% 10%, rgba(6, 182, 212, 0.1), transparent 32%),
+    linear-gradient(180deg, #080a12 0%, #090f14 100%);
+  --bg-card-frosted: rgba(18, 22, 33, 0.58);
+  --bg-card-subtle: rgba(255, 255, 255, 0.035);
+  --bg-field: rgba(0, 0, 0, 0.22);
+  --border-card-frosted: rgba(255, 255, 255, 0.08);
+  --border-card-hover: rgba(255, 255, 255, 0.16);
+  --border-soft: rgba(255, 255, 255, 0.08);
+  --shadow-card: 0 20px 50px rgba(0, 0, 0, 0.4);
+  --shadow-card-hover: 0 25px 60px rgba(0, 0, 0, 0.5);
+  --primary-glow: linear-gradient(135deg, hsl(265, 90%, 65%), hsl(190, 95%, 55%));
+  --clr-text-primary: #f1f5f9;
+  --clr-text-secondary: #cbd5e1;
+  --clr-text-muted: #94a3b8;
+  --clr-accent-purple: hsl(265, 90%, 65%);
+  --clr-accent-cyan: hsl(190, 95%, 55%);
+}
+
 /* ── BASE & GLOBAL STYLES ────────────────────────────────────────────────── */
 * {
   box-sizing: border-box;
@@ -49,7 +83,7 @@ html {
 
 body {
   font-family: var(--font-family);
-  background-color: var(--bg-deep-space);
+  background: var(--bg-page-wash);
   color: var(--clr-text-primary);
   height: 100vh;
   overflow: hidden;
@@ -70,6 +104,11 @@ body {
   pointer-events: none;
   z-index: 0;
   filter: blur(160px);
+  opacity: 0.16;
+  mix-blend-mode: multiply;
+}
+
+:root[data-theme="dark"] .blur-glow {
   opacity: 0.18;
   mix-blend-mode: screen;
 }
@@ -101,7 +140,7 @@ body {
   max-height: 100vh;
   min-height: 0;
   overflow-y: auto;
-  padding: 22px 30px;
+  padding: 22px 30px 30px;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -119,13 +158,13 @@ body {
    default Windows bar. */
 .container {
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.14) transparent;
+  scrollbar-color: rgba(71, 85, 105, 0.35) transparent;
 }
 .container::-webkit-scrollbar {
   width: 8px;
 }
 .container::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.14);
+  background: rgba(71, 85, 105, 0.35);
   border-radius: 4px;
 }
 .container::-webkit-scrollbar-track {
@@ -139,7 +178,7 @@ body {
   align-items: center;
   margin-bottom: 22px;
   padding-bottom: 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--border-soft);
 }
 
 .logo-area {
@@ -147,6 +186,45 @@ body {
   align-items: baseline;
   gap: 8px;
   user-select: none;
+}
+
+.top-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  padding: 4px;
+}
+
+:root[data-theme="dark"] .top-nav {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.nav-btn {
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  color: var(--clr-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 7px 14px;
+}
+
+.nav-btn.active {
+  background: var(--clr-text-primary);
+  color: var(--bg-deep-space);
+}
+
+.nav-btn:focus-visible,
+.btn:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid rgba(6, 182, 212, 0.36);
+  outline-offset: 2px;
 }
 
 .logo-accent {
@@ -176,10 +254,14 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.72);
   padding: 6px 14px;
   border-radius: 30px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border-soft);
+}
+
+:root[data-theme="dark"] .status-indicator {
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .pulse-dot {
@@ -250,13 +332,13 @@ body {
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid var(--border-card-frosted);
   border-radius: 20px;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-card);
   transition: border-color 0.4s ease, box-shadow 0.4s ease, transform 0.4s ease;
 }
 
 .frosted:hover {
   border-color: var(--border-card-hover);
-  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-card-hover);
 }
 
 /* ── VIEWS TRANSITIONS ───────────────────────────────────────────────────── */
@@ -282,21 +364,62 @@ body {
 }
 
 /* ── VIEW 1: DASHBOARD OVERVIEW ──────────────────────────────────────────── */
+.dashboard-hero,
+.settings-hero {
+  align-items: center;
+  display: grid;
+  gap: 22px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-bottom: 22px;
+  padding: 24px;
+}
+
+.dashboard-copy h1,
+.settings-hero h1 {
+  font-size: clamp(30px, 5vw, 48px);
+  letter-spacing: -1.4px;
+  line-height: 1;
+  margin: 4px 0 12px;
+}
+
+.dashboard-copy p,
+.settings-subtitle {
+  color: var(--clr-text-secondary);
+  font-size: 15px;
+  line-height: 1.55;
+  max-width: 620px;
+}
+
+.eyebrow {
+  color: var(--clr-accent-cyan);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+}
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 230px;
+}
+
 .dashboard-grid {
   display: grid;
   grid-template-columns: 1fr 1.3fr;
-  gap: 25px;
+  gap: 18px;
   margin-bottom: 22px;
 }
 
 .stat-card {
-  padding: 24px;
+  padding: 22px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
-  min-height: 250px;
+  min-height: 190px;
 }
 
 .stat-card h2 {
@@ -309,7 +432,7 @@ body {
 }
 
 .large-number {
-  font-size: 80px;
+  font-size: 72px;
   font-weight: 800;
   line-height: 1;
   background: var(--primary-glow);
@@ -336,16 +459,16 @@ body {
   font-size: 12px;
   font-weight: 500;
   color: var(--clr-text-primary);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   padding: 6px 12px;
   border-radius: 8px;
   transition: background 0.3s, border-color 0.3s;
 }
 
 .domain-tag:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(14, 165, 233, 0.08);
+  border-color: rgba(14, 165, 233, 0.24);
 }
 
 .empty-tag {
@@ -360,38 +483,191 @@ body {
   margin-top: 15px;
 }
 
-.setup-meta-row {
+/* ── SETTINGS VIEW ───────────────────────────────────────────────────────── */
+.settings-list {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 1fr;
+}
+
+.settings-card {
+  padding: 18px 20px;
+}
+
+.settings-card-header {
+  align-items: flex-start;
   display: flex;
-  align-items: center;
+  gap: 16px;
   justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 10px 12px;
-  margin-top: 10px;
+  margin-bottom: 12px;
 }
 
-.setup-meta-item,
-#setup-status,
-#update-status {
-  line-height: 1.4;
-  min-width: 0;
-  overflow-wrap: anywhere;
+.settings-card h2 {
+  color: var(--clr-text-primary);
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.7px;
+  margin-bottom: 14px;
+  text-transform: uppercase;
 }
 
+.settings-card-header h2 {
+  margin-bottom: 4px;
+}
+
+.settings-card-help {
+  color: var(--clr-text-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.settings-row {
+  align-items: center;
+  border-top: 1px solid var(--border-soft);
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 11px 0;
+}
+
+.settings-row:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.settings-row span,
+.settings-field span {
+  color: var(--clr-text-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.settings-row code,
 #setup-card code {
+  color: var(--clr-text-secondary);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.settings-row-stack {
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.settings-row-stack code {
+  text-align: left;
+}
+
+.settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.settings-field {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-field select,
+.observer-window-select {
+  background: var(--bg-field);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  color: var(--clr-text-primary);
+  color-scheme: light;
+  font: inherit;
+  padding: 10px 12px;
+}
+
+:root[data-theme="dark"] .settings-field select,
+:root[data-theme="dark"] .observer-window-select {
+  color-scheme: dark;
+}
+
+.settings-status-row {
+  min-height: 20px;
+}
+
+.workspace-list {
+  display: grid;
+  gap: 8px;
+}
+
+.workspace-row {
+  align-items: center;
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  display: flex;
+  gap: 14px;
+  justify-content: space-between;
+  padding: 12px;
+}
+
+.workspace-row[data-active="true"] {
+  border-color: rgba(14, 165, 233, 0.38);
+  box-shadow: inset 3px 0 0 var(--clr-accent-cyan);
+}
+
+.workspace-main {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.workspace-title-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.workspace-title {
+  color: var(--clr-text-primary);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.workspace-badge {
+  background: rgba(14, 165, 233, 0.12);
+  border: 1px solid rgba(14, 165, 233, 0.28);
+  border-radius: 999px;
+  color: var(--clr-accent-cyan);
+  font-size: 11px;
+  font-weight: 800;
+  padding: 2px 8px;
+  text-transform: uppercase;
+}
+
+.workspace-row code {
   color: var(--clr-text-secondary);
   overflow-wrap: anywhere;
 }
 
-.setup-update-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
+.workspace-meta,
+.workspace-more {
+  color: var(--clr-text-muted);
+  font-size: 12px;
 }
 
+.workspace-actions {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+#setup-status,
 #update-status {
+  line-height: 1.4;
+  margin-top: 10px;
   min-height: 18px;
-  margin-top: 6px;
+  overflow-wrap: anywhere;
 }
 
 .observer-panel {
@@ -431,22 +707,14 @@ body {
 
 .observer-window-select {
   min-width: 0;
-  background: rgba(7, 8, 13, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
-  color: var(--clr-text-primary);
-  /* Render the native popup list dark so options aren't grey-on-white. */
-  color-scheme: dark;
-  font: inherit;
   font-size: 13px;
-  padding: 10px 12px;
-  outline: none;
+  outline: transparent;
 }
 
 /* Explicit dark option styling for WebView2/Chromium, which otherwise paints
    the dropdown list on a light system background. */
 .observer-window-select option {
-  background-color: #121621;
+  background-color: var(--bg-deep-space);
   color: var(--clr-text-primary);
 }
 
@@ -474,10 +742,10 @@ body {
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
-  background: rgba(0, 0, 0, 0.32);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   border-radius: 10px;
-  color: #a5f3fc;
+  color: var(--clr-accent-cyan);
   font-family: 'Courier New', Courier, monospace;
   font-size: 12px;
   line-height: 1.45;
@@ -518,8 +786,8 @@ body {
 }
 
 .observer-report-card {
-  background: rgba(255, 255, 255, 0.035);
-  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   border-radius: 10px;
   padding: 12px;
 }
@@ -561,7 +829,7 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 30px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--border-soft);
   padding-bottom: 15px;
 }
 
@@ -596,8 +864,8 @@ body {
 .bloom-badge.bloom-5 { background: rgba(255, 99, 132, 0.1); border-color: rgba(255, 99, 132, 0.3); color: var(--bloom-5); }
 
 .domain-badge {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   color: var(--clr-text-secondary);
 }
 
@@ -631,21 +899,21 @@ body {
 textarea {
   width: 100%;
   min-height: 130px;
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-field);
+  border: 1px solid var(--border-soft);
   border-radius: 12px;
   padding: 16px;
   font-family: inherit;
   font-size: 15px;
   color: var(--clr-text-primary);
-  outline: none;
+  outline: transparent;
   resize: vertical;
   transition: border-color 0.3s, background 0.3s;
 }
 
 textarea:focus {
   border-color: var(--clr-accent-cyan);
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-field);
 }
 
 textarea::placeholder {
@@ -787,18 +1055,18 @@ textarea::placeholder {
 }
 
 #lbl-ai-feedback-title {
-  color: #c084fc;
+  color: var(--clr-accent-purple);
 }
 
 .ai-feedback-text {
   font-size: 15px;
   line-height: 1.5;
-  color: #e9d5ff;
+  color: var(--clr-text-primary);
 }
 
 .answer-box {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   border-radius: 12px;
   padding: 20px;
 }
@@ -832,13 +1100,13 @@ textarea::placeholder {
 /* Code block context reference */
 .reveal-code-box {
   margin-top: 8px;
-  background: rgba(0, 0, 0, 0.4);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   border-radius: 8px;
   padding: 12px;
   font-family: 'Courier New', Courier, monospace;
   font-size: 13px;
-  color: #a5f3fc;
+  color: var(--clr-accent-cyan);
   overflow-x: auto;
   white-space: pre-wrap;
 }
@@ -847,7 +1115,7 @@ textarea::placeholder {
 .rating-bar-container {
   margin-top: 15px;
   padding-top: 20px;
-  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  border-top: 1px solid var(--border-soft);
 }
 
 .rating-instruction {
@@ -864,8 +1132,8 @@ textarea::placeholder {
 }
 
 .rating-btn {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   border-radius: 12px;
   padding: 12px 8px;
   display: flex;
@@ -880,7 +1148,7 @@ textarea::placeholder {
 .rating-btn .rating-num {
   font-size: 11px;
   font-weight: 700;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(100, 116, 139, 0.12);
   padding: 2px 6px;
   border-radius: 4px;
   color: var(--clr-text-muted);
@@ -942,7 +1210,7 @@ textarea::placeholder {
   border-radius: 10px;
   border: 1px solid transparent;
   cursor: pointer;
-  outline: none;
+  outline: transparent;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -965,8 +1233,8 @@ textarea::placeholder {
 }
 
 .primary-btn:disabled {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: rgba(255, 255, 255, 0.05);
+  background: rgba(100, 116, 139, 0.1);
+  border-color: rgba(100, 116, 139, 0.18);
   color: var(--clr-text-muted);
   cursor: not-allowed;
 }
@@ -975,20 +1243,24 @@ textarea::placeholder {
   animation: buttonPulse 3s infinite alternate;
 }
 
+.glow-btn:disabled {
+  animation: none;
+}
+
 @keyframes buttonPulse {
   0% { box-shadow: 0 0 10px rgba(139, 92, 246, 0.15); }
   100% { box-shadow: 0 0 25px rgba(6, 182, 212, 0.35); }
 }
 
 .secondary-btn {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   color: var(--clr-text-secondary);
 }
 
 .secondary-btn:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.15);
+  background: rgba(14, 165, 233, 0.08);
+  border-color: rgba(14, 165, 233, 0.24);
   color: var(--clr-text-primary);
 }
 
@@ -1028,6 +1300,34 @@ textarea::placeholder {
   justify-content: flex-end;
 }
 
+.completion-card {
+  align-items: center;
+  gap: 20px;
+  justify-content: center;
+  padding: 50px 30px;
+  text-align: center;
+}
+
+.completion-card h2 {
+  font-size: 24px;
+  font-weight: 800;
+  margin-bottom: 0;
+}
+
+.completion-card p {
+  color: var(--clr-text-secondary);
+  line-height: 1.6;
+  max-width: 520px;
+}
+
+.completion-mark {
+  color: var(--clr-good);
+  filter: drop-shadow(0 0 15px rgba(34, 197, 94, 0.28));
+  font-size: 60px;
+  font-weight: 900;
+  line-height: 1;
+}
+
 /* Util Helpers */
 .loading-pulse {
   animation: dotsPulseAnimation 1.2s infinite alternate ease-in-out;
@@ -1047,7 +1347,7 @@ textarea::placeholder {
 .error-banner {
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  color: #fecaca;
+  color: #991b1b;
   border-radius: 12px;
   padding: 14px 18px;
   margin-bottom: 20px;
@@ -1055,6 +1355,10 @@ textarea::placeholder {
   font-weight: 500;
   line-height: 1.4;
   word-break: break-word;
+}
+
+:root[data-theme="dark"] .error-banner {
+  color: #fecaca;
 }
 
 /* ==========================================================================
@@ -1084,7 +1388,7 @@ textarea::placeholder {
   gap: 8px;
   margin-bottom: 12px;
   padding-bottom: 10px;
-  border-bottom: 1px solid rgba(255,255,255,0.06);
+  border-bottom: 1px solid var(--border-soft);
 }
 
 .graph-title {
@@ -1098,7 +1402,7 @@ textarea::placeholder {
   margin-left: 10px;
   font-size: 12px;
   padding: 2px 8px;
-  background: rgba(255,255,255,0.06);
+  background: rgba(100, 116, 139, 0.12);
   border-radius: 999px;
   color: var(--clr-text-secondary);
 }
@@ -1135,8 +1439,8 @@ textarea::placeholder {
 
 .graph-canvas-wrap {
   position: relative;
-  background: rgba(0,0,0,0.25);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   border-radius: 16px;
   overflow: hidden;
   display: flex;
@@ -1200,11 +1504,13 @@ textarea::placeholder {
 }
 
 .neighbor-pill {
+  color: var(--clr-text-secondary);
+  font: inherit;
   font-size: 11px;
   padding: 3px 8px;
   border-radius: 999px;
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.08);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   cursor: pointer;
   transition: all 0.1s ease;
   max-width: 100%;
@@ -1214,7 +1520,7 @@ textarea::placeholder {
 }
 
 .neighbor-pill:hover {
-  background: rgba(255,255,255,0.1);
+  background: rgba(14, 165, 233, 0.08);
   border-color: var(--clr-accent-cyan);
 }
 
@@ -1224,7 +1530,7 @@ textarea::placeholder {
   color: var(--clr-text-muted);
   font-style: italic;
   padding-top: 8px;
-  border-top: 1px solid rgba(255,255,255,0.04);
+  border-top: 1px solid var(--border-soft);
 }
 
 /* Domain filter / selector for independent knowledge areas */
@@ -1240,8 +1546,8 @@ textarea::placeholder {
   font-size: 11px;
   padding: 2px 9px;
   border-radius: 999px;
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.08);
+  background: var(--bg-card-subtle);
+  border: 1px solid var(--border-soft);
   color: var(--clr-text-secondary);
   cursor: pointer;
   transition: all 0.1s ease;
@@ -1259,4 +1565,64 @@ textarea::placeholder {
   border-color: var(--clr-accent-cyan);
   color: #67e8f9;
   font-weight: 600;
+}
+
+@media (max-width: 820px) {
+  .app-header,
+  .status-area {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .top-nav {
+    order: 3;
+  }
+
+  .dashboard-hero,
+  .settings-hero,
+  .dashboard-grid,
+  .settings-list,
+  .graph-main {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-actions {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .stat-card {
+    min-height: 160px;
+  }
+
+  .settings-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .settings-row code {
+    text-align: left;
+  }
+
+  .workspace-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .workspace-actions {
+    justify-content: flex-start;
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/docs/adr/2026-06-25a-machine-local-llm-role-configuration.md
+++ b/docs/adr/2026-06-25a-machine-local-llm-role-configuration.md
@@ -1,0 +1,116 @@
+# Machine-local LLM Role Configuration
+
+**Status:** Proposed
+**Deciders:** Thomas (project owner)
+**Related:**
+[2026-06-23-pluggable-providers-and-agent-harnesses.md](2026-06-23-pluggable-providers-and-agent-harnesses.md) ·
+[2026-06-22-screen-recording-observer.md](2026-06-22-screen-recording-observer.md) ·
+[2026-06-20-observer-permission-model.md](2026-06-20-observer-permission-model.md)
+
+---
+
+## Context
+
+ZAM already separates provider roles in code: `recall`, `vision`, and `text`
+resolve through `getProviderForRole()`, with legacy `llm.*` and
+`llm.vision.*` settings kept as a compatibility path. That solves the conceptual
+problem from ADR 2026-06-23: the model that coaches a learning session is not
+necessarily the same model that inspects screenshots or videos.
+
+The remaining problem is where those choices live. Local LLM availability is
+machine-specific:
+
+- a Ryzen AI Windows machine may work well with Microsoft Foundry Local or FLM;
+- a Snapdragon X laptop may support Foundry but not Ollama;
+- a Mac mini M4 may run Ollama well;
+- a work laptop may allow no local LLM at all;
+- cloud contracts may differ between private and work contexts.
+
+A role binding stored only in the synchronized learning database is therefore
+wrong: it can make another machine try to use a local runner, model, endpoint, or
+work contract that does not exist there.
+
+## Decision
+
+Use a layered provider configuration model.
+
+1. **Roles stay explicit.**
+   - `recall`: learning-session text tasks such as question generation,
+     translation, and answer feedback.
+   - `vision`: observer screenshot/video/image analysis.
+   - `text`: future general text helper role.
+
+2. **Machine-local active choices live in `~/.zam/config.json`.**
+   This file already records install/channel state and is deliberately
+   per-machine. It is the right place for:
+   - local provider records,
+   - active role bindings,
+   - local runner hints,
+   - hardware-specific defaults.
+
+3. **Secrets stay outside shared state.**
+   Provider records reference credentials by `apiKeyRef`; actual keys stay in
+   `~/.zam/credentials.json`.
+
+4. **Cloud provider records may be shared only when secret-free.**
+   A shared provider catalog can describe URLs, model IDs, and API flavor, but
+   never contains keys. A future context/profile layer can distinguish private,
+   work, team, and other cloud contracts.
+
+5. **Vision is privacy-first.**
+   The observer role defaults to local-only or disabled. Any cloud fallback for
+   screenshots/video is explicit opt-in and remains gated by `ObserverPolicy`
+   before pixels leave the machine.
+
+6. **Compatibility lasts one release.**
+   Legacy `llm.*` and `llm.vision.*` settings continue to resolve through the
+   existing shim during the 0.5.0 transition.
+
+## Consequences
+
+**Easier**
+
+- Different machines can use different local runners without fighting over the
+  same synchronized database settings.
+- A user can run `recall` on DeepSeek V4 Flash while keeping `vision` local via
+  FLM/Foundry.
+- Work and private cloud contracts are not accidentally merged.
+
+**Harder**
+
+- The provider resolver must read from both the database and machine-local
+  config.
+- The UI must explain which layer is active instead of showing a single
+  ambiguous "LLM" status.
+
+## Examples
+
+```jsonc
+{
+  "ai": {
+    "providers": {
+      "foundry-gemma": {
+        "label": "Foundry Gemma local",
+        "url": "http://localhost:8000/v1",
+        "model": "gemma4-it:e4b",
+        "apiFlavor": "chat-completions",
+        "local": true
+      },
+      "deepseek-work": {
+        "label": "Work DeepSeek",
+        "url": "https://api.deepseek.com/v1",
+        "model": "deepseek-v4-flash",
+        "apiFlavor": "chat-completions",
+        "apiKeyRef": "deepseek-work"
+      }
+    },
+    "roles": {
+      "recall": { "primary": "deepseek-work" },
+      "vision": { "primary": "foundry-gemma" }
+    }
+  }
+}
+```
+
+This extends ADR 2026-06-23 by moving the active hardware-dependent role choices
+to the machine-local layer.

--- a/docs/adr/2026-06-25b-visible-ai-status-in-studio.md
+++ b/docs/adr/2026-06-25b-visible-ai-status-in-studio.md
@@ -1,0 +1,63 @@
+# Visible AI Status in the Studio
+
+**Status:** Proposed
+**Deciders:** Thomas (project owner)
+**Related:**
+[2026-06-25a-machine-local-llm-role-configuration.md](2026-06-25a-machine-local-llm-role-configuration.md) ·
+[2026-06-23-pluggable-providers-and-agent-harnesses.md](2026-06-23-pluggable-providers-and-agent-harnesses.md)
+
+---
+
+## Context
+
+The desktop Studio already shows the application version in the "Setup & Data"
+card. It also has a top-right "Local AI" indicator, but that indicator is too
+coarse:
+
+- it implies that one local model covers all AI tasks;
+- it does not show the configured model ID;
+- it does not distinguish the learning-session model from the observer model;
+- it does not make cloud-vs-local privacy implications visible.
+
+For ZAM, this distinction is load-bearing. A user may reasonably want a cloud
+text model for learning feedback, while keeping screenshots and video analysis
+local.
+
+## Decision
+
+Show role-based AI status wherever the Studio shows setup/version information.
+
+The "Setup & Data" card should display:
+
+- **Learning model**: the active `recall` provider/model, local/cloud
+  classification, enabled state, and readiness.
+- **Observer model**: the active `vision` provider/model, local/cloud
+  classification, enabled state, readiness, and whether cloud upload is enabled.
+
+The bridge exposes a secret-safe provider status command that returns role
+summaries from the same resolver used by the CLI. The response never includes API
+keys.
+
+The top-right status indicator remains compact, but it is no longer the only
+place where model state is visible.
+
+## Consequences
+
+**Easier**
+
+- Users can verify the configured LLMs in the same place they verify the app
+  version.
+- The recall-vs-observer distinction becomes discoverable.
+- Accidental cloud use for visual observation is less likely.
+
+**Harder**
+
+- The desktop needs localized labels and bridge data for provider summaries.
+- Provider status must be rendered carefully so disabled, offline, missing-model,
+  unsupported-provider, and privacy-sensitive states are understandable.
+
+## Open follow-up
+
+0.5.0 should at least display the role configuration and expose CLI/bridge entry
+points. A fuller desktop provider editor can follow once the data model has
+stabilized.

--- a/docs/adr/2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md
+++ b/docs/adr/2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md
@@ -1,0 +1,89 @@
+# Flexible ZAM Workspaces and Skill Wiring
+
+**Status:** Proposed
+**Deciders:** Thomas (project owner)
+**Related:**
+[2026-03-26-personal-workflow-foundations.md](2026-03-26-personal-workflow-foundations.md) ·
+[2026-05-30b-hardware-setup-and-agent-distribution.md](2026-05-30b-hardware-setup-and-agent-distribution.md) ·
+[2026-06-13b-approachable-setup-and-self-update.md](2026-06-13b-approachable-setup-and-self-update.md)
+
+---
+
+## Context
+
+ZAM started from a personal repository model: a personal instance contains
+human-authored knowledge files, and `zam setup` copies the ZAM skill into that
+repository for agent use.
+
+Real use is broader:
+
+- a team may already have a central knowledge repo;
+- that repo may live in Azure DevOps rather than GitHub;
+- users may want personal, team, family, community, and organization workspaces;
+- ZAM should work in an existing repo instead of requiring a new `zam-personal`
+  or `zam-private-team` clone;
+- Copilot and Claude need to be supported first.
+
+Current code has `repo.personal`, `repo.team`, and `repo.org` settings plus
+`personal.workspace_dir`, but this is a fixed shape and does not describe skill
+installation state, source-control provider, or arbitrary workspace kinds.
+
+## Decision
+
+Introduce a flexible workspace registry.
+
+Each workspace record has:
+
+- `id`, for example `personal`, `team`, `family`, `community-pgr`, or
+  `cops-management`;
+- `label`;
+- `kind`: `personal | team | family | community | organization | custom`;
+- `path`;
+- optional `sourceControl`: `github | azure-devops | git | none`;
+- optional `knowledgeScopes`, such as `beliefs`, `goals`, `concepts`, or
+  `foundation`;
+- optional default agent/harness.
+
+Workspace paths are machine-local because directory layouts differ between
+machines. The registry therefore lives in `~/.zam/config.json`, while the
+workspace contents remain normal files in the selected repositories.
+
+`zam setup` gains an explicit target mode so it can wire ZAM into existing
+repositories:
+
+```powershell
+zam workspace add cops-management --kind team --path C:\src\Cops.Management --source-control azure-devops
+zam workspace setup cops-management --agents copilot,claude
+```
+
+Skill setup is non-destructive:
+
+- copy or refresh `.agents\skills\zam\SKILL.md` for Copilot/Codex-style repo
+  skills;
+- copy or refresh `.claude\skills\zam\SKILL.md` for Claude Code;
+- preserve existing `CLAUDE.md`, `AGENTS.md`, and
+  `.github\copilot-instructions.md`;
+- create or refresh only clearly marked ZAM instruction blocks;
+- support `--dry-run` and `--force`.
+
+The installed ZAM package or desktop resource bundle remains the source of skill
+files. A source checkout is not required.
+
+## Consequences
+
+**Easier**
+
+- Existing team repositories can become ZAM workspaces.
+- Azure DevOps repositories are supported because skill wiring only needs local
+  files and Git-compatible paths.
+- Personal and shared knowledge can live in different workspaces without
+  forcing one repository layout.
+
+**Harder**
+
+- Setup must avoid clobbering existing agent instructions.
+- Host-specific invocation differs. Not every agent exposes a literal `/zam`
+  slash command; the skill must be installed and documented according to each
+  host's supported mechanism.
+- Goal and belief resolution must evolve from fixed personal/team/org settings
+  toward workspace records, while preserving compatibility.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,6 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-06-21](2026-06-21-code-signing-and-trusted-installers.md) | Code Signing and Trusted Installers | Proposed |
 | [2026-06-22](2026-06-22-screen-recording-observer.md) | Screen Recording Observer and Local/Cloud Vision Fallbacks | Proposed |
 | [2026-06-23](2026-06-23-pluggable-providers-and-agent-harnesses.md) | Pluggable AI Providers, Agent Harnesses, and Approachable UI Setup | Proposed |
+| [2026-06-25a](2026-06-25a-machine-local-llm-role-configuration.md) | Machine-local LLM Role Configuration | Proposed |
+| [2026-06-25b](2026-06-25b-visible-ai-status-in-studio.md) | Visible AI Status in the Studio | Proposed |
+| [2026-06-25c](2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md) | Flexible ZAM Workspaces and Skill Wiring | Proposed |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -138,7 +138,13 @@ export function planHarnessLaunch(
 /** Launch the harness: a terminal window for CLI, a detached process for app. */
 export function launchHarness(
   harness: AgentHarness,
-  opts: { executable: string; workspace: string; shell: TerminalShell },
+  opts: {
+    executable: string;
+    workspace: string;
+    shell: TerminalShell;
+    silent?: boolean;
+    platform?: NodeJS.Platform;
+  },
 ): void {
   const plan = planHarnessLaunch(harness, opts);
   if (plan.kind === "cli") {
@@ -147,6 +153,8 @@ export function launchHarness(
       label: `agent-${harness.id}`,
       dir: opts.workspace,
       shell: plan.shell,
+      silent: opts.silent,
+      platform: opts.platform,
     });
     return;
   }
@@ -155,5 +163,7 @@ export function launchHarness(
     stdio: "ignore",
     windowsHide: true,
   }).unref();
-  console.log(`Launched ${harness.label} in ${opts.workspace}`);
+  if (!opts.silent) {
+    console.log(`Launched ${harness.label} in ${opts.workspace}`);
+  }
 }

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -9,7 +9,7 @@ import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { Command } from "commander";
 import type {
   BloomLevel,
@@ -35,6 +35,7 @@ import {
   generatePrompt,
   getAgentSkill,
   getCardDeletionImpact,
+  getConfiguredWorkspaces,
   getDatabaseTargetInfo,
   getDueCards,
   getSetting,
@@ -56,6 +57,8 @@ import {
   startSession,
   syncObserverSidecarPolicy,
   uiObservationLogExists,
+  upsertConfiguredWorkspace,
+  type WorkspaceKind,
 } from "../../kernel/index.js";
 import {
   AGENT_HARNESSES,
@@ -71,6 +74,7 @@ import {
   getAvailableModels,
   getLlmConfig,
   getProviderForRole,
+  getProviderRoleStatus,
   isLlmOnline,
   translateQuestionViaLLM,
 } from "../llm/client.js";
@@ -272,6 +276,82 @@ bridgeCommand
   });
 
 bridgeCommand
+  .command("workspace-list")
+  .description("List configured ZAM workspaces (JSON)")
+  .action(async () => {
+    await withDb(async (db) => {
+      const workspaceDir =
+        (await getSetting(db, "personal.workspace_dir")) || null;
+      jsonOut({
+        workspaces: getConfiguredWorkspaces(),
+        workspaceDir,
+        defaultWorkspaceDir: join(homedir(), "Documents", "zam"),
+        dataDir: join(homedir(), ".zam"),
+      });
+    });
+  });
+
+function workspaceIdFromPath(dir: string): string {
+  const base = basename(dir)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const prefix = base || "workspace";
+  const existing = new Set(getConfiguredWorkspaces().map((item) => item.id));
+  if (!existing.has(prefix)) return prefix;
+  let index = 2;
+  while (existing.has(`${prefix}-${index}`)) index++;
+  return `${prefix}-${index}`;
+}
+
+function parseBridgeWorkspaceKind(value?: string): WorkspaceKind {
+  const kind = (value || "custom").toLowerCase();
+  if (
+    kind === "personal" ||
+    kind === "team" ||
+    kind === "family" ||
+    kind === "community" ||
+    kind === "organization" ||
+    kind === "custom"
+  ) {
+    return kind;
+  }
+  jsonError(`Invalid workspace kind: ${value}`);
+}
+
+bridgeCommand
+  .command("workspace-add")
+  .description("Register an existing directory as a ZAM workspace (JSON)")
+  .requiredOption("--path <dir>", "Existing workspace/repository directory")
+  .option("--id <id>", "Workspace id")
+  .option("--label <label>", "Human-readable label")
+  .option("--kind <kind>", "Workspace kind", "custom")
+  .action(async (opts) => {
+    const raw = String(opts.path ?? "").trim();
+    if (!raw) jsonError("A non-empty --path is required");
+    const path = resolve(raw);
+    if (!existsSync(path)) jsonError(`Workspace path does not exist: ${path}`);
+    const id = String(opts.id || workspaceIdFromPath(path)).trim();
+    if (!id) jsonError("A non-empty --id is required");
+    const workspace = {
+      id,
+      label: opts.label || basename(path) || id,
+      kind: parseBridgeWorkspaceKind(opts.kind),
+      path,
+    };
+    await withDb(async (db) => {
+      await setSetting(db, "personal.workspace_dir", path);
+      upsertConfiguredWorkspace(workspace);
+      jsonOut({
+        ok: true,
+        workspace,
+        workspaces: getConfiguredWorkspaces(),
+        workspaceDir: path,
+      });
+    });
+  });
+
+bridgeCommand
   .command("set-workspace-dir")
   .description("Set the personal workspace directory (JSON)")
   .requiredOption("--dir <path>", "Path to the workspace directory")
@@ -317,6 +397,8 @@ bridgeCommand
     "--id <id>",
     "Harness id (default: agent.default setting, else first detected)",
   )
+  .option("--workspace <id>", "Configured workspace id to open")
+  .option("--dir <path>", "Explicit workspace directory to open")
   .action(async (opts) => {
     await withDb(async (db) => {
       let id: string | undefined =
@@ -341,7 +423,15 @@ bridgeCommand
           `${harness.label} was not detected. Set its path: zam settings set agent.${harness.id}.command <path>`,
         );
       }
+      const configuredWorkspace = opts.workspace
+        ? getConfiguredWorkspaces().find((item) => item.id === opts.workspace)
+        : undefined;
+      if (opts.workspace && !configuredWorkspace) {
+        jsonError(`Workspace is not configured: ${opts.workspace}`);
+      }
       let workspace =
+        opts.dir ||
+        configuredWorkspace?.path ||
         (await getSetting(db, "personal.workspace_dir")) ||
         join(homedir(), "Documents", "zam");
       if (!existsSync(workspace)) workspace = homedir();
@@ -349,6 +439,7 @@ bridgeCommand
         executable,
         workspace,
         shell: normalizeShell(undefined),
+        silent: true,
       });
       jsonOut({
         ok: true,
@@ -1868,6 +1959,20 @@ bridgeCommand
         apiFlavor: provider.apiFlavor,
         unsupportedProvider,
       });
+    });
+  });
+
+bridgeCommand
+  .command("provider-status")
+  .description("Show secret-safe provider status for LLM roles (JSON)")
+  .action(async () => {
+    await withDb(async (db) => {
+      const [recall, vision, text] = await Promise.all([
+        getProviderRoleStatus(db, "recall"),
+        getProviderRoleStatus(db, "vision"),
+        getProviderRoleStatus(db, "text"),
+      ]);
+      jsonOut({ roles: { recall, vision, text } });
     });
   });
 

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Command } from "commander";
@@ -58,6 +58,12 @@ import {
   uiObservationLogExists,
 } from "../../kernel/index.js";
 import {
+  AGENT_HARNESSES,
+  getHarness,
+  launchHarness,
+  resolveHarnessExecutable,
+} from "../agent-harness.js";
+import {
   checkVisionReadiness,
   ensureHighQualityQuestion,
   ensureLlmReadyHeadless,
@@ -69,6 +75,7 @@ import {
   translateQuestionViaLLM,
 } from "../llm/client.js";
 import { observeUiSnapshotViaLLM } from "../llm/vision.js";
+import { normalizeShell } from "../terminal-open.js";
 import { ensureDefaultUser, resolveUser } from "./resolve-user.js";
 import { withDb as sharedWithDb } from "./shared/db.js";
 import { backupDatabaseTo } from "./workspace.js";
@@ -275,6 +282,81 @@ bridgeCommand
     await withDb(async (db) => {
       await setSetting(db, "personal.workspace_dir", dir);
       jsonOut({ ok: true, workspaceDir: dir });
+    });
+  });
+
+// ── zam bridge agent-list / agent-open ─────────────────────────────────────
+
+bridgeCommand
+  .command("agent-list")
+  .description("List agent harnesses with detection state + the default (JSON)")
+  .action(async () => {
+    await withDb(async (db) => {
+      const configuredDefault = (await getSetting(db, "agent.default")) || null;
+      const harnesses = await Promise.all(
+        AGENT_HARNESSES.map(async (h) => {
+          const override =
+            (await getSetting(db, `agent.${h.id}.command`)) || undefined;
+          return {
+            id: h.id,
+            label: h.label,
+            kind: h.kind,
+            detected: resolveHarnessExecutable(h, override) !== null,
+          };
+        }),
+      );
+      const fallbackDefault = harnesses.find((h) => h.detected)?.id ?? null;
+      jsonOut({ harnesses, default: configuredDefault ?? fallbackDefault });
+    });
+  });
+
+bridgeCommand
+  .command("agent-open")
+  .description("Launch an agent harness in the workspace (JSON)")
+  .option(
+    "--id <id>",
+    "Harness id (default: agent.default setting, else first detected)",
+  )
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      let id: string | undefined =
+        opts.id || (await getSetting(db, "agent.default")) || undefined;
+      if (!id) {
+        id = AGENT_HARNESSES.find((h) => resolveHarnessExecutable(h))?.id;
+      }
+      if (!id) {
+        jsonError(
+          "No agent harness configured or detected. Install one (Claude Code, Codex, opencode) or set agent.default.",
+        );
+      }
+      const harness = getHarness(id);
+      if (!harness) {
+        jsonError(`Unknown harness: ${id}`);
+      }
+      const override =
+        (await getSetting(db, `agent.${harness.id}.command`)) || undefined;
+      const executable = resolveHarnessExecutable(harness, override);
+      if (!executable) {
+        jsonError(
+          `${harness.label} was not detected. Set its path: zam settings set agent.${harness.id}.command <path>`,
+        );
+      }
+      let workspace =
+        (await getSetting(db, "personal.workspace_dir")) ||
+        join(homedir(), "Documents", "zam");
+      if (!existsSync(workspace)) workspace = homedir();
+      launchHarness(harness, {
+        executable,
+        workspace,
+        shell: normalizeShell(undefined),
+      });
+      jsonOut({
+        ok: true,
+        id: harness.id,
+        label: harness.label,
+        kind: harness.kind,
+        workspace,
+      });
     });
   });
 

--- a/src/cli/commands/provider.ts
+++ b/src/cli/commands/provider.ts
@@ -15,9 +15,11 @@ import { Command } from "commander";
 import type { Database } from "../../kernel/index.js";
 import {
   clearProviderApiKey,
+  getMachineAiConfig,
   getProviderApiKey,
   getSetting,
   listProviderApiKeyRefs,
+  saveMachineAiConfig,
   setProviderApiKey,
   setSetting,
 } from "../../kernel/index.js";
@@ -31,10 +33,13 @@ export const VALID_API_FLAVORS: ApiFlavor[] = [
 export const VALID_ROLES: LlmRole[] = ["vision", "recall", "text"];
 
 export interface ProviderRecord {
+  label?: string;
   url?: string;
   model?: string;
   apiFlavor?: ApiFlavor;
   apiKeyRef?: string;
+  local?: boolean;
+  runner?: string;
 }
 export type ProvidersMap = Record<string, ProviderRecord>;
 export interface RoleBinding {
@@ -56,6 +61,9 @@ export function upsertProviderRecord(
   if (patch.model !== undefined) merged.model = patch.model;
   if (patch.apiFlavor !== undefined) merged.apiFlavor = patch.apiFlavor;
   if (patch.apiKeyRef !== undefined) merged.apiKeyRef = patch.apiKeyRef;
+  if (patch.label !== undefined) merged.label = patch.label;
+  if (patch.local !== undefined) merged.local = patch.local;
+  if (patch.runner !== undefined) merged.runner = patch.runner;
   return { ...providers, [name]: merged };
 }
 
@@ -101,6 +109,9 @@ export interface ProviderListingRow {
   model?: string;
   apiFlavor: ApiFlavor;
   apiKeyRef?: string;
+  label?: string;
+  local?: boolean;
+  runner?: string;
   keyState: "set" | "missing" | "none";
 }
 
@@ -115,7 +126,7 @@ export function buildProviderListing(
     let keyState: ProviderListingRow["keyState"];
     if (!rec.apiKeyRef) keyState = "none";
     else keyState = hasKey(rec.apiKeyRef) ? "set" : "missing";
-    return {
+    const row: ProviderListingRow = {
       name,
       url: rec.url,
       model: rec.model,
@@ -123,6 +134,10 @@ export function buildProviderListing(
       apiKeyRef: rec.apiKeyRef,
       keyState,
     };
+    if (rec.label !== undefined) row.label = rec.label;
+    if (rec.local !== undefined) row.local = rec.local;
+    if (rec.runner !== undefined) row.runner = rec.runner;
+    return row;
   });
 }
 
@@ -156,11 +171,65 @@ const readProviders = (db: Database): Promise<ProvidersMap> =>
 const readRoles = (db: Database): Promise<RolesMap> =>
   readJson<RolesMap>(db, "llm.roles", {});
 
-async function writeProviders(db: Database, p: ProvidersMap): Promise<void> {
+async function readScopedProviders(
+  db: Database | undefined,
+  machine: boolean,
+): Promise<ProvidersMap> {
+  if (machine) return getMachineAiConfig().providers ?? {};
+  if (!db)
+    throw new Error("Database is required for shared provider settings.");
+  return readProviders(db);
+}
+
+async function readScopedRoles(
+  db: Database | undefined,
+  machine: boolean,
+): Promise<RolesMap> {
+  if (machine) return getMachineAiConfig().roles ?? {};
+  if (!db)
+    throw new Error("Database is required for shared provider settings.");
+  return readRoles(db);
+}
+
+async function writeScopedProviders(
+  db: Database | undefined,
+  machine: boolean,
+  p: ProvidersMap,
+): Promise<void> {
+  if (machine) {
+    const config = getMachineAiConfig();
+    saveMachineAiConfig({ ...config, providers: p });
+    return;
+  }
+  if (!db)
+    throw new Error("Database is required for shared provider settings.");
   await setSetting(db, "llm.providers", JSON.stringify(p));
 }
-async function writeRoles(db: Database, r: RolesMap): Promise<void> {
+
+async function writeScopedRoles(
+  db: Database | undefined,
+  machine: boolean,
+  r: RolesMap,
+): Promise<void> {
+  if (machine) {
+    const config = getMachineAiConfig();
+    saveMachineAiConfig({ ...config, roles: r });
+    return;
+  }
+  if (!db)
+    throw new Error("Database is required for shared provider settings.");
   await setSetting(db, "llm.roles", JSON.stringify(r));
+}
+
+async function withProviderScope(
+  machine: boolean,
+  action: (db: Database | undefined) => Promise<void>,
+): Promise<void> {
+  if (machine) {
+    await action(undefined);
+    return;
+  }
+  await withDb(action);
 }
 
 // ── Command ──────────────────────────────────────────────────────────────────
@@ -175,10 +244,12 @@ providerCommand
   .command("list")
   .description("Show configured providers, role bindings, and key status")
   .option("--json", "Output as JSON")
+  .option("--machine", "Read machine-local providers from ~/.zam/config.json")
   .action(async (opts) => {
-    await withDb(async (db) => {
-      const providers = await readProviders(db);
-      const roles = await readRoles(db);
+    const machine = Boolean(opts.machine);
+    await withProviderScope(machine, async (db) => {
+      const providers = await readScopedProviders(db, machine);
+      const roles = await readScopedRoles(db, machine);
       const rows = buildProviderListing(
         providers,
         (ref) => getProviderApiKey(ref) !== null,
@@ -187,12 +258,23 @@ providerCommand
 
       if (opts.json) {
         console.log(
-          JSON.stringify({ providers: rows, roles, orphans }, null, 2),
+          JSON.stringify(
+            {
+              scope: machine ? "machine" : "shared",
+              providers: rows,
+              roles,
+              orphans,
+            },
+            null,
+            2,
+          ),
         );
         return;
       }
 
-      console.log("Providers (llm.providers):\n");
+      console.log(
+        `Providers (${opts.machine ? "~/.zam/config.json ai.providers" : "llm.providers"}):\n`,
+      );
       if (rows.length === 0) {
         console.log(
           "  (none) — add one: zam provider add <name> --url <url> --model <model>",
@@ -209,6 +291,11 @@ providerCommand
           console.log(`      url:    ${row.url ?? "(inherits llm.url)"}`);
           console.log(`      model:  ${row.model ?? "(inherits llm.model)"}`);
           console.log(`      flavor: ${row.apiFlavor}`);
+          if (row.label) console.log(`      label:  ${row.label}`);
+          if (row.local !== undefined) {
+            console.log(`      local:  ${row.local ? "yes" : "no"}`);
+          }
+          if (row.runner) console.log(`      runner: ${row.runner}`);
           if (row.apiKeyRef) console.log(`      key-ref: ${row.apiKeyRef}`);
         }
       }
@@ -237,8 +324,14 @@ providerCommand
 providerCommand
   .command("add <name>")
   .description("Add or update a provider record in llm.providers")
+  .option("--label <label>", "Human-readable provider label")
   .option("--url <url>", "Endpoint base URL (e.g. https://api.deepseek.com/v1)")
   .option("--model <model>", "Model id (e.g. deepseek-v4-flash)")
+  .option("--local", "Mark this provider as a local/on-device endpoint")
+  .option(
+    "--runner <runner>",
+    "Local runner hint (flm, foundry-local, ollama, ...)",
+  )
   .option(
     "--flavor <flavor>",
     `Wire protocol: ${VALID_API_FLAVORS.join(" | ")} (default: inferred from URL)`,
@@ -251,6 +344,7 @@ providerCommand
     "--key <value>",
     "Store this API key now (prefer `set-key` to keep it out of shell history)",
   )
+  .option("--machine", "Store this provider in ~/.zam/config.json")
   .action(async (name, opts) => {
     let apiFlavor: ApiFlavor | undefined;
     if (opts.flavor) {
@@ -265,21 +359,32 @@ providerCommand
     const apiKeyRef: string | undefined =
       opts.keyRef ?? (opts.key ? name : undefined);
 
-    await withDb(async (db) => {
-      const providers = await readProviders(db);
+    const machine = Boolean(opts.machine);
+    await withProviderScope(machine, async (db) => {
+      const providers = await readScopedProviders(db, machine);
       const next = upsertProviderRecord(providers, name, {
+        label: opts.label,
         url: opts.url,
         model: opts.model,
         apiFlavor,
         apiKeyRef,
+        local: opts.local ? true : undefined,
+        runner: opts.runner,
       });
-      await writeProviders(db, next);
+      await writeScopedProviders(db, machine, next);
       if (opts.key && apiKeyRef) setProviderApiKey(apiKeyRef, opts.key);
 
       const rec = next[name];
-      console.log(`Provider "${name}" saved:`);
+      console.log(
+        `Provider "${name}" saved (${machine ? "machine-local" : "shared"}):`,
+      );
       console.log(`  url:     ${rec.url ?? "(inherits llm.url)"}`);
       console.log(`  model:   ${rec.model ?? "(inherits llm.model)"}`);
+      if (rec.label) console.log(`  label:   ${rec.label}`);
+      if (rec.local !== undefined) {
+        console.log(`  local:   ${rec.local ? "yes" : "no"}`);
+      }
+      if (rec.runner) console.log(`  runner:  ${rec.runner}`);
       console.log(
         `  flavor:  ${
           rec.apiFlavor ??
@@ -310,9 +415,11 @@ providerCommand
 providerCommand
   .command("remove <name>")
   .description("Remove a provider record from llm.providers")
-  .action(async (name) => {
-    await withDb(async (db) => {
-      const providers = await readProviders(db);
+  .option("--machine", "Remove from ~/.zam/config.json instead of the DB")
+  .action(async (name, opts) => {
+    const machine = Boolean(opts.machine);
+    await withProviderScope(machine, async (db) => {
+      const providers = await readScopedProviders(db, machine);
       const { providers: next, removed } = removeProviderRecord(
         providers,
         name,
@@ -321,10 +428,15 @@ providerCommand
         console.log(`No such provider: ${name}`);
         return;
       }
-      await writeProviders(db, next);
-      console.log(`Removed provider "${name}".`);
+      await writeScopedProviders(db, machine, next);
+      console.log(
+        `Removed provider "${name}" (${machine ? "machine-local" : "shared"}).`,
+      );
 
-      const referencing = rolesReferencing(await readRoles(db), name);
+      const referencing = rolesReferencing(
+        await readScopedRoles(db, machine),
+        name,
+      );
       if (referencing.length > 0) {
         console.log(
           `  ⚠ Still referenced by role(s): ${referencing.join(", ")} — rebind with: zam provider use <role> --primary <name>`,
@@ -340,6 +452,7 @@ providerCommand
   .description(`Bind providers to a role (${VALID_ROLES.join(" | ")})`)
   .option("--primary <name>", "Primary provider")
   .option("--fallback <name>", "Fallback provider (optional)")
+  .option("--machine", "Bind the role in ~/.zam/config.json")
   .action(async (role, opts) => {
     if (!VALID_ROLES.includes(role)) {
       console.error(`Invalid role: ${role}. Use ${VALID_ROLES.join(", ")}.`);
@@ -349,19 +462,23 @@ providerCommand
       console.error("--primary is required.");
       process.exit(1);
     }
-    await withDb(async (db) => {
-      const providers = await readProviders(db);
-      await writeRoles(
+    const machine = Boolean(opts.machine);
+    await withProviderScope(machine, async (db) => {
+      const providers = await readScopedProviders(db, machine);
+      await writeScopedRoles(
         db,
+        machine,
         bindRoleProviders(
-          await readRoles(db),
+          await readScopedRoles(db, machine),
           role,
           opts.primary,
           opts.fallback,
         ),
       );
       const fb = opts.fallback ? `, fallback: ${opts.fallback}` : "";
-      console.log(`Role "${role}" → primary: ${opts.primary}${fb}`);
+      console.log(
+        `Role "${role}" → primary: ${opts.primary}${fb} (${machine ? "machine-local" : "shared"})`,
+      );
 
       for (const [label, ref] of [
         ["primary", opts.primary],

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -7,8 +7,14 @@
  * upgrading zam (with --force) to refresh the skill files.
  */
 
-import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import {
@@ -26,25 +32,67 @@ const packageRoot =
   ].find((candidate) => existsSync(join(candidate, "package.json"))) ??
   fileURLToPath(new URL("../..", import.meta.url));
 
-const SKILL_PAIRS: Array<{ from: string; to: string }> = [
+export type SetupAgent = "claude" | "copilot" | "codex" | "agent";
+
+const ALL_SETUP_AGENTS: SetupAgent[] = ["claude", "copilot", "codex", "agent"];
+
+const SKILL_PAIRS: Array<{
+  from: string;
+  to: string;
+  agents: SetupAgent[];
+}> = [
   {
     from: join(packageRoot, ".claude", "skills", "zam", "SKILL.md"),
     to: join(".claude", "skills", "zam", "SKILL.md"),
+    agents: ["claude"],
   },
   {
     from: join(packageRoot, ".agent", "skills", "zam", "SKILL.md"),
     to: join(".agent", "skills", "zam", "SKILL.md"),
+    agents: ["agent"],
   },
   {
     from: join(packageRoot, ".agents", "skills", "zam", "SKILL.md"),
     to: join(".agents", "skills", "zam", "SKILL.md"),
+    agents: ["copilot", "codex"],
   },
 ];
 
-export function copySkills(force: boolean, cwd: string = process.cwd()): void {
+export function parseSetupAgents(value?: string): Set<SetupAgent> {
+  if (!value || value.trim().toLowerCase() === "all") {
+    return new Set(ALL_SETUP_AGENTS);
+  }
+  const aliases: Record<string, SetupAgent[]> = {
+    claude: ["claude"],
+    copilot: ["copilot"],
+    codex: ["codex"],
+    agent: ["agent"],
+    opencode: ["agent"],
+  };
+  const selected = new Set<SetupAgent>();
+  for (const raw of value.split(",")) {
+    const key = raw.trim().toLowerCase();
+    const mapped = aliases[key];
+    if (!mapped) {
+      throw new Error(
+        `Unknown agent "${raw}". Use: all, claude, copilot, codex, agent.`,
+      );
+    }
+    for (const item of mapped) selected.add(item);
+  }
+  return selected;
+}
+
+export function copySkills(
+  force: boolean,
+  cwd: string = process.cwd(),
+  agents: Set<SetupAgent> = parseSetupAgents(),
+  dryRun = false,
+): void {
   let anyAction = false;
 
-  for (const { from, to } of SKILL_PAIRS) {
+  for (const { from, to, agents: pairAgents } of SKILL_PAIRS) {
+    if (!pairAgents.some((agent) => agents.has(agent))) continue;
     const dest = join(cwd, to);
 
     if (!existsSync(from)) {
@@ -54,6 +102,12 @@ export function copySkills(force: boolean, cwd: string = process.cwd()): void {
 
     if (existsSync(dest) && !force) {
       console.log(`  skip  ${to} (already present â€” use --force to update)`);
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`  would copy  ${to}`);
+      anyAction = true;
       continue;
     }
 
@@ -102,22 +156,84 @@ async function initDatabase(skipInit: boolean): Promise<void> {
   }
 }
 
+const ZAM_BLOCK_START = "<!-- ZAM:START -->";
+const ZAM_BLOCK_END = "<!-- ZAM:END -->";
+
+function upsertMarkedBlock(
+  dest: string,
+  blockBody: string,
+  dryRun: boolean,
+): "write" | "update" | "skip" {
+  const block = `${ZAM_BLOCK_START}\n${blockBody.trim()}\n${ZAM_BLOCK_END}`;
+  if (!existsSync(dest)) {
+    if (!dryRun) {
+      mkdirSync(dirname(dest), { recursive: true });
+      writeFileSync(dest, `${block}\n`, "utf8");
+    }
+    return "write";
+  }
+
+  const existing = readFileSync(dest, "utf8");
+  if (existing.includes(block)) return "skip";
+
+  const start = existing.indexOf(ZAM_BLOCK_START);
+  const end = existing.indexOf(ZAM_BLOCK_END);
+  const next =
+    start >= 0 && end > start
+      ? `${existing.slice(0, start)}${block}${existing.slice(end + ZAM_BLOCK_END.length)}`
+      : `${existing.trimEnd()}\n\n${block}\n`;
+
+  if (!dryRun) writeFileSync(dest, next, "utf8");
+  return start >= 0 && end > start ? "update" : "write";
+}
+
+function logInstructionAction(
+  action: "write" | "update" | "skip",
+  label: string,
+  dryRun: boolean,
+): void {
+  if (action === "skip") {
+    console.log(`  skip  ${label} (ZAM block already present)`);
+  } else {
+    console.log(`  ${dryRun ? "would " : ""}${action} ${label}`);
+  }
+}
+
+export interface InstructionWriteOptions {
+  dryRun?: boolean;
+  updateExisting?: boolean;
+}
+
 export function writeClaudeMd(
   skipClaudeMd: boolean,
   cwd: string = process.cwd(),
+  opts: InstructionWriteOptions = {},
 ): void {
   if (skipClaudeMd) return;
 
   const dest = join(cwd, "CLAUDE.md");
   if (existsSync(dest)) {
-    console.log(`  skip  CLAUDE.md (already present)`);
+    if (!opts.updateExisting) {
+      console.log(`  skip  CLAUDE.md (already present)`);
+      return;
+    }
+    const action = upsertMarkedBlock(
+      dest,
+      `## ZAM learning sessions
+
+ZAM is available in this repository. Use the \`zam\` skill in Claude Code to turn real work into an observed learning session with active recall and FSRS scheduling.
+
+- Skill files live under \`.claude/skills/zam/\`.
+- Fast-changing review data lives in \`~/.zam/\`, not in this repository.
+- Run \`zam setup --target . --agents claude --force\` after upgrading ZAM to refresh the skill.`,
+      Boolean(opts.dryRun),
+    );
+    logInstructionAction(action, "CLAUDE.md", Boolean(opts.dryRun));
     return;
   }
 
   const name = basename(cwd);
-  writeFileSync(
-    dest,
-    `# ZAM Personal Kernel â€” ${name}
+  const content = `# ZAM Personal Kernel â€” ${name}
 
 This is a ZAM personal instance. ZAM builds lasting skills through spaced
 repetition during real work â€” not separate study sessions.
@@ -136,28 +252,45 @@ Run \`/zam\` to start a learning session on whatever you are working on.
 Learning tokens, cards, and review history live in local SQLite by default.
 Use \`zam connector setup turso\` to store cloud credentials in
 \`~/.zam/credentials.json\` and use a Turso database across machines.
-`,
-    "utf8",
-  );
-  console.log(`  write CLAUDE.md`);
+`;
+  if (opts.dryRun) {
+    console.log(`  would write CLAUDE.md`);
+  } else {
+    writeFileSync(dest, content, "utf8");
+    console.log(`  write CLAUDE.md`);
+  }
 }
 
 export function writeAgentsMd(
   skipAgentsMd: boolean,
   cwd: string = process.cwd(),
+  opts: InstructionWriteOptions = {},
 ): void {
   if (skipAgentsMd) return;
 
   const dest = join(cwd, "AGENTS.md");
   if (existsSync(dest)) {
-    console.log(`  skip  AGENTS.md (already present)`);
+    if (!opts.updateExisting) {
+      console.log(`  skip  AGENTS.md (already present)`);
+      return;
+    }
+    const action = upsertMarkedBlock(
+      dest,
+      `## ZAM learning sessions
+
+ZAM is available in this repository. Select the \`zam\` skill through \`/skills\` or invoke \`$zam\` where supported to turn real work into an observed learning session with active recall and FSRS scheduling.
+
+- Skill files live under \`.agents/skills/zam/\`.
+- Fast-changing review data lives in \`~/.zam/\`, not in this repository.
+- Run \`zam setup --target . --agents copilot,codex --force\` after upgrading ZAM to refresh the skill.`,
+      Boolean(opts.dryRun),
+    );
+    logInstructionAction(action, "AGENTS.md", Boolean(opts.dryRun));
     return;
   }
 
   const name = basename(cwd);
-  writeFileSync(
-    dest,
-    `# ZAM Personal Kernel - ${name}
+  const content = `# ZAM Personal Kernel - ${name}
 
 This is a ZAM personal instance. ZAM builds lasting skills through spaced
 repetition during real work, not separate study sessions.
@@ -183,10 +316,35 @@ Use \`zam connector setup turso\` to store cloud credentials in
 ## Codex skills
 Codex discovers repository skills under \`.agents/skills/\`. Run
 \`zam setup --force\` after upgrading \`zam-core\` to refresh them.
-`,
-    "utf8",
+`;
+  if (opts.dryRun) {
+    console.log(`  would write AGENTS.md`);
+  } else {
+    writeFileSync(dest, content, "utf8");
+    console.log(`  write AGENTS.md`);
+  }
+}
+
+export function writeCopilotInstructions(
+  cwd: string = process.cwd(),
+  opts: InstructionWriteOptions = {},
+): void {
+  const dest = join(cwd, ".github", "copilot-instructions.md");
+  const action = upsertMarkedBlock(
+    dest,
+    `## ZAM learning sessions
+
+ZAM is available in this repository through \`.agents/skills/zam/\`. Use the \`zam\` skill from Copilot-compatible skill selection surfaces to turn real work into an observed learning session with active recall and FSRS scheduling.
+
+- Fast-changing review data lives in \`~/.zam/\`, not in this repository.
+- Run \`zam setup --target . --agents copilot --force\` after upgrading ZAM to refresh the skill.`,
+    Boolean(opts.dryRun),
   );
-  console.log(`  write AGENTS.md`);
+  logInstructionAction(
+    action,
+    ".github/copilot-instructions.md",
+    Boolean(opts.dryRun),
+  );
 }
 
 export const setupCommand = new Command("setup")
@@ -201,19 +359,60 @@ export const setupCommand = new Command("setup")
   .option("--skip-init", "skip database initialization", false)
   .option("--skip-claude-md", "skip CLAUDE.md generation", false)
   .option("--skip-agents-md", "skip AGENTS.md generation", false)
+  .option("--target <path>", "repository/workspace directory to set up")
+  .option(
+    "--agents <list>",
+    "comma-separated agents to wire: all, claude, copilot, codex, agent",
+  )
+  .option(
+    "--dry-run",
+    "show what would be written without changing files",
+    false,
+  )
   .action(
     async (opts: {
       force: boolean;
       skipInit: boolean;
       skipClaudeMd: boolean;
       skipAgentsMd: boolean;
+      target?: string;
+      agents?: string;
+      dryRun: boolean;
     }) => {
-      console.log(`Setting up ZAM in ${process.cwd()}\n`);
+      let agents: Set<SetupAgent>;
+      try {
+        agents = parseSetupAgents(opts.agents);
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
 
-      copySkills(opts.force);
-      await initDatabase(opts.skipInit);
-      writeClaudeMd(opts.skipClaudeMd);
-      writeAgentsMd(opts.skipAgentsMd);
+      const target = resolve(opts.target ?? process.cwd());
+      const updateExistingInstructions = Boolean(opts.target) || opts.force;
+      console.log(
+        `Setting up ZAM in ${target}${opts.dryRun ? " (dry run)" : ""}\n`,
+      );
+
+      copySkills(opts.force, target, agents, opts.dryRun);
+      await initDatabase(opts.skipInit || opts.dryRun);
+      if (agents.has("claude")) {
+        writeClaudeMd(opts.skipClaudeMd, target, {
+          dryRun: opts.dryRun,
+          updateExisting: updateExistingInstructions,
+        });
+      }
+      if (agents.has("copilot") || agents.has("codex") || agents.has("agent")) {
+        writeAgentsMd(opts.skipAgentsMd, target, {
+          dryRun: opts.dryRun,
+          updateExisting: updateExistingInstructions,
+        });
+      }
+      if (agents.has("copilot") && (opts.target || opts.agents)) {
+        writeCopilotInstructions(target, {
+          dryRun: opts.dryRun,
+          updateExisting: updateExistingInstructions,
+        });
+      }
 
       console.log(
         "\nDone. Run `zam whoami --set <your-id>` to set your identity. Start the `zam` skill with `/zam` in Claude/Gemini-compatible clients or `$zam` (or `/skills`) in Codex.",

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -9,16 +9,28 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { confirm, input } from "@inquirer/prompts";
 import { Command } from "commander";
 import type { Database } from "../../kernel/index.js";
 import {
+  getConfiguredWorkspaces,
   getDatabaseTargetInfo,
   getSetting,
   hasCommand,
   openDatabase,
+  upsertConfiguredWorkspace,
+  type WorkspaceConfig,
+  type WorkspaceKind,
+  type WorkspaceSourceControl,
 } from "../../kernel/index.js";
+import {
+  copySkills,
+  parseSetupAgents,
+  writeAgentsMd,
+  writeClaudeMd,
+  writeCopilotInstructions,
+} from "./setup.js";
 
 /**
  * Execute a shell command inside a specific directory.
@@ -51,6 +63,195 @@ export function gitRemoteArgs(githubUrl: string, hasOrigin: boolean): string[] {
 export const workspaceCommand = new Command("workspace").description(
   "Manage your ZAM learning workspace",
 );
+
+const WORKSPACE_KINDS: WorkspaceKind[] = [
+  "personal",
+  "team",
+  "family",
+  "community",
+  "organization",
+  "custom",
+];
+const WORKSPACE_SOURCE_CONTROLS: WorkspaceSourceControl[] = [
+  "github",
+  "azure-devops",
+  "git",
+  "none",
+];
+
+function parseWorkspaceKind(value?: string): WorkspaceKind {
+  const kind = (value ?? "custom").toLowerCase();
+  if (WORKSPACE_KINDS.includes(kind as WorkspaceKind)) {
+    return kind as WorkspaceKind;
+  }
+  throw new Error(
+    `Invalid workspace kind: ${value}. Use ${WORKSPACE_KINDS.join(", ")}.`,
+  );
+}
+
+function parseWorkspaceSourceControl(
+  value?: string,
+): WorkspaceSourceControl | undefined {
+  if (!value) return undefined;
+  const source = value.toLowerCase();
+  if (WORKSPACE_SOURCE_CONTROLS.includes(source as WorkspaceSourceControl)) {
+    return source as WorkspaceSourceControl;
+  }
+  throw new Error(
+    `Invalid source control: ${value}. Use ${WORKSPACE_SOURCE_CONTROLS.join(", ")}.`,
+  );
+}
+
+function parseScopes(value?: string): string[] | undefined {
+  if (!value) return undefined;
+  const scopes = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return scopes.length > 0 ? scopes : undefined;
+}
+
+function requireWorkspace(id: string): WorkspaceConfig {
+  const workspace = getConfiguredWorkspaces().find((item) => item.id === id);
+  if (!workspace) {
+    throw new Error(
+      `Workspace "${id}" is not configured. Add it with: zam workspace add ${id} --path <dir>`,
+    );
+  }
+  return workspace;
+}
+
+workspaceCommand
+  .command("list")
+  .description("List configured ZAM workspaces")
+  .option("--json", "Output as JSON")
+  .action((opts: { json?: boolean }) => {
+    const workspaces = getConfiguredWorkspaces();
+    if (opts.json) {
+      console.log(JSON.stringify({ workspaces }, null, 2));
+      return;
+    }
+
+    console.log("Configured ZAM workspaces:\n");
+    if (workspaces.length === 0) {
+      console.log(
+        "  (none) — add one: zam workspace add personal --path <dir>",
+      );
+      return;
+    }
+
+    for (const workspace of workspaces) {
+      const label = workspace.label ? ` (${workspace.label})` : "";
+      console.log(`  ${workspace.id}${label}`);
+      console.log(`      kind: ${workspace.kind}`);
+      console.log(`      path: ${workspace.path}`);
+      if (workspace.sourceControl) {
+        console.log(`      source: ${workspace.sourceControl}`);
+      }
+      if (workspace.knowledgeScopes?.length) {
+        console.log(`      scopes: ${workspace.knowledgeScopes.join(", ")}`);
+      }
+    }
+  });
+
+workspaceCommand
+  .command("add <id>")
+  .description("Register an existing directory as a ZAM workspace")
+  .requiredOption("--path <dir>", "Existing workspace/repository directory")
+  .option(
+    "--kind <kind>",
+    `Workspace kind (${WORKSPACE_KINDS.join(" | ")})`,
+    "custom",
+  )
+  .option("--label <label>", "Human-readable label")
+  .option(
+    "--source-control <provider>",
+    `Source-control provider (${WORKSPACE_SOURCE_CONTROLS.join(" | ")})`,
+  )
+  .option("--scopes <list>", "Comma-separated knowledge scopes")
+  .option("--default-agent <id>", "Default agent harness for this workspace")
+  .action((id, opts) => {
+    try {
+      const path = resolve(String(opts.path));
+      if (!existsSync(path)) {
+        console.error(`Workspace path does not exist: ${path}`);
+        process.exit(1);
+      }
+      const workspace: WorkspaceConfig = {
+        id,
+        kind: parseWorkspaceKind(opts.kind),
+        path,
+        ...(opts.label ? { label: opts.label } : {}),
+        ...(opts.sourceControl
+          ? { sourceControl: parseWorkspaceSourceControl(opts.sourceControl) }
+          : {}),
+        ...(parseScopes(opts.scopes)
+          ? { knowledgeScopes: parseScopes(opts.scopes) }
+          : {}),
+        ...(opts.defaultAgent ? { defaultAgent: opts.defaultAgent } : {}),
+      };
+      upsertConfiguredWorkspace(workspace);
+      console.log(`Registered workspace "${id}" at ${path}.`);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+workspaceCommand
+  .command("setup <id>")
+  .description("Install ZAM skills into a configured workspace")
+  .option(
+    "--agents <list>",
+    "comma-separated agents to wire: all, claude, copilot, codex, agent",
+  )
+  .option(
+    "--force",
+    "overwrite existing skill files and refresh ZAM blocks",
+    false,
+  )
+  .option(
+    "--dry-run",
+    "show what would be written without changing files",
+    false,
+  )
+  .action((id, opts) => {
+    try {
+      const workspace = requireWorkspace(id);
+      const agents = parseSetupAgents(opts.agents);
+      console.log(
+        `Setting up workspace "${workspace.id}" in ${workspace.path}${opts.dryRun ? " (dry run)" : ""}\n`,
+      );
+
+      copySkills(
+        Boolean(opts.force),
+        workspace.path,
+        agents,
+        Boolean(opts.dryRun),
+      );
+      if (agents.has("claude")) {
+        writeClaudeMd(false, workspace.path, {
+          dryRun: Boolean(opts.dryRun),
+          updateExisting: true,
+        });
+      }
+      if (agents.has("copilot") || agents.has("codex") || agents.has("agent")) {
+        writeAgentsMd(false, workspace.path, {
+          dryRun: Boolean(opts.dryRun),
+          updateExisting: true,
+        });
+      }
+      if (agents.has("copilot")) {
+        writeCopilotInstructions(workspace.path, {
+          dryRun: Boolean(opts.dryRun),
+          updateExisting: true,
+        });
+      }
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
 
 workspaceCommand
   .command("publish")

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -16,6 +16,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import type { Database, SupportedLocale } from "../../kernel/index.js";
 import {
+  getMachineAiConfig,
   getProviderApiKey,
   getSetting,
   getSystemProfile,
@@ -95,6 +96,10 @@ export interface ProviderConfig {
   apiKey: string;
   apiFlavor: ApiFlavor;
   locale: SupportedLocale;
+  providerName?: string;
+  label?: string;
+  source: "legacy" | "shared" | "machine";
+  local: boolean;
   /** Vision only: max frames to sample from a recording. */
   maxFrames?: number;
   /** Optional next endpoint to try when the primary is unusable. */
@@ -113,11 +118,14 @@ export function inferApiFlavor(url: string): ApiFlavor {
 }
 
 interface ProviderRecord {
+  label?: string;
   url?: string;
   model?: string;
   apiFlavor?: ApiFlavor;
   apiKey?: string;
   apiKeyRef?: string;
+  local?: boolean;
+  runner?: string;
 }
 type ProvidersMap = Record<string, ProviderRecord>;
 interface RoleBinding {
@@ -174,22 +182,64 @@ export async function getProviderForRole(
   const roles = await readJsonSetting<RolesMap>(db, "llm.roles");
   const binding = roles?.[role];
 
+  let resolved = base;
   if (providers && binding?.primary && providers[binding.primary]) {
-    const primary = materializeProvider(providers[binding.primary], base, role);
+    const primary = materializeProvider(
+      providers[binding.primary],
+      base,
+      role,
+      {
+        providerName: binding.primary,
+        source: "shared",
+      },
+    );
     const fallback =
       binding.fallback && providers[binding.fallback]
-        ? materializeProvider(providers[binding.fallback], base, role)
+        ? materializeProvider(providers[binding.fallback], base, role, {
+            providerName: binding.fallback,
+            source: "shared",
+          })
+        : undefined;
+    resolved = { ...primary, fallback };
+  }
+
+  const machine = getMachineAiConfig();
+  const machineProviders = machine.providers as ProvidersMap | undefined;
+  const machineBinding = machine.roles?.[role];
+  if (
+    machineProviders &&
+    machineBinding?.primary &&
+    machineProviders[machineBinding.primary]
+  ) {
+    const primary = materializeProvider(
+      machineProviders[machineBinding.primary],
+      resolved,
+      role,
+      { providerName: machineBinding.primary, source: "machine" },
+    );
+    const fallback =
+      machineBinding.fallback && machineProviders[machineBinding.fallback]
+        ? materializeProvider(
+            machineProviders[machineBinding.fallback],
+            resolved,
+            role,
+            { providerName: machineBinding.fallback, source: "machine" },
+          )
         : undefined;
     return { ...primary, fallback };
   }
 
-  return base;
+  return resolved;
 }
 
 function materializeProvider(
   rec: ProviderRecord,
   base: ProviderConfig,
   role: LlmRole,
+  meta: {
+    providerName: string;
+    source: ProviderConfig["source"];
+  },
 ): ProviderConfig {
   const url = rec.url || base.url;
   return {
@@ -199,6 +249,10 @@ function materializeProvider(
     apiKey: resolveProviderApiKey(rec),
     apiFlavor: rec.apiFlavor || inferApiFlavor(url),
     locale: base.locale,
+    providerName: meta.providerName,
+    label: rec.label,
+    source: meta.source,
+    local: rec.local ?? isLocalEndpoint(url),
     ...(role === "vision" ? { maxFrames: base.maxFrames } : {}),
   };
 }
@@ -224,6 +278,8 @@ async function getLegacyRoleConfig(
       apiKey: (await getSetting(db, "llm.vision.api_key")) || base.apiKey,
       apiFlavor: inferApiFlavor(url),
       locale: base.locale,
+      source: "legacy",
+      local: isLocalEndpoint(url),
       maxFrames: Number.isNaN(parsed) ? 100 : parsed,
     };
   }
@@ -236,6 +292,8 @@ async function getLegacyRoleConfig(
     apiKey: base.apiKey,
     apiFlavor: inferApiFlavor(base.url),
     locale: base.locale,
+    source: "legacy",
+    local: isLocalEndpoint(base.url),
   };
 }
 
@@ -628,11 +686,21 @@ async function isVisionProviderModelExplicit(
   const providers = await readJsonSetting<ProvidersMap>(db, "llm.providers");
   const roles = await readJsonSetting<RolesMap>(db, "llm.roles");
   const binding = roles?.vision;
-  if (!providers || !binding) return false;
-
-  return [binding.primary, binding.fallback].some((id) => {
+  const sharedExplicit = [binding?.primary, binding?.fallback].some((id) => {
     if (!id) return false;
-    const rec = providers[id];
+    const rec = providers?.[id];
+    return (
+      rec?.model === active.model &&
+      (rec.url === undefined || rec.url === active.url)
+    );
+  });
+  if (sharedExplicit) return true;
+
+  const machine = getMachineAiConfig();
+  const machineBinding = machine.roles?.vision;
+  return [machineBinding?.primary, machineBinding?.fallback].some((id) => {
+    if (!id) return false;
+    const rec = machine.providers?.[id];
     return (
       rec?.model === active.model &&
       (rec.url === undefined || rec.url === active.url)
@@ -678,6 +746,130 @@ export async function checkVisionReadiness(
     usable: cfg.enabled && online && modelAvailable,
     visionModelExplicit,
     warning,
+  };
+}
+
+export interface ProviderRoleStatus {
+  role: LlmRole;
+  enabled: boolean;
+  providerName?: string;
+  label?: string;
+  source: ProviderConfig["source"];
+  url: string;
+  model: string;
+  apiFlavor: ApiFlavor;
+  local: boolean;
+  online: boolean;
+  modelAvailable: boolean;
+  availableModels: string[];
+  usable: boolean;
+  reason?: "disabled" | "offline" | "model-not-found" | "unsupported-provider";
+  fallback?: {
+    providerName?: string;
+    label?: string;
+    source: ProviderConfig["source"];
+    url: string;
+    model: string;
+    apiFlavor: ApiFlavor;
+    local: boolean;
+  };
+}
+
+function summarizeFallback(
+  provider: ProviderConfig | undefined,
+): ProviderRoleStatus["fallback"] {
+  if (!provider) return undefined;
+  return {
+    providerName: provider.providerName,
+    label: provider.label,
+    source: provider.source,
+    url: provider.url,
+    model: provider.model,
+    apiFlavor: provider.apiFlavor,
+    local: provider.local,
+  };
+}
+
+/** Secret-safe status for a provider role, suitable for bridge/UI output. */
+export async function getProviderRoleStatus(
+  db: Database,
+  role: LlmRole,
+): Promise<ProviderRoleStatus> {
+  const cfg = await getProviderForRole(db, role);
+  const unsupportedProvider =
+    role !== "vision" && cfg.apiFlavor !== "chat-completions";
+
+  if (!cfg.enabled) {
+    return {
+      role,
+      enabled: false,
+      providerName: cfg.providerName,
+      label: cfg.label,
+      source: cfg.source,
+      url: cfg.url,
+      model: cfg.model,
+      apiFlavor: cfg.apiFlavor,
+      local: cfg.local,
+      online: false,
+      modelAvailable: false,
+      availableModels: [],
+      usable: false,
+      reason: "disabled",
+      fallback: summarizeFallback(cfg.fallback),
+    };
+  }
+
+  if (unsupportedProvider) {
+    return {
+      role,
+      enabled: true,
+      providerName: cfg.providerName,
+      label: cfg.label,
+      source: cfg.source,
+      url: cfg.url,
+      model: cfg.model,
+      apiFlavor: cfg.apiFlavor,
+      local: cfg.local,
+      online: false,
+      modelAvailable: false,
+      availableModels: [],
+      usable: false,
+      reason: "unsupported-provider",
+      fallback: summarizeFallback(cfg.fallback),
+    };
+  }
+
+  let selected: ProviderEndpointReadiness;
+  if (role === "vision") {
+    const chain = await checkProviderChain(cfg);
+    selected = chain.firstUsable ?? chain.primary;
+  } else {
+    selected = await checkProviderEndpoint(cfg);
+  }
+  const active = selected.endpoint;
+  const usable = selected.online && selected.modelAvailable;
+  const reason = usable
+    ? undefined
+    : selected.online
+      ? "model-not-found"
+      : "offline";
+
+  return {
+    role,
+    enabled: true,
+    providerName: active.providerName,
+    label: active.label,
+    source: active.source,
+    url: active.url,
+    model: active.model,
+    apiFlavor: active.apiFlavor,
+    local: active.local,
+    online: selected.online,
+    modelAvailable: selected.modelAvailable,
+    availableModels: selected.availableModels,
+    usable,
+    reason,
+    fallback: summarizeFallback(cfg.fallback),
   };
 }
 

--- a/src/cli/terminal-open.ts
+++ b/src/cli/terminal-open.ts
@@ -173,7 +173,12 @@ function isItermRunning(): boolean {
   }
 }
 
-function openMacTerminal(shellSetup: string, label: string, dir: string): void {
+function openMacTerminal(
+  shellSetup: string,
+  label: string,
+  dir: string,
+  silent: boolean,
+): void {
   const useIterm = isItermRunning();
   const escaped = shellSetup.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 
@@ -194,14 +199,18 @@ end tell`;
   try {
     writeFileSync(tmpFile, appleScript);
     execSync(`osascript ${JSON.stringify(tmpFile)}`, { stdio: "ignore" });
-    console.log(
-      `Opened ${useIterm ? "iTerm2" : "Terminal.app"} window (${label})`,
-    );
-    console.log(`  Directory: ${dir}`);
+    if (!silent) {
+      console.log(
+        `Opened ${useIterm ? "iTerm2" : "Terminal.app"} window (${label})`,
+      );
+      console.log(`  Directory: ${dir}`);
+    }
   } catch (err) {
-    console.error(`Failed to open terminal: ${(err as Error).message}`);
-    console.log(`\nRun this manually in a new terminal:\n`);
-    console.log(`  ${shellSetup}`);
+    if (!silent) {
+      console.error(`Failed to open terminal: ${(err as Error).message}`);
+      console.log(`\nRun this manually in a new terminal:\n`);
+      console.log(`  ${shellSetup}`);
+    }
   } finally {
     try {
       unlinkSync(tmpFile);
@@ -216,6 +225,7 @@ function openWindowsPowerShell(
   label: string,
   dir: string,
   requestedShell: TerminalShell,
+  silent: boolean,
 ): void {
   const requestedExecutable =
     requestedShell === "powershell" ? "powershell.exe" : "pwsh.exe";
@@ -238,14 +248,18 @@ function openWindowsPowerShell(
         stdio: "ignore",
       },
     );
-    console.log(
-      `Opened ${executable === "pwsh.exe" ? "PowerShell" : "Windows PowerShell"} window (${label})`,
-    );
-    console.log(`  Directory: ${dir}`);
+    if (!silent) {
+      console.log(
+        `Opened ${executable === "pwsh.exe" ? "PowerShell" : "Windows PowerShell"} window (${label})`,
+      );
+      console.log(`  Directory: ${dir}`);
+    }
   } catch (err) {
-    console.error(`Failed to open PowerShell: ${(err as Error).message}`);
-    console.log(`\nRun this manually in a new PowerShell terminal:\n`);
-    console.log(`  ${shellSetup}`);
+    if (!silent) {
+      console.error(`Failed to open PowerShell: ${(err as Error).message}`);
+      console.log(`\nRun this manually in a new PowerShell terminal:\n`);
+      console.log(`  ${shellSetup}`);
+    }
   }
 }
 
@@ -254,22 +268,27 @@ export function openTerminalWindow(opts: {
   label: string;
   dir: string;
   shell: TerminalShell;
+  silent?: boolean;
+  platform?: NodeJS.Platform;
 }): void {
-  const { shellSetup, label, dir, shell } = opts;
+  const { shellSetup, label, dir, shell, silent = false } = opts;
+  const platform = opts.platform ?? process.platform;
 
-  if (process.platform === "darwin" && !isPowerShellShell(shell)) {
-    openMacTerminal(shellSetup, label, dir);
+  if (platform === "darwin" && !isPowerShellShell(shell)) {
+    openMacTerminal(shellSetup, label, dir, silent);
     return;
   }
 
-  if (process.platform === "win32" && isPowerShellShell(shell)) {
-    openWindowsPowerShell(shellSetup, label, dir, shell);
+  if (platform === "win32" && isPowerShellShell(shell)) {
+    openWindowsPowerShell(shellSetup, label, dir, shell, silent);
     return;
   }
 
-  console.log(`Run this in a new terminal:\n`);
-  console.log(`  ${shellSetup}\n`);
-  console.log(
-    `(Automatic terminal opening is only supported on macOS Terminal/iTerm2 and Windows PowerShell for now.)`,
-  );
+  if (!silent) {
+    console.log(`Run this in a new terminal:\n`);
+    console.log(`  ${shellSetup}\n`);
+    console.log(
+      `(Automatic terminal opening is only supported on macOS Terminal/iTerm2 and Windows PowerShell for now.)`,
+    );
+  }
 }

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -324,15 +324,29 @@ export {
 } from "./system/hooks.js";
 export type { TranslationKey } from "./system/i18n.js";
 export { t } from "./system/i18n.js";
-export type { InstallConfig, InstallMode } from "./system/install-config.js";
+export type {
+  InstallConfig,
+  InstallMode,
+  MachineAiConfig,
+  MachineProviderRecord,
+  MachineRoleBinding,
+  WorkspaceConfig,
+  WorkspaceKind,
+  WorkspaceSourceControl,
+} from "./system/install-config.js";
 export {
   detectSyncProvider,
+  getConfiguredWorkspaces,
   getInstallChannel,
   getInstallMode,
+  getMachineAiConfig,
   loadInstallConfig,
+  saveConfiguredWorkspaces,
   saveInstallConfig,
+  saveMachineAiConfig,
   setInstallChannel,
   setInstallMode,
+  upsertConfiguredWorkspace,
 } from "./system/install-config.js";
 export type {
   InstallPlan,

--- a/src/kernel/system/install-config.ts
+++ b/src/kernel/system/install-config.ts
@@ -24,12 +24,61 @@ export interface InstallConfig {
   mode?: InstallMode;
   /** How this copy was installed; drives the self-update mechanism. */
   channel?: InstallChannel;
+  /** Machine-local AI provider choices; never synchronized through the DB. */
+  ai?: MachineAiConfig;
+  /** Machine-local paths to existing personal/team/community workspaces. */
+  workspaces?: WorkspaceConfig[];
 }
 
-const DEFAULT_CONFIG_PATH = join(homedir(), ".zam", "config.json");
+export type MachineAiRole = "vision" | "recall" | "text";
+export type MachineApiFlavor = "chat-completions" | "anthropic-messages";
+
+export interface MachineProviderRecord {
+  label?: string;
+  url?: string;
+  model?: string;
+  apiFlavor?: MachineApiFlavor;
+  apiKeyRef?: string;
+  local?: boolean;
+  runner?: string;
+}
+
+export interface MachineRoleBinding {
+  primary?: string;
+  fallback?: string;
+}
+
+export interface MachineAiConfig {
+  providers?: Record<string, MachineProviderRecord>;
+  roles?: Partial<Record<MachineAiRole, MachineRoleBinding>>;
+}
+
+export type WorkspaceKind =
+  | "personal"
+  | "team"
+  | "family"
+  | "community"
+  | "organization"
+  | "custom";
+
+export type WorkspaceSourceControl = "github" | "azure-devops" | "git" | "none";
+
+export interface WorkspaceConfig {
+  id: string;
+  label?: string;
+  kind: WorkspaceKind;
+  path: string;
+  sourceControl?: WorkspaceSourceControl;
+  knowledgeScopes?: string[];
+  defaultAgent?: string;
+}
+
+function defaultConfigPath(): string {
+  return process.env.ZAM_CONFIG_PATH || join(homedir(), ".zam", "config.json");
+}
 
 /** Load ~/.zam/config.json. Returns an empty config if missing or unreadable. */
-export function loadInstallConfig(path = DEFAULT_CONFIG_PATH): InstallConfig {
+export function loadInstallConfig(path = defaultConfigPath()): InstallConfig {
   if (!existsSync(path)) return {};
   try {
     return JSON.parse(readFileSync(path, "utf-8")) as InstallConfig;
@@ -41,7 +90,7 @@ export function loadInstallConfig(path = DEFAULT_CONFIG_PATH): InstallConfig {
 /** Persist the install config, preserving any unrelated keys already on disk. */
 export function saveInstallConfig(
   config: InstallConfig,
-  path = DEFAULT_CONFIG_PATH,
+  path = defaultConfigPath(),
 ): void {
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
@@ -53,13 +102,13 @@ export function saveInstallConfig(
  * mode — so existing source/CLI installs keep their behavior. A packaged
  * "default" install writes mode explicitly at install time.
  */
-export function getInstallMode(path = DEFAULT_CONFIG_PATH): InstallMode {
+export function getInstallMode(path = defaultConfigPath()): InstallMode {
   return loadInstallConfig(path).mode ?? "developer";
 }
 
 export function setInstallMode(
   mode: InstallMode,
-  path = DEFAULT_CONFIG_PATH,
+  path = defaultConfigPath(),
 ): void {
   const config = loadInstallConfig(path);
   config.mode = mode;
@@ -71,7 +120,7 @@ export function setInstallMode(
  * back to "developer" for developer mode and "direct" for an installed app
  * whose channel was not recorded.
  */
-export function getInstallChannel(path = DEFAULT_CONFIG_PATH): InstallChannel {
+export function getInstallChannel(path = defaultConfigPath()): InstallChannel {
   const config = loadInstallConfig(path);
   if (config.channel) return config.channel;
   return (config.mode ?? "developer") === "developer" ? "developer" : "direct";
@@ -79,11 +128,54 @@ export function getInstallChannel(path = DEFAULT_CONFIG_PATH): InstallChannel {
 
 export function setInstallChannel(
   channel: InstallChannel,
-  path = DEFAULT_CONFIG_PATH,
+  path = defaultConfigPath(),
 ): void {
   const config = loadInstallConfig(path);
   config.channel = channel;
   saveInstallConfig(config, path);
+}
+
+export function getMachineAiConfig(
+  path = defaultConfigPath(),
+): MachineAiConfig {
+  return loadInstallConfig(path).ai ?? {};
+}
+
+export function saveMachineAiConfig(
+  ai: MachineAiConfig,
+  path = defaultConfigPath(),
+): void {
+  const config = loadInstallConfig(path);
+  config.ai = ai;
+  saveInstallConfig(config, path);
+}
+
+export function getConfiguredWorkspaces(
+  path = defaultConfigPath(),
+): WorkspaceConfig[] {
+  return loadInstallConfig(path).workspaces ?? [];
+}
+
+export function saveConfiguredWorkspaces(
+  workspaces: WorkspaceConfig[],
+  path = defaultConfigPath(),
+): void {
+  const config = loadInstallConfig(path);
+  config.workspaces = workspaces;
+  saveInstallConfig(config, path);
+}
+
+export function upsertConfiguredWorkspace(
+  workspace: WorkspaceConfig,
+  path = defaultConfigPath(),
+): WorkspaceConfig[] {
+  const current = getConfiguredWorkspaces(path);
+  const next = [
+    ...current.filter((candidate) => candidate.id !== workspace.id),
+    workspace,
+  ];
+  saveConfiguredWorkspaces(next, path);
+  return next;
 }
 
 /**

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type AgentHarness,
   AGENT_HARNESSES,
   getHarness,
+  launchHarness,
   planHarnessLaunch,
   resolveHarnessExecutable,
 } from "../../src/cli/agent-harness.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("agent harness registry", () => {
   it("includes the documented harnesses (ADR 2026-06-23)", () => {
@@ -99,6 +104,23 @@ describe("planHarnessLaunch", () => {
       kind: "cli",
       shell: "pwsh",
       shellSetup: "Set-Location -LiteralPath 'C:/work'; & 'C:/bin/claude.cmd'",
+    });
+  });
+
+  describe("launchHarness", () => {
+    it("passes silent mode through for CLI harness terminal output", () => {
+      const claude = getHarness("claude-code") as AgentHarness;
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      launchHarness(claude, {
+        executable: "/usr/bin/claude",
+        workspace: "/work",
+        shell: "bash",
+        platform: "linux",
+        silent: true,
+      });
+
+      expect(log).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/cli/llm-providers.test.ts
+++ b/tests/cli/llm-providers.test.ts
@@ -11,6 +11,7 @@ import { observeUiSnapshotViaLLM } from "../../src/cli/llm/vision.js";
 import {
   getProviderApiKey,
   openDatabase,
+  saveMachineAiConfig,
   setProviderApiKey,
   setSetting,
 } from "../../src/kernel/index.js";
@@ -131,6 +132,62 @@ describe("getProviderForRole", () => {
         apiKey: "sk-mimo",
       });
     } finally {
+      await db.close();
+    }
+  });
+
+  it("lets machine-local role bindings override shared DB bindings", async () => {
+    const db = await openDb();
+    const configDir = mkdtempSync(join(tmpdir(), "zam-machine-ai-"));
+    tempDirs.push(configDir);
+    const configPath = join(configDir, "config.json");
+    const previousConfigPath = process.env.ZAM_CONFIG_PATH;
+    process.env.ZAM_CONFIG_PATH = configPath;
+
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(
+      db,
+      "llm.providers",
+      JSON.stringify({
+        shared: {
+          url: "https://api.deepseek.com/v1",
+          model: "deepseek-v4-flash",
+        },
+      }),
+    );
+    await setSetting(
+      db,
+      "llm.roles",
+      JSON.stringify({ recall: { primary: "shared" } }),
+    );
+    saveMachineAiConfig({
+      providers: {
+        localFoundry: {
+          label: "Foundry Gemma",
+          url: "http://localhost:8000/v1",
+          model: "gemma4-it:e4b",
+          local: true,
+        },
+      },
+      roles: { recall: { primary: "localFoundry" } },
+    });
+
+    try {
+      const p = await getProviderForRole(db, "recall");
+      expect(p).toMatchObject({
+        providerName: "localFoundry",
+        label: "Foundry Gemma",
+        source: "machine",
+        url: "http://localhost:8000/v1",
+        model: "gemma4-it:e4b",
+        local: true,
+      });
+    } finally {
+      if (previousConfigPath === undefined) {
+        delete process.env.ZAM_CONFIG_PATH;
+      } else {
+        process.env.ZAM_CONFIG_PATH = previousConfigPath;
+      }
       await db.close();
     }
   });

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -1,11 +1,19 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   copySkills,
   formatDatabaseInitTarget,
+  parseSetupAgents,
   writeAgentsMd,
+  writeCopilotInstructions,
 } from "../../src/cli/commands/setup.js";
 
 describe("setup command helpers", () => {
@@ -40,6 +48,49 @@ describe("setup command helpers", () => {
       expect(content).toContain("$setup");
       expect(content).toContain("$zam");
       expect(content).toContain(".agents/skills/");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("parses targeted agent setup selections", () => {
+    expect([...parseSetupAgents("copilot,claude")].sort()).toEqual([
+      "claude",
+      "copilot",
+    ]);
+    expect(parseSetupAgents("all").has("agent")).toBe(true);
+  });
+
+  it("updates existing instruction files with a marked ZAM block", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "zam-existing-instructions-"));
+
+    try {
+      const agentsPath = join(cwd, "AGENTS.md");
+      writeFileSync(agentsPath, "# Existing instructions\n", "utf8");
+
+      writeAgentsMd(false, cwd, { updateExisting: true });
+
+      const content = readFileSync(agentsPath, "utf8");
+      expect(content).toContain("# Existing instructions");
+      expect(content).toContain("<!-- ZAM:START -->");
+      expect(content).toContain(".agents/skills/zam/");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writes Copilot instructions non-destructively", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "zam-copilot-instructions-"));
+
+    try {
+      writeCopilotInstructions(cwd);
+
+      const content = readFileSync(
+        join(cwd, ".github", "copilot-instructions.md"),
+        "utf8",
+      );
+      expect(content).toContain("<!-- ZAM:START -->");
+      expect(content).toContain(".agents/skills/zam/");
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/cli/terminal-open.test.ts
+++ b/tests/cli/terminal-open.test.ts
@@ -1,12 +1,13 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildShellSetupCommand,
   findExecutable,
   isPowerShellShell,
   normalizeShell,
+  openTerminalWindow,
   psSingleQuoted,
 } from "../../src/cli/terminal-open.js";
 
@@ -19,6 +20,7 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+  vi.restoreAllMocks();
 });
 
 function makeExecutable(name: string): string {
@@ -104,5 +106,22 @@ describe("findExecutable", () => {
     } finally {
       process.env.PATH = originalPath;
     }
+  });
+});
+
+describe("openTerminalWindow", () => {
+  it("suppresses fallback instructions when silent", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    openTerminalWindow({
+      shellSetup: "echo hello",
+      label: "agent-codex",
+      dir: "/work",
+      shell: "bash",
+      platform: "linux",
+      silent: true,
+    });
+
+    expect(log).not.toHaveBeenCalled();
   });
 });

--- a/tests/kernel/install-config.test.ts
+++ b/tests/kernel/install-config.test.ts
@@ -4,10 +4,14 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   detectSyncProvider,
+  getConfiguredWorkspaces,
   getInstallMode,
+  getMachineAiConfig,
   loadInstallConfig,
   saveInstallConfig,
+  saveMachineAiConfig,
   setInstallMode,
+  upsertConfiguredWorkspace,
 } from "../../src/kernel/index.js";
 
 const tempDirs: string[] = [];
@@ -57,6 +61,65 @@ describe("install config", () => {
     const path = tempConfigPath();
     writeFileSync(path, "{ not json", "utf-8");
     expect(getInstallMode(path)).toBe("developer");
+  });
+
+  it("round-trips machine-local AI config without touching install mode", () => {
+    const path = tempConfigPath();
+    saveInstallConfig({ mode: "default" }, path);
+
+    saveMachineAiConfig(
+      {
+        providers: {
+          foundry: {
+            label: "Foundry Gemma",
+            url: "http://localhost:8000/v1",
+            model: "gemma4-it:e4b",
+            local: true,
+          },
+        },
+        roles: { recall: { primary: "foundry" } },
+      },
+      path,
+    );
+
+    expect(getInstallMode(path)).toBe("default");
+    expect(getMachineAiConfig(path).roles?.recall?.primary).toBe("foundry");
+    expect(getMachineAiConfig(path).providers?.foundry?.model).toBe(
+      "gemma4-it:e4b",
+    );
+  });
+
+  it("upserts configured workspaces", () => {
+    const path = tempConfigPath();
+    upsertConfiguredWorkspace(
+      {
+        id: "team",
+        kind: "team",
+        path: "C:\\src\\Cops.Management",
+        sourceControl: "azure-devops",
+        knowledgeScopes: ["goals", "concepts"],
+      },
+      path,
+    );
+
+    upsertConfiguredWorkspace(
+      {
+        id: "team",
+        label: "Cops Management",
+        kind: "team",
+        path: "D:\\work\\Cops.Management",
+      },
+      path,
+    );
+
+    expect(getConfiguredWorkspaces(path)).toEqual([
+      {
+        id: "team",
+        label: "Cops Management",
+        kind: "team",
+        path: "D:\\work\\Cops.Management",
+      },
+    ]);
   });
 
   it("detects file-sync providers from a folder path", () => {


### PR DESCRIPTION
## Summary
- bump ZAM desktop/CLI release metadata to 0.5.0 and rename the Tauri package binary to `zam-app`
- add machine-local LLM role configuration/status and flexible workspace registry support
- redesign Studio Settings as a light-first, hierarchical UI with workspace terminal opening and visible learning/observer models
- add ADRs and tests for provider, setup, workspace, and terminal behavior

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`
- `Push-Location C:\src\zam\desktop; npm run build; Pop-Location`
- `cargo check --manifest-path C:\src\zam\desktop\src-tauri\Cargo.toml --locked`
- visual browser pass with mocked Tauri bridge; Lighthouse accessibility 100