### PR TITLE
fix: wire Copilot skills to Claude-compatible path

### DIFF
--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -81,9 +81,9 @@ After running the setup skill, `zam-core` distributes its own skill file:
 .agents/skills/zam/SKILL.md    ← from node_modules/zam-core/.agents/skills/zam/
 ```
 
-Claude- and Gemini-compatible clients invoke their skills with `/setup` and
-`/zam`. Codex invokes repository skills with `$setup` and `$zam`, or selects
-them through `/skills`.
+Claude-, Copilot-, and Gemini-compatible clients invoke their skills with
+`/setup` and `/zam`. Codex invokes repository skills with `$setup` and `$zam`,
+or selects them through `/skills`.
 
 ### Personal config schema (`.zam/config.yaml`)
 
@@ -237,12 +237,14 @@ Skill files always travel with the package that defines them:
 
 | Package / repo | Owns skill group | Distributes via |
 |----------------|-----------------|-----------------|
-| `zam-core` | `.claude/skills/zam/`, `.agent/skills/zam/`, `.agents/skills/zam/` | `zam setup` (copies from `node_modules/zam-core/`) |
+| `zam-core` | `.claude/skills/zam/` for Claude/Copilot, `.agent/skills/zam/`, `.agents/skills/zam/` for Codex | `zam setup` (copies from `node_modules/zam-core/`) |
 | Personal/community template | `.claude/skills/setup/`, `.gemini/skills/setup/`, `.agents/skills/setup/` | Static in template (always present before setup runs) |
 | Future: `zam-devops` | Per-client `skills/devops/` | `devops setup` (copies from `node_modules/zam-devops/`) |
 
 The naming convention `<ai-cli>/skills/<group>/SKILL.md` provides natural
-namespacing. Codex specifically requires the plural `.agents/skills` path.
+namespacing. Copilot CLI currently reads the Claude-compatible
+`.claude/skills` project manifest path, while Codex specifically requires the
+plural `.agents/skills` path.
 No central registry is needed — each package owns its subdirectory.
 
 ---

--- a/docs/adr/2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md
+++ b/docs/adr/2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md
@@ -58,9 +58,9 @@ zam workspace setup cops-management --agents copilot,claude
 
 Skill setup is non-destructive:
 
-- copy or refresh `.agents\skills\zam\SKILL.md` for Copilot/Codex-style repo
-  skills;
-- copy or refresh `.claude\skills\zam\SKILL.md` for Claude Code;
+- copy or refresh `.claude\skills\zam\SKILL.md` for Claude Code and
+  Copilot CLI project skills;
+- copy or refresh `.agents\skills\zam\SKILL.md` for Codex-style repo skills;
 - preserve existing `CLAUDE.md`, `AGENTS.md`, and
   `.github\copilot-instructions.md`;
 - create or refresh only clearly marked ZAM instruction blocks;

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -44,7 +44,7 @@ const SKILL_PAIRS: Array<{
   {
     from: join(packageRoot, ".claude", "skills", "zam", "SKILL.md"),
     to: join(".claude", "skills", "zam", "SKILL.md"),
-    agents: ["claude"],
+    agents: ["claude", "copilot"],
   },
   {
     from: join(packageRoot, ".agent", "skills", "zam", "SKILL.md"),
@@ -54,7 +54,7 @@ const SKILL_PAIRS: Array<{
   {
     from: join(packageRoot, ".agents", "skills", "zam", "SKILL.md"),
     to: join(".agents", "skills", "zam", "SKILL.md"),
-    agents: ["copilot", "codex"],
+    agents: ["codex"],
   },
 ];
 
@@ -225,7 +225,7 @@ ZAM is available in this repository. Use the \`zam\` skill in Claude Code to tur
 
 - Skill files live under \`.claude/skills/zam/\`.
 - Fast-changing review data lives in \`~/.zam/\`, not in this repository.
-- Run \`zam setup --target . --agents claude --force\` after upgrading ZAM to refresh the skill.`,
+- Run \`zam setup --target . --agents claude,copilot --force\` after upgrading ZAM to refresh the skill.`,
       Boolean(opts.dryRun),
     );
     logInstructionAction(action, "CLAUDE.md", Boolean(opts.dryRun));
