### PR TITLE
feat: junction-based workspace skill wiring + add/remove UI

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -183,12 +183,12 @@
                 <h2 id="lbl-settings-workspace-title">Workspace &amp; agents</h2>
                 <p id="lbl-workspaces-help" class="settings-card-help">Register personal, team, family, or community work directories for this machine.</p>
               </div>
+              <button id="btn-choose-workspace" class="btn secondary-btn btn-sm" type="button">
+                + Add workspace…
+              </button>
             </div>
             <div id="workspace-list" class="workspace-list" aria-live="polite"></div>
             <div class="settings-actions">
-              <button id="btn-choose-workspace" class="btn secondary-btn btn-sm" type="button">
-                Choose workspace…
-              </button>
               <button id="btn-open-terminal" class="btn primary-btn btn-sm" type="button">
                 Open Terminal
               </button>

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -130,7 +130,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     setup_backup_failed_generic: "Backup failed.",
     setup_open_folder_failed: "Could not open the data folder: {message}",
     lbl_workspace: "Workspace",
-    btn_choose_workspace: "Choose workspace…",
+    btn_choose_workspace: "+ Add workspace…",
     btn_open_terminal: "Open Terminal",
     terminal_opening: "Opening terminal...",
     terminal_opened: "Opened terminal in {workspace}",
@@ -152,6 +152,11 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     workspace_set: "Workspace set to {path}",
     workspace_added: "Workspace added: {path}",
     workspace_pick_failed: "Could not set workspace: {message}",
+    workspace_remove: "Remove",
+    workspace_remove_confirm:
+      'Remove "{label}" from ZAM? Files and links in the folder will stay unchanged.',
+    workspace_removed: "Workspace removed: {label}",
+    workspace_remove_failed: "Could not remove workspace: {message}",
     lbl_app_version: "Version",
     lbl_learning_model: "Learning model",
     lbl_observer_model: "Observer model",
@@ -290,7 +295,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     setup_backup_failed: "Sicherung fehlgeschlagen: {message}",
     setup_backup_failed_generic: "Sicherung fehlgeschlagen.",
     setup_open_folder_failed: "Datenordner konnte nicht geöffnet werden: {message}",
-    btn_choose_workspace: "Arbeitsbereich wählen…",
+    btn_choose_workspace: "+ Arbeitsbereich hinzufügen…",
     btn_open_terminal: "Terminal öffnen",
     terminal_opening: "Terminal wird geöffnet...",
     terminal_opened: "Terminal in {workspace} geöffnet",
@@ -312,6 +317,11 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     workspace_set: "Arbeitsbereich gesetzt: {path}",
     workspace_added: "Arbeitsbereich hinzugefügt: {path}",
     workspace_pick_failed: "Arbeitsbereich konnte nicht gesetzt werden: {message}",
+    workspace_remove: "Entfernen",
+    workspace_remove_confirm:
+      '"{label}" aus ZAM entfernen? Dateien und Verknüpfungen im Ordner bleiben unverändert.',
+    workspace_removed: "Arbeitsbereich entfernt: {label}",
+    workspace_remove_failed: "Arbeitsbereich konnte nicht entfernt werden: {message}",
     lbl_app_version: "Version",
     lbl_learning_model: "Lernmodell",
     lbl_observer_model: "Observer-Modell",
@@ -881,6 +891,16 @@ function renderWorkspaceList(info: WorkspaceListResponse): void {
     });
 
     actions.append(useButton, terminalButton);
+    if (info.workspaces.some((item) => item.id === workspace.id)) {
+      const removeButton = document.createElement("button");
+      removeButton.className = "btn danger-btn btn-sm";
+      removeButton.type = "button";
+      removeButton.textContent = t("workspace_remove");
+      removeButton.addEventListener("click", () => {
+        void removeWorkspace(workspace);
+      });
+      actions.appendChild(removeButton);
+    }
     row.append(main, actions);
     list.appendChild(row);
   }
