### PR TITLE
fix(desktop): prefer dev checkout CLI over bundled runtime

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -270,24 +270,29 @@ fn resolve_observer_runtime(app: &tauri::AppHandle) -> Option<ObserverRuntime> {
 }
 
 fn resolve_bridge_runtime(app: &tauri::AppHandle) -> Option<BridgeRuntime> {
-    if let Some(runtime) = bundled_runtime(app) {
-        return Some(runtime);
+    // Prefer an explicit developer checkout (ZAM_HOME, ~/.zam/cli_path written
+    // by `zam ui`, or a checkout in the working directory) over the bundled
+    // runtime. This keeps a `git pull` + `npm run build` immediately live in the
+    // desktop app, and — crucially — makes skill junctions created from the UI
+    // point at the checkout, so `git pull` refreshes every workspace. Installed
+    // apps have no checkout marker and fall through to the bundled runtime.
+    if let Some(cli_path) = resolve_dev_cli_path() {
+        let working_dir = cli_path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        return Some(BridgeRuntime {
+            node_path: env::var_os("ZAM_NODE")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("node")),
+            cli_path,
+            working_dir,
+        });
     }
 
-    let cli_path = resolve_dev_cli_path()?;
-    let working_dir = cli_path
-        .parent()
-        .and_then(Path::parent)
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
-    Some(BridgeRuntime {
-        node_path: env::var_os("ZAM_NODE")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("node")),
-        cli_path,
-        working_dir,
-    })
+    bundled_runtime(app)
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Problem

`resolve_bridge_runtime` checked `bundled_runtime()` **before** `resolve_dev_cli_path()`. In a developer build, `target/<profile>/resources/zam-cli` exists from a prior package step, so the desktop app spawned a **stale bundled CLI snapshot** for every bridge call.

Discovered while live-testing the Studio workspace UI ([zam#86](https://github.com/zam-os/zam/pull/86)): the bundled CLI was 2 days old and didn't even have `workspace-list` (`error: unknown command`). The fresh Vite frontend called it, the CLI rejected it, and `loadWorkspaceList`'s `catch {}` swallowed the error → the workspace panel rendered empty and the model panel showed "unknown".

Worse for the core requirement: skill junctions created from the UI used the bundle's `packageRoot`, so they pointed at `target/.../resources/zam-cli/.claude/skills/zam` instead of the checkout — meaning **`git pull` would not refresh UI-added workspaces**.

## Fix

Try `resolve_dev_cli_path()` first (honors `ZAM_HOME`, `~/.zam/cli_path` written by `zam ui`, or a checkout in the cwd), and fall back to `bundled_runtime()`. A `git pull` + `npm run build` is now immediately live in the desktop app, and UI-created junctions point at the checkout.

Installed apps have no checkout marker (`resolve_dev_cli_path` returns `None`) and fall through to the bundled runtime exactly as before.

## Verified live (computer-use, dev build)
- Bridge log now resolves `cli=C:\src\zam\dist\cli\index.js`, `working_dir=C:\src\zam`.
- Studio → *Einstellungen → Arbeitsbereiche*: list renders, **+ Add** opens the picker, **Entfernen** is non-destructive and falls back to the remaining workspace.
- A workspace added via the UI gets a junction `Target: C:\src\zam\.claude\skills\zam` (the payoff).
- Bonus: the *KI-Modelle* panel now shows the real local model instead of "unknown".

🤖 Generated with [Claude Code](https://claude.com/claude-code)