### PR TITLE
feat(curriculum): LehrplanPLUS provider registry + navigation (Phase 1)

### DIFF
--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -92,6 +92,16 @@ import {
   resolveHarnessExecutable,
 } from "../agent-harness.js";
 import {
+  CURRICULUM_PROVIDERS,
+  type CurriculumBreadcrumb,
+  type CurriculumLevel,
+  type CurriculumSelection,
+  getCurriculumProvider,
+  getLastCurriculumSelection,
+  setLastCurriculumSelection,
+  type TopicNode,
+} from "../curriculum/index.js";
+import {
   type ApiFlavor,
   checkVisionReadiness,
   DEFAULT_LLM_MODEL,
@@ -3294,6 +3304,164 @@ bridgeCommand
         createdCount: result.createdCount,
         ensuredCount: result.linkedCount,
       });
+    });
+  });
+
+// ── zam bridge curriculum-list-providers ────────────────────────────────────
+
+bridgeCommand
+  .command("curriculum-list-providers")
+  .description("List registered curriculum providers (JSON)")
+  .action(() => {
+    jsonOut({
+      success: true,
+      providers: CURRICULUM_PROVIDERS.map((provider) => ({
+        id: provider.id,
+        country: provider.country,
+        countryLabel: provider.countryLabel,
+        region: provider.region,
+        regionLabel: provider.regionLabel,
+        label: provider.label,
+      })),
+    });
+  });
+
+// ── zam bridge curriculum-list-level ────────────────────────────────────────
+
+const CURRICULUM_LEVELS: CurriculumLevel[] = [
+  "schoolType",
+  "grade",
+  "subject",
+  "track",
+  "topic",
+];
+
+bridgeCommand
+  .command("curriculum-list-level")
+  .description("List taxonomy options for the next import-wizard step (JSON)")
+  .requiredOption("--provider <id>", "Curriculum provider id")
+  .requiredOption(
+    "--level <level>",
+    `Level to list: ${CURRICULUM_LEVELS.join("|")}`,
+  )
+  .option("--selection <json>", "JSON selection made so far", "{}")
+  .action((opts) => {
+    const provider = getCurriculumProvider(opts.provider);
+    if (!provider) jsonError(`Unknown curriculum provider: ${opts.provider}`);
+
+    if (!CURRICULUM_LEVELS.includes(opts.level)) {
+      jsonError(
+        `Invalid --level: ${opts.level}. Use one of ${CURRICULUM_LEVELS.join(", ")}.`,
+      );
+    }
+
+    let selection: CurriculumSelection;
+    try {
+      selection = JSON.parse(opts.selection);
+    } catch {
+      jsonError("Invalid --selection JSON");
+      return;
+    }
+
+    const level = opts.level as CurriculumLevel;
+    if (level === "schoolType") {
+      jsonOut({ success: true, options: provider.listSchoolTypes() });
+      return;
+    }
+
+    if (!selection.schoolType) jsonError("selection.schoolType is required");
+    if (level === "grade") {
+      jsonOut({
+        success: true,
+        options: provider.listGrades(selection.schoolType),
+      });
+      return;
+    }
+
+    if (!selection.grade) jsonError("selection.grade is required");
+    if (level === "subject") {
+      jsonOut({
+        success: true,
+        options: provider.listSubjects(selection.schoolType, selection.grade),
+      });
+      return;
+    }
+
+    if (!selection.subject) jsonError("selection.subject is required");
+    if (level === "track") {
+      jsonOut({
+        success: true,
+        options: provider.listTracks(
+          selection.schoolType,
+          selection.grade,
+          selection.subject,
+        ),
+      });
+      return;
+    }
+
+    jsonOut({ success: true, options: provider.listTopics(selection) });
+  });
+
+// ── zam bridge curriculum-resolve-topics ─────────────────────────────────────
+
+bridgeCommand
+  .command("curriculum-resolve-topics")
+  .description("Resolve selected curriculum topics to source URLs (JSON)")
+  .requiredOption("--provider <id>", "Curriculum provider id")
+  .requiredOption("--topics <json>", "JSON array of topic nodes to resolve")
+  .action((opts) => {
+    const provider = getCurriculumProvider(opts.provider);
+    if (!provider) jsonError(`Unknown curriculum provider: ${opts.provider}`);
+
+    let topics: TopicNode[];
+    try {
+      topics = JSON.parse(opts.topics);
+    } catch {
+      jsonError("Invalid --topics JSON");
+      return;
+    }
+
+    const resolved = topics.map((topic) => provider.resolveTopic(topic));
+    jsonOut({ success: true, resolved });
+  });
+
+// ── zam bridge curriculum-get-last-selection ─────────────────────────────────
+
+bridgeCommand
+  .command("curriculum-get-last-selection")
+  .description("Read the learner's last navigated curriculum path (JSON)")
+  .action(async () => {
+    await withDb(async (db) => {
+      const breadcrumb = await getLastCurriculumSelection(db);
+      jsonOut({ success: true, breadcrumb: breadcrumb ?? null });
+    });
+  });
+
+// ── zam bridge curriculum-set-last-selection ─────────────────────────────────
+
+bridgeCommand
+  .command("curriculum-set-last-selection")
+  .description("Persist the learner's last navigated curriculum path (JSON)")
+  .requiredOption(
+    "--breadcrumb <json>",
+    "JSON breadcrumb: {providerId, schoolType?, grade?, subject?, track?}",
+  )
+  .action(async (opts) => {
+    await withDb(async (db) => {
+      let breadcrumb: CurriculumBreadcrumb;
+      try {
+        breadcrumb = JSON.parse(opts.breadcrumb);
+      } catch {
+        jsonError("Invalid --breadcrumb JSON");
+        return;
+      }
+      if (!breadcrumb.providerId) {
+        jsonError("breadcrumb.providerId is required");
+        return;
+      }
+      await setLastCurriculumSelection(db, breadcrumb);
+      jsonOut({ success: true });
     });
   });
 