@@ -914,6 +934,30 @@ async function setActiveWorkspace(dir: string): Promise<void> {
     await loadWorkspaceList();
     if (status) {
       status.textContent = tf("workspace_set", { path: res.workspaceDir });
+    }
+  }
+}
+
+async function removeWorkspace(workspace: WorkspaceConfig): Promise<void> {
+  const label = workspace.label || workspace.id;
+  if (!window.confirm(tf("workspace_remove_confirm", { label }))) return;
+
+  const status = document.getElementById("setup-status");
+  try {
+    const result = await runBridge<{ workspaceDir?: string }>(
+      "workspace-remove",
+      ["--id", workspace.id],
+    );
+    activeWorkspaceDir = result.workspaceDir ?? activeWorkspaceDir;
+    await loadWorkspaceList();
+    if (status) {
+      status.textContent = tf("workspace_removed", { label });
+    }
+  } catch (err) {
+    if (status) {
+      status.textContent = tf("workspace_remove_failed", {
+        message: errorMessage(err),
+      });
     }
   }
 }

--- a/docs/adr/2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md
+++ b/docs/adr/2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md
@@ -1,6 +1,6 @@
 # Flexible ZAM Workspaces and Skill Wiring
 
-**Status:** Proposed
+**Status:** Accepted
 **Deciders:** Thomas (project owner)
 **Related:**
 [2026-03-26-personal-workflow-foundations.md](2026-03-26-personal-workflow-foundations.md) ·
@@ -58,16 +58,19 @@ zam workspace setup cops-management --agents copilot,claude
 
 Skill setup is non-destructive:
 
-- copy or refresh `.claude\skills\zam\SKILL.md` for Claude Code and
-  Copilot CLI project skills;
-- copy or refresh `.agents\skills\zam\SKILL.md` for Codex-style repo skills;
+- create a directory junction on Windows, or a directory symlink on macOS/Linux,
+  from each agent-specific `skills/zam` directory to the installed ZAM skill;
+- migrate the old single-file ZAM copies automatically;
+- preserve unmanaged skill directories unless `--force` is explicit;
 - preserve existing `CLAUDE.md`, `AGENTS.md`, and
   `.github\copilot-instructions.md`;
 - create or refresh only clearly marked ZAM instruction blocks;
 - support `--dry-run` and `--force`.
 
-The installed ZAM package or desktop resource bundle remains the source of skill
-files. A source checkout is not required.
+The installed ZAM package, desktop resource bundle, or developer checkout
+remains the single source of skill files. Updating that source immediately
+updates every linked workspace. Workspace-specific ignore rules remain under
+the repository owner's control.
 
 ## Consequences
 
@@ -81,7 +84,7 @@ files. A source checkout is not required.
 
 **Harder**
 
-- Setup must avoid clobbering existing agent instructions.
+- Setup must avoid clobbering existing agent instructions or unmanaged skill directories.
 - Host-specific invocation differs. Not every agent exposes a literal `/zam`
   slash command; the skill must be installed and documented according to each
   host's supported mechanism.

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -7,7 +7,13 @@
 
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { Command } from "commander";
@@ -51,6 +57,7 @@ import {
   pairCommands,
   readMonitorLog,
   readUiObservationLog,
+  removeConfiguredWorkspace,
   resolveObserverPolicy,
   resolveReviewContext,
   setSetting,
@@ -81,6 +88,7 @@ import {
 import { observeUiSnapshotViaLLM } from "../llm/vision.js";
 import { normalizeShell } from "../terminal-open.js";
 import { ensureDefaultUser, resolveUser } from "./resolve-user.js";
+import { parseSetupAgents, wireSkills } from "./setup.js";
 import { withDb as sharedWithDb } from "./shared/db.js";
 import { backupDatabaseTo } from "./workspace.js";
 
@@ -275,6 +283,55 @@ bridgeCommand
     });
   });
 
+function sameWorkspacePath(left: string, right: string): boolean {
+  const normalize = (value: string) => {
+    const path = resolve(value);
+    return process.platform === "win32" ? path.toLowerCase() : path;
+  };
+  return normalize(left) === normalize(right);
+}
+
+async function ensureDesktopWorkspace(db: Database): Promise<{
+  workspaceDir: string;
+  skillLinks: ReturnType<typeof wireSkills>;
+}> {
+  const configured = getConfiguredWorkspaces();
+  const savedWorkspaceDir = await getSetting(db, "personal.workspace_dir");
+  const workspaceDir =
+    savedWorkspaceDir ||
+    configured.find((workspace) => workspace.kind === "personal")?.path ||
+    join(homedir(), "Documents", "zam");
+
+  mkdirSync(workspaceDir, { recursive: true });
+  if (!savedWorkspaceDir) {
+    await setSetting(db, "personal.workspace_dir", workspaceDir);
+  }
+
+  if (
+    !configured.some((workspace) =>
+      sameWorkspacePath(workspace.path, workspaceDir),
+    )
+  ) {
+    const id = configured.some((workspace) => workspace.id === "personal")
+      ? workspaceIdFromPath(workspaceDir)
+      : "personal";
+    upsertConfiguredWorkspace({
+      id,
+      label: basename(workspaceDir) || "ZAM",
+      kind: "personal",
+      path: workspaceDir,
+    });
+  }
+
+  const skillLinks = getConfiguredWorkspaces().flatMap((workspace) =>
+    existsSync(workspace.path)
+      ? wireSkills(workspace.path, parseSetupAgents(), { quiet: true })
+      : [],
+  );
+
+  return { workspaceDir, skillLinks };
+}
+
 bridgeCommand
   .command("workspace-list")
   .description("List configured ZAM workspaces (JSON)")
