### PR TITLE
docs: Free Learning goal + Funded Learning belief

### DIFF
--- a/beliefs/README.md
+++ b/beliefs/README.md
@@ -11,6 +11,7 @@ This folder captures the premises on which ZAM is built. They are beliefs, not p
 3. **[Knowledge structure](knowledge-structure/)** — Knowledge is a shared graph; learning is a personal journey through it.
 4. **[Learning in context](learning-in-context/)** — Real work is the most effective classroom.
 5. **[Openness](openness/)** — The learning kernel must not depend on any specific AI vendor or interface.
+6. **[Funded learning](funded-learning/)** — Learning is free to the learner when those who benefit from an informed person fund it, and ZAM stays a connector, not a toll booth.
 
 ## Grounding in external work
 

--- a/beliefs/funded-learning/README.md
+++ b/beliefs/funded-learning/README.md
@@ -1,0 +1,78 @@
+# Funded Learning
+
+**Belief**: Learning that is free *to the learner* is sustainable when the people
+and institutions who benefit from an informed, capable person pay for it — provided
+ZAM stays a connector rather than a toll booth, names every funder, and never lets
+paid influence masquerade as the learner's own goals.
+
+This is an economic hypothesis, not a proven model. It is deliberately scoped to what
+can bootstrap **now**, locally. The larger ambitions — state-curriculum funding, a
+cash-bearing credit economy, ratings recognised as formal credentials — are parked in
+[Open questions](#open-questions) until the local wedge is proven.
+
+## Components
+
+1. **Beneficiary-funded, not learner-funded** — the learner never pays. Those who
+   gain from an informed person do: first a local club, parish, kindergarten, or town
+   that needs its members to reliably *know things* (where waste goes, how to register
+   a child, what a membership costs). Local demand is concrete and bootstrappable;
+   national or ministry funding is a much slower, much later prospect.
+2. **Connector, never a payment intermediary** — money flows **directly** between the
+   parties, through their own banking. ZAM matches, and optionally invoices, but never
+   holds or routes funds. This is what keeps a sub-1% fee possible at all, and keeps
+   ZAM out of [e-money and payment-services regulation](https://en.wikipedia.org/wiki/Electronic_money).
+3. **Minimal, transparent take-rate** — the referral fee is **≤1% of the gross
+   transaction value, billed separately** — never skimmed from a money flow (ZAM
+   controls none). For scale: marketplaces like eBay take ~13%, and card processors
+   alone ~2–3%; ZAM's fee is an order of magnitude lower *because* it never touches the
+   money. A standing fee waiver below a low monthly turnover protects small earners —
+   this is ZAM's *own* fee, distinct from any state tax allowance.
+4. **Mandatory funder transparency** — any funded or promoted content **names who paid
+   for it**, visibly. Quality is sorted by learners and ratings, not by a gatekeeper.
+   Disclosure is the non-negotiable floor that keeps "funded" from sliding into covert
+   advertising.
+5. **Ephemeral vs. durable knowledge** — not all knowledge is meant to be kept. A
+   concert announcement matters until the concert; correct waste-sorting matters for
+   years. Only the **learner's own** goals drive the long-term
+   [spaced-repetition](https://en.wikipedia.org/wiki/Spaced_repetition) graph; funded
+   and ephemeral items default to short-lived and never enter long-term retention
+   unless the learner chooses it.
+6. **Non-monetary credits** — "ZAM credits" are progress and access points (they
+   unlock premium content and signal achievement). They are **not cashable** and carry
+   no monetary value, which keeps them clear of e-money regulation. Credits granted by
+   an employer or organisation are recognition, not wages.
+
+## Related beliefs
+
+- [Openness](../openness/) — the kernel stays vendor-neutral; the funding model must
+  likewise avoid lock-in to any single payer or payment rail.
+- [Symbiosis](../symbiosis/) and the founding line *"[Don't just automate — Elevate](../README.md)"*
+  — the funding model must serve the learner's growth, never quietly redirect it.
+
+## What this is NOT (yet)
+
+Deliberately out of near-term scope (see [Open questions](#open-questions)):
+
+- State / ministry curriculum funding as a revenue pillar.
+- Credits that convert to money.
+- ZAM-issued credentials, or ratings treated as equivalent to formal degrees.
+- A pricing formula based on "the cost of ignorance."
+
+## Open questions
+
+- **The SRS integrity risk is real even with disclosure.** A spaced-repetition engine
+  is, by design, exceptionally good at making content *stick permanently*. Disclosure
+  lets a learner judge "education vs. advertising," but it pushes that judgment onto
+  the learner. Is transparency + ratings *enough*, or does funded content need a hard
+  structural cap on how deep into long-term retention it can reach?
+- **Conflict of interest: tool vs. marketplace.** Earning from transactions tempts ZAM
+  to steer learners toward *monetisable* skills over intrinsically valuable ones. What
+  structural guard keeps the money from bending the curriculum?
+- **Take-rate base.** "≤1% of gross transaction value" is the working definition. Does
+  the fee-waiver threshold scale with anything, and who audits it?
+- **Cold start.** Local funders pay when there are learners; learners come when there
+  is content. What is the very first turn of the flywheel — a single community, fully
+  served?
+- **Tax & legal surface.** Even as a pure connector, earners face income tax, and
+  possibly VAT, trade registration, or bogus-self-employment questions. How much of
+  this does the agent surface versus handle?

--- a/goals/README.md
+++ b/goals/README.md
@@ -7,6 +7,7 @@ ZAM's purpose is to ensure that as AI becomes more capable, humans become more c
 1. **[Phase 1: Individual Symbiosis](phase-1/README.md)** — Creating a deep, learning-focused connection between a person and their personal agent.
 2. **[Phase 2: Connected Community](phase-2/README.md)** — Scaling symbiosis to the community layer through agent-to-agent matching.
 3. **[Human Elevation](human-elevation/README.md)** — The long-term philosophical goal: automation that prevents cognitive decline and fosters growth.
+4. **[Free Learning](free-learning/README.md)** — Capability at no personal cost, turned into a livelihood through credentials or demonstrated, rated work. Bridges Phase 1 growth and Phase 2 marketplace.
 
 ## Architecture Guidelines for Goals
 

--- a/goals/free-learning/README.md
+++ b/goals/free-learning/README.md
@@ -1,0 +1,62 @@
+# Free Learning: Capability Without Cost
+
+**Target State**: Anyone can raise their own capabilities at no personal cost, and turn
+those capabilities into a livelihood — through recognised credentials where they exist,
+and through demonstrated, positively-rated work where they do not. Phase 1's value is
+**personal growth**; the livelihood follows from it.
+
+## Target Components
+
+1. **Free at the point of learning** — the learner never pays; the cost is borne by
+   those who benefit from an informed person. *How* this stays sustainable is the
+   [Funded Learning](../../beliefs/funded-learning/) belief.
+2. **Two kinds of value, both protected** — learning is worth the **joy of growth and
+   understanding** *and* the **marketable capability** it builds. The second must never
+   be allowed to crowd out the first (see [Open Questions](#open-questions)).
+3. **Capability becomes livelihood** — the point of growing is to be *able to deliver
+   work worth doing*. Learning aims at real output, not at scores.
+4. **Two paths to proof** — (a) **preparation** toward recognised certificates
+   (Abitur, Bachelor, Meister, PhD …) that ZAM does not issue but helps people reach;
+   and (b) **demonstrated outcomes** — artifacts created and positively-rated services
+   — as portfolio-based proof of ability. This extends Phase 2's
+   *[Marketplace Offerings, Not Resumes](../phase-2/successful-artist.md)*.
+5. **Output as evidence** — a positive rating is a *relevant* signal of capability for
+   practical work. It is not a claim that it outranks a formal degree; the two measure
+   different things.
+6. **Local-first adoption** — the first learners, and the first people willing to fund
+   them, come from communities (a town, a club, a parish), not from national programmes.
+
+## Relationship to other goals
+
+- Rests on the [Funded Learning](../../beliefs/funded-learning/) belief — the economic
+  substrate that makes "free" possible.
+- Feeds [Phase 2 → The Successful Artist](../phase-2/successful-artist.md) —
+  demonstrated, rated work is exactly the "offering, not resume" the marketplace runs on.
+- Serves [Human Elevation → Universal Access to Wisdom](../human-elevation/README.md) —
+  capability regardless of prior education or means.
+
+## Definition of Done (near-term)
+
+A first, narrow milestone — not the whole vision:
+
+- One real learner reaches a self-declared capability through ZAM at **zero personal
+  cost**.
+- At least one **local funder** (an organisation or community) pays — via direct
+  settlement, ZAM's fee billed separately and ≤1% — for content their members actually
+  learn.
+- The learner can show **demonstrated output** (an artifact or a rated service) as
+  proof of that capability.
+
+## Open Questions
+
+- **Does "free" stay honest?** Once a funder pays, it buys an interest. The guard is
+  funder transparency plus learner-owned goals (see the belief) — is that enough to keep
+  growth, not influence, in the driver's seat?
+- **Ratings as credential.** For a rating to *substitute* for a certificate, enough
+  people must trust it — a hard cold-start. What is the minimum trust base, and in which
+  trades does it work first?
+- **Protecting non-marketable learning.** If funding rewards marketable skills, what
+  keeps philosophy, parenting, or music-for-its-own-sake fundable too?
+- **Formal credentials** (Bachelor, Meister, PhD) are legally gated to universities and
+  chambers — ZAM can only *prepare*. Where exactly is the line between preparation and
+  the credential itself?


### PR DESCRIPTION
## What

Captures the **"Freies Lernen"** vision as two cross-linked, house-style documents:

- **`goals/free-learning/README.md`** — capability at no personal cost, turned into a livelihood via recognised credentials *or* demonstrated, positively-rated work. Bridges Phase 1 (personal growth) and Phase 2 (marketplace).
- **`beliefs/funded-learning/README.md`** — the economic premise behind it (new top-level belief; the `beliefs/` tree had no economic axis before).

Index updates in `beliefs/README.md` (belief #6) and `goals/README.md` (goal #4).

## Design decisions baked in

The original draft was stress-tested; four choices were made to keep the model plausible **now**:

| Question | Decision |
|---|---|
| Promoter integrity | **Market regulates + mandatory transparency** — every funder is named; learners + ratings sort quality (no accreditation gate). |
| Fee mechanics | **Pure connector, no money flow** — payment is direct between parties; ZAM bills a **≤1% referral fee separately**. Keeps it out of e-money/PSP regulation and below the impossible ~2–3% card-processing floor. |
| Ambition scope | **Near-term bootstrappable only** — local/community funders lead; ministries, the full credit economy, and ratings-as-credentials are parked. |
| ZAM credits | **Non-monetary points** — not cashable → no BaFin/e-money surface. |

## Unvarnished critique → now in "Open Questions"

Rather than smoothing over the weak spots, the load-bearing risks are recorded in each doc:

- **SRS integrity risk** — a spaced-repetition engine is built to make content stick *permanently*; disclosure pushes the "education vs. advertising" judgment onto the learner. Is transparency enough, or is a structural cap on funded content's long-term retention needed?
- **Tool-vs-marketplace conflict of interest** — earning from transactions tempts steering learners toward monetisable skills.
- **Cold start** — every revenue line presumes existing scale.
- **Tax/legal surface** — income tax, VAT, trade registration, bogus self-employment remain on the earner even with a pure-connector model.

## Deliberately parked (not in scope)

State/ministry curriculum funding as a pillar · cash-convertible credits · ZAM-issued or "ratings = formal degree" credentials · "cost-of-ignorance" pricing formula. The original draft's `1% of Bruttogewinn` example mixed three bases (gross revenue / gross profit / net-after-tax) and conflated ZAM's fee with the state's tax allowance — both corrected: the working definition is now **≤1% of gross transaction value**, and the small-earner protection is framed as **ZAM's own fee waiver**, distinct from the Grundfreibetrag.

## Note for review

- Written in **English** to match every sibling in `beliefs/`/`goals/`; Germany-specific examples (Verein, Pfarrei, town) kept inline. Happy to provide a German version if preferred.
- Per the repo's belief-change protocol, this is a conceptual addition (no code depends on it yet); review the *concept* first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