--- a/src/cli/curriculum/breadcrumb.ts
+++ b/src/cli/curriculum/breadcrumb.ts
@@ -1,0 +1,34 @@
+/**
+ * Persists the learner's last navigated curriculum path so a reopened
+ * wizard can show it first and jump straight back to the right level,
+ * instead of re-navigating all steps from scratch (ADR 2026-07-02,
+ * resolved decision 6). Backed by the existing settings/user_config store.
+ */
+
+import { type Database, getSetting, setSetting } from "../../kernel/index.js";
+import type { CurriculumSelection } from "./types.js";
+
+const LAST_SELECTION_KEY = "curriculum.lastSelection";
+
+export interface CurriculumBreadcrumb extends CurriculumSelection {
+  providerId: string;
+}
+
+export async function getLastCurriculumSelection(
+  db: Database,
+): Promise<CurriculumBreadcrumb | undefined> {
+  const raw = await getSetting(db, LAST_SELECTION_KEY);
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as CurriculumBreadcrumb;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function setLastCurriculumSelection(
+  db: Database,
+  breadcrumb: CurriculumBreadcrumb,
+): Promise<void> {
+  await setSetting(db, LAST_SELECTION_KEY, JSON.stringify(breadcrumb));
+}

--- a/src/cli/curriculum/index.ts
+++ b/src/cli/curriculum/index.ts
@@ -1,0 +1,20 @@
+export type { CurriculumBreadcrumb } from "./breadcrumb.js";
+export {
+  getLastCurriculumSelection,
+  setLastCurriculumSelection,
+} from "./breadcrumb.js";
+export {
+  CURRICULUM_PROVIDERS,
+  type CurriculumRegionOption,
+  getCurriculumProvider,
+  listCurriculumCountries,
+  listCurriculumRegions,
+} from "./registry.js";
+export type {
+  CurriculumLevel,
+  CurriculumProvider,
+  CurriculumSelection,
+  ResolvedSource,
+  TaxonomyNode,
+  TopicNode,
+} from "./types.js";

--- a/src/cli/curriculum/providers/lehrplanplus-bayern/index.ts
+++ b/src/cli/curriculum/providers/lehrplanplus-bayern/index.ts
@@ -1,0 +1,77 @@
+import type {
+  CurriculumProvider,
+  CurriculumSelection,
+  ResolvedSource,
+  TaxonomyNode,
+  TopicNode,
+} from "../../types.js";
+import { LEHRPLANPLUS_BAYERN_MANIFEST as MANIFEST } from "./manifest.js";
+
+function levelKey(
+  schoolType: string,
+  grade: string,
+  subject: string,
+  track?: string,
+): string {
+  return track
+    ? `${schoolType}|${grade}|${subject}|${track}`
+    : `${schoolType}|${grade}|${subject}`;
+}
+
+export const lehrplanplusBayernProvider: CurriculumProvider = {
+  id: "lehrplanplus-bayern",
+  country: "DE",
+  countryLabel: "Deutschland",
+  region: "BY",
+  regionLabel: "Bayern",
+  label: "LehrplanPLUS (Bayern)",
+
+  listSchoolTypes(): TaxonomyNode[] {
+    return MANIFEST.schoolTypes;
+  },
+
+  listGrades(schoolType: string): TaxonomyNode[] {
+    return (MANIFEST.grades[schoolType] ?? []).map((grade) => ({
+      id: grade,
+      label: grade,
+    }));
+  },
+
+  listSubjects(schoolType: string, _grade: string): TaxonomyNode[] {
+    return MANIFEST.subjects[schoolType] ?? [];
+  },
+
+  listTracks(
+    schoolType: string,
+    grade: string,
+    subject: string,
+  ): TaxonomyNode[] {
+    return MANIFEST.tracks[levelKey(schoolType, grade, subject)] ?? [];
+  },
+
+  listTopics(selection: CurriculumSelection): TopicNode[] {
+    const { schoolType, grade, subject, track } = selection;
+    if (!schoolType || !grade || !subject) return [];
+    const key = levelKey(schoolType, grade, subject, track);
+    return (MANIFEST.topics[key] ?? []).map((topic) => ({
+      ...topic,
+      sourceRef: key,
+    }));
+  },
+
+  resolveTopic(topic: TopicNode): ResolvedSource {
+    const uri = MANIFEST.contentUrls[topic.sourceRef];
+    if (!uri) {
+      throw new Error(
+        `LehrplanPLUS Bayern: no resolvable source URL for topic "${topic.id}" ` +
+          `(${topic.sourceRef}). The manifest only covers the combinations ` +
+          `curated as of ${MANIFEST.capturedOn}.`,
+      );
+    }
+    return {
+      provider: "lehrplanplus-bayern",
+      topicId: `${topic.sourceRef}#${topic.id}`,
+      uri,
+    };
+  },
+};

--- a/src/cli/curriculum/providers/lehrplanplus-bayern/manifest.ts
+++ b/src/cli/curriculum/providers/lehrplanplus-bayern/manifest.ts
@@ -1,0 +1,165 @@
+/**
+ * Bundled LehrplanPLUS (Bayern) taxonomy manifest.
+ *
+ * Per ADR 2026-07-02, this manifest is refreshed by an agent once per
+ * school year (not a scraper script), because an agent can adapt to a
+ * redesigned page or a moved link the way a brittle parser cannot. Each
+ * refresh is expected to add or revise entries rather than replace the
+ * whole file — `capturedOn` marks when a given branch was last verified
+ * against the live site.
+ *
+ * Every entry below was captured by navigating https://www.lehrplanplus.bayern.de
+ * on `capturedOn`; nothing here is inferred or guessed. Coverage is
+ * intentionally partial — only Realschule, grade 9, and three subjects are
+ * curated so far. Extending coverage (more grades, subjects, or school
+ * types) is future agent work, not a Phase 1 requirement.
+ */
+
+import type { TaxonomyNode } from "../../types.js";
+
+interface ManifestTopic extends TaxonomyNode {
+  hours?: number;
+}
+
+export interface LehrplanPlusBayernManifest {
+  /** Bavarian school year this branch of the manifest was captured for. */
+  schoolYear: string;
+  /** Date the entries below were last verified against the live site. */
+  capturedOn: string;
+  /** The official curriculum edition these entries were read from. */
+  sourceRevision: string;
+  schoolTypes: TaxonomyNode[];
+  /** Verified grade options, keyed by school-type id. */
+  grades: Record<string, string[]>;
+  /** Verified subject catalog, keyed by school-type id. */
+  subjects: Record<string, TaxonomyNode[]>;
+  /** Verified track (Ausprägung) options, keyed by "schoolType|grade|subject". */
+  tracks: Record<string, TaxonomyNode[]>;
+  /** Verified Lernbereiche, keyed by "schoolType|grade|subject[|track]". */
+  topics: Record<string, ManifestTopic[]>;
+  /** Verified content-page URL, keyed the same way as `topics`. */
+  contentUrls: Record<string, string>;
+}
+
+export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
+  schoolYear: "2026/2027",
+  capturedOn: "2026-07-02",
+  sourceRevision: "LehrplanPLUS Realschule – Oktober 2023",
+
+  schoolTypes: [
+    { id: "grundschule", label: "Grundschule" },
+    { id: "mittelschule", label: "Mittelschule" },
+    { id: "foerderschule", label: "Förderschule" },
+    { id: "realschule", label: "Realschule" },
+    { id: "gymnasium", label: "Gymnasium" },
+    { id: "wirtschaftsschule", label: "Wirtschaftsschule" },
+    { id: "fos", label: "Fachoberschule" },
+    { id: "bos", label: "Berufsoberschule" },
+  ],
+
+  grades: {
+    realschule: ["5", "6", "7", "8", "9", "10"],
+  },
+
+  subjects: {
+    realschule: [
+      {
+        id: "bwl-rechnungswesen",
+        label: "Betriebswirtschaftslehre / Rechnungswesen",
+      },
+      { id: "biologie", label: "Biologie" },
+      { id: "chemie", label: "Chemie" },
+      { id: "deutsch", label: "Deutsch" },
+      { id: "englisch", label: "Englisch" },
+      { id: "ernaehrung_und_gesundheit", label: "Ernährung und Gesundheit" },
+      { id: "ethik", label: "Ethik" },
+      {
+        id: "evangelische-religionslehre",
+        label: "Evangelische Religionslehre",
+      },
+      { id: "franzoesisch", label: "Französisch" },
+      { id: "geographie", label: "Geographie" },
+      { id: "geschichte", label: "Geschichte" },
+      { id: "it", label: "Informationstechnologie" },
+      { id: "iu", label: "Islamischer Unterricht" },
+      { id: "ir", label: "Israelitische Religionslehre" },
+      {
+        id: "katholische-religionslehre",
+        label: "Katholische Religionslehre",
+      },
+      { id: "kunst", label: "Kunst" },
+      { id: "mathematik", label: "Mathematik" },
+      { id: "musik", label: "Musik" },
+      { id: "or", label: "Orthodoxe Religionslehre" },
+      { id: "physik", label: "Physik" },
+      { id: "pug", label: "Politik und Gesellschaft" },
+      { id: "soziallehre", label: "Soziallehre" },
+      { id: "sozialwesen", label: "Sozialwesen" },
+      { id: "spanisch", label: "Spanisch" },
+      { id: "sport", label: "Sport" },
+      { id: "textiles-gestalten", label: "Textiles Gestalten" },
+      { id: "werken", label: "Werken" },
+      { id: "wirtschaft-und-recht", label: "Wirtschaft und Recht" },
+    ],
+  },
+
+  tracks: {
+    "realschule|9|mathematik": [
+      { id: "wpfg1", label: "Mathematik 9 (I)" },
+      { id: "wpfg2-3", label: "Mathematik 9 (II/III)" },
+    ],
+  },
+
+  topics: {
+    "realschule|9|mathematik|wpfg1": [
+      { id: "lb1", label: "Reelle Zahlen", hours: 10 },
+      { id: "lb2", label: "Zentrische Streckung", hours: 17 },
+      { id: "lb3", label: "Rechtwinklige Dreiecke", hours: 20 },
+      { id: "lb4", label: "Kreis", hours: 10 },
+      { id: "lb5", label: "Raumgeometrie", hours: 20 },
+      { id: "lb6", label: "Systeme linearer Gleichungen", hours: 12 },
+      {
+        id: "lb7",
+        label: "Quadratische Funktionen und quadratische Gleichungen",
+        hours: 42,
+      },
+      { id: "lb8", label: "Daten und Zufall", hours: 9 },
+    ],
+    "realschule|9|mathematik|wpfg2-3": [
+      { id: "lb1", label: "Reelle Zahlen", hours: 7 },
+      { id: "lb2", label: "Zentrische Streckung", hours: 13 },
+      { id: "lb3", label: "Rechtwinklige Dreiecke", hours: 20 },
+      { id: "lb4", label: "Kreis", hours: 10 },
+      { id: "lb5", label: "Lineare Funktionen", hours: 15 },
+      { id: "lb6", label: "Systeme linearer Gleichungen", hours: 10 },
+      { id: "lb7", label: "Daten und Zufall", hours: 9 },
+    ],
+    "realschule|9|deutsch": [
+      { id: "lb1", label: "Sprechen und Zuhören" },
+      { id: "lb2", label: "Lesen – mit Texten und weiteren Medien umgehen" },
+      { id: "lb3", label: "Schreiben" },
+      {
+        id: "lb4",
+        label: "Sprachgebrauch und Sprache untersuchen und reflektieren",
+      },
+    ],
+    "realschule|9|englisch": [
+      { id: "lb1", label: "Kommunikative Kompetenzen" },
+      { id: "lb2", label: "Interkulturelle Kompetenzen" },
+      { id: "lb3", label: "Text- und Medienkompetenzen" },
+      { id: "lb4", label: "Methodische Kompetenzen" },
+      { id: "lb5", label: "Themengebiete" },
+    ],
+  },
+
+  contentUrls: {
+    "realschule|9|mathematik|wpfg1":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=9&wt_3=jgs&w_auspraegung=wpfg1",
+    "realschule|9|mathematik|wpfg2-3":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=9&wt_3=jgs&w_auspraegung=wpfg2-3",
+    "realschule|9|deutsch":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/deutsch/inhalt/fachlehrplaene",
+    "realschule|9|englisch":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/englisch/inhalt/fachlehrplaene",
+  },
+};