@@ -339,6 +396,7 @@ bridgeCommand
       kind: parseBridgeWorkspaceKind(opts.kind),
       path,
     };
+    const skillLinks = wireSkills(path, parseSetupAgents(), { quiet: true });
     await withDb(async (db) => {
       await setSetting(db, "personal.workspace_dir", path);
       upsertConfiguredWorkspace(workspace);
@@ -347,6 +405,50 @@ bridgeCommand
         workspace,
         workspaces: getConfiguredWorkspaces(),
         workspaceDir: path,
+        skillLinks,
+      });
+    });
+  });
+
+bridgeCommand
+  .command("workspace-remove")
+  .description("Unregister a ZAM workspace without deleting its files (JSON)")
+  .requiredOption("--id <id>", "Workspace id")
+  .action(async (opts) => {
+    const id = String(opts.id ?? "").trim();
+    if (!id) jsonError("A non-empty --id is required");
+    const workspace = getConfiguredWorkspaces().find((item) => item.id === id);
+    if (!workspace) jsonError(`Workspace "${id}" is not configured`);
+
+    await withDb(async (db) => {
+      const activeWorkspaceDir =
+        (await getSetting(db, "personal.workspace_dir")) || null;
+      const remaining = removeConfiguredWorkspace(id);
+      let workspaceDir = activeWorkspaceDir;
+      let skillLinks: ReturnType<typeof wireSkills> = [];
+
+      if (
+        activeWorkspaceDir &&
+        sameWorkspacePath(activeWorkspaceDir, workspace.path)
+      ) {
+        if (remaining.length > 0) {
+          workspaceDir = remaining[0].path;
+          await setSetting(db, "personal.workspace_dir", workspaceDir);
+        } else {
+          workspaceDir = join(homedir(), "Documents", "zam");
+          await setSetting(db, "personal.workspace_dir", workspaceDir);
+          const ensured = await ensureDesktopWorkspace(db);
+          workspaceDir = ensured.workspaceDir;
+          skillLinks = ensured.skillLinks;
+        }
+      }
+
+      jsonOut({
+        ok: true,
+        removed: workspace,
+        workspaces: getConfiguredWorkspaces(),
+        workspaceDir,
+        skillLinks,
       });
     });
   });
@@ -359,9 +461,11 @@ bridgeCommand
     const raw = String(opts.dir ?? "").trim();
     if (!raw) jsonError("A non-empty --dir is required");
     const dir = resolve(raw);
+    if (!existsSync(dir)) jsonError(`Workspace path does not exist: ${dir}`);
+    const skillLinks = wireSkills(dir, parseSetupAgents(), { quiet: true });
     await withDb(async (db) => {
       await setSetting(db, "personal.workspace_dir", dir);
-      jsonOut({ ok: true, workspaceDir: dir });
+      jsonOut({ ok: true, workspaceDir: dir, skillLinks });
     });
   });
 
