### PR TITLE
chore: release v0.5.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.5.0"
+version = "0.5.1"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump to **0.5.1** (zam-core + desktop + zam-app).

## Changes since v0.5.0
- feat: junction-based workspace skill wiring + add/remove UI ([zam#86](https://github.com/zam-os/zam/pull/86))
- fix(desktop): prefer dev checkout CLI over bundled runtime ([zam#87](https://github.com/zam-os/zam/pull/87))
- fix: wire Copilot skills to Claude-compatible path ([zam#85](https://github.com/zam-os/zam/pull/85))

## Verification
`npm run build` ✓ · `npm run lint` ✓ · `npm run test` → 328 passed ✓ · workspace add/remove + junction verified live in the desktop dev build.

Once merged, tagging `v0.5.1` triggers the release workflow (npm publish + signed installers + draft release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)