--- a/src/cli/curriculum/registry.ts
+++ b/src/cli/curriculum/registry.ts
@@ -1,0 +1,41 @@
+import { lehrplanplusBayernProvider } from "./providers/lehrplanplus-bayern/index.js";
+import type { CurriculumProvider, TaxonomyNode } from "./types.js";
+
+/** Registered curriculum providers. Add a new plugin here to extend it. */
+export const CURRICULUM_PROVIDERS: CurriculumProvider[] = [
+  lehrplanplusBayernProvider,
+];
+
+export function getCurriculumProvider(
+  id: string,
+): CurriculumProvider | undefined {
+  return CURRICULUM_PROVIDERS.find((provider) => provider.id === id);
+}
+
+export interface CurriculumRegionOption extends TaxonomyNode {
+  providerId: string;
+}
+
+/** Distinct countries across all registered providers (wizard step 1). */
+export function listCurriculumCountries(): TaxonomyNode[] {
+  const countries: TaxonomyNode[] = [];
+  for (const provider of CURRICULUM_PROVIDERS) {
+    if (!countries.some((c) => c.id === provider.country)) {
+      countries.push({ id: provider.country, label: provider.countryLabel });
+    }
+  }
+  return countries;
+}
+
+/** Regions within a country, each naming the provider that serves it (wizard step 2). */
+export function listCurriculumRegions(
+  country: string,
+): CurriculumRegionOption[] {
+  return CURRICULUM_PROVIDERS.filter(
+    (provider) => provider.country === country,
+  ).map((provider) => ({
+    id: provider.region,
+    label: provider.regionLabel,
+    providerId: provider.id,
+  }));
+}

--- a/src/cli/curriculum/types.ts
+++ b/src/cli/curriculum/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Curriculum Provider Plugin contract (ADR 2026-07-02-lehrplanplus-import-wizard).
+ *
+ * A curriculum provider turns one official school curriculum into a
+ * navigable taxonomy: school type -> grade -> subject -> (optional track)
+ * -> topic. The import wizard walks this level by level; `resolveTopic`
+ * turns a selected topic into a source URL that flows into the existing
+ * personal-source-import / personal-card-import-curriculum /
+ * personal-source-confirm-import pipeline. No provider is hard-wired into
+ * that pipeline or the kernel — this is the only contract they share.
+ */
+
+export interface TaxonomyNode {
+  id: string;
+  label: string;
+}
+
+export interface TopicNode extends TaxonomyNode {
+  /** Groups sibling topics that resolve to the same source page. */
+  sourceRef: string;
+  /** Approximate teaching hours, when the curriculum specifies them. */
+  hours?: number;
+}
+
+export interface ResolvedSource {
+  provider: string;
+  topicId: string;
+  uri: string;
+}
+
+export interface CurriculumSelection {
+  schoolType?: string;
+  grade?: string;
+  subject?: string;
+  /** Some subjects split into tracks (e.g. Bavarian Realschule Wahlpflichtfächergruppen). */
+  track?: string;
+}
+
+export type CurriculumLevel =
+  | "schoolType"
+  | "grade"
+  | "subject"
+  | "track"
+  | "topic";
+
+export interface CurriculumProvider {
+  id: string;
+  /** ISO 3166-1 alpha-2 country code, e.g. "DE". */
+  country: string;
+  countryLabel: string;
+  /** State/region code, e.g. "BY" for Bayern. */
+  region: string;
+  regionLabel: string;
+  label: string;
+
+  listSchoolTypes(): TaxonomyNode[];
+  listGrades(schoolType: string): TaxonomyNode[];
+  listSubjects(schoolType: string, grade: string): TaxonomyNode[];
+  /** Empty when the subject has one unified curriculum (no track step needed). */
+  listTracks(
+    schoolType: string,
+    grade: string,
+    subject: string,
+  ): TaxonomyNode[];
+  listTopics(selection: CurriculumSelection): TopicNode[];
+  resolveTopic(topic: TopicNode): ResolvedSource;
+}

--- a/tests/cli/bridge-curriculum.test.ts
+++ b/tests/cli/bridge-curriculum.test.ts
@@ -1,0 +1,205 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("bridge curriculum-* commands", () => {
+  let tempHome: string;
+  let tempCwd: string;
+  let cliPath: string;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "zam-bridge-curriculum-home-"));
+    tempCwd = mkdtempSync(join(tmpdir(), "zam-bridge-curriculum-cwd-"));
+    cliPath = join(process.cwd(), "dist", "cli", "index.js");
+  });
+
+  afterEach(() => {
+    for (const dir of [tempHome, tempCwd]) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  });
+
+  function runBridge(args: string[]): unknown {
+    const env = { ...process.env, USERPROFILE: tempHome, HOME: tempHome };
+    const out = execFileSync("node", [cliPath, "bridge", ...args], {
+      env,
+      cwd: tempCwd,
+      encoding: "utf-8",
+    });
+    return JSON.parse(out);
+  }
+
+  it("lists the registered LehrplanPLUS Bayern provider", () => {
+    const result = runBridge(["curriculum-list-providers"]) as {
+      success: boolean;
+      providers: Array<{ id: string; country: string; region: string }>;
+    };
+    expect(result.success).toBe(true);
+    expect(result.providers).toContainEqual({
+      id: "lehrplanplus-bayern",
+      country: "DE",
+      countryLabel: "Deutschland",
+      region: "BY",
+      regionLabel: "Bayern",
+      label: "LehrplanPLUS (Bayern)",
+    });
+  });
+
+  it("walks all six wizard levels down to a concrete Lernbereich", () => {
+    const schoolTypes = runBridge([
+      "curriculum-list-level",
+      "--provider",
+      "lehrplanplus-bayern",
+      "--level",
+      "schoolType",
+    ]) as { success: boolean; options: Array<{ id: string }> };
+    expect(schoolTypes.options.map((o) => o.id)).toContain("realschule");
+
+    const grades = runBridge([
+      "curriculum-list-level",
+      "--provider",
+      "lehrplanplus-bayern",
+      "--level",
+      "grade",
+      "--selection",
+      JSON.stringify({ schoolType: "realschule" }),
+    ]) as { options: Array<{ id: string }> };
+    expect(grades.options.map((o) => o.id)).toContain("9");
+
+    const subjects = runBridge([
+      "curriculum-list-level",
+      "--provider",
+      "lehrplanplus-bayern",
+      "--level",
+      "subject",
+      "--selection",
+      JSON.stringify({ schoolType: "realschule", grade: "9" }),
+    ]) as { options: Array<{ id: string }> };
+    expect(subjects.options.map((o) => o.id)).toContain("mathematik");
+
+    const tracks = runBridge([
+      "curriculum-list-level",
+      "--provider",
+      "lehrplanplus-bayern",
+      "--level",
+      "track",
+      "--selection",
+      JSON.stringify({
+        schoolType: "realschule",
+        grade: "9",
+        subject: "mathematik",
+      }),
+    ]) as { options: Array<{ id: string; label: string }> };
+    expect(tracks.options).toEqual([
+      { id: "wpfg1", label: "Mathematik 9 (I)" },
+      { id: "wpfg2-3", label: "Mathematik 9 (II/III)" },
+    ]);
+
+    const topics = runBridge([
+      "curriculum-list-level",
+      "--provider",
+      "lehrplanplus-bayern",
+      "--level",
+      "topic",
+      "--selection",
+      JSON.stringify({
+        schoolType: "realschule",
+        grade: "9",
+        subject: "mathematik",
+        track: "wpfg1",
+      }),
+    ]) as { options: Array<{ id: string; label: string }> };
+    expect(topics.options).toHaveLength(8);
+    expect(topics.options[0]).toMatchObject({ label: "Reelle Zahlen" });
+  });
+
+  it("resolves selected topics to their LehrplanPLUS source URLs (batch)", () => {
+    const topics = runBridge([
+      "curriculum-list-level",
+      "--provider",
+      "lehrplanplus-bayern",
+      "--level",
+      "topic",
+      "--selection",
+      JSON.stringify({
+        schoolType: "realschule",
+        grade: "9",
+        subject: "deutsch",
+      }),
+    ]) as { options: Array<{ id: string; label: string; sourceRef: string }> };
+
+    const resolved = runBridge([
+      "curriculum-resolve-topics",
+      "--provider",
+      "lehrplanplus-bayern",
+      "--topics",
+      JSON.stringify(topics.options.slice(0, 2)),
+    ]) as {
+      success: boolean;
+      resolved: Array<{ provider: string; topicId: string; uri: string }>;
+    };
+
+    expect(resolved.resolved).toHaveLength(2);
+    expect(resolved.resolved[0].topicId).toBe("realschule|9|deutsch#lb1");
+    expect(resolved.resolved[0].uri).toBe(resolved.resolved[1].uri);
+    expect(resolved.resolved[0].uri).toContain(
+      "/schulart/realschule/jgs/9/fach/deutsch/",
+    );
+  });
+
+  it("rejects an unknown provider", () => {
+    expect(() =>
+      runBridge([
+        "curriculum-list-level",
+        "--provider",
+        "nope",
+        "--level",
+        "schoolType",
+      ]),
+    ).toThrow();
+  });
+
+  it("round-trips the last navigated breadcrumb through the bridge", () => {
+    const before = runBridge(["curriculum-get-last-selection"]) as {
+      success: boolean;
+      breadcrumb: unknown;
+    };
+    expect(before.breadcrumb).toBeNull();
+
+    const setResult = runBridge([
+      "curriculum-set-last-selection",
+      "--breadcrumb",
+      JSON.stringify({
+        providerId: "lehrplanplus-bayern",
+        schoolType: "realschule",
+        grade: "9",
+        subject: "mathematik",
+        track: "wpfg1",
+      }),
+    ]) as { success: boolean };
+    expect(setResult.success).toBe(true);
+
+    const after = runBridge(["curriculum-get-last-selection"]) as {
+      breadcrumb: {
+        providerId: string;
+        schoolType: string;
+        grade: string;
+        subject: string;
+        track: string;
+      };
+    };
+    expect(after.breadcrumb).toEqual({
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+      grade: "9",
+      subject: "mathematik",
+      track: "wpfg1",
+    });
+  });
+});

--- a/tests/cli/curriculum-breadcrumb.test.ts
+++ b/tests/cli/curriculum-breadcrumb.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type Database, openDatabase } from "../../src/kernel/index.js";
+import {
+  getLastCurriculumSelection,
+  setLastCurriculumSelection,
+} from "../../src/cli/curriculum/breadcrumb.js";
+
+describe("curriculum breadcrumb persistence", () => {
+  let db: Database;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-curriculum-breadcrumb-"));
+    db = await openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    try {
+      rmSync(tempDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 50,
+      });
+    } catch {
+      // Best-effort cleanup
+    }
+  });
+
+  it("returns undefined when nothing has been navigated yet", async () => {
+    expect(await getLastCurriculumSelection(db)).toBeUndefined();
+  });
+
+  it("round-trips a full breadcrumb", async () => {
+    await setLastCurriculumSelection(db, {
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+      grade: "9",
+      subject: "mathematik",
+      track: "wpfg1",
+    });
+
+    expect(await getLastCurriculumSelection(db)).toEqual({
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+      grade: "9",
+      subject: "mathematik",
+      track: "wpfg1",
+    });
+  });
+
+  it("round-trips a partial breadcrumb from an abandoned mid-navigation", async () => {
+    await setLastCurriculumSelection(db, {
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+    });
+
+    expect(await getLastCurriculumSelection(db)).toEqual({
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+    });
+  });
+
+  it("overwrites the previous breadcrumb on repeated navigation", async () => {
+    await setLastCurriculumSelection(db, {
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+      grade: "9",
+      subject: "deutsch",
+    });
+    await setLastCurriculumSelection(db, {
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+      grade: "9",
+      subject: "englisch",
+    });
+
+    expect(await getLastCurriculumSelection(db)).toEqual({
+      providerId: "lehrplanplus-bayern",
+      schoolType: "realschule",
+      grade: "9",
+      subject: "englisch",
+    });
+  });
+});

--- a/tests/cli/curriculum-lehrplanplus-bayern.test.ts
+++ b/tests/cli/curriculum-lehrplanplus-bayern.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { lehrplanplusBayernProvider as provider } from "../../src/cli/curriculum/providers/lehrplanplus-bayern/index.js";
+
+describe("LehrplanPLUS Bayern provider — navigation (real, agent-captured data)", () => {
+  it("lists all eight Bavarian school types", () => {
+    const schoolTypes = provider.listSchoolTypes();
+    expect(schoolTypes).toHaveLength(8);
+    expect(schoolTypes.map((s) => s.id)).toEqual(
+      expect.arrayContaining([
+        "grundschule",
+        "mittelschule",
+        "foerderschule",
+        "realschule",
+        "gymnasium",
+        "wirtschaftsschule",
+        "fos",
+        "bos",
+      ]),
+    );
+  });
+
+  it("lists Realschule grades 5 through 10", () => {
+    expect(provider.listGrades("realschule").map((g) => g.id)).toEqual([
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+    ]);
+  });
+
+  it("returns no grades for an uncurated school type", () => {
+    expect(provider.listGrades("gymnasium")).toEqual([]);
+  });
+
+  it("lists the full Realschule subject catalog, including Mathematik", () => {
+    const subjects = provider.listSubjects("realschule", "9");
+    expect(subjects).toHaveLength(28);
+    expect(subjects).toContainEqual({ id: "mathematik", label: "Mathematik" });
+    expect(subjects).toContainEqual({ id: "deutsch", label: "Deutsch" });
+  });
+
+  it("lists the two Wahlpflichtfächergruppe tracks for Realschule Mathematik 9", () => {
+    expect(provider.listTracks("realschule", "9", "mathematik")).toEqual([
+      { id: "wpfg1", label: "Mathematik 9 (I)" },
+      { id: "wpfg2-3", label: "Mathematik 9 (II/III)" },
+    ]);
+  });
+
+  it("returns no tracks for a subject with one unified curriculum", () => {
+    expect(provider.listTracks("realschule", "9", "deutsch")).toEqual([]);
+  });
+
+  it("lists the eight Lernbereiche of Mathematik 9 (I)", () => {
+    const topics = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "mathematik",
+      track: "wpfg1",
+    });
+    expect(topics).toHaveLength(8);
+    expect(topics[0]).toEqual({
+      id: "lb1",
+      label: "Reelle Zahlen",
+      hours: 10,
+      sourceRef: "realschule|9|mathematik|wpfg1",
+    });
+    expect(topics.map((t) => t.label)).toContain(
+      "Quadratische Funktionen und quadratische Gleichungen",
+    );
+  });
+
+  it("lists a different Lernbereich set for Mathematik 9 (II/III)", () => {
+    const topics = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "mathematik",
+      track: "wpfg2-3",
+    });
+    expect(topics).toHaveLength(7);
+    expect(topics.map((t) => t.label)).toContain("Lineare Funktionen");
+    expect(topics.map((t) => t.label)).not.toContain(
+      "Quadratische Funktionen und quadratische Gleichungen",
+    );
+  });
+
+  it("lists Deutsch 9's four Lernbereiche without requiring a track", () => {
+    const topics = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "deutsch",
+    });
+    expect(topics.map((t) => t.label)).toEqual([
+      "Sprechen und Zuhören",
+      "Lesen – mit Texten und weiteren Medien umgehen",
+      "Schreiben",
+      "Sprachgebrauch und Sprache untersuchen und reflektieren",
+    ]);
+  });
+
+  it("lists Englisch 9's five Lernbereiche", () => {
+    const topics = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "englisch",
+    });
+    expect(topics).toHaveLength(5);
+  });
+
+  it("returns no topics for an incomplete or uncurated selection", () => {
+    expect(provider.listTopics({ schoolType: "realschule" })).toEqual([]);
+    expect(
+      provider.listTopics({
+        schoolType: "realschule",
+        grade: "9",
+        subject: "physik",
+      }),
+    ).toEqual([]);
+  });
+
+  it("resolves a topic to its stable LehrplanPLUS source URL", () => {
+    const [topic] = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "deutsch",
+    });
+    const resolved = provider.resolveTopic(topic);
+    expect(resolved).toEqual({
+      provider: "lehrplanplus-bayern",
+      topicId: "realschule|9|deutsch#lb1",
+      uri: "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/deutsch/inhalt/fachlehrplaene",
+    });
+  });
+
+  it("resolves sibling Mathematik tracks to their distinct Ausprägung URLs", () => {
+    const [track1Topic] = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "mathematik",
+      track: "wpfg1",
+    });
+    const [track23Topic] = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "mathematik",
+      track: "wpfg2-3",
+    });
+    expect(provider.resolveTopic(track1Topic).uri).toContain(
+      "w_auspraegung=wpfg1",
+    );
+    expect(provider.resolveTopic(track23Topic).uri).toContain(
+      "w_auspraegung=wpfg2-3",
+    );
+  });
+
+  it("throws when asked to resolve a topic outside curated coverage", () => {
+    expect(() =>
+      provider.resolveTopic({
+        id: "lb1",
+        label: "Fake",
+        sourceRef: "realschule|9|physik",
+      }),
+    ).toThrow(/no resolvable source URL/i);
+  });
+});

--- a/tests/cli/curriculum-registry.test.ts
+++ b/tests/cli/curriculum-registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURRICULUM_PROVIDERS,
+  getCurriculumProvider,
+  listCurriculumCountries,
+  listCurriculumRegions,
+} from "../../src/cli/curriculum/index.js";
+
+describe("curriculum provider registry", () => {
+  it("registers the LehrplanPLUS Bayern provider (ADR 2026-07-02)", () => {
+    const ids = CURRICULUM_PROVIDERS.map((p) => p.id);
+    expect(ids).toContain("lehrplanplus-bayern");
+  });
+
+  it("resolves a provider by id", () => {
+    expect(getCurriculumProvider("lehrplanplus-bayern")?.label).toBe(
+      "LehrplanPLUS (Bayern)",
+    );
+    expect(getCurriculumProvider("nope")).toBeUndefined();
+  });
+
+  it("lists distinct countries across registered providers (wizard step 1)", () => {
+    const countries = listCurriculumCountries();
+    expect(countries).toEqual([{ id: "DE", label: "Deutschland" }]);
+  });
+
+  it("lists regions within a country, naming the serving provider (wizard step 2)", () => {
+    expect(listCurriculumRegions("DE")).toEqual([
+      { id: "BY", label: "Bayern", providerId: "lehrplanplus-bayern" },
+    ]);
+    expect(listCurriculumRegions("FR")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the LehrplanPLUS Curriculum Import Wizard: the provider-plugin contract, a registry, and the LehrplanPLUS (Bayern) provider, wired into new `zam bridge curriculum-*` JSON commands. Builds on the accepted ADR in #98.

No desktop UI yet (Phase 2) and no live content fetch yet (Phase 3) — `resolveTopic` returns a stable source URL that the **existing** `personal-source-import` → AI proposals → `personal-source-confirm-import` pipeline picks up from there. No changes to any existing bridge contract.

## What's in this PR

- **`src/cli/curriculum/types.ts`** — the `CurriculumProvider` contract: schoolType → grade → subject → *optional track* → topic. The track level is a refinement of the ADR's illustrative interface, discovered while researching the real site: Bavarian Realschule Mathematik splits into Wahlpflichtfächergruppen (I / II-III) with genuinely different Lernbereiche.
- **`providers/lehrplanplus-bayern/manifest.ts`** — a bundled taxonomy manifest seeded **entirely from live navigation** of lehrplanplus.bayern.de (nothing fabricated, per resolved decision 5):
  - all 8 Bavarian school types
  - Realschule grades 5–10 and its 28-subject catalog
  - full real Lernbereiche for **Mathematik 9** (both Ausprägung tracks — 8 and 7 Lernbereiche respectively, with hour allocations), **Deutsch 9** (4 Lernbereiche), and **Englisch 9** (5 Lernbereiche)
  - stamped with `schoolYear` / `capturedOn`, per the ADR's agent-driven (not scripted) yearly refresh decision. Coverage is intentionally partial — extending it is future agent work.
- **`registry.ts`** — a static provider list + lookup functions, mirroring the existing `AGENT_HARNESSES` pattern (`src/cli/agent-harness.ts`) rather than introducing a new dynamic-registration API.
- **`breadcrumb.ts`** — persists the learner's last navigated path via the existing settings/`user_config` store, so a reopened wizard can jump back to the right level (resolved decision 6).
- **`bridge.ts`** — five new JSON-only commands: `curriculum-list-providers`, `curriculum-list-level`, `curriculum-resolve-topics`, `curriculum-get-last-selection`, `curriculum-set-last-selection`.

## Testing

- `tests/cli/curriculum-registry.test.ts` — provider registration/lookup, country/region listing.
- `tests/cli/curriculum-lehrplanplus-bayern.test.ts` — full level-by-level navigation against the real manifest data, including the two distinct Mathematik tracks and topic resolution.
- `tests/cli/curriculum-breadcrumb.test.ts` — round-trips full and partial breadcrumbs against a temp DB.
- `tests/cli/bridge-curriculum.test.ts` — end-to-end CLI invocation (mirrors `bridge-provider.test.ts`), walking all six wizard levels down to a concrete Lernbereich and back.

**393/393 tests passing (27 new)**, lint clean, typecheck clean.

## Next

- Phase 2 — desktop wizard UI (six steps, breadcrumb-first reopen).
- Phase 3 — live content fetch through the existing safe web adapter, batched multi-topic review, precise provenance.

Related: #98 (ADR, Accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