@@ -2109,10 +2213,13 @@ bridgeCommand
     await withDb(async (db) => {
       const userId = await ensureDefaultUser(db, opts.user);
       const { enabled, url, model, locale } = await getLlmConfig(db);
+      const { workspaceDir, skillLinks } = await ensureDesktopWorkspace(db);
       jsonOut({
         userId,
         locale,
         llm: { enabled, url, model },
+        workspaceDir,
+        skillLinks,
       });
     });
   });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -11,7 +11,7 @@
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { confirm, input } from "@inquirer/prompts";
 import { Command } from "commander";
 import {
@@ -24,7 +24,9 @@ import {
   openDatabaseWithSync,
   prepareLocalModel,
   setSetting,
+  upsertConfiguredWorkspace,
 } from "../../kernel/index.js";
+import { parseSetupAgents, wireSkills } from "./setup.js";
 
 const HOME = homedir();
 
@@ -89,13 +91,22 @@ export const initCommand = new Command("init")
     console.log("\n\x1b[1m[1/5] Setting up Local Workspace Sandbox\x1b[0m");
     const defaultWorkspace = join(HOME, "Documents", "zam");
 
-    const workspacePath = await input({
-      message: "Choose your ZAM workspace directory:",
-      default: defaultWorkspace,
-    });
+    const workspacePath = resolve(
+      await input({
+        message: "Choose your ZAM workspace directory:",
+        default: defaultWorkspace,
+      }),
+    );
 
     try {
       bootstrapSandboxWorkspace(workspacePath);
+      wireSkills(workspacePath, parseSetupAgents());
+      upsertConfiguredWorkspace({
+        id: "personal",
+        label: "Personal",
+        kind: "personal",
+        path: workspacePath,
+      });
       console.log(
         `\x1b[32m✓ Local Sandbox created at: ${workspacePath}\x1b[0m`,
       );

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,17 +1,21 @@
 /**
- * `zam setup` — Distribute skill files from the zam package into the current
+ * `zam setup` — Link skill directories from the ZAM package into the current
  * personal instance's agent skill directories, and optionally initialize the
  * ZAM database and generate agent-specific instruction files.
  *
- * Run this once after cloning a ZAM personal instance, and again after
- * upgrading zam (with --force) to refresh the skill files.
+ * Run this once after cloning a ZAM personal instance. Linked workspaces pick
+ * up future ZAM updates automatically.
  */
 
 import {
-  copyFileSync,
   existsSync,
+  lstatSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -83,45 +87,162 @@ export function parseSetupAgents(value?: string): Set<SetupAgent> {
   return selected;
 }
 
-export function copySkills(
-  force: boolean,
+export type SkillWireAction = "linked" | "relinked" | "skipped";
+
+export interface SkillWireResult {
+  source: string;
+  destination: string;
+  action: SkillWireAction;
+  reason?: string;
+}
+
+export interface SkillWireOptions {
+  force?: boolean;
+  dryRun?: boolean;
+  quiet?: boolean;
+}
+
+function pathExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function comparableRealPath(path: string): string {
+  const real = realpathSync(path);
+  return process.platform === "win32" ? real.toLowerCase() : real;
+}
+
+function pathsResolveToSameDirectory(
+  sourceDir: string,
+  destinationDir: string,
+): boolean {
+  try {
+    return comparableRealPath(destinationDir) === comparableRealPath(sourceDir);
+  } catch {
+    return false;
+  }
+}
+
+function linkPointsTo(sourceDir: string, destinationDir: string): boolean {
+  try {
+    return (
+      lstatSync(destinationDir).isSymbolicLink() &&
+      pathsResolveToSameDirectory(sourceDir, destinationDir)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isReplaceableCopiedSkill(destinationDir: string): boolean {
+  try {
+    if (!lstatSync(destinationDir).isDirectory()) return false;
+    const entries = readdirSync(destinationDir);
+    if (entries.length !== 1 || entries[0] !== "SKILL.md") return false;
+    return /^name:\s*zam\s*$/m.test(
+      readFileSync(join(destinationDir, "SKILL.md"), "utf8"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function wireSkills(
   cwd: string = process.cwd(),
   agents: Set<SetupAgent> = parseSetupAgents(),
-  dryRun = false,
-): void {
-  let anyAction = false;
+  opts: SkillWireOptions = {},
+): SkillWireResult[] {
+  const results: SkillWireResult[] = [];
+  const log = (message: string) => {
+    if (!opts.quiet) console.log(message);
+  };
 
   for (const { from, to, agents: pairAgents } of SKILL_PAIRS) {
     if (!pairAgents.some((agent) => agents.has(agent))) continue;
-    const dest = join(cwd, to);
+    const sourceDir = dirname(from);
+    const destinationDir = dirname(join(cwd, to));
 
-    if (!existsSync(from)) {
-      console.warn(`  warn  source not found, skipping: ${from}`);
+    if (!existsSync(sourceDir)) {
+      if (!opts.quiet) {
+        console.warn(`  warn  source not found, skipping: ${sourceDir}`);
+      }
+      results.push({
+        source: sourceDir,
+        destination: destinationDir,
+        action: "skipped",
+        reason: "source-not-found",
+      });
       continue;
     }
 
-    if (existsSync(dest) && !force) {
-      console.log(`  skip  ${to} (already present â€” use --force to update)`);
+    if (
+      pathsResolveToSameDirectory(sourceDir, destinationDir) &&
+      !lstatSync(destinationDir).isSymbolicLink()
+    ) {
+      log(`  skip  ${dirname(to)} (package source)`);
+      results.push({
+        source: sourceDir,
+        destination: destinationDir,
+        action: "skipped",
+        reason: "source-directory",
+      });
       continue;
     }
 
-    if (dryRun) {
-      console.log(`  would copy  ${to}`);
-      anyAction = true;
+    if (linkPointsTo(sourceDir, destinationDir)) {
+      log(`  skip  ${dirname(to)} (already linked)`);
+      results.push({
+        source: sourceDir,
+        destination: destinationDir,
+        action: "skipped",
+        reason: "already-linked",
+      });
       continue;
     }
 
-    mkdirSync(dirname(dest), { recursive: true });
-    copyFileSync(from, dest);
-    console.log(`  copy  ${to}`);
-    anyAction = true;
+    const destinationExists = pathExists(destinationDir);
+    const replaceExisting =
+      destinationExists &&
+      (Boolean(opts.force) || isReplaceableCopiedSkill(destinationDir));
+
+    if (destinationExists && !replaceExisting) {
+      if (!opts.quiet) {
+        console.warn(
+          `  warn  ${dirname(to)} already exists and is not managed by ZAM; use --force to replace it`,
+        );
+      }
+      results.push({
+        source: sourceDir,
+        destination: destinationDir,
+        action: "skipped",
+        reason: "unmanaged-destination",
+      });
+      continue;
+    }
+
+    const action: SkillWireAction = destinationExists ? "relinked" : "linked";
+    if (opts.dryRun) {
+      log(`  would ${action === "linked" ? "link" : "relink"}  ${dirname(to)}`);
+    } else {
+      if (destinationExists) {
+        rmSync(destinationDir, { recursive: true, force: true });
+      }
+      mkdirSync(dirname(destinationDir), { recursive: true });
+      symlinkSync(
+        sourceDir,
+        destinationDir,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      log(`  ${action === "linked" ? "link" : "relink"}  ${dirname(to)}`);
+    }
+    results.push({ source: sourceDir, destination: destinationDir, action });
   }
 
-  if (!anyAction && !force) {
-    console.log(
-      "\nSkill files are already up to date. Run with --force to overwrite.",
-    );
-  }
+  return results;
 }
 
 export function formatDatabaseInitTarget(target: DatabaseTargetInfo): string {
@@ -225,7 +346,7 @@ ZAM is available in this repository. Use the \`zam\` skill in Claude Code to tur
 
 - Skill files live under \`.claude/skills/zam/\`.
 - Fast-changing review data lives in \`~/.zam/\`, not in this repository.
-- Run \`zam setup --target . --agents claude,copilot --force\` after upgrading ZAM to refresh the skill.`,
+- The skill directory is linked to this ZAM installation and updates with it.`,
       Boolean(opts.dryRun),
     );
     logInstructionAction(action, "CLAUDE.md", Boolean(opts.dryRun));
@@ -282,7 +403,7 @@ ZAM is available in this repository. Select the \`zam\` skill through \`/skills\
 
 - Skill files live under \`.agents/skills/zam/\`.
 - Fast-changing review data lives in \`~/.zam/\`, not in this repository.
-- Run \`zam setup --target . --agents codex,agent --force\` after upgrading ZAM to refresh the skill.`,
+- The skill directory is linked to this ZAM installation and updates with it.`,
       Boolean(opts.dryRun),
     );
     logInstructionAction(action, "AGENTS.md", Boolean(opts.dryRun));
@@ -337,7 +458,7 @@ export function writeCopilotInstructions(
 ZAM is available in this repository through \`.claude/skills/zam/\`. Use the \`zam\` project skill from Copilot-compatible skill selection surfaces to turn real work into an observed learning session with active recall and FSRS scheduling.
 
 - Fast-changing review data lives in \`~/.zam/\`, not in this repository.
-- Run \`zam setup --target . --agents copilot --force\` after upgrading ZAM to refresh the skill.`,
+- The skill directory is linked to this ZAM installation and updates with it.`,
     Boolean(opts.dryRun),
   );
   logInstructionAction(
@@ -349,13 +470,9 @@ ZAM is available in this repository through \`.claude/skills/zam/\`. Use the \`z
 
 export const setupCommand = new Command("setup")
   .description(
-    "Distribute ZAM skill files into this personal instance and initialize the database",
+    "Link ZAM skill directories into this workspace and initialize the database",
   )
-  .option(
-    "--force",
-    "overwrite existing skill files (use after upgrading zam)",
-    false,
-  )
+  .option("--force", "replace an unmanaged existing ZAM skill directory", false)
   .option("--skip-init", "skip database initialization", false)
   .option("--skip-claude-md", "skip CLAUDE.md generation", false)
   .option("--skip-agents-md", "skip AGENTS.md generation", false)
@@ -393,7 +510,10 @@ export const setupCommand = new Command("setup")
         `Setting up ZAM in ${target}${opts.dryRun ? " (dry run)" : ""}\n`,
       );
 
-      copySkills(opts.force, target, agents, opts.dryRun);
+      wireSkills(target, agents, {
+        force: opts.force,
+        dryRun: opts.dryRun,
+      });
       await initDatabase(opts.skipInit || opts.dryRun);
       if (agents.has("claude")) {
         writeClaudeMd(opts.skipClaudeMd, target, {

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -19,14 +19,15 @@ import {
   getSetting,
   hasCommand,
   openDatabase,
+  removeConfiguredWorkspace,
   upsertConfiguredWorkspace,
   type WorkspaceConfig,
   type WorkspaceKind,
   type WorkspaceSourceControl,
 } from "../../kernel/index.js";
 import {
-  copySkills,
   parseSetupAgents,
+  wireSkills,
   writeAgentsMd,
   writeClaudeMd,
   writeCopilotInstructions,
@@ -190,12 +191,30 @@ workspaceCommand
           : {}),
         ...(opts.defaultAgent ? { defaultAgent: opts.defaultAgent } : {}),
       };
+      // Provision the skill junctions first; only record the workspace once
+      // linking succeeds, so a junction failure never leaves an orphaned entry.
+      wireSkills(path, parseSetupAgents());
       upsertConfiguredWorkspace(workspace);
-      console.log(`Registered workspace "${id}" at ${path}.`);
+      console.log(`Registered and linked workspace "${id}" at ${path}.`);
     } catch (err) {
       console.error(`Error: ${(err as Error).message}`);
       process.exit(1);
     }
+  });
+
+workspaceCommand
+  .command("remove <id>")
+  .description("Unregister a ZAM workspace without deleting its files")
+  .action((id) => {
+    const existing = getConfiguredWorkspaces().find((item) => item.id === id);
+    if (!existing) {
+      console.error(`Workspace "${id}" is not configured.`);
+      process.exit(1);
+    }
+    removeConfiguredWorkspace(id);
+    console.log(
+      `Unregistered workspace "${id}". Files in ${existing.path} were not changed.`,
+    );
   });
 
 workspaceCommand
@@ -223,12 +242,10 @@ workspaceCommand
         `Setting up workspace "${workspace.id}" in ${workspace.path}${opts.dryRun ? " (dry run)" : ""}\n`,
       );
 
-      copySkills(
-        Boolean(opts.force),
-        workspace.path,
-        agents,
-        Boolean(opts.dryRun),
-      );
+      wireSkills(workspace.path, agents, {
+        force: Boolean(opts.force),
+        dryRun: Boolean(opts.dryRun),
+      });
       if (agents.has("claude")) {
         writeClaudeMd(false, workspace.path, {
           dryRun: Boolean(opts.dryRun),

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -341,6 +341,7 @@ export {
   getInstallMode,
   getMachineAiConfig,
   loadInstallConfig,
+  removeConfiguredWorkspace,
   saveConfiguredWorkspaces,
   saveInstallConfig,
   saveMachineAiConfig,

--- a/src/kernel/system/install-config.ts
+++ b/src/kernel/system/install-config.ts
@@ -178,6 +178,17 @@ export function upsertConfiguredWorkspace(
   return next;
 }
 
+export function removeConfiguredWorkspace(
+  id: string,
+  path = defaultConfigPath(),
+): WorkspaceConfig[] {
+  const next = getConfiguredWorkspaces(path).filter(
+    (workspace) => workspace.id !== id,
+  );
+  saveConfiguredWorkspaces(next, path);
+  return next;
+}
+
 /**
  * Best-effort detection of the file-sync provider a folder lives in, from its
  * path. Used only for friendly messaging ("this folder syncs via OneDrive —

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -1,27 +1,30 @@
 import {
   existsSync,
+  lstatSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  copySkills,
   formatDatabaseInitTarget,
   parseSetupAgents,
   writeAgentsMd,
+  wireSkills,
   writeCopilotInstructions,
 } from "../../src/cli/commands/setup.js";
 
 describe("setup command helpers", () => {
-  it("copies ZAM skills for Claude/Copilot, shared agents, and Codex", () => {
+  it("links ZAM skills for Claude/Copilot, shared agents, and Codex", () => {
     const cwd = mkdtempSync(join(tmpdir(), "zam-setup-skills-"));
 
     try {
-      copySkills(false, cwd);
+      const first = wireSkills(cwd);
 
       const destinations = [
         join(cwd, ".claude", "skills", "zam", "SKILL.md"),
@@ -31,8 +34,94 @@ describe("setup command helpers", () => {
 
       for (const destination of destinations) {
         expect(existsSync(destination)).toBe(true);
+        expect(lstatSync(dirname(destination)).isSymbolicLink()).toBe(true);
       }
+      expect(first.map((result) => result.action)).toEqual([
+        "linked",
+        "linked",
+        "linked",
+      ]);
       expect(readFileSync(destinations[2], "utf8")).toContain("$zam");
+      expect(realpathSync(dirname(destinations[2]))).toBe(
+        realpathSync(join(process.cwd(), ".agents", "skills", "zam")),
+      );
+
+      const second = wireSkills(cwd, parseSetupAgents(), { quiet: true });
+      expect(second.every((result) => result.reason === "already-linked")).toBe(
+        true,
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("never replaces the package skill source with a self-link", () => {
+    const [result] = wireSkills(
+      process.cwd(),
+      parseSetupAgents("codex"),
+      { quiet: true },
+    );
+
+    expect(result).toMatchObject({
+      action: "skipped",
+      reason: "source-directory",
+    });
+    expect(
+      lstatSync(join(process.cwd(), ".agents", "skills", "zam")).isSymbolicLink(),
+    ).toBe(false);
+  });
+
+  it("migrates an old copied ZAM skill into a live link", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "zam-setup-migrate-"));
+    const destinationDir = join(cwd, ".agents", "skills", "zam");
+
+    try {
+      mkdirSync(destinationDir, { recursive: true });
+      writeFileSync(
+        join(destinationDir, "SKILL.md"),
+        readFileSync(
+          join(process.cwd(), ".agents", "skills", "zam", "SKILL.md"),
+          "utf8",
+        ),
+        "utf8",
+      );
+
+      const [result] = wireSkills(cwd, parseSetupAgents("codex"), {
+        quiet: true,
+      });
+
+      expect(result.action).toBe("relinked");
+      expect(lstatSync(destinationDir).isSymbolicLink()).toBe(true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves an unmanaged skill directory unless force is explicit", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "zam-setup-unmanaged-"));
+    const destinationDir = join(cwd, ".agents", "skills", "zam");
+
+    try {
+      mkdirSync(destinationDir, { recursive: true });
+      writeFileSync(
+        join(destinationDir, "SKILL.md"),
+        "---\nname: custom-zam\n---\n",
+        "utf8",
+      );
+      writeFileSync(join(destinationDir, "notes.md"), "keep", "utf8");
+
+      const [result] = wireSkills(cwd, parseSetupAgents("codex"), {
+        quiet: true,
+      });
+
+      expect(result).toMatchObject({
+        action: "skipped",
+        reason: "unmanaged-destination",
+      });
+      expect(lstatSync(destinationDir).isSymbolicLink()).toBe(false);
+      expect(readFileSync(join(destinationDir, "notes.md"), "utf8")).toBe(
+        "keep",
+      );
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -65,7 +154,7 @@ describe("setup command helpers", () => {
     const cwd = mkdtempSync(join(tmpdir(), "zam-copilot-skills-"));
 
     try {
-      copySkills(false, cwd, parseSetupAgents("copilot"));
+      wireSkills(cwd, parseSetupAgents("copilot"));
 
       expect(
         existsSync(join(cwd, ".claude", "skills", "zam", "SKILL.md")),

--- a/tests/integration/cli-e2e.test.ts
+++ b/tests/integration/cli-e2e.test.ts
@@ -4,6 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+// Each test shells out to the built CLI several times via execSync. Cold Node
+// startup on Windows makes 6–7 spawns exceed Vitest's 5s default, so give these
+// process-spawning integration tests generous, file-scoped headroom.
+const E2E_TIMEOUT_MS = 30_000;
+
 describe("cli E2E tests", () => {
   let tempHome: string;
   let tempCwd: string;
@@ -61,7 +66,7 @@ describe("cli E2E tests", () => {
     // 4. Verify identity is saved and read correctly
     const whoamiOutput = runCli(["whoami"]);
     expect(whoamiOutput).toContain("e2e-test-user");
-  });
+  }, E2E_TIMEOUT_MS);
 
   it("can get and set observer policy settings", () => {
     // Initialize DB
@@ -85,7 +90,7 @@ describe("cli E2E tests", () => {
     // Verify change via settings get
     const settingsGetScope = runCli(["settings", "get", "observer.scope"]);
     expect(settingsGetScope.trim()).toBe("fullscreen");
-  });
+  }, E2E_TIMEOUT_MS);
 
   it("bridge get-observer-policy returns the parsed presets", () => {
     runCli(["setup", "--skip-claude-md", "--skip-agents-md"]);
@@ -102,5 +107,5 @@ describe("cli E2E tests", () => {
       runCli(["bridge", "get-observer-policy"]),
     );
     expect(updatedBridgePolicy.scope).toBe("off");
-  });
+  }, E2E_TIMEOUT_MS);
 });

--- a/tests/kernel/install-config.test.ts
+++ b/tests/kernel/install-config.test.ts
@@ -8,6 +8,7 @@ import {
   getInstallMode,
   getMachineAiConfig,
   loadInstallConfig,
+  removeConfiguredWorkspace,
   saveInstallConfig,
   saveMachineAiConfig,
   setInstallMode,
@@ -120,6 +121,25 @@ describe("install config", () => {
         path: "D:\\work\\Cops.Management",
       },
     ]);
+  });
+
+  it("removes a configured workspace without touching the others", () => {
+    const path = tempConfigPath();
+    upsertConfiguredWorkspace(
+      { id: "family", kind: "family", path: "C:\\family" },
+      path,
+    );
+    upsertConfiguredWorkspace(
+      { id: "team", kind: "team", path: "C:\\team" },
+      path,
+    );
+
+    const remaining = removeConfiguredWorkspace("family", path);
+
+    expect(remaining).toEqual([
+      { id: "team", kind: "team", path: "C:\\team" },
+    ]);
+    expect(getConfiguredWorkspaces(path)).toEqual(remaining);
   });
 
   it("detects file-sync providers from a folder path", () => {


### PR DESCRIPTION
## Summary

Continues Codex's WIP from the last two days and fixes the three issues it flagged as open. Provisions ZAM skills into workspaces via **Windows junctions / POSIX symlinks** instead of file copies, so a single source updates every linked workspace at once.

This satisfies the requirement: **a `git pull` on the ZAM checkout refreshes the skill in every configured workspace** (personal `zam-Thomas` + team/family/community dirs) through its junction — verified empirically (junction `Target: C:\src\zam\.claude\skills\zam`, resolves `SKILL.md`).

## What's in here

**Skill wiring (`setup.ts`)**
- `wireSkills()` replaces `copySkills()`: links each agent `skills/zam` directory.
- Auto-migrates old single-file copies into live links.
- Preserves *unmanaged* skill directories unless `--force` is explicit.
- Never self-links the package source (checkout safety).

**Provisioning paths**
- `zam init`, desktop first-run (`ensureDesktopWorkspace` → `Documents/zam`), and `zam workspace add` all wire the skill.
- A workspace is registered **only after** linking succeeds — no orphaned registry entries on junction failure (was [workspace.ts:194](https://github.com/zam-os/zam/blob/main/src/cli/commands/workspace.ts)).

**Studio UI**
- `+ Add workspace…` header button (native folder picker → `workspace-add`).
- Per-row, non-destructive **Remove** button → `workspace-remove` (files & links untouched).

**Fixes for Codex's open items**
- ✅ Orphaned-entry ordering (wire-then-register).
- ✅ Three mechanical lint corrections.
- ✅ File-scoped 30s timeout for the process-spawning CLI E2E tests.

> `.gitignore` for the linked skill dirs is intentionally **not** implemented — the workspace owner manages that.

## Verification
- `npm run build` ✓ · `npm run lint` ✓ · `npm run test` → **328 passed** ✓ · desktop `tsc --noEmit` ✓
- Junction creation smoke-tested end-to-end (correct `Junction` LinkType + dev-checkout target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)