@@ -282,7 +282,7 @@ ZAM is available in this repository. Select the \`zam\` skill through \`/skills\
 
 - Skill files live under \`.agents/skills/zam/\`.
 - Fast-changing review data lives in \`~/.zam/\`, not in this repository.
-- Run \`zam setup --target . --agents copilot,codex --force\` after upgrading ZAM to refresh the skill.`,
+- Run \`zam setup --target . --agents codex,agent --force\` after upgrading ZAM to refresh the skill.`,
       Boolean(opts.dryRun),
     );
     logInstructionAction(action, "AGENTS.md", Boolean(opts.dryRun));
@@ -334,7 +334,7 @@ export function writeCopilotInstructions(
     dest,
     `## ZAM learning sessions
 
-ZAM is available in this repository through \`.agents/skills/zam/\`. Use the \`zam\` skill from Copilot-compatible skill selection surfaces to turn real work into an observed learning session with active recall and FSRS scheduling.
+ZAM is available in this repository through \`.claude/skills/zam/\`. Use the \`zam\` project skill from Copilot-compatible skill selection surfaces to turn real work into an observed learning session with active recall and FSRS scheduling.
 
 - Fast-changing review data lives in \`~/.zam/\`, not in this repository.
 - Run \`zam setup --target . --agents copilot --force\` after upgrading ZAM to refresh the skill.`,
@@ -401,7 +401,7 @@ export const setupCommand = new Command("setup")
           updateExisting: updateExistingInstructions,
         });
       }
-      if (agents.has("copilot") || agents.has("codex") || agents.has("agent")) {
+      if (agents.has("codex") || agents.has("agent")) {
         writeAgentsMd(opts.skipAgentsMd, target, {
           dryRun: opts.dryRun,
           updateExisting: updateExistingInstructions,
@@ -415,7 +415,7 @@ export const setupCommand = new Command("setup")
       }
 
       console.log(
-        "\nDone. Run `zam whoami --set <your-id>` to set your identity. Start the `zam` skill with `/zam` in Claude/Gemini-compatible clients or `$zam` (or `/skills`) in Codex.",
+        "\nDone. Run `zam whoami --set <your-id>` to set your identity. Start the `zam` skill with `/zam` in Claude/Copilot/Gemini-compatible clients or `$zam` (or `/skills`) in Codex.",
       );
     },
   );

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -235,7 +235,7 @@ workspaceCommand
           updateExisting: true,
         });
       }
-      if (agents.has("copilot") || agents.has("codex") || agents.has("agent")) {
+      if (agents.has("codex") || agents.has("agent")) {
         writeAgentsMd(false, workspace.path, {
           dryRun: Boolean(opts.dryRun),
           updateExisting: true,

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../../src/cli/commands/setup.js";
 
 describe("setup command helpers", () => {
-  it("copies ZAM skills for Claude, shared agents, and Codex", () => {
+  it("copies ZAM skills for Claude/Copilot, shared agents, and Codex", () => {
     const cwd = mkdtempSync(join(tmpdir(), "zam-setup-skills-"));
 
     try {
@@ -61,6 +61,26 @@ describe("setup command helpers", () => {
     expect(parseSetupAgents("all").has("agent")).toBe(true);
   });
 
+  it("maps Copilot setup to the project skill manifest path Copilot loads", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "zam-copilot-skills-"));
+
+    try {
+      copySkills(false, cwd, parseSetupAgents("copilot"));
+
+      expect(
+        existsSync(join(cwd, ".claude", "skills", "zam", "SKILL.md")),
+      ).toBe(true);
+      expect(
+        existsSync(join(cwd, ".agents", "skills", "zam", "SKILL.md")),
+      ).toBe(false);
+      expect(
+        existsSync(join(cwd, ".agent", "skills", "zam", "SKILL.md")),
+      ).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("updates existing instruction files with a marked ZAM block", () => {
     const cwd = mkdtempSync(join(tmpdir(), "zam-existing-instructions-"));
 
@@ -90,7 +110,7 @@ describe("setup command helpers", () => {
         "utf8",
       );
       expect(content).toContain("<!-- ZAM:START -->");
-      expect(content).toContain(".agents/skills/zam/");
+      expect(content).toContain(".claude/skills/zam/");
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- install the ZAM project skill for Copilot under `.claude/skills/zam/SKILL.md`
- keep Codex/open-agent skill wiring under `.agents`/`AGENTS.md`
- update docs and tests for the Claude/Copilot vs Codex skill paths

## Validation
- npm run lint
- npm run build
- npm run typecheck
- npm run test