### PR TITLE
docs(adr): closed-group learning library — curation, privacy and deployment

### DIFF
--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -226,20 +226,26 @@ own-data display filter labeled as cosmetic, not a security boundary.
 For DocuWare colleagues. This is an **additional** path selected by
 configuration, never a replacement.
 
-**This deployment is a pilot.** During the development phase it runs on the
-project owner's Visual Studio Professional subscription and its monthly Azure
-credit. Once the company is ready to carry the cost, the data moves to a
-company-owned subscription (project owner, 2026-07-25). The pilot is therefore
-designed to be **left behind**: the schema, the data and the library model must
-survive that move, while the infrastructure and every role grant are expected
-to be recreated. Decision 7 makes that explicit.
+**Hosted in a company subscription in the `docuware.com` tenant from the
+start** (project owner, 2026-07-25). An earlier plan would have piloted on the
+project owner's Visual Studio Professional credit and migrated later; that
+subscription could not be activated, and going straight to a company-owned one
+turns out to be the simpler design anyway:
 
-**Tenant: `docuware.com`** (project owner, 2026-07-25). The Visual Studio
-Professional subscription is associated with the corporate directory, so
-colleagues authenticate as ordinary tenant members — no B2B guest invitations,
-no personally-owned identity boundary, and offboarding follows the corporate
-directory automatically. What changes at the subscription move is the billing
-owner and the Azure resource, not the identity domain.
+- Colleagues authenticate as **ordinary tenant members** — no B2B guest
+  invitations, no personally-owned identity boundary, and offboarding follows
+  the corporate directory automatically.
+- **There is no planned migration**, so the schema, the role grants and the
+  data all live in their final home from day one. The migration drill the
+  earlier draft required disappears with it.
+- Nobody's learning history depends on a personal subscription staying funded.
+
+The cost is a dependency: this needs DocuWare to provide a subscription and
+carry the (small) bill before the first colleague can use it. That is a
+conversation to have early, not a technical risk.
+
+This remains a **pilot in scope** — a small group, a deliberately limited
+library — just not a pilot in infrastructure.
 
 - **Store:** Azure Database for PostgreSQL Flexible Server, Burstable tier,
   32 GiB (the service's storage floor — ZAM's data is far smaller: 768-dim
@@ -313,44 +319,47 @@ owner and the Azure resource, not the identity domain.
   process it does not control, and no colleague ends up in the company library
   without having been told what that means.
 
-- **Consequence: Deployment B is online-first for reviews.** With state in the
-  server, a review needs the network — the same trade the companion already
-  accepted (ADR 2026-07-23). Deployment A remains the offline-capable path and
-  the default for anyone who needs it. A local read-through cache with
-  write-back for Deployment B is deliberately *not* in scope for the pilot;
-  see Open Question 5.
+- **Consequence: Deployment B is online-only for reviews** (project owner,
+  2026-07-25). With state in the server, a review needs the network — the same
+  trade the companion already accepted (ADR 2026-07-23). Deployment A remains
+  the offline-capable path for anyone who needs it.
 
-### 7. Subscription and tenant portability is a requirement, not a later concern
+  A local cache with write-back would fix this and is deliberately **not**
+  built: it brings back exactly the sync state machine, conflict policy and
+  online/offline test matrix that the write-asymmetry otherwise lets this ADR
+  avoid, and it would be built against a guess. The pilot answers the question
+  instead — how often does someone actually stand in front of ZAM with no
+  network? On a company PC that is rare; if the pilot shows otherwise, an
+  offline cache is a well-motivated follow-up with its own ADR.
 
-Because the pilot is known in advance to move, the design constraint is set now
-rather than discovered during the migration.
+### 7. ZAM's data never marries Entra
+
+The planned subscription migration is gone (Decision 6), but the constraint it
+implied is kept, because it is right for its own reasons.
 
 - **Entra identifiers never become keys in ZAM's data.** A learner stays a ZAM
   ULID `user_id`. A single deployment-scoped mapping table binds that ULID to
   an Entra principal (object id + UPN). Everything else — cards, assignments,
   provenance, curator attribution — references the ULID only.
 
-  This is the whole migration story in one rule. Entra object ids are
-  tenant-specific: the same colleague in a DocuWare-owned tenant is a different
-  principal with a different oid. If curator attribution or assignment rows
-  referenced Entra oids directly, moving tenants would corrupt authorship and
-  ownership across the entire library. With the indirection, the move rewrites
-  one small mapping table and nothing else.
+  The rule earns its place three times over. Deployment A has no Entra at all,
+  so the kernel cannot depend on one. Entra object ids are tenant-specific, so
+  any future move — a tenant reorganisation, an acquisition, a self-hosted
+  server on PostgreSQL 18 OAuth — would otherwise corrupt authorship and
+  ownership across the whole library. And a colleague who leaves and returns,
+  or whose account is recreated, keeps their learning history instead of
+  becoming a stranger to it.
 
 - **Role grants are deployment configuration, not data.** The
-  `pgaadauth_create_principal` mappings and the RLS grants are recreated from a
-  runbook in the target subscription. They are never expected to survive a
-  `pg_dump`.
+  `pgaadauth_create_principal` mappings and the RLS grants live in a runbook,
+  are applied to the server, and are never expected to survive a `pg_dump`.
+  Restoring a backup restores the library, not the permissions.
 
-- **Nothing depends on subscription-specific features.** The store must stay
-  ordinary PostgreSQL plus `pgvector`, so the target can be another Azure
-  subscription, another tenant, or eventually a self-hosted server using
-  PostgreSQL 18's native OAuth.
-
-- **The migration is a documented drill, not a one-off.** `pg_dump`/`pg_restore`
-  of a database this small is minutes of work; the runbook covers the identity
-  re-mapping, which is the only genuinely fiddly part, and should be rehearsed
-  once during the pilot rather than first attempted under pressure.
+- **Nothing depends on subscription-specific features.** The store stays
+  ordinary PostgreSQL plus `pgvector`, so an export is restorable anywhere —
+  another subscription, another tenant, or a self-hosted server using
+  PostgreSQL 18's native OAuth. This is now an insurance policy rather than a
+  scheduled task, which is the right amount of effort to spend on it.
 
 ### 8. The kernel stays single-learner
 
@@ -476,12 +485,12 @@ reverse it into "who failed it". Nothing here is in the pilot either; it is
 recorded so a later reader can see that "no aggregates" was a decision about
 *people*, not a refusal to help curators.
 
-## Cost (Deployment B, pilot phase)
+## Cost (Deployment B)
 
-The pilot's budget is the Visual Studio Professional subscription's monthly
-Azure credit (~$50). That is a **development-phase ceiling, not a sizing
-target**: production sizing is the company's decision once the data moves to a
-company subscription, and it is deliberately out of scope here.
+The company subscription carries the bill (Decision 6), so the figures below
+are not a budget ceiling — they exist so the ask is small and concrete when
+someone at DocuWare has to approve it. The honest version of that ask is
+"roughly the price of one lunch per month, and it can be switched off".
 
 Indicative only — **verify in the Azure pricing calculator for the actual
 region before committing**, since tiers and prices move:
@@ -493,16 +502,11 @@ region before committing**, since tiers and prices move:
 | 32 GiB storage | ~$4 |
 | Backup (within storage size) | included |
 
-B1ms plus storage lands near $20/month and B2s near $35 — both inside the
-credit, with room for the pilot to stop and start the server when idle (which
-pauses compute billing). Two caveats worth checking early: Burstable instances
-have a low `max_connections` ceiling, and built-in connection pooling is not
-offered on every tier — a pilot group of ~30 with desktop, CLI and mobile
-clients may need B2s or an external pooler.
-
-Keeping comfortably inside the credit is itself a design goal for the pilot: an
-overrun on a personal subscription is a bad reason for a colleague's learning
-history to become unavailable.
+B1ms plus storage lands near $20/month and B2s near $35. Flexible Server can be
+stopped when idle, which pauses compute billing. Two caveats worth checking
+early: Burstable instances have a low `max_connections` ceiling, and built-in
+connection pooling is not offered on every tier — a group of ~30 with desktop,
+CLI and mobile clients may need B2s or an external pooler.
 
 **Why Azure and not something cheaper.** Neon, Supabase or a €5 Hetzner VM all
 run Postgres with pgvector for less. None of them offer "an administrator
@@ -524,18 +528,16 @@ becomes due now and the next rating recalibrates FSRS (Decision 3). An
 assignment binds while it stands, and the cards outlive it under the learner's
 control (Decision 10). The residual superuser exposure is disclosed by ZAM
 itself, in-app and alongside a working local alternative (Decision 6).
-Aggregates about people are not built at all (Decision 11).
+Aggregates about people are not built at all (Decision 11). Deployment B is
+online-only for reviews; whether an offline cache is worth its sync complexity
+is a question the pilot answers rather than a guess made up front (Decision 6).
+The deployment now starts in a company subscription in the `docuware.com`
+tenant, so the planned migration — and its rehearsal — is gone (Decision 6).
 
-1. **Offline for Deployment B.** With learning state in the server, reviews
-   need the network. Deployment A stays the offline path, but if colleagues
-   want offline reviews *and* cross-device progress, a local read-through
-   cache with write-back is the answer — and it brings back exactly the sync
-   and conflict work this ADR otherwise avoids. Defer until the pilot shows
-   whether it actually hurts.
-2. **Conflict policy for concurrent curation.** Last-write-wins on
+1. **Conflict policy for concurrent curation.** Last-write-wins on
    `updated_at` plus a curation log is probably enough at this scale; verify
    against a real two-curator case before building merge UI.
-3. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
+2. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
    means "a dialect audit of every kernel query". A survey on 2026-07-25 found
    the actual surface small: `datetime('now')` ×21, `LIKE` ×16 (SQLite's is
    case-insensitive for ASCII, Postgres' is not — needs `ILIKE`),
@@ -559,8 +561,6 @@ Aggregates about people are not built at all (Decision 11).
   Entra principal mapping, RLS policies **with an isolation test suite**, the
   per-device database binding carrying the context (Decision 9), and the admin
   runbook for granting Entra groups access.
-- **Phase C2 — rehearse the subscription move** once, while the pilot is small
-  and nobody depends on it, so the runbook is proven rather than hypothetical.
 - **Phase D — assignments** (Decision 10). Aggregates are not part of the
   plan (Decision 11).
 

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -62,7 +62,9 @@ the most valuable thing a curated group library can offer.
   record what someone failed, how often, and when. In a company, that is
   performance data about an employee. Sharing *content* must never quietly mean
   sharing *performance*.
-- **Offline-first for reviews.** Reviews happen on trains and in meeting rooms.
+- **Offline matters for reviews.** Reviews happen on trains and in meeting
+  rooms. This pulls against cross-device progress, and the two deployments
+  below resolve the tension differently rather than pretending it away.
 - **The existing database paths must keep working** (project owner,
   2026-07-25): local SQLite, embedded libsql replica, and Turso/`sqld` remote
   stay supported and remain the default. Anything new is parallel and opt-in.
@@ -75,7 +77,9 @@ the most valuable thing a curated group library can offer.
 1. **Editorial quality first** — the library exists so a few people can make
    content good for everyone.
 2. **Knowledge shared, learning state private by default**, aggregates opt-in.
-3. **Offline-first** — a learner's reviews never block on a server.
+3. **Offline-first stays available** — Deployment A never blocks a review on a
+   server. Deployment B trades this for cross-device progress, deliberately and
+   with Deployment A still there for anyone who needs offline (Decision 6).
 4. **Additive** — existing single-learner and Turso/`sqld` paths keep working.
 5. **A fix must reach the people who learned the broken version.**
 6. **Smallest credible step** before new deployables.
@@ -86,8 +90,13 @@ the most valuable thing a curated group library can offer.
 |-------|--------|---------|---------|
 | **Knowledge** | tokens, prerequisites, sources, token_sources, token_embeddings, agent_skills (curated) | Shared library, versioned | Curators |
 | **Assignment** | *new:* assignments (who should learn what, by when) | Visible to assigner + learner | Curators/leads |
-| **Learning state** | cards, review_logs, sessions, session_steps, session_syntheses | **Private to the learner; local by default** | The learner only |
+| **Learning state** | cards, review_logs, sessions, session_steps, session_syntheses | **Private to the learner.** Deployment A: local. Deployment B: in the shared database, isolated by RLS | The learner only |
 | **Aggregates** | *derived:* coverage %, due counts | Opt-in, coarse, learner-controlled | Published explicitly |
+
+"Private to the learner" is the invariant; *where* the rows sit is a deployment
+choice. In Deployment A it holds because the data never leaves the machine; in
+Deployment B it holds because RLS says so — a weaker guarantee against a
+superuser, which Decision 6 states plainly rather than papering over.
 
 ## Decision
 
@@ -95,8 +104,9 @@ the most valuable thing a curated group library can offer.
 
 A group library is a set of tokens (plus prerequisites, sources, embeddings)
 that carry an editorial state and a content version. Learners consume
-**published** versions; they never see another learner's cards or review logs
-by construction, because those are a different data class that does not travel.
+**published** versions. What is shared is knowledge; a learner never sees
+another learner's cards or review logs — in Deployment A because that data
+never leaves the machine, in Deployment B because RLS forbids it (Decision 6).
 
 ### 2. An editorial workflow, because that is what quality control is
 
@@ -119,6 +129,20 @@ draft ──► in-review ──► published ──► deprecated
   follow (ADR 2026-07-17); an OKF article is the natural `source_link` target
   for a curated token.
 
+**Where the loop runs (project owner, 2026-07-25): content in git, release in
+the Studio.** Authoring and peer review happen as they already do for OKF —
+articles and token drafts in a repository, reviewed through pull requests,
+where diffs, history and reviewer identity are solved problems and no new UI is
+needed. What the Studio owns is the **release step**: a curator sees what a
+merge would change for learners, classifies each change (Decision 3), and
+publishes. Merging a pull request therefore does not by itself reach anybody's
+queue — publishing does.
+
+The split follows the two different questions being asked. "Is this text
+correct?" is a review question git answers well. "What should happen to the
+people who already learned the old version?" is a scheduling question only ZAM
+can answer, and it needs the curator in front of ZAM.
+
 ### 3. Content changes classify as cosmetic or material — and material changes touch FSRS
 
 This is the part a plain shared database cannot do, and the reason curation is
@@ -140,8 +164,14 @@ confidently wrong on a comfortable review interval. Making a correction
 propagate into scheduling is what turns "someone checks the content" into a
 real guarantee.
 
-Cosmetic is the default only when the curator says so; ZAM never guesses
-materiality from a text diff.
+**There is no default** (project owner, 2026-07-25). Publishing forces the
+curator to classify the change; ZAM never guesses materiality from a text diff
+and never picks the safe-looking option on the curator's behalf. Defaulting to
+cosmetic would let a real correction slip through and leave learners
+confidently wrong; defaulting to material would reset cards for typo fixes
+until people stopped trusting the library. The small friction per publish *is*
+the quality gate — it is the moment a curator has to think about the people who
+already learned it.
 
 ### 4. Roles
 
@@ -178,6 +208,13 @@ designed to be **left behind**: the schema, the data and the library model must
 survive that move, while the infrastructure and every role grant are expected
 to be recreated. Decision 7 makes that explicit.
 
+**Tenant: `docuware.com`** (project owner, 2026-07-25). The Visual Studio
+Professional subscription is associated with the corporate directory, so
+colleagues authenticate as ordinary tenant members — no B2B guest invitations,
+no personally-owned identity boundary, and offboarding follows the corporate
+directory automatically. What changes at the subscription move is the billing
+owner and the Azure resource, not the identity domain.
+
 - **Store:** Azure Database for PostgreSQL Flexible Server, Burstable tier,
   32 GiB (the service's storage floor — ZAM's data is far smaller: 768-dim
   embeddings are ≈3 KB per token, so 100k tokens ≈ 300 MB). `pgvector` provides
@@ -201,13 +238,41 @@ to be recreated. Decision 7 makes that explicit.
   security rather than by convention: published knowledge readable by every
   member, writable only by curators; assignments visible to their learner and
   author.
-- **Learning state stays local.** For this tier the recommendation is that
-  `cards`, `review_logs` and `sessions` do **not** go into the corporate
-  database at all. This keeps reviews offline-capable, and it removes the
-  awkward question of what an employer's database administrator can read —
-  because RLS does not protect data from a superuser, and on a managed service
-  the subscription owner is close enough to one. What the company hosts is the
-  *library*; what the employee keeps is their *learning*.
+- **Learning state lives in the shared database too** (project owner,
+  2026-07-25), so a colleague's progress follows them across machines instead
+  of being trapped on one laptop. `cards`, `review_logs`, `sessions`,
+  `session_steps` and `session_syntheses` are stored per learner and isolated
+  by RLS.
+
+  This makes RLS the **load-bearing privacy boundary**, not a convenience, and
+  that has to be built accordingly:
+
+  - Every learning-state table carries the learner's ULID and an RLS policy
+    keyed to the connected principal's mapped ULID (Decision 7). A learner's
+    role can read and write only their own rows; there is no group-wide
+    `SELECT` on these tables for anyone, including curators.
+  - `ALTER TABLE … FORCE ROW LEVEL SECURITY`, so the policy also applies to the
+    table owner. Without it, the owning role bypasses RLS silently.
+  - The schema owner is a **separate role from any human administrator**, and
+    no person logs in as it during normal operation.
+  - The policies are tested, not assumed: a test suite asserts that learner A
+    cannot read learner B's cards or review logs through any supported query
+    path. A privacy boundary nobody tests is a privacy claim, not a boundary.
+
+  **Stated honestly:** a PostgreSQL superuser, and anyone who can act as the
+  Azure server administrator, can still read every row. RLS does not defend
+  against them. In this deployment the learners and the administrators are
+  colleagues at the same employer, and review logs are performance-adjacent
+  data about employees, so this residual exposure is a policy question for
+  DocuWare, not something the database can solve. It should be written down for
+  participants before the first real colleague joins — see Open Question 4.
+
+- **Consequence: Deployment B is online-first for reviews.** With state in the
+  server, a review needs the network — the same trade the companion already
+  accepted (ADR 2026-07-23). Deployment A remains the offline-capable path and
+  the default for anyone who needs it. A local read-through cache with
+  write-back for Deployment B is deliberately *not* in scope for the pilot;
+  see Open Question 5.
 
 ### 7. Subscription and tenant portability is a requirement, not a later concern
 
@@ -247,6 +312,56 @@ No RLS, no auth, no HTTP in the kernel. Multi-learner semantics live in the
 CLI/sync layer, exactly like LLM access does. The kernel's only multi-user
 awareness stays what it already has: `user_id` columns.
 
+### 9. The database selection carries the knowledge context
+
+Choosing the database chooses the knowledge context (project owner,
+2026-07-25). Connecting to the company library *is* being at work; the private
+local database *is* private (and school). A learner does not pick the two
+independently.
+
+This puts two existing concepts in the right order. The knowledge-contexts ADR
+(2026-07-04) is explicit that a context is a **library slice and not an
+authorization boundary** — "tagging something `work` must never make it
+shareable by itself". The deployment is the real boundary. Deriving the context
+from the connection therefore removes a whole class of mistake: you cannot
+misfile a private card into the company library by picking the wrong entry in a
+dropdown, because the company library only ever offers its own contexts.
+
+**In practice the binding is per device, not a toggle** (project owner,
+2026-07-25): the phone at home is connected to the private database; the work
+PC is connected to the company database. That matches where the connection
+already lives — machine-local config in `~/.zam/config.json`, never in the
+shared database — so a device is set up once and simply *is* a work device or a
+private one. The mobile companion pairing (ADR 2026-07-23) is the private
+server database in exactly this picture.
+
+Concretely:
+
+- `contexts` rows live in the database they belong to, so each deployment
+  already carries its own set. The active context resolves to the connected
+  library's default; the context picker only offers what that database
+  contains.
+- Switching database is a context boundary in the same sense the companion
+  context bar already means it (ADR 2026-07-16): reset the local view, do not
+  carry a stale context across the switch.
+- Authoring language follows for free. The contexts ADR gave contexts a
+  `language` field precisely because the team area is English while private
+  content is German; connecting to the corporate library therefore switches the
+  authoring-language default without a separate setting.
+
+The honest consequence of a per-device binding is that **there is no single
+"everything I owe today" view across both worlds.** At work you see work cards;
+at home on the phone you see private ones. For work–life separation that is
+arguably the feature rather than the cost — and it is the same separation that
+keeps private learning out of an employer's database entirely. But it should be
+a stated choice, not a surprise: someone who wants one combined queue will not
+get it, and the fix would be a cross-library aggregation view that deliberately
+does not exist yet.
+
+This does **not** promote context to an authorization boundary. It makes the
+boundary the thing that *selects* the context. Inside the company library,
+contexts remain ordinary slices.
+
 ## Cost (Deployment B, pilot phase)
 
 The pilot's budget is the Visual Studio Professional subscription's monthly
@@ -285,38 +400,34 @@ self-hosted server can validate Entra tokens directly.
 
 ## Open questions
 
-0. **Which tenant do the pilot's colleagues authenticate against?** This is the
-   first thing to verify, because it can invalidate the pilot's shape rather
-   than just adjust it. Azure PostgreSQL validates Entra tokens against the
-   tenant behind the hosting subscription. On a Visual Studio Professional
-   subscription that is the owner's own tenant — not DocuWare's — so DocuWare
-   colleagues would have to be invited as **B2B guests** into it. Two things to
-   check before building anything: whether DocuWare's directory policy permits
-   its users to accept outbound guest invitations, and whether routing
-   colleagues' learning activity through a personally-owned tenant is
-   acceptable to the company at all, even for a pilot. If either answer is no,
-   the realistic options are a company-owned subscription earlier than planned,
-   or a pilot run with non-DocuWare test identities and no real colleague data.
-   Decision 7's identity indirection is what keeps that pivot cheap.
+Resolved on 2026-07-25 (project owner): the pilot tenant is `docuware.com`, so
+colleagues are ordinary tenant members and no B2B guest path is needed
+(Decision 6); curation is git for content plus a Studio release step
+(Decision 2); learning state lives in the shared database behind RLS
+(Decision 6); and materiality has no default — publishing forces the choice
+(Decision 3).
 
-1. **Where does curation actually happen?** ZAM already has an OKF knowledge
-   base curated through git and pull requests. For a company library, the
-   proposal→review→publish loop could reuse that (review content as OKF
-   articles in a repo, sync published tokens to the database) instead of
-   building review UI in the Studio. This is likely the smallest credible first
-   step and should be decided before any workflow code is written.
-2. **Materiality classification UX.** Curators must classify every published
-   change. What is the default, what does the learner see when a card resets,
-   and can a learner appeal a reset?
-3. **Assignment ↔ card lifecycle.** Does deleting an assignment retire the
+1. **What does a learner see when a material change resets their card, and can
+   they push back?** The reset is correct but it is also someone else deciding
+   that your memory is now wrong. It needs an explanation naming the change and
+   the curator, and a decision on whether a learner may defer or dispute it.
+2. **Assignment ↔ card lifecycle.** Does deleting an assignment retire the
    card, and does the learner keep the history?
+3. **Where does the residual-visibility policy get written down?** Decision 6
+   states that a superuser or Azure server administrator can read every row.
+   Participants should be told this in plain language before the first real
+   colleague joins, and someone at DocuWare — not this ADR — has to own that
+   statement. Blocking for real colleague data; not blocking for a pilot on
+   test identities.
 4. **Aggregate vocabulary.** Which opt-in metrics exist and at what
    granularity — needs a concrete lead/coach story before freezing. At an
    employer this needs to be conservative by default.
-5. **Does Deployment B ever need offline?** Decision 6 keeps learning state
-   local, so reviews stay offline-capable and only *library sync* needs
-   network. If the group later wants cross-device learning state, that
-   reopens both the offline question and the DBA-visibility question.
+5. **Offline for Deployment B.** With learning state in the server, reviews
+   need the network. Deployment A stays the offline path, but if colleagues
+   want offline reviews *and* cross-device progress, a local read-through
+   cache with write-back is the answer — and it brings back exactly the sync
+   and conflict work this ADR otherwise avoids. Defer until the pilot shows
+   whether it actually hurts.
 6. **Conflict policy for concurrent curation.** Last-write-wins on
    `updated_at` plus a curation log is probably enough at this scale; verify
    against a real two-curator case before building merge UI.
@@ -341,8 +452,9 @@ self-hosted server can validate Entra tokens directly.
   worth doing on the existing paths first.
 - **Phase C — Deployment B pilot:** the Postgres provider behind the existing
   async `Database` contract, Entra token acquisition and refresh, the ULID ↔
-  Entra principal mapping, RLS policies, and the admin runbook for granting
-  Entra groups access. Gated on Open Question 0.
+  Entra principal mapping, RLS policies **with an isolation test suite**, the
+  per-device database binding carrying the context (Decision 9), and the admin
+  runbook for granting Entra groups access.
 - **Phase C2 — rehearse the subscription move** once, while the pilot is small
   and nobody depends on it, so the runbook is proven rather than hypothetical.
 - **Phase D — assignments**, then opt-in aggregates.
@@ -360,9 +472,14 @@ self-hosted server can validate Entra tokens directly.
   accountable for, and corrections that actually reach the people holding the
   outdated version.
 - The privacy line — knowledge shared, learning state the learner's — becomes
-  an architectural invariant rather than a UI promise, and it holds *more*
-  strongly at an employer because learning state simply is not in the corporate
-  database.
+  an architectural invariant rather than a UI promise. In Deployment B it is
+  enforced by RLS and must be *tested* like any other security boundary; the
+  residual superuser exposure is written down rather than glossed over.
+- Private learning never reaches the employer's database at all, because the
+  device binding puts it in a different database entirely. That separation is
+  physical rather than a policy anyone has to honour.
+- The same binding costs a combined cross-world view of what is due. Work
+  cards live at work; private cards live at home.
 - Phase B pays off on every deployment, including single-learner, because
   versioned content with a materiality signal is useful even for one person
   correcting their own old cards.

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -451,6 +451,10 @@ This does **not** promote context to an authorization boundary. It makes the
 boundary the thing that *selects* the context. Inside the company library,
 contexts remain ordinary slices.
 
+This is the pilot's rule rather than a general law: a later read-only
+curriculum library would be a content *source* without being a store, which
+separates the two again. See "Direction beyond the pilot".
+
 ### 10. An assignment binds while it stands; the learning outlives it
 
 An assignment ("learn these 12 tokens by March") creates ordinary cards in the
@@ -790,6 +794,50 @@ remains is one engineering note rather than a decision:
   runbook for granting Entra groups access.
 - **Phase D — assignments** (Decision 10). Aggregates are not part of the
   plan (Decision 11).
+- **Phase E — a broad curriculum library**, gated on real experience from the
+  closed group: read-only content, no learning state, little identity. See
+  "Direction beyond the pilot" below for the constraint it puts on Phase B.
+
+## Direction beyond the pilot: a content source is not a workspace
+
+Once the closed group has produced real experience, the natural next step is a
+much broader library — a **Bayern-Lehrplan database**, say (project owner,
+2026-07-25). Not built here, and deliberately gated on that experience, but
+recorded because it constrains what Phase B may assume.
+
+Its shape is different from Deployment B in one decisive way: **the learning
+data really stays with the learner.** A curriculum library is a *source of good
+content* — so that an agent grounds itself in reviewed material instead of
+inventing a curriculum on every device — and nothing more. It holds no cards,
+no review logs, no sessions, and needs no notion of who is learning from it.
+
+| | Deployment B (company) | Curriculum library (future) |
+|---|---|---|
+| Membership | closed group, Entra | broad or public |
+| Content flows | both ways (colleagues propose) | one way, read-only |
+| Learning state | in the database, RLS | **never — stays with the learner** |
+| Identity needed | yes | little or none |
+
+**The constraint this puts on Phase B:** the *library* and the *learner's
+store* must stay separately addressable. Deployment B happens to collapse them
+— the company database is both the library and where cards live — and it would
+be easy to bake that coincidence into the model. The curriculum case breaks it
+immediately: a learner keeps a local store on their own machine while consuming
+content from a remote library they can only read.
+
+So Decision 9's "the database selection carries the context" is the *pilot's*
+rule, not a law. The general form is one **store** per device (where my cards
+and my state live, exactly one) plus zero or more **content sources**
+(libraries I read from). Deployment A has a store and no source; Deployment B
+has a store that is also its source; the curriculum library is a source nobody
+stores into. Phase B should model a published token version as something that
+can *arrive from* a source rather than something that necessarily lives in the
+same database as the card pointing at it.
+
+This also closes the loop with ADR 2026-07-25's second motivation: a learner
+attaching to already-published curriculum tokens is a database operation
+measured in milliseconds, where device-side generation of the same material
+costs minutes per topic, per learner, every time.
 
 ## Out of scope
 

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -1,9 +1,14 @@
-# Shared Curated Learning Content in a Closed Group
+# Closed-Group Learning Library: Curation, Privacy and Deployment
 
-**Status:** Proposed (rewritten 2026-07-25; supersedes the 2026-07-04 draft)
-**Date:** 2026-07-04, rewritten 2026-07-25
+**Status:** Accepted (2026-07-25; rewritten from and superseding the
+2026-07-04 draft)
+**Date:** 2026-07-04, rewritten and accepted 2026-07-25
 **Deciders:** Thomas (project owner)
 **Related:**
+[2026-07-25-shared-curated-learning-content.md](2026-07-25-shared-curated-learning-content.md)
+(**the product principle this ADR implements** — see below) ·
+[2026-07-04-knowledge-contexts.md](2026-07-04-knowledge-contexts.md)
+(Decision 9 binds context to the database) ·
 [2026-07-03-rag-semantic-token-search.md](2026-07-03-rag-semantic-token-search.md)
 (Decision 4 + Open Question 2) ·
 [2026-06-09-async-database-providers.md](2026-06-09-async-database-providers.md) ·
@@ -31,6 +36,23 @@ everything below follows from it.
 > been thought through yet (project owner, 2026-07-25). This rewrite starts
 > from content quality. The data-class privacy table survives from the draft
 > because it is load-bearing; the sync-service design does not.
+
+### Relationship to ADR 2026-07-25
+
+[2026-07-25 "Review Once, Serve Many"](2026-07-25-shared-curated-learning-content.md)
+establishes the **product principle**: curated learning content is a
+first-class shared asset, the expensive review step is paid once, tokens are
+shared while cards stay personal, and generation cost is amortised at publish
+time. It explicitly lists *"defining the schema of the central Lehrplan
+database"* among its non-goals.
+
+**This ADR supplies exactly that missing half** for one concrete setting — a
+closed group such as a company. Where 2026-07-25 says content should be
+reviewed once and served to many, this one specifies *how*: the editorial
+states and who may move between them, what a published version is, what happens
+to learners when content changes, where the data lives, who may read it, and
+how a member is identified. Read 2026-07-25 for **why**, this one for **how**;
+neither overrides the other.
 
 ### What "quality" actually means here
 

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -167,8 +167,16 @@ own-data display filter labeled as cosmetic, not a security boundary.
 
 ### 6. Deployment B — closed company group on Azure PostgreSQL with Microsoft Entra (new, parallel)
 
-For DocuWare colleagues, hosted on the project owner's Azure subscription.
-This is an **additional** path selected by configuration, never a replacement.
+For DocuWare colleagues. This is an **additional** path selected by
+configuration, never a replacement.
+
+**This deployment is a pilot.** During the development phase it runs on the
+project owner's Visual Studio Professional subscription and its monthly Azure
+credit. Once the company is ready to carry the cost, the data moves to a
+company-owned subscription (project owner, 2026-07-25). The pilot is therefore
+designed to be **left behind**: the schema, the data and the library model must
+survive that move, while the infrastructure and every role grant are expected
+to be recreated. Decision 7 makes that explicit.
 
 - **Store:** Azure Database for PostgreSQL Flexible Server, Burstable tier,
   32 GiB (the service's storage floor — ZAM's data is far smaller: 768-dim
@@ -201,13 +209,50 @@ This is an **additional** path selected by configuration, never a replacement.
   the subscription owner is close enough to one. What the company hosts is the
   *library*; what the employee keeps is their *learning*.
 
-### 7. The kernel stays single-learner
+### 7. Subscription and tenant portability is a requirement, not a later concern
+
+Because the pilot is known in advance to move, the design constraint is set now
+rather than discovered during the migration.
+
+- **Entra identifiers never become keys in ZAM's data.** A learner stays a ZAM
+  ULID `user_id`. A single deployment-scoped mapping table binds that ULID to
+  an Entra principal (object id + UPN). Everything else — cards, assignments,
+  provenance, curator attribution — references the ULID only.
+
+  This is the whole migration story in one rule. Entra object ids are
+  tenant-specific: the same colleague in a DocuWare-owned tenant is a different
+  principal with a different oid. If curator attribution or assignment rows
+  referenced Entra oids directly, moving tenants would corrupt authorship and
+  ownership across the entire library. With the indirection, the move rewrites
+  one small mapping table and nothing else.
+
+- **Role grants are deployment configuration, not data.** The
+  `pgaadauth_create_principal` mappings and the RLS grants are recreated from a
+  runbook in the target subscription. They are never expected to survive a
+  `pg_dump`.
+
+- **Nothing depends on subscription-specific features.** The store must stay
+  ordinary PostgreSQL plus `pgvector`, so the target can be another Azure
+  subscription, another tenant, or eventually a self-hosted server using
+  PostgreSQL 18's native OAuth.
+
+- **The migration is a documented drill, not a one-off.** `pg_dump`/`pg_restore`
+  of a database this small is minutes of work; the runbook covers the identity
+  re-mapping, which is the only genuinely fiddly part, and should be rehearsed
+  once during the pilot rather than first attempted under pressure.
+
+### 8. The kernel stays single-learner
 
 No RLS, no auth, no HTTP in the kernel. Multi-learner semantics live in the
 CLI/sync layer, exactly like LLM access does. The kernel's only multi-user
 awareness stays what it already has: `user_id` columns.
 
-## Cost (Deployment B)
+## Cost (Deployment B, pilot phase)
+
+The pilot's budget is the Visual Studio Professional subscription's monthly
+Azure credit (~$50). That is a **development-phase ceiling, not a sizing
+target**: production sizing is the company's decision once the data moves to a
+company subscription, and it is deliberately out of scope here.
 
 Indicative only — **verify in the Azure pricing calculator for the actual
 region before committing**, since tiers and prices move:
@@ -220,11 +265,15 @@ region before committing**, since tiers and prices move:
 | Backup (within storage size) | included |
 
 B1ms plus storage lands near $20/month and B2s near $35 — both inside the
-$50/month allowance. Flexible Server can be stopped when idle, which pauses
-compute billing. Two caveats worth checking early: Burstable instances have a
-low `max_connections` ceiling, and built-in connection pooling is not offered
-on every tier — a group of ~30 with desktop, CLI and mobile clients may need
-B2s or an external pooler.
+credit, with room for the pilot to stop and start the server when idle (which
+pauses compute billing). Two caveats worth checking early: Burstable instances
+have a low `max_connections` ceiling, and built-in connection pooling is not
+offered on every tier — a pilot group of ~30 with desktop, CLI and mobile
+clients may need B2s or an external pooler.
+
+Keeping comfortably inside the credit is itself a design goal for the pilot: an
+overrun on a personal subscription is a bad reason for a colleague's learning
+history to become unavailable.
 
 **Why Azure and not something cheaper.** Neon, Supabase or a €5 Hetzner VM all
 run Postgres with pgvector for less. None of them offer "an administrator
@@ -235,6 +284,20 @@ being true, PostgreSQL 18's native OAuth support is the portability exit: a
 self-hosted server can validate Entra tokens directly.
 
 ## Open questions
+
+0. **Which tenant do the pilot's colleagues authenticate against?** This is the
+   first thing to verify, because it can invalidate the pilot's shape rather
+   than just adjust it. Azure PostgreSQL validates Entra tokens against the
+   tenant behind the hosting subscription. On a Visual Studio Professional
+   subscription that is the owner's own tenant — not DocuWare's — so DocuWare
+   colleagues would have to be invited as **B2B guests** into it. Two things to
+   check before building anything: whether DocuWare's directory policy permits
+   its users to accept outbound guest invitations, and whether routing
+   colleagues' learning activity through a personally-owned tenant is
+   acceptable to the company at all, even for a pilot. If either answer is no,
+   the realistic options are a company-owned subscription earlier than planned,
+   or a pilot run with non-DocuWare test identities and no real colleague data.
+   Decision 7's identity indirection is what keeps that pivot cheap.
 
 1. **Where does curation actually happen?** ZAM already has an OKF knowledge
    base curated through git and pull requests. For a company library, the
@@ -276,9 +339,12 @@ self-hosted server can validate Entra tokens directly.
   and the cosmetic/material change classification with its FSRS consequence.
   This is the heart of the ADR and is **independent of any deployment** — it is
   worth doing on the existing paths first.
-- **Phase C — Deployment B:** the Postgres provider behind the existing async
-  `Database` contract, Entra token acquisition and refresh, RLS policies, and
-  the admin runbook for granting Entra groups access.
+- **Phase C — Deployment B pilot:** the Postgres provider behind the existing
+  async `Database` contract, Entra token acquisition and refresh, the ULID ↔
+  Entra principal mapping, RLS policies, and the admin runbook for granting
+  Entra groups access. Gated on Open Question 0.
+- **Phase C2 — rehearse the subscription move** once, while the pilot is small
+  and nobody depends on it, so the runbook is proven rather than hypothetical.
 - **Phase D — assignments**, then opt-in aggregates.
 
 ## Out of scope

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -570,11 +570,78 @@ server are free (billing is per server). Three reasons, the third decisive:
   move once Azure supports Entra on it (Decision 13). On a shared server that
   rehearsal is impossible by construction.
 
-**The Azure dev instance is ephemeral.** It exists to verify the identity path
-and to rehearse upgrades, not to be online. Azure bills compute hourly, so
-creating a B1ms, running the checks and deleting it costs cents per session —
-far less than keeping a second server idling, and with no seven-day
-auto-restart to automate around.
+**Entra sign-in cannot be reproduced locally — and does not need to be.** Stock
+PostgreSQL 17 has no OAuth; Azure's Entra support on 17 is an Azure-side
+extension that accepts the access token **in the password field**. Locally the
+client connects with an ordinary password over the *same code path*: only the
+origin of the string differs. Token acquisition and the refresh-before-expiry
+loop are therefore unit-testable with an injected provider and a fake clock,
+and nothing about them requires a cloud database.
+
+Running PostgreSQL 18 locally to get native OAUTHBEARER would be a trap: 18
+ships the framework but no validator, the Entra validators are not
+production-ready, and 18 is precisely the version where Azure's Entra auth does
+not work (Decision 13). It would test a path ZAM does not ship.
+
+What genuinely needs a real Azure server is a short list — that a live Entra
+token is accepted, that `pgaadauth_create_principal` grants behave like the
+local roles, and that reconnect-on-expiry works end to end. Decision 15 gives
+that a permanent home at no extra cost.
+
+### 15. ZAM is a co-tenant on a server DocuWare needs anyway
+
+The server is not being bought for ZAM (project owner, 2026-07-25). It is set
+up as the **prototype for migrating an existing Azure SQL resource to Azure
+PostgreSQL** for another service, hosting roughly five databases: three for the
+service being replaced, plus **`zam_test`** and **`zam_prod`**.
+
+ZAM's marginal cost is therefore **zero** — billing is per server, and two more
+databases on it are free. ZAM also earns its seat: it is a low-risk first
+tenant that exercises the migration prototype before the real service depends
+on it.
+
+Four consequences follow, and the first two are constraints on other people's
+work, so they need agreeing rather than assuming.
+
+- **The PostgreSQL major version is server-wide, and ZAM needs 17.** All
+  databases on a Flexible Server share one major version, and an in-place major
+  upgrade is server-wide and **irreversible**. ZAM requires 17 because Entra
+  sign-in is broken on 18 (Decision 13). If the Azure SQL migration targets 18,
+  the two cannot share a server. **This is the sharpest risk in the whole
+  arrangement and should be settled before the server is created.**
+
+- **PostgreSQL roles are cluster-wide — there are no per-database users.** This
+  is a real difference from Azure SQL, where *contained database users* live
+  inside a database and need no server login. Postgres has no equivalent: every
+  role, including every Entra principal created with
+  `pgaadauth_create_principal`, exists at server level and is visible in
+  `pg_roles` to every database on the server.
+
+  The isolation is still achievable, just built rather than inherited:
+  `REVOKE CONNECT ON DATABASE … FROM PUBLIC`, then `GRANT CONNECT` only to that
+  database's own roles, plus schema and table grants inside. The effect matches
+  contained users; the mechanism does not. Worth flagging to the migration
+  prototype too — it is exactly the kind of assumption that survives a schema
+  conversion and then surprises everyone.
+
+- **Point-in-time restore is per server, not per database.** ZAM cannot ask for
+  a server rollback without also rewinding the other service's three databases.
+  ZAM's recovery story is therefore **logical**: regular `pg_dump` of
+  `zam_prod`, restored into place. Server PITR belongs to the co-tenant, and
+  ZAM must never be the reason it is used.
+
+- **The set of people who can read everything grows.** Decision 6 already
+  states that a superuser or server administrator can read every row and has
+  ZAM disclose it in-app. On a shared server that group now includes whoever
+  operates the co-tenant service. The disclosure already says "database
+  administrators" without naming a team, so it stays accurate — but the fact
+  should be known rather than discovered.
+
+**`zam_test` replaces the ephemeral instance** from Decision 14. A permanent
+test database at no extra cost is strictly better: it gives the Entra identity
+path — real tokens, `pgaadauth_create_principal`, reconnect-on-expiry — a
+standing home to be verified against, while local Docker keeps serving the
+inner development loop.
 
 ## Cost (Deployment B)
 
@@ -608,21 +675,28 @@ Two levers, neither needed on day one:
 Storage is the floor, not a driver: ZAM would have to grow by two orders of
 magnitude before 32 GiB mattered.
 
-### What a development environment adds
+### What ZAM actually adds to the bill: nothing
 
-Billing is **per server, not per database**, so the answer depends entirely on
-which of these "two databases" means:
+The figures above describe a server bought for ZAM alone. That is not the plan
+(Decision 15): the server exists for the Azure SQL → PostgreSQL migration
+prototype, and ZAM adds `zam_test` and `zam_prod` to roughly five databases on
+it. Billing is **per server, not per database**, so:
 
-| Setup | Monthly | |
-|-------|---------|---|
-| Local Docker dev + one prod server | **~$16–19** | **Chosen** (Decision 14) — dev costs nothing |
-| Two databases inside the one server | ~$16–19 | Free, but rejected for dev/prod: shared restore, shared vCore, shared upgrades |
-| Prod + an *ephemeral* Azure dev server | ~$17–20 | A few hours of B1ms per verification session, billed hourly |
-| Two permanent servers | ~$32–38 (~$18–20 reserved) | Only if a always-on staging environment is ever genuinely needed |
+| | Monthly |
+|---|---|
+| ZAM's marginal cost on the shared server | **$0** |
+| Local Docker for development | **$0** |
+| A standalone server, if ZAM ever needed its own | ~$16–19 (~$9–10 reserved) |
 
-So a development environment is effectively **free**, and the answer to "what
-if we need two" is "not much" — as long as the second one is local, or exists
-only while it is being used.
+**Development stays local regardless** (project owner, 2026-07-25) — a test
+user with a password against Docker Postgres 17, which is the same client code
+path as an Entra token (Decision 14). Even a free database on the shared server
+would be a worse inner loop than a container that starts in a second and can be
+thrown away.
+
+The standalone figure is kept because it is the fallback if the version
+constraint in Decision 15 turns out to be irreconcilable, and because it is the
+honest answer to "what would this cost if it had to stand alone".
 
 ### Cheaper alternatives, and why they lose
 
@@ -685,7 +759,8 @@ remains is one engineering note rather than a decision:
   worth doing on the existing paths first.
 - **Phase C0 — local Postgres first:** the Postgres provider and its contract
   case, the dialect delta, `pgvector`, and the RLS isolation suite, all on
-  Docker Postgres 17 in CI (Decision 14). No Azure resource exists yet.
+  Docker Postgres 17 in CI with a test user and password (Decision 14). No
+  Azure resource exists yet, and none is needed to prove the privacy boundary.
 - **Phase C — Deployment B pilot:** the Postgres provider behind the existing
   async `Database` contract, Entra token acquisition and refresh, the ULID ↔
   Entra principal mapping, RLS policies **with an isolation test suite**, the

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -144,6 +144,15 @@ correct?" is a review question git answers well. "What should happen to the
 people who already learned the old version?" is a scheduling question only ZAM
 can answer, and it needs the curator in front of ZAM.
 
+**Corollary: concurrent curation needs no design of its own** (project owner,
+2026-07-25). Two curators editing the same token is a **merge conflict**,
+resolved by tools that have done exactly this for decades, with diff, history
+and blame included. The database only ever receives the *result* of a publish,
+so it has no competing writers for knowledge at all. No last-write-wins rule,
+no curation log, no merge UI — the draft's Open Question about conflict policy
+dissolves rather than being answered, which is the best outcome an open
+question can have.
+
 ### 3. Content changes classify as cosmetic or material — and material changes touch FSRS
 
 This is the part a plain shared database cannot do, and the reason curation is
@@ -518,26 +527,26 @@ self-hosted server can validate Entra tokens directly.
 
 ## Open questions
 
-Resolved on 2026-07-25 (project owner): the pilot tenant is `docuware.com`, so
-colleagues are ordinary tenant members and no B2B guest path is needed
-(Decision 6); curation is git for content plus a Studio release step
-(Decision 2); learning state lives in the shared database behind RLS
-(Decision 6); and materiality has no default — publishing forces the choice
-(Decision 3). A material change **re-tests rather than resets** — the card
-becomes due now and the next rating recalibrates FSRS (Decision 3). An
-assignment binds while it stands, and the cards outlive it under the learner's
-control (Decision 10). The residual superuser exposure is disclosed by ZAM
-itself, in-app and alongside a working local alternative (Decision 6).
-Aggregates about people are not built at all (Decision 11). Deployment B is
-online-only for reviews; whether an offline cache is worth its sync complexity
-is a question the pilot answers rather than a guess made up front (Decision 6).
-The deployment now starts in a company subscription in the `docuware.com`
-tenant, so the planned migration — and its rehearsal — is gone (Decision 6).
+All questions this ADR raised for the project owner were resolved on
+2026-07-25:
 
-1. **Conflict policy for concurrent curation.** Last-write-wins on
-   `updated_at` plus a curation log is probably enough at this scale; verify
-   against a real two-curator case before building merge UI.
-2. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
+| Question | Answer |
+|----------|--------|
+| Which tenant? | `docuware.com`, in a company subscription from day one — ordinary members, no B2B guests, no planned migration (Decision 6) |
+| Where does curation happen? | Content in git, release step in the Studio (Decision 2) |
+| Learning state in the shared database? | Yes, isolated by RLS — which makes RLS load-bearing and testable (Decision 6) |
+| Default for materiality? | None; publishing forces the curator to classify (Decision 3) |
+| What happens on a material change? | The card re-tests rather than resets: due now, next rating recalibrates FSRS (Decision 3) |
+| Assignment withdrawn? | Binding while it stands; cards and history then stay with the learner (Decision 10) |
+| Residual admin visibility? | ZAM discloses it in-app, beside a working local alternative (Decision 6) |
+| Aggregates about people? | Not built at all (Decision 11) |
+| Offline in Deployment B? | Online-only; the pilot measures whether a cache is worth its complexity (Decision 6) |
+| Concurrent curation? | A git merge conflict — the database never has competing writers (Decision 2) |
+
+Every question this ADR raised for the project owner is now answered. What
+remains is one engineering note rather than a decision:
+
+1. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
    means "a dialect audit of every kernel query". A survey on 2026-07-25 found
    the actual surface small: `datetime('now')` ×21, `LIKE` ×16 (SQLite's is
    case-insensitive for ASCII, Postgres' is not — needs `ILIKE`),

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -531,6 +531,51 @@ costs nothing but a restart if the pilot proves it wrong. Two things would
 force B2s: the Burstable `max_connections` ceiling with many concurrent
 desktop/CLI/mobile clients, and `pgvector` index builds over a large library.
 
+### 14. Development and testing run on local Postgres, not on Azure
+
+Almost nothing about this work needs a cloud database.
+
+**Local: Docker PostgreSQL 17 + `pgvector`.** The kernel already runs its
+provider suite through `describeDatabaseContract(...)`
+(`tests/kernel/provider-contract.test.ts`), today against local SQLite and an
+Hrana stub. A Postgres provider joins as a third case, and CI gains a Postgres
+service container. That covers:
+
+- the whole dialect delta (`datetime('now')`, `ILIKE`, `ON CONFLICT DO
+  NOTHING`, `RETURNING`, `?`→`$n`) and the schema/migrations;
+- `pgvector` search;
+- the library model — editorial state, `content_version`, materiality and the
+  due-now consequence;
+- **the RLS isolation suite.** This matters most: RLS is the load-bearing
+  privacy boundary (Decision 6), and it is ordinary PostgreSQL. "Learner A
+  cannot read learner B's review logs" is fully testable locally and on every
+  CI run, against plain roles. The privacy boundary does not need Azure to be
+  proven.
+
+**Only the Azure-specific identity path needs Azure:**
+`pgaadauth_create_principal`, acquiring a real Entra token, presenting it as
+the password, and refreshing it before expiry. Even these are mostly seam-
+testable — the token provider is a function returning a string, so tests inject
+a fake one and drive the refresh loop with a fake clock. Locally the same code
+path connects with an ordinary password.
+
+**Dev and prod do not share one server**, even though extra databases on a
+server are free (billing is per server). Three reasons, the third decisive:
+
+- point-in-time restore is per *server*, so restoring prod would roll dev back
+  too;
+- one B1ms has a single vCore — a careless dev query is a prod outage;
+- maintenance and **major-version upgrades hit the whole server at once**. The
+  main reason to want a dev environment here is to rehearse the PostgreSQL 18
+  move once Azure supports Entra on it (Decision 13). On a shared server that
+  rehearsal is impossible by construction.
+
+**The Azure dev instance is ephemeral.** It exists to verify the identity path
+and to rehearse upgrades, not to be online. Azure bills compute hourly, so
+creating a B1ms, running the checks and deleting it costs cents per session —
+far less than keeping a second server idling, and with no seven-day
+auto-restart to automate around.
+
 ## Cost (Deployment B)
 
 The company subscription carries the bill (Decision 6), so the figures below
@@ -562,6 +607,22 @@ Two levers, neither needed on day one:
 
 Storage is the floor, not a driver: ZAM would have to grow by two orders of
 magnitude before 32 GiB mattered.
+
+### What a development environment adds
+
+Billing is **per server, not per database**, so the answer depends entirely on
+which of these "two databases" means:
+
+| Setup | Monthly | |
+|-------|---------|---|
+| Local Docker dev + one prod server | **~$16–19** | **Chosen** (Decision 14) — dev costs nothing |
+| Two databases inside the one server | ~$16–19 | Free, but rejected for dev/prod: shared restore, shared vCore, shared upgrades |
+| Prod + an *ephemeral* Azure dev server | ~$17–20 | A few hours of B1ms per verification session, billed hourly |
+| Two permanent servers | ~$32–38 (~$18–20 reserved) | Only if a always-on staging environment is ever genuinely needed |
+
+So a development environment is effectively **free**, and the answer to "what
+if we need two" is "not much" — as long as the second one is local, or exists
+only while it is being used.
 
 ### Cheaper alternatives, and why they lose
 
@@ -622,6 +683,9 @@ remains is one engineering note rather than a decision:
   and the cosmetic/material change classification with its FSRS consequence.
   This is the heart of the ADR and is **independent of any deployment** — it is
   worth doing on the existing paths first.
+- **Phase C0 — local Postgres first:** the Postgres provider and its contract
+  case, the dialect delta, `pgvector`, and the RLS isolation suite, all on
+  Docker Postgres 17 in CI (Decision 14). No Azure resource exists yet.
 - **Phase C — Deployment B pilot:** the Postgres provider behind the existing
   async `Database` contract, Entra token acquisition and refresh, the ULID ↔
   Entra principal mapping, RLS policies **with an isolation test suite**, the

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -154,15 +154,40 @@ learned against. When a curator publishes a change they classify it:
 - **Cosmetic** (typo, clearer phrasing, formatting): learners keep their FSRS
   state untouched. The card silently updates.
 - **Material** (the answer changed, the scope changed, it was simply wrong):
-  every learner who already learned the old version is **told**, and the card's
-  scheduling is reset — its stability no longer describes what they now need to
-  know.
+  the card becomes **due now**, and the learner sees what changed and who
+  changed it.
 
 Without this, quality control is cosmetic in the worst sense: a curator fixes a
 wrong card and everyone who already memorized the wrong answer stays
 confidently wrong on a comfortable review interval. Making a correction
 propagate into scheduling is what turns "someone checks the content" into a
 real guarantee.
+
+**A material change does not reset FSRS state directly — it re-tests**
+(project owner, 2026-07-25):
+
+```
+curator publishes (material)
+        │
+        ▼
+due_at = now, notice on the card:
+  "content changed by <curator>, <date>"  + what changed
+        │
+        ▼
+learner answers, rates 1–4
+        │
+        ▼
+FSRS recomputes stability from the real answer
+```
+
+This is the FSRS-native answer and it avoids inventing a number. A hard reset
+throws away history that the scheduler could have used and punishes people who
+already knew the correction; a "soft reset" needs a stability penalty that
+nobody can justify. Re-testing needs neither: the scheduler already knows how
+to tell "still knew it" from "did not", and the learner's actual rating is
+better evidence than any guess ZAM could make on their behalf. Someone who
+already knew the new answer rates it well once and is back on their previous
+rhythm; someone who held the outdated version lapses, which is exactly correct.
 
 **There is no default** (project owner, 2026-07-25). Publishing forces the
 curator to classify the change; ZAM never guesses materiality from a text diff
@@ -405,33 +430,30 @@ colleagues are ordinary tenant members and no B2B guest path is needed
 (Decision 6); curation is git for content plus a Studio release step
 (Decision 2); learning state lives in the shared database behind RLS
 (Decision 6); and materiality has no default — publishing forces the choice
-(Decision 3).
+(Decision 3). A material change **re-tests rather than resets** — the card
+becomes due now and the next rating recalibrates FSRS (Decision 3).
 
-1. **What does a learner see when a material change resets their card, and can
-   they push back?** The reset is correct but it is also someone else deciding
-   that your memory is now wrong. It needs an explanation naming the change and
-   the curator, and a decision on whether a learner may defer or dispute it.
-2. **Assignment ↔ card lifecycle.** Does deleting an assignment retire the
+1. **Assignment ↔ card lifecycle.** Does deleting an assignment retire the
    card, and does the learner keep the history?
-3. **Where does the residual-visibility policy get written down?** Decision 6
+2. **Where does the residual-visibility policy get written down?** Decision 6
    states that a superuser or Azure server administrator can read every row.
    Participants should be told this in plain language before the first real
    colleague joins, and someone at DocuWare — not this ADR — has to own that
    statement. Blocking for real colleague data; not blocking for a pilot on
    test identities.
-4. **Aggregate vocabulary.** Which opt-in metrics exist and at what
+3. **Aggregate vocabulary.** Which opt-in metrics exist and at what
    granularity — needs a concrete lead/coach story before freezing. At an
    employer this needs to be conservative by default.
-5. **Offline for Deployment B.** With learning state in the server, reviews
+4. **Offline for Deployment B.** With learning state in the server, reviews
    need the network. Deployment A stays the offline path, but if colleagues
    want offline reviews *and* cross-device progress, a local read-through
    cache with write-back is the answer — and it brings back exactly the sync
    and conflict work this ADR otherwise avoids. Defer until the pilot shows
    whether it actually hurts.
-6. **Conflict policy for concurrent curation.** Last-write-wins on
+5. **Conflict policy for concurrent curation.** Last-write-wins on
    `updated_at` plus a curation log is probably enough at this scale; verify
    against a real two-curator case before building merge UI.
-7. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
+6. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
    means "a dialect audit of every kernel query". A survey on 2026-07-25 found
    the actual surface small: `datetime('now')` ×21, `LIKE` ×16 (SQLite's is
    case-insensitive for ASCII, Postgres' is not — needs `ILIKE`),

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -76,7 +76,8 @@ the most valuable thing a curated group library can offer.
 
 1. **Editorial quality first** — the library exists so a few people can make
    content good for everyone.
-2. **Knowledge shared, learning state private by default**, aggregates opt-in.
+2. **Knowledge shared, learning state the learner's** — and no aggregates about
+   people at all (Decision 11).
 3. **Offline-first stays available** — Deployment A never blocks a review on a
    server. Deployment B trades this for cross-device progress, deliberately and
    with Deployment A still there for anyone who needs offline (Decision 6).
@@ -91,7 +92,7 @@ the most valuable thing a curated group library can offer.
 | **Knowledge** | tokens, prerequisites, sources, token_sources, token_embeddings, agent_skills (curated) | Shared library, versioned | Curators |
 | **Assignment** | *new:* assignments (who should learn what, by when) | Visible to assigner + learner | Curators/leads |
 | **Learning state** | cards, review_logs, sessions, session_steps, session_syntheses | **Private to the learner.** Deployment A: local. Deployment B: in the shared database, isolated by RLS | The learner only |
-| **Aggregates** | *derived:* coverage %, due counts | Opt-in, coarse, learner-controlled | Published explicitly |
+| **Aggregates** | *derived:* coverage %, due counts | **Not built** — nobody but the learner sees their numbers (Decision 11) | — |
 
 "Private to the learner" is the invariant; *where* the rows sit is a deployment
 choice. In Deployment A it holds because the data never leaves the machine; in
@@ -434,6 +435,47 @@ append-only from every direction except the person they belong to.
 Assignment provenance survives as context on the card ("assigned by … , March
 2026"), so a learner can still see why a card entered their queue.
 
+### 11. No aggregates — nobody but the learner sees their numbers
+
+The draft reserved room for opt-in aggregates (coverage %, due counts) that a
+guardian or coach could receive. **They are not built** (project owner,
+2026-07-25). A learner sees their own figures; no one else sees them at any
+granularity, opt-in or otherwise.
+
+Three reasons, and the third is the one that decides it:
+
+- **No demonstrated demand.** No concrete lead-or-coach story exists that needs
+  them. Designing a privacy-sensitive feature against an imagined user is how
+  you get a feature nobody asked for and everybody has to live with.
+- **High misuse potential at an employer.** "Coverage 40%" is one screenshot
+  away from being read as an appraisal. And "voluntary" sharing with one's own
+  manager is rarely as voluntary as the checkbox suggests.
+- **It would corrupt the data it reports on.** FSRS only works when people rate
+  themselves honestly — a rating of 1 has to be safe to give. A learner who
+  believes their failures are visible to a colleague will start rating
+  generously, and the scheduler immediately begins optimising against fiction:
+  intervals stretch, weak material stops coming back, and the tool quietly
+  becomes worse at the one thing it exists to do. Surveillance does not just
+  cost trust here; it costs accuracy.
+
+This is a ratchet, so it is easier not to start: aggregates can be added later
+if a real need appears, but a group that has once seen colleagues' numbers
+cannot unsee them. Curators who want to find weak *content* are served by
+Decision 12 instead, which never needs a person's identity.
+
+### 12. Content-level signals are allowed, because they are about cards
+
+Curators do need feedback to do their job — the point of the library is that
+someone improves it. That feedback can be entirely about the material:
+"this card is failed by most people who attempt it" is a content-quality
+signal, not a personnel signal.
+
+If and when this is built it must be **anonymous and thresholded** — reported
+only above a minimum number of distinct learners, so a small group cannot
+reverse it into "who failed it". Nothing here is in the pilot either; it is
+recorded so a later reader can see that "no aggregates" was a decision about
+*people*, not a refusal to help curators.
+
 ## Cost (Deployment B, pilot phase)
 
 The pilot's budget is the Visual Studio Professional subscription's monthly
@@ -482,20 +524,18 @@ becomes due now and the next rating recalibrates FSRS (Decision 3). An
 assignment binds while it stands, and the cards outlive it under the learner's
 control (Decision 10). The residual superuser exposure is disclosed by ZAM
 itself, in-app and alongside a working local alternative (Decision 6).
+Aggregates about people are not built at all (Decision 11).
 
-1. **Aggregate vocabulary.** Which opt-in metrics exist and at what
-   granularity — needs a concrete lead/coach story before freezing. At an
-   employer this needs to be conservative by default.
-2. **Offline for Deployment B.** With learning state in the server, reviews
+1. **Offline for Deployment B.** With learning state in the server, reviews
    need the network. Deployment A stays the offline path, but if colleagues
    want offline reviews *and* cross-device progress, a local read-through
    cache with write-back is the answer — and it brings back exactly the sync
    and conflict work this ADR otherwise avoids. Defer until the pilot shows
    whether it actually hurts.
-3. **Conflict policy for concurrent curation.** Last-write-wins on
+2. **Conflict policy for concurrent curation.** Last-write-wins on
    `updated_at` plus a curation log is probably enough at this scale; verify
    against a real two-curator case before building merge UI.
-4. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
+3. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
    means "a dialect audit of every kernel query". A survey on 2026-07-25 found
    the actual surface small: `datetime('now')` ×21, `LIKE` ×16 (SQLite's is
    case-insensitive for ASCII, Postgres' is not — needs `ILIKE`),
@@ -521,7 +561,8 @@ itself, in-app and alongside a working local alternative (Decision 6).
   runbook for granting Entra groups access.
 - **Phase C2 — rehearse the subscription move** once, while the pilot is small
   and nobody depends on it, so the runbook is proven rather than hypothetical.
-- **Phase D — assignments**, then opt-in aggregates.
+- **Phase D — assignments** (Decision 10). Aggregates are not part of the
+  plan (Decision 11).
 
 ## Out of scope
 

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -1,12 +1,14 @@
-# Multi-Learner Tier: Shared Knowledge, Private Learning State
+# Shared Curated Learning Content in a Closed Group
 
-**Status:** Accepted (2026-07-04)
-**Date:** 2026-07-04
+**Status:** Proposed (rewritten 2026-07-25; supersedes the 2026-07-04 draft)
+**Date:** 2026-07-04, rewritten 2026-07-25
 **Deciders:** Thomas (project owner)
 **Related:**
 [2026-07-03-rag-semantic-token-search.md](2026-07-03-rag-semantic-token-search.md)
 (Decision 4 + Open Question 2) ·
 [2026-06-09-async-database-providers.md](2026-06-09-async-database-providers.md) ·
+[2026-07-17-okf-knowledge-base.md](2026-07-17-okf-knowledge-base.md) ·
+[2026-07-23-online-only-server-db-and-mobile-gating.md](2026-07-23-online-only-server-db-and-mobile-gating.md) ·
 [2026-07-02-lehrplanplus-import-wizard.md](2026-07-02-lehrplanplus-import-wizard.md)
 (the "central sync service" follow-up idea)
 
@@ -14,193 +16,292 @@
 
 ## Context
 
-ZAM is single-learner-first: one local SQLite file, one implicit user, with
-optional Turso sync for the *same person's* other machines. The domain model
-already separates the two halves cleanly — **tokens** (knowledge, "shared
-across users" by design) and **cards/review_logs/sessions** (one learner's
-FSRS state) — and `cards.user_id` plus `bridge database-select-user` show the
-multi-profile seam exists. What does not exist is any story for **several
-people sharing one knowledge base**: a family working through school
-curricula, a team curating company know-how, a class with a teacher.
+Inside a closed group — a company like DocuWare, a family, a class — people
+learn overlapping material. Today each learner curates alone: everyone imports
+the same curriculum, writes their own version of the same card, re-embeds the
+same tokens, and repeats the same mistakes in wording, scope and Bloom level.
 
-Two prior decisions point here and wait on this ADR:
+The reason to put a group on one library is not storage and not sync. It is
+that **a few people can take responsibility for the quality of the learning
+content, and everyone else benefits from that work.** That is the core idea;
+everything below follows from it.
 
-1. The semantic-search ADR put search behind an abstraction so "the shared
-   company tier" can plug in a different backend (its Phase 4), and left
-   **Open Question 2** — self-hosted `sqld` vs. Postgres + pgvector — to be
-   answered "when the multi-learner ADR is written". This is that ADR.
-2. The LehrplanPLUS wizard work noted a future **central sync service** so a
-   curated curriculum import lands once and reaches every learner.
+> The 2026-07-04 draft of this ADR led with sync topology and a bespoke sync
+> service. That put the plumbing before the purpose, and the purpose had not
+> been thought through yet (project owner, 2026-07-25). This rewrite starts
+> from content quality. The data-class privacy table survives from the draft
+> because it is load-bearing; the sync-service design does not.
+
+### What "quality" actually means here
+
+A curator is not a database administrator. The properties they are responsible
+for are editorial:
+
+- the token is **atomic** — one concept, one question, one answer;
+- the **Bloom level** matches what the question really demands;
+- there is a **real source** (`source_link`: an OKF article, a spec, a
+  curriculum entry), not folklore;
+- no **duplicates** and no **contradictions** with the rest of the library;
+- **prerequisite edges** reflect actual dependency, so blocking is meaningful;
+- the content is **still true** — and when it stops being true, someone fixes
+  it and the fix reaches people who already learned the old version.
+
+That last point is the one a shared database alone does not solve, and it is
+the most valuable thing a curated group library can offer.
 
 ### Forces at play
 
-- **Learning state is intimate.** Review logs record what someone failed, how
-  often, and when. In a family or company setting, sharing *knowledge* must
-  not silently mean sharing *performance*. ZAM's symbiosis stance implies the
-  learner owns their learning state — a teacher/employer sees progress only by
-  explicit opt-in. This is the defining constraint, not an afterthought.
-- **Write patterns differ per data class.** Tokens/prerequisites: few writers
-  (curators), many readers, low conflict. Cards/review_logs: exactly one
-  writer each (the learner), append-heavy, no cross-user conflicts by
-  construction. This asymmetry is a gift — exploited correctly, the
-  multi-learner problem needs no CRDTs and no distributed transactions.
-- **Offline-first is non-negotiable.** Reviews happen on trains and in
-  classrooms. The learner's working set must live locally; the shared tier can
-  only ever be a sync target, never a hard runtime dependency.
-- **The stack already speaks three providers** (better-sqlite3, native libsql
-  replica, Turso HTTP) behind one async `Database` contract. A self-hosted
-  `sqld` server is wire-compatible with the existing Turso paths — the
-  cheapest possible shared store. Postgres would mean a fourth provider AND a
-  dialect audit of every kernel query.
-- **Embeddings are now part of the knowledge.** `token_embeddings` rows are
-  portable BLOBs with a canonical model id — they can (and should) be synced
-  with the tokens so one machine's embedding work benefits every learner.
-- **Self-hosted, no license cost** (inherited from the search ADR): OSI
-  licenses, runs on a home server or company VM.
-- **Scale is modest.** Family: 2–5 learners. Class: ~30. Company team:
-  10–100s. Nothing here needs web-scale infrastructure; everything needs
-  clear ownership boundaries.
+- **Content quality is the product.** A shared library full of sloppy cards is
+  worse than no shared library: it multiplies one person's errors across the
+  whole group and lends them false authority.
+- **Write patterns are deeply asymmetric.** Knowledge: few writers, many
+  readers, low conflict. Learning state: exactly one writer each, append-heavy,
+  no cross-user conflicts by construction. Exploited correctly this needs no
+  CRDTs and no distributed transactions.
+- **Learning state is intimate — and sharper at an employer.** Review logs
+  record what someone failed, how often, and when. In a company, that is
+  performance data about an employee. Sharing *content* must never quietly mean
+  sharing *performance*.
+- **Offline-first for reviews.** Reviews happen on trains and in meeting rooms.
+- **The existing database paths must keep working** (project owner,
+  2026-07-25): local SQLite, embedded libsql replica, and Turso/`sqld` remote
+  stay supported and remain the default. Anything new is parallel and opt-in.
+- **A closed group needs an identity boundary** — someone must be able to say
+  who is in and who is out, and revoke it when a colleague leaves.
+- **Scale is modest.** Family 2–5, class ~30, company team 10–100s.
 
 ## Decision drivers
 
-1. **Privacy by data class** — knowledge shared, learning state private by
-   default, aggregates opt-in.
-2. **Offline-first** — a learner's reviews never block on a server.
-3. **Smallest credible step** — reuse the existing provider/sync machinery
-   before building services.
-4. **One knowledge base, many learners** — curriculum imports, token curation,
-   and embeddings land once and reach everyone.
-5. **Self-hosted, no license cost, kernel stays SQL/SQLite-dialect.**
-6. **A seam that survives growth** — the same client-visible contract from
-   family scale to company scale.
+1. **Editorial quality first** — the library exists so a few people can make
+   content good for everyone.
+2. **Knowledge shared, learning state private by default**, aggregates opt-in.
+3. **Offline-first** — a learner's reviews never block on a server.
+4. **Additive** — existing single-learner and Turso/`sqld` paths keep working.
+5. **A fix must reach the people who learned the broken version.**
+6. **Smallest credible step** before new deployables.
 
-## Data classes (the core of this ADR)
+## Data classes
 
 | Class | Tables | Sharing | Writers |
 |-------|--------|---------|---------|
-| **Knowledge** | tokens, prerequisites, sources, token_sources, token_embeddings, agent_skills (curated) | Shared library, versioned | Curators (role) |
-| **Assignment** | *new:* assignments (who should learn what, by whom, due) | Visible to assigner + learner | Curators/guardians |
-| **Learning state** | cards, review_logs, sessions, session_steps, session_syntheses | **Private to the learner; stays local by default** | The learner only |
-| **Aggregates** | *derived:* coverage %, due counts, streaks | Opt-in, coarse, learner-controlled | Derived client-side, published explicitly |
+| **Knowledge** | tokens, prerequisites, sources, token_sources, token_embeddings, agent_skills (curated) | Shared library, versioned | Curators |
+| **Assignment** | *new:* assignments (who should learn what, by when) | Visible to assigner + learner | Curators/leads |
+| **Learning state** | cards, review_logs, sessions, session_steps, session_syntheses | **Private to the learner; local by default** | The learner only |
+| **Aggregates** | *derived:* coverage %, due counts | Opt-in, coarse, learner-controlled | Published explicitly |
 
-## Options considered
+## Decision
 
-| Option | Privacy model | Offline | Migration | Notes |
-|--------|---------------|---------|-----------|-------|
-| **A. One shared self-hosted `sqld`, every learner an embedded replica** | ❌ none — every client replicates the *entire* DB including everyone's review_logs | ✅ excellent | **None** — existing providers work against `sqld` today | Perfect for a **trusted circle** (family) where mutual visibility is acceptable; untenable beyond it. Auth = one DB token, all-or-nothing. |
-| **B. ZAM Sync Service: small self-hosted API syncing per data class; clients stay local-SQLite** | ✅ enforced at the API: knowledge shared, state never uploaded without opt-in | ✅ local DB remains source of truth for state | Medium — one new service + a client sync command | The service owns authorization; its *internal* store is an implementation detail (start `sqld`/libsql, swap to Postgres+pgvector if scale demands) — which quietly answers the search ADR's Open Question 2: **the seam moves from the SQL dialect to the service API.** |
-| **C. Postgres + pgvector as a fourth kernel provider, RLS for privacy** | ✅ via RLS, but complex to get right | ❌ weak — kernel queries go remote, offline needs a second local store anyway | **Large** — dialect audit of the whole kernel | Row-level security is attractive, but buys privacy at the cost of the offline-first property and the biggest migration. Kept as the *internal* scaling exit of Option B, not as the client contract. |
-| **D. Managed Turso cloud, one DB per learner + one shared DB** | partial | ✅ | small | Vendor-dependent and per-seat cost; conflicts with self-hosted-no-cost. Rejected as the *required* path; remains possible since B/A speak the same protocol. |
+### 1. The unit of sharing is a published token version, not a database
 
-## Decision (proposed)
+A group library is a set of tokens (plus prerequisites, sources, embeddings)
+that carry an editorial state and a content version. Learners consume
+**published** versions; they never see another learner's cards or review logs
+by construction, because those are a different data class that does not travel.
 
-**1. Two tiers, one principle.** Sharing is organized by **data class**, not by
-database: knowledge is shared, learning state is private by default,
-aggregates are explicit opt-ins. Both tiers below implement the same table
-above — they differ only in enforcement strength.
+### 2. An editorial workflow, because that is what quality control is
 
-**2. Trusted-circle tier now (Option A): a shared self-hosted `sqld` for
-small circles that accept mutual visibility.** Families and 2–3-person teams
-get multi-learner ZAM immediately: one `sqld` on a home server/NAS, every
-member connected via the existing Turso-compatible providers (embedded
-replica for offline). Per-user separation stays what it is today —
-`cards.user_id` discipline, not enforcement. Deliverables are documentation,
-a `zam connector setup` path for plain `sqld` URLs, and multi-user smoke
-tests. No schema changes.
+```
+draft ──► in-review ──► published ──► deprecated
+  ▲           │
+  └── changes requested
+```
 
-**3. Organization tier as the target (Option B): a small self-hosted ZAM Sync
-Service.** A single self-hosted API (Node, same repo, Apache-2.0) that syncs
-per data class:
+- **Anyone in the group may author a draft or propose a change** to an existing
+  token. Learning surfaces friction better than curating does: the person who
+  just failed a badly worded card is the best-placed to report it.
+- **Only curators publish.** Publishing is the quality gate and the only way
+  content reaches other learners' queues.
+- **Deprecated, never deleted.** `review_logs` reference tokens; retiring a
+  token stops scheduling new reviews and hides it from search, but history
+  stays intact.
+- Provenance is recorded — author, reviewer, timestamp — so a learner can see
+  who stands behind a card. This is the same discipline OKF articles already
+  follow (ADR 2026-07-17); an OKF article is the natural `source_link` target
+  for a curated token.
 
-- **Library sync (down/up):** tokens, prerequisites, sources, embeddings —
-  curators push, everyone pulls. Embedding vectors travel with the tokens
-  (canonical model id makes them portable), so one machine embeds and all
-  benefit.
-- **Assignments (down):** "learn these 12 tokens by March" lands in the
-  learner's queue as ordinary cards, created locally.
-- **Learning state: never uploaded by default.** The service cannot see
-  review logs. An explicit `zam share progress --with <circle>` publishes
-  coarse aggregates (coverage, due counts) — revocable, learner-initiated.
-- **Roles:** `curator` (write library), `learner` (read library, own state),
-  `guardian/coach` (read the aggregates a learner opted to publish).
-- **Identity (owner decision):** the service authenticates via **OIDC with
-  the major providers — Microsoft, Google, Apple** — because that is the
-  family's and team's reality (every member already has Microsoft and
-  Google accounts, Apple partially; the youngest gets a family Google
-  account before she ever uses ZAM). ZAM never stores passwords.
-  **Invites remain the membership flow:** an invitation binds an OIDC
-  identity (verified e-mail) to a circle and role; authentication and
-  authorization stay cleanly separated. Self-hosting consequence: each
-  deployment registers its own OIDC clients (client IDs for
-  Microsoft/Google/Apple) — a documented one-time setup step.
-- **Server store:** starts as `sqld`/libsql — one dialect everywhere, native
-  vector search available server-side, satisfying the search ADR's Phase 4.
-  If an org outgrows it, the service swaps its internal store to Postgres +
-  pgvector **without changing the client protocol** — resolving Open
-  Question 2 of the search ADR: *`sqld` first, Postgres as the internal
-  scaling exit, and the stable seam is the service API, not the SQL dialect.*
+### 3. Content changes classify as cosmetic or material — and material changes touch FSRS
 
-**4. The kernel stays single-learner.** No RLS, no auth, no HTTP in the
-kernel. Multi-learner semantics live in the sync layer (CLI/service), exactly
-like LLM access does. The kernel's only multi-user awareness remains what it
-already has: `user_id` columns.
+This is the part a plain shared database cannot do, and the reason curation is
+worth the effort.
+
+Tokens carry a `content_version`. A learner's card records the version it was
+learned against. When a curator publishes a change they classify it:
+
+- **Cosmetic** (typo, clearer phrasing, formatting): learners keep their FSRS
+  state untouched. The card silently updates.
+- **Material** (the answer changed, the scope changed, it was simply wrong):
+  every learner who already learned the old version is **told**, and the card's
+  scheduling is reset — its stability no longer describes what they now need to
+  know.
+
+Without this, quality control is cosmetic in the worst sense: a curator fixes a
+wrong card and everyone who already memorized the wrong answer stays
+confidently wrong on a comfortable review interval. Making a correction
+propagate into scheduling is what turns "someone checks the content" into a
+real guarantee.
+
+Cosmetic is the default only when the curator says so; ZAM never guesses
+materiality from a text diff.
+
+### 4. Roles
+
+| Role | May |
+|------|-----|
+| **Curator** | publish, deprecate, approve proposals, classify changes |
+| **Contributor** | author drafts, propose changes (any group member) |
+| **Learner** | read published content, own their learning state |
+| **Admin** | manage membership of the closed group |
+
+Roles are per library, not global. A person is typically contributor+learner,
+and a handful are also curators.
+
+### 5. Deployment A — existing paths, unchanged (the default)
+
+Local SQLite, the embedded libsql replica, and Turso/`sqld` remote keep working
+exactly as today, single-learner or trusted-circle. A family or a 2–3 person
+team can share one `sqld` and accept mutual visibility; the honest caveat
+stays documented (every replica technically sees everything), with the Studio's
+own-data display filter labeled as cosmetic, not a security boundary.
+
+**No schema-breaking change and no forced migration for anyone on these paths.**
+
+### 6. Deployment B — closed company group on Azure PostgreSQL with Microsoft Entra (new, parallel)
+
+For DocuWare colleagues, hosted on the project owner's Azure subscription.
+This is an **additional** path selected by configuration, never a replacement.
+
+- **Store:** Azure Database for PostgreSQL Flexible Server, Burstable tier,
+  32 GiB (the service's storage floor — ZAM's data is far smaller: 768-dim
+  embeddings are ≈3 KB per token, so 100k tokens ≈ 300 MB). `pgvector` provides
+  server-side vector search, which completes Phase 4 of the search ADR for this
+  tier and answers its Open Question 2: **Postgres, but only for this tier, and
+  only as a deployment choice — not as the kernel's dialect.**
+- **Identity = the closed group.** Microsoft Entra authentication is enabled on
+  the server; an administrator grants access by mapping Entra principals or
+  **groups** to database roles (`pgaadauth_create_principal`). Membership of
+  the group *is* membership of the library, so onboarding and offboarding
+  follow the corporate directory instead of a ZAM-specific invite list.
+- **Passwordless sign-in from the local user identity.** The client acquires an
+  Entra access token (scope
+  `https://ossrdbms-aad.database.windows.net/.default`) through an MSAL public
+  client — interactive browser or device-code — and presents it in the
+  connection's password field. ZAM stores no password and no long-lived secret.
+  Tokens are short-lived (roughly an hour), so the provider must refresh and
+  reconnect transparently; that refresh loop is the one genuinely new piece of
+  client machinery this tier needs.
+- **Authorization by data class** is enforced by Postgres grants and row-level
+  security rather than by convention: published knowledge readable by every
+  member, writable only by curators; assignments visible to their learner and
+  author.
+- **Learning state stays local.** For this tier the recommendation is that
+  `cards`, `review_logs` and `sessions` do **not** go into the corporate
+  database at all. This keeps reviews offline-capable, and it removes the
+  awkward question of what an employer's database administrator can read —
+  because RLS does not protect data from a superuser, and on a managed service
+  the subscription owner is close enough to one. What the company hosts is the
+  *library*; what the employee keeps is their *learning*.
+
+### 7. The kernel stays single-learner
+
+No RLS, no auth, no HTTP in the kernel. Multi-learner semantics live in the
+CLI/sync layer, exactly like LLM access does. The kernel's only multi-user
+awareness stays what it already has: `user_id` columns.
+
+## Cost (Deployment B)
+
+Indicative only — **verify in the Azure pricing calculator for the actual
+region before committing**, since tiers and prices move:
+
+| Item | Rough monthly |
+|------|---------------|
+| Burstable B1ms (1 vCore, 2 GiB) | ~$12–15 |
+| Burstable B2s (2 vCore, 4 GiB) | ~$25–30 |
+| 32 GiB storage | ~$4 |
+| Backup (within storage size) | included |
+
+B1ms plus storage lands near $20/month and B2s near $35 — both inside the
+$50/month allowance. Flexible Server can be stopped when idle, which pauses
+compute billing. Two caveats worth checking early: Burstable instances have a
+low `max_connections` ceiling, and built-in connection pooling is not offered
+on every tier — a group of ~30 with desktop, CLI and mobile clients may need
+B2s or an external pooler.
+
+**Why Azure and not something cheaper.** Neon, Supabase or a €5 Hetzner VM all
+run Postgres with pgvector for less. None of them offer "an administrator
+grants Microsoft Entra identities access in the database" as a supported
+feature — each would mean building and owning the identity bridge. The Entra
+requirement, not the database, is what selects Azure here. If that ever stops
+being true, PostgreSQL 18's native OAuth support is the portability exit: a
+self-hosted server can validate Entra tokens directly.
 
 ## Open questions
 
-1. ~~**Auth mechanism for the service.**~~ **Resolved (2026-07-04):**
-   OIDC with Microsoft, Google, and Apple as identity providers; invites
-   bind identities to circles and roles (see Decision 3). Plain invite
-   tokens were rejected — the family already lives in these ecosystems,
-   and no-password operation is worth the one-time OIDC client setup.
-2. **Conflict policy for curated knowledge.** Last-write-wins with
-   `updated_at` + a curation log is likely sufficient at expected scale;
-   verify against the multi-curator case before building merge UI.
+1. **Where does curation actually happen?** ZAM already has an OKF knowledge
+   base curated through git and pull requests. For a company library, the
+   proposal→review→publish loop could reuse that (review content as OKF
+   articles in a repo, sync published tokens to the database) instead of
+   building review UI in the Studio. This is likely the smallest credible first
+   step and should be decided before any workflow code is written.
+2. **Materiality classification UX.** Curators must classify every published
+   change. What is the default, what does the learner see when a card resets,
+   and can a learner appeal a reset?
 3. **Assignment ↔ card lifecycle.** Does deleting an assignment retire the
-   card (learner keeps history?) — interacts with FSRS-state ownership.
-4. **Aggregate vocabulary.** Which opt-in metrics exist (coverage, streak,
-   due-count) and their exact granularity — needs a guardian/coach user story
-   before freezing.
-5. ~~**Does the trusted-circle tier need soft privacy?**~~ **Resolved
-   (2026-07-04):** both — document honestly (in a shared `sqld`, every
-   replica technically sees everything; a family setting) AND ship the
-   cosmetic courtesy: Studio/CLI hide other users' learning state by
-   default, explicitly labeled as a display filter, not a security
-   boundary.
+   card, and does the learner keep the history?
+4. **Aggregate vocabulary.** Which opt-in metrics exist and at what
+   granularity — needs a concrete lead/coach story before freezing. At an
+   employer this needs to be conservative by default.
+5. **Does Deployment B ever need offline?** Decision 6 keeps learning state
+   local, so reviews stay offline-capable and only *library sync* needs
+   network. If the group later wants cross-device learning state, that
+   reopens both the offline question and the DBA-visibility question.
+6. **Conflict policy for concurrent curation.** Last-write-wins on
+   `updated_at` plus a curation log is probably enough at this scale; verify
+   against a real two-curator case before building merge UI.
+7. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
+   means "a dialect audit of every kernel query". A survey on 2026-07-25 found
+   the actual surface small: `datetime('now')` ×21, `LIKE` ×16 (SQLite's is
+   case-insensitive for ASCII, Postgres' is not — needs `ILIKE`),
+   `INSERT OR IGNORE` ×4, `last_insert_rowid` ×3, plus mechanical `?`→`$n`
+   placeholder translation in the adapter. ULIDs everywhere mean almost no
+   autoincrement coupling. Worth re-confirming against the full CLI query
+   surface before scheduling the work, but this is tens of sites, not hundreds.
 
 ## Scope and delivery plan
 
-- **Phase 0 — This ADR** proposed for sign-off.
-- **Phase A — Trusted circle on `sqld`** (small): setup docs + connector path
-  for self-hosted `sqld` URLs, multi-user smoke test, honest privacy note,
-  and the default own-data display filter in Studio/CLI (cosmetic, labeled
-  as such).
-- **Phase B — Sync Service MVP** (library down-sync only): read-only shared
-  library, `zam library pull`, embeddings included. Curation still happens on
-  the curator's machine.
-- **Phase C — Library up-sync + roles + assignments.**
-- **Phase D — Opt-in aggregates** (guardian/coach view) and, only if scale
-  demands, the internal Postgres+pgvector swap (search ADR Phase 4 completes
-  here at the latest — `sqld` native vectors may already cover it in B).
+- **Phase 0 — this ADR** for sign-off.
+- **Phase A — trusted circle on `sqld`** (docs + connector path + multi-user
+  smoke test + honest privacy note). No schema changes. Unchanged from the
+  draft.
+- **Phase B — library model:** editorial state, `content_version`, provenance,
+  and the cosmetic/material change classification with its FSRS consequence.
+  This is the heart of the ADR and is **independent of any deployment** — it is
+  worth doing on the existing paths first.
+- **Phase C — Deployment B:** the Postgres provider behind the existing async
+  `Database` contract, Entra token acquisition and refresh, RLS policies, and
+  the admin runbook for granting Entra groups access.
+- **Phase D — assignments**, then opt-in aggregates.
 
 ## Out of scope
 
-- Real-time collaboration/presence; CRDT merging (write asymmetry makes it
-  unnecessary at this scale).
+- Real-time collaboration, presence, CRDT merging.
 - Central review scheduling — FSRS runs on the learner's device, always.
-- Billing/tenancy for a hosted product; this ADR is self-hosted only.
-- The Studio UI for curation workflows (own design effort once Phase B
-  exists).
+- Billing/tenancy for a hosted commercial product.
+- Replacing or deprecating any existing database path.
 
 ## Consequences
 
-- Families get multi-learner ZAM with zero new code (Phase A is docs +
-  connector polish), at the honest cost of mutual visibility.
-- The privacy line — knowledge shared, state private — becomes an
-  architectural invariant enforced by the service, not a UI promise, and it
-  matches the symbiosis philosophy: the system serves the learner, it does
-  not surveil them.
-- A new deployable (the sync service) enters the repo: more surface, but the
-  kernel and CLI remain unchanged in character, and the service reuses the
-  bridge-protocol discipline (JSON contracts, versioned).
-- Open Question 2 of the search ADR is answered without a datastore bet:
-  `sqld` first; if Postgres ever arrives, it arrives *inside* the service.
+- The group gets something a shared folder cannot give it: content somebody is
+  accountable for, and corrections that actually reach the people holding the
+  outdated version.
+- The privacy line — knowledge shared, learning state the learner's — becomes
+  an architectural invariant rather than a UI promise, and it holds *more*
+  strongly at an employer because learning state simply is not in the corporate
+  database.
+- Phase B pays off on every deployment, including single-learner, because
+  versioned content with a materiality signal is useful even for one person
+  correcting their own old cards.
+- A fourth database provider is a real cost, but a bounded and measured one,
+  and it is confined to one opt-in deployment.
+- ZAM takes a dependency on Microsoft Entra for that deployment only. The
+  identity boundary of the closed group becomes the corporate directory, which
+  is the honest place for it.

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -387,6 +387,33 @@ This does **not** promote context to an authorization boundary. It makes the
 boundary the thing that *selects* the context. Inside the company library,
 contexts remain ordinary slices.
 
+### 10. An assignment binds while it stands; the learning outlives it
+
+An assignment ("learn these 12 tokens by March") creates ordinary cards in the
+learner's queue. Two rules govern their life (project owner, 2026-07-25):
+
+- **While the assignment is active, the learner cannot detach the card.** The
+  "not for me" opt-out is unavailable. That unavailability is precisely what
+  makes it an assignment rather than a suggestion. It constrains the *queue*,
+  never the answer: ZAM still never compels a rating, and the learner's results
+  remain their own private data like any other.
+- **When the assignment is withdrawn or completed, the cards and their full
+  FSRS history stay with the learner.** What someone worked to learn belongs to
+  them, not to the task that prompted it — a lead changing their mind must not
+  erase a colleague's learning. The assignment was the occasion, not the owner.
+
+From that moment the card is ordinary personal content and the learner has full
+control: keep it (the default — it simply keeps scheduling), detach it with
+**"not for me"**, or delete it outright in the Studio. Both are one action.
+
+The asymmetry is deliberate. An assigner may withdraw an assignment; an
+assigner may never delete another person's cards or review history. Deletion of
+learning state is always the learner's own act — which also keeps `review_logs`
+append-only from every direction except the person they belong to.
+
+Assignment provenance survives as context on the card ("assigned by … , March
+2026"), so a learner can still see why a card entered their queue.
+
 ## Cost (Deployment B, pilot phase)
 
 The pilot's budget is the Visual Studio Professional subscription's monthly
@@ -431,29 +458,29 @@ colleagues are ordinary tenant members and no B2B guest path is needed
 (Decision 2); learning state lives in the shared database behind RLS
 (Decision 6); and materiality has no default — publishing forces the choice
 (Decision 3). A material change **re-tests rather than resets** — the card
-becomes due now and the next rating recalibrates FSRS (Decision 3).
+becomes due now and the next rating recalibrates FSRS (Decision 3). An
+assignment binds while it stands, and the cards outlive it under the learner's
+control (Decision 10).
 
-1. **Assignment ↔ card lifecycle.** Does deleting an assignment retire the
-   card, and does the learner keep the history?
-2. **Where does the residual-visibility policy get written down?** Decision 6
+1. **Where does the residual-visibility policy get written down?** Decision 6
    states that a superuser or Azure server administrator can read every row.
    Participants should be told this in plain language before the first real
    colleague joins, and someone at DocuWare — not this ADR — has to own that
    statement. Blocking for real colleague data; not blocking for a pilot on
    test identities.
-3. **Aggregate vocabulary.** Which opt-in metrics exist and at what
+2. **Aggregate vocabulary.** Which opt-in metrics exist and at what
    granularity — needs a concrete lead/coach story before freezing. At an
    employer this needs to be conservative by default.
-4. **Offline for Deployment B.** With learning state in the server, reviews
+3. **Offline for Deployment B.** With learning state in the server, reviews
    need the network. Deployment A stays the offline path, but if colleagues
    want offline reviews *and* cross-device progress, a local read-through
    cache with write-back is the answer — and it brings back exactly the sync
    and conflict work this ADR otherwise avoids. Defer until the pilot shows
    whether it actually hurts.
-5. **Conflict policy for concurrent curation.** Last-write-wins on
+4. **Conflict policy for concurrent curation.** Last-write-wins on
    `updated_at` plus a curation log is probably enough at this scale; verify
    against a real two-curator case before building merge UI.
-6. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
+5. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
    means "a dialect audit of every kernel query". A survey on 2026-07-25 found
    the actual surface small: `datetime('now')` ×21, `LIKE` ×16 (SQLite's is
    case-insensitive for ASCII, Postgres' is not — needs `ILIKE`),

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -1,0 +1,189 @@
+# Multi-Learner Tier: Shared Knowledge, Private Learning State
+
+**Status:** Proposed (draft)
+**Date:** 2026-07-04
+**Deciders:** Thomas (project owner)
+**Related:**
+[2026-07-03-rag-semantic-token-search.md](2026-07-03-rag-semantic-token-search.md)
+(Decision 4 + Open Question 2) ·
+[2026-06-09-async-database-providers.md](2026-06-09-async-database-providers.md) ·
+[2026-07-02-lehrplanplus-import-wizard.md](2026-07-02-lehrplanplus-import-wizard.md)
+(the "central sync service" follow-up idea)
+
+---
+
+## Context
+
+ZAM is single-learner-first: one local SQLite file, one implicit user, with
+optional Turso sync for the *same person's* other machines. The domain model
+already separates the two halves cleanly — **tokens** (knowledge, "shared
+across users" by design) and **cards/review_logs/sessions** (one learner's
+FSRS state) — and `cards.user_id` plus `bridge database-select-user` show the
+multi-profile seam exists. What does not exist is any story for **several
+people sharing one knowledge base**: a family working through school
+curricula, a team curating company know-how, a class with a teacher.
+
+Two prior decisions point here and wait on this ADR:
+
+1. The semantic-search ADR put search behind an abstraction so "the shared
+   company tier" can plug in a different backend (its Phase 4), and left
+   **Open Question 2** — self-hosted `sqld` vs. Postgres + pgvector — to be
+   answered "when the multi-learner ADR is written". This is that ADR.
+2. The LehrplanPLUS wizard work noted a future **central sync service** so a
+   curated curriculum import lands once and reaches every learner.
+
+### Forces at play
+
+- **Learning state is intimate.** Review logs record what someone failed, how
+  often, and when. In a family or company setting, sharing *knowledge* must
+  not silently mean sharing *performance*. ZAM's symbiosis stance implies the
+  learner owns their learning state — a teacher/employer sees progress only by
+  explicit opt-in. This is the defining constraint, not an afterthought.
+- **Write patterns differ per data class.** Tokens/prerequisites: few writers
+  (curators), many readers, low conflict. Cards/review_logs: exactly one
+  writer each (the learner), append-heavy, no cross-user conflicts by
+  construction. This asymmetry is a gift — exploited correctly, the
+  multi-learner problem needs no CRDTs and no distributed transactions.
+- **Offline-first is non-negotiable.** Reviews happen on trains and in
+  classrooms. The learner's working set must live locally; the shared tier can
+  only ever be a sync target, never a hard runtime dependency.
+- **The stack already speaks three providers** (better-sqlite3, native libsql
+  replica, Turso HTTP) behind one async `Database` contract. A self-hosted
+  `sqld` server is wire-compatible with the existing Turso paths — the
+  cheapest possible shared store. Postgres would mean a fourth provider AND a
+  dialect audit of every kernel query.
+- **Embeddings are now part of the knowledge.** `token_embeddings` rows are
+  portable BLOBs with a canonical model id — they can (and should) be synced
+  with the tokens so one machine's embedding work benefits every learner.
+- **Self-hosted, no license cost** (inherited from the search ADR): OSI
+  licenses, runs on a home server or company VM.
+- **Scale is modest.** Family: 2–5 learners. Class: ~30. Company team:
+  10–100s. Nothing here needs web-scale infrastructure; everything needs
+  clear ownership boundaries.
+
+## Decision drivers
+
+1. **Privacy by data class** — knowledge shared, learning state private by
+   default, aggregates opt-in.
+2. **Offline-first** — a learner's reviews never block on a server.
+3. **Smallest credible step** — reuse the existing provider/sync machinery
+   before building services.
+4. **One knowledge base, many learners** — curriculum imports, token curation,
+   and embeddings land once and reach everyone.
+5. **Self-hosted, no license cost, kernel stays SQL/SQLite-dialect.**
+6. **A seam that survives growth** — the same client-visible contract from
+   family scale to company scale.
+
+## Data classes (the core of this ADR)
+
+| Class | Tables | Sharing | Writers |
+|-------|--------|---------|---------|
+| **Knowledge** | tokens, prerequisites, sources, token_sources, token_embeddings, agent_skills (curated) | Shared library, versioned | Curators (role) |
+| **Assignment** | *new:* assignments (who should learn what, by whom, due) | Visible to assigner + learner | Curators/guardians |
+| **Learning state** | cards, review_logs, sessions, session_steps, session_syntheses | **Private to the learner; stays local by default** | The learner only |
+| **Aggregates** | *derived:* coverage %, due counts, streaks | Opt-in, coarse, learner-controlled | Derived client-side, published explicitly |
+
+## Options considered
+
+| Option | Privacy model | Offline | Migration | Notes |
+|--------|---------------|---------|-----------|-------|
+| **A. One shared self-hosted `sqld`, every learner an embedded replica** | ❌ none — every client replicates the *entire* DB including everyone's review_logs | ✅ excellent | **None** — existing providers work against `sqld` today | Perfect for a **trusted circle** (family) where mutual visibility is acceptable; untenable beyond it. Auth = one DB token, all-or-nothing. |
+| **B. ZAM Sync Service: small self-hosted API syncing per data class; clients stay local-SQLite** | ✅ enforced at the API: knowledge shared, state never uploaded without opt-in | ✅ local DB remains source of truth for state | Medium — one new service + a client sync command | The service owns authorization; its *internal* store is an implementation detail (start `sqld`/libsql, swap to Postgres+pgvector if scale demands) — which quietly answers the search ADR's Open Question 2: **the seam moves from the SQL dialect to the service API.** |
+| **C. Postgres + pgvector as a fourth kernel provider, RLS for privacy** | ✅ via RLS, but complex to get right | ❌ weak — kernel queries go remote, offline needs a second local store anyway | **Large** — dialect audit of the whole kernel | Row-level security is attractive, but buys privacy at the cost of the offline-first property and the biggest migration. Kept as the *internal* scaling exit of Option B, not as the client contract. |
+| **D. Managed Turso cloud, one DB per learner + one shared DB** | partial | ✅ | small | Vendor-dependent and per-seat cost; conflicts with self-hosted-no-cost. Rejected as the *required* path; remains possible since B/A speak the same protocol. |
+
+## Decision (proposed)
+
+**1. Two tiers, one principle.** Sharing is organized by **data class**, not by
+database: knowledge is shared, learning state is private by default,
+aggregates are explicit opt-ins. Both tiers below implement the same table
+above — they differ only in enforcement strength.
+
+**2. Trusted-circle tier now (Option A): a shared self-hosted `sqld` for
+small circles that accept mutual visibility.** Families and 2–3-person teams
+get multi-learner ZAM immediately: one `sqld` on a home server/NAS, every
+member connected via the existing Turso-compatible providers (embedded
+replica for offline). Per-user separation stays what it is today —
+`cards.user_id` discipline, not enforcement. Deliverables are documentation,
+a `zam connector setup` path for plain `sqld` URLs, and multi-user smoke
+tests. No schema changes.
+
+**3. Organization tier as the target (Option B): a small self-hosted ZAM Sync
+Service.** A single self-hosted API (Node, same repo, Apache-2.0) that syncs
+per data class:
+
+- **Library sync (down/up):** tokens, prerequisites, sources, embeddings —
+  curators push, everyone pulls. Embedding vectors travel with the tokens
+  (canonical model id makes them portable), so one machine embeds and all
+  benefit.
+- **Assignments (down):** "learn these 12 tokens by March" lands in the
+  learner's queue as ordinary cards, created locally.
+- **Learning state: never uploaded by default.** The service cannot see
+  review logs. An explicit `zam share progress --with <circle>` publishes
+  coarse aggregates (coverage, due counts) — revocable, learner-initiated.
+- **Roles:** `curator` (write library), `learner` (read library, own state),
+  `guardian/coach` (read the aggregates a learner opted to publish).
+- **Server store:** starts as `sqld`/libsql — one dialect everywhere, native
+  vector search available server-side, satisfying the search ADR's Phase 4.
+  If an org outgrows it, the service swaps its internal store to Postgres +
+  pgvector **without changing the client protocol** — resolving Open
+  Question 2 of the search ADR: *`sqld` first, Postgres as the internal
+  scaling exit, and the stable seam is the service API, not the SQL dialect.*
+
+**4. The kernel stays single-learner.** No RLS, no auth, no HTTP in the
+kernel. Multi-learner semantics live in the sync layer (CLI/service), exactly
+like LLM access does. The kernel's only multi-user awareness remains what it
+already has: `user_id` columns.
+
+## Open questions
+
+1. **Auth mechanism for the service.** Start with invite tokens per circle
+   (simple, self-hosted-friendly); OIDC/SSO only if a company deployment
+   demands it. Lean invite tokens.
+2. **Conflict policy for curated knowledge.** Last-write-wins with
+   `updated_at` + a curation log is likely sufficient at expected scale;
+   verify against the multi-curator case before building merge UI.
+3. **Assignment ↔ card lifecycle.** Does deleting an assignment retire the
+   card (learner keeps history?) — interacts with FSRS-state ownership.
+4. **Aggregate vocabulary.** Which opt-in metrics exist (coverage, streak,
+   due-count) and their exact granularity — needs a guardian/coach user story
+   before freezing.
+5. **Does the trusted-circle tier need soft privacy?** E.g. client-side
+   filtering of other users' review_logs in UI — cosmetic, since replicas see
+   the file; decide whether to bother or document honestly.
+
+## Scope and delivery plan
+
+- **Phase 0 — This ADR** proposed for sign-off.
+- **Phase A — Trusted circle on `sqld`** (small): setup docs + connector path
+  for self-hosted `sqld` URLs, multi-user smoke test, honest privacy note.
+- **Phase B — Sync Service MVP** (library down-sync only): read-only shared
+  library, `zam library pull`, embeddings included. Curation still happens on
+  the curator's machine.
+- **Phase C — Library up-sync + roles + assignments.**
+- **Phase D — Opt-in aggregates** (guardian/coach view) and, only if scale
+  demands, the internal Postgres+pgvector swap (search ADR Phase 4 completes
+  here at the latest — `sqld` native vectors may already cover it in B).
+
+## Out of scope
+
+- Real-time collaboration/presence; CRDT merging (write asymmetry makes it
+  unnecessary at this scale).
+- Central review scheduling — FSRS runs on the learner's device, always.
+- Billing/tenancy for a hosted product; this ADR is self-hosted only.
+- The Studio UI for curation workflows (own design effort once Phase B
+  exists).
+
+## Consequences
+
+- Families get multi-learner ZAM with zero new code (Phase A is docs +
+  connector polish), at the honest cost of mutual visibility.
+- The privacy line — knowledge shared, state private — becomes an
+  architectural invariant enforced by the service, not a UI promise, and it
+  matches the symbiosis philosophy: the system serves the learner, it does
+  not surveil them.
+- A new deployable (the sync service) enters the repo: more surface, but the
+  kernel and CLI remain unchanged in character, and the service reuses the
+  bridge-protocol discipline (JSON contracts, versioned).
+- Open Question 2 of the search ADR is answered without a datastore bet:
+  `sqld` first; if Postgres ever arrives, it arrives *inside* the service.

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -1,6 +1,6 @@
 # Multi-Learner Tier: Shared Knowledge, Private Learning State
 
-**Status:** Proposed (draft)
+**Status:** Accepted (2026-07-04)
 **Date:** 2026-07-04
 **Deciders:** Thomas (project owner)
 **Related:**
@@ -123,6 +123,16 @@ per data class:
   coarse aggregates (coverage, due counts) — revocable, learner-initiated.
 - **Roles:** `curator` (write library), `learner` (read library, own state),
   `guardian/coach` (read the aggregates a learner opted to publish).
+- **Identity (owner decision):** the service authenticates via **OIDC with
+  the major providers — Microsoft, Google, Apple** — because that is the
+  family's and team's reality (every member already has Microsoft and
+  Google accounts, Apple partially; the youngest gets a family Google
+  account before she ever uses ZAM). ZAM never stores passwords.
+  **Invites remain the membership flow:** an invitation binds an OIDC
+  identity (verified e-mail) to a circle and role; authentication and
+  authorization stay cleanly separated. Self-hosting consequence: each
+  deployment registers its own OIDC clients (client IDs for
+  Microsoft/Google/Apple) — a documented one-time setup step.
 - **Server store:** starts as `sqld`/libsql — one dialect everywhere, native
   vector search available server-side, satisfying the search ADR's Phase 4.
   If an org outgrows it, the service swaps its internal store to Postgres +
@@ -137,9 +147,11 @@ already has: `user_id` columns.
 
 ## Open questions
 
-1. **Auth mechanism for the service.** Start with invite tokens per circle
-   (simple, self-hosted-friendly); OIDC/SSO only if a company deployment
-   demands it. Lean invite tokens.
+1. ~~**Auth mechanism for the service.**~~ **Resolved (2026-07-04):**
+   OIDC with Microsoft, Google, and Apple as identity providers; invites
+   bind identities to circles and roles (see Decision 3). Plain invite
+   tokens were rejected — the family already lives in these ecosystems,
+   and no-password operation is worth the one-time OIDC client setup.
 2. **Conflict policy for curated knowledge.** Last-write-wins with
    `updated_at` + a curation log is likely sufficient at expected scale;
    verify against the multi-curator case before building merge UI.
@@ -148,15 +160,20 @@ already has: `user_id` columns.
 4. **Aggregate vocabulary.** Which opt-in metrics exist (coverage, streak,
    due-count) and their exact granularity — needs a guardian/coach user story
    before freezing.
-5. **Does the trusted-circle tier need soft privacy?** E.g. client-side
-   filtering of other users' review_logs in UI — cosmetic, since replicas see
-   the file; decide whether to bother or document honestly.
+5. ~~**Does the trusted-circle tier need soft privacy?**~~ **Resolved
+   (2026-07-04):** both — document honestly (in a shared `sqld`, every
+   replica technically sees everything; a family setting) AND ship the
+   cosmetic courtesy: Studio/CLI hide other users' learning state by
+   default, explicitly labeled as a display filter, not a security
+   boundary.
 
 ## Scope and delivery plan
 
 - **Phase 0 — This ADR** proposed for sign-off.
 - **Phase A — Trusted circle on `sqld`** (small): setup docs + connector path
-  for self-hosted `sqld` URLs, multi-user smoke test, honest privacy note.
+  for self-hosted `sqld` URLs, multi-user smoke test, honest privacy note,
+  and the default own-data display filter in Studio/CLI (cosmetic, labeled
+  as such).
 - **Phase B — Sync Service MVP** (library down-sync only): read-only shared
   library, `zam library pull`, embeddings included. Curation still happens on
   the curator's machine.

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -256,9 +256,11 @@ conversation to have early, not a technical risk.
 This remains a **pilot in scope** — a small group, a deliberately limited
 library — just not a pilot in infrastructure.
 
-- **Store:** Azure Database for PostgreSQL Flexible Server, Burstable tier,
-  32 GiB (the service's storage floor — ZAM's data is far smaller: 768-dim
-  embeddings are ≈3 KB per token, so 100k tokens ≈ 300 MB). `pgvector` provides
+- **Store:** Azure Database for PostgreSQL Flexible Server, Burstable **B1ms**,
+  32 GiB, **PostgreSQL 17** — the exact SKU and the reason for pinning 17 are
+  in Decision 13. (The storage figure is the service's floor; ZAM's data is far
+  smaller: 768-dim embeddings are ≈3 KB per token, so 100k tokens ≈ 300 MB.)
+  `pgvector` provides
   server-side vector search, which completes Phase 4 of the search ADR for this
   tier and answers its Open Question 2: **Postgres, but only for this tier, and
   only as a deployment choice — not as the kernel's dialect.**
@@ -354,10 +356,9 @@ implied is kept, because it is right for its own reasons.
   The rule earns its place three times over. Deployment A has no Entra at all,
   so the kernel cannot depend on one. Entra object ids are tenant-specific, so
   any future move — a tenant reorganisation, an acquisition, a self-hosted
-  server on PostgreSQL 18 OAuth — would otherwise corrupt authorship and
-  ownership across the whole library. And a colleague who leaves and returns,
-  or whose account is recreated, keeps their learning history instead of
-  becoming a stranger to it.
+  server — would otherwise corrupt authorship and ownership across the whole
+  library. And a colleague who leaves and returns, or whose account is
+  recreated, keeps their learning history instead of becoming a stranger to it.
 
 - **Role grants are deployment configuration, not data.** The
   `pgaadauth_create_principal` mappings and the RLS grants live in a runbook,
@@ -366,9 +367,11 @@ implied is kept, because it is right for its own reasons.
 
 - **Nothing depends on subscription-specific features.** The store stays
   ordinary PostgreSQL plus `pgvector`, so an export is restorable anywhere —
-  another subscription, another tenant, or a self-hosted server using
-  PostgreSQL 18's native OAuth. This is now an insurance policy rather than a
-  scheduled task, which is the right amount of effort to spend on it.
+  another subscription, another tenant, or a self-hosted server. What would
+  *not* travel is the passwordless sign-in: outside Azure there is no
+  production-ready way to authenticate Postgres against Entra today
+  (Decision 13). Portability here means the data and the schema, not the
+  identity integration — an insurance policy rather than a scheduled task.
 
 ### 8. The kernel stays single-learner
 
@@ -494,6 +497,40 @@ reverse it into "who failed it". Nothing here is in the pilot either; it is
 recorded so a later reader can see that "no aggregates" was a decision about
 *people*, not a refusal to help curators.
 
+### 13. The concrete database: Flexible Server B1ms, 32 GiB, **PostgreSQL 17**
+
+Named explicitly so nobody has to re-derive it:
+
+| | |
+|---|---|
+| Service | Azure Database for PostgreSQL **Flexible Server** |
+| Tier / SKU | **Burstable B1ms** (1 vCore, 2 GiB RAM) — the smallest offered |
+| Storage | **32 GiB** (the service floor; ZAM needs far less) |
+| Engine | **PostgreSQL 17** — *not* 18, see below |
+| Extensions | `pgvector` |
+| Auth | Microsoft Entra, token presented as the connection password |
+
+**Pin PostgreSQL 17.** PostgreSQL 18 replaced the authentication framework with
+native OAuth2/OAUTHBEARER, and Azure's Entra integration is still built on the
+older PG11–17 token model. Entra sign-in therefore **fails on PG18 today**, and
+the documented workaround is static passwords — which would throw away the one
+property this deployment exists for. PG17 is the supported version for Entra
+authentication and is what the pilot uses; PG18 is revisited only once Azure
+states that Entra works on it.
+
+That finding also retires a claim in an earlier draft of this ADR: PG18's native
+OAuth is *not* yet a portability exit to self-hosted Postgres. The community
+validator modules needed to make it work with Entra are explicitly not
+production-ready. Treat self-hosting as "possible for the data, unsolved for
+the identity" until that changes.
+
+**Sizing.** B1ms is chosen because ZAM's workload is genuinely tiny — a few
+dozen learners doing short review sessions, a library measured in hundreds of
+megabytes. Compute is an online scale-up operation, so starting at the floor
+costs nothing but a restart if the pilot proves it wrong. Two things would
+force B2s: the Burstable `max_connections` ceiling with many concurrent
+desktop/CLI/mobile clients, and `pgvector` index builds over a large library.
+
 ## Cost (Deployment B)
 
 The company subscription carries the bill (Decision 6), so the figures below
@@ -501,29 +538,49 @@ are not a budget ceiling — they exist so the ask is small and concrete when
 someone at DocuWare has to approve it. The honest version of that ask is
 "roughly the price of one lunch per month, and it can be switched off".
 
-Indicative only — **verify in the Azure pricing calculator for the actual
-region before committing**, since tiers and prices move:
+Figures checked July 2026; region-dependent, so **confirm in the Azure pricing
+calculator for the chosen region before committing**.
 
-| Item | Rough monthly |
-|------|---------------|
-| Burstable B1ms (1 vCore, 2 GiB) | ~$12–15 |
-| Burstable B2s (2 vCore, 4 GiB) | ~$25–30 |
-| 32 GiB storage | ~$4 |
-| Backup (within storage size) | included |
+### Minimal build-out
 
-B1ms plus storage lands near $20/month and B2s near $35. Flexible Server can be
-stopped when idle, which pauses compute billing. Two caveats worth checking
-early: Burstable instances have a low `max_connections` ceiling, and built-in
-connection pooling is not offered on every tier — a group of ~30 with desktop,
-CLI and mobile clients may need B2s or an external pooler.
+| Item | Monthly |
+|------|---------|
+| Burstable B1ms compute, always on | ~$12–15 |
+| 32 GiB storage (~$0.115/GiB) | ~$4 |
+| Backup within the provisioned size | included |
+| **Total, no optimisation** | **~$16–19** |
 
-**Why Azure and not something cheaper.** Neon, Supabase or a €5 Hetzner VM all
-run Postgres with pgvector for less. None of them offer "an administrator
-grants Microsoft Entra identities access in the database" as a supported
-feature — each would mean building and owning the identity bridge. The Entra
-requirement, not the database, is what selects Azure here. If that ever stops
-being true, PostgreSQL 18's native OAuth support is the portability exit: a
-self-hosted server can validate Entra tokens directly.
+Two levers, neither needed on day one:
+
+- **A one-year reservation** takes up to ~65% off compute, bringing the total
+  to roughly **$9–10**. Sensible once the pilot is known to continue; pointless
+  before that.
+- **Stopping the server when idle** pauses compute billing (storage still
+  bills). One caveat that matters for automation: a stopped Flexible Server
+  **restarts itself after seven days**, so "stop it over the holidays" needs a
+  scheduled job rather than a single click.
+
+Storage is the floor, not a driver: ZAM would have to grow by two orders of
+magnitude before 32 GiB mattered.
+
+### Cheaper alternatives, and why they lose
+
+The Entra requirement — an administrator grants **Microsoft Entra identities**
+access *in the database*, and ZAM signs in with no password — is what decides
+this, not the price.
+
+| Option | Cost | Verdict |
+|--------|------|---------|
+| **Neon Serverless Postgres (Azure Native)** | free tier 100 CU-h/month; then ~$0.106/CU-h + $0.35/GiB — plausibly **$0–10** with scale-to-zero after 5 min idle | Genuinely cheaper and a real Azure-native service billed through the subscription. But its Entra integration documents **provisioning, portal and billing** — not Entra identities as *database* logins. Fails the deciding requirement unless that turns out to be supported; worth a check if cost ever becomes the binding constraint. |
+| **Self-hosted Postgres on a small Azure VM** | ~$8–10 | Cheaper compute, but there is no production-ready way to authenticate Postgres against Entra: PG17 has no OAuth, and PG18's OAuth validators for Entra are explicitly not production-ready. Also hands us patching, backup and HA. |
+| **Supabase / Hetzner / any non-Azure Postgres** | €5–25 | Same failure, plus the data leaves the corporate tenant — a harder conversation at DocuWare than the $16 it saves. |
+| **Azure SQL Database serverless** | can auto-pause to near-zero | Excellent native Entra auth and now has vector types, but T-SQL moves the dialect distance from "tens of sites" (Open Question 1) to a rewrite. Not worth it to save ~$10. |
+
+**Conclusion: nothing cheaper currently satisfies the Entra requirement.** The
+managed service is being bought for the identity integration; Postgres and the
+hardware are almost incidental at this size. At ~$16–19/month — and under $10
+with a reservation — the difference to the cheapest theoretical option is small
+enough that operational simplicity wins.
 
 ## Open questions
 

--- a/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
+++ b/docs/adr/2026-07-04-multi-learner-shared-knowledge.md
@@ -288,9 +288,29 @@ owner and the Azure resource, not the identity domain.
   Azure server administrator, can still read every row. RLS does not defend
   against them. In this deployment the learners and the administrators are
   colleagues at the same employer, and review logs are performance-adjacent
-  data about employees, so this residual exposure is a policy question for
-  DocuWare, not something the database can solve. It should be written down for
-  participants before the first real colleague joins — see Open Question 4.
+  data about employees.
+
+  **ZAM says so itself, in the app** (project owner, 2026-07-25). Connecting a
+  device to a company library shows a plain-language disclosure once, and the
+  same statement stays permanently visible in Settings:
+
+  > Your learning progress is stored in a database operated by your
+  > organisation. Other learners cannot see it. Database administrators
+  > technically can.
+  >
+  > **[Understood]  [Learn locally instead]**
+
+  Two things make this more than a notice. It is written in the language a
+  colleague actually thinks in, not as a legal clause — and it comes with a
+  **real alternative**, because Deployment A is right there and fully
+  supported. A disclosure with no way out is an announcement; a disclosure next
+  to a working local option is a choice.
+
+  Deliberately, this does not wait on a works-council agreement or a corporate
+  privacy review. Those may well follow and are DocuWare's to run, but the
+  honesty is part of the product and ships with it. ZAM is not blocked by a
+  process it does not control, and no colleague ends up in the company library
+  without having been told what that means.
 
 - **Consequence: Deployment B is online-first for reviews.** With state in the
   server, a review needs the network — the same trade the companion already
@@ -460,27 +480,22 @@ colleagues are ordinary tenant members and no B2B guest path is needed
 (Decision 3). A material change **re-tests rather than resets** — the card
 becomes due now and the next rating recalibrates FSRS (Decision 3). An
 assignment binds while it stands, and the cards outlive it under the learner's
-control (Decision 10).
+control (Decision 10). The residual superuser exposure is disclosed by ZAM
+itself, in-app and alongside a working local alternative (Decision 6).
 
-1. **Where does the residual-visibility policy get written down?** Decision 6
-   states that a superuser or Azure server administrator can read every row.
-   Participants should be told this in plain language before the first real
-   colleague joins, and someone at DocuWare — not this ADR — has to own that
-   statement. Blocking for real colleague data; not blocking for a pilot on
-   test identities.
-2. **Aggregate vocabulary.** Which opt-in metrics exist and at what
+1. **Aggregate vocabulary.** Which opt-in metrics exist and at what
    granularity — needs a concrete lead/coach story before freezing. At an
    employer this needs to be conservative by default.
-3. **Offline for Deployment B.** With learning state in the server, reviews
+2. **Offline for Deployment B.** With learning state in the server, reviews
    need the network. Deployment A stays the offline path, but if colleagues
    want offline reviews *and* cross-device progress, a local read-through
    cache with write-back is the answer — and it brings back exactly the sync
    and conflict work this ADR otherwise avoids. Defer until the pilot shows
    whether it actually hurts.
-4. **Conflict policy for concurrent curation.** Last-write-wins on
+3. **Conflict policy for concurrent curation.** Last-write-wins on
    `updated_at` plus a curation log is probably enough at this scale; verify
    against a real two-curator case before building merge UI.
-5. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
+4. **Dialect cost, measured.** The 2026-07-04 draft assumed a Postgres provider
    means "a dialect audit of every kernel query". A survey on 2026-07-25 found
    the actual surface small: `datetime('now')` ×21, `LIKE` ×16 (SQLite's is
    case-insensitive for ASCII, Postgres' is not — needs `ILIKE`),

--- a/docs/adr/2026-07-25-shared-curated-learning-content.md
+++ b/docs/adr/2026-07-25-shared-curated-learning-content.md
@@ -15,7 +15,11 @@
 [2026-07-12a-agent-backed-ai-provider.md](2026-07-12a-agent-backed-ai-provider.md)
 (personal AI for recall and assistance; not the path for canonical curricula) ·
 [2026-07-18-okf-learning-import.md](2026-07-18-okf-learning-import.md)
-(repo knowledge → personal tokens; different product surface)
+(repo knowledge → personal tokens; different product surface) ·
+[2026-07-04-multi-learner-shared-knowledge.md](2026-07-04-multi-learner-shared-knowledge.md)
+(**implements this principle for a closed group**: editorial workflow,
+content versioning, privacy and deployment — it supplies the "central
+library schema" this ADR lists as a non-goal)
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,7 +37,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
 | [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
-| [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Shared Curated Learning Content in a Closed Group | Proposed |
+| [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Closed-Group Learning Library: Curation, Privacy and Deployment | Accepted |
 | [2026-07-05](../plans/2026-07-05-titles-doctor-adaptation.md) | Human-friendly Titles + `zam doctor` adaptation plan (post Fable 5 review) | In progress |
 | [2026-07-06a](2026-07-06a-mcp-agent-transport-and-surfaces.md) | MCP as the Canonical Agent Transport (and the Surface Topology Around It) | Partially implemented |
 | [2026-07-06b](2026-07-06b-checkpointed-review-dialogue.md) | Checkpointed Review Dialogue | Implemented |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,7 +37,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
 | [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
-| [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Multi-Learner Tier: Shared Knowledge, Private Learning State | Proposed |
+| [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Multi-Learner Tier: Shared Knowledge, Private Learning State | Accepted |
 | [2026-07-05](../plans/2026-07-05-titles-doctor-adaptation.md) | Human-friendly Titles + `zam doctor` adaptation plan (post Fable 5 review) | In progress |
 | [2026-07-06a](2026-07-06a-mcp-agent-transport-and-surfaces.md) | MCP as the Canonical Agent Transport (and the Surface Topology Around It) | Partially implemented |
 | [2026-07-06b](2026-07-06b-checkpointed-review-dialogue.md) | Checkpointed Review Dialogue | Implemented |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,7 +37,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
 | [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
-| [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Multi-Learner Tier: Shared Knowledge, Private Learning State | Accepted |
+| [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Shared Curated Learning Content in a Closed Group | Proposed |
 | [2026-07-05](../plans/2026-07-05-titles-doctor-adaptation.md) | Human-friendly Titles + `zam doctor` adaptation plan (post Fable 5 review) | In progress |
 | [2026-07-06a](2026-07-06a-mcp-agent-transport-and-surfaces.md) | MCP as the Canonical Agent Transport (and the Surface Topology Around It) | Partially implemented |
 | [2026-07-06b](2026-07-06b-checkpointed-review-dialogue.md) | Checkpointed Review Dialogue | Implemented |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
 | [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
+| [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Multi-Learner Tier: Shared Knowledge, Private Learning State | Proposed |
 | [2026-07-05](../plans/2026-07-05-titles-doctor-adaptation.md) | Human-friendly Titles + `zam doctor` adaptation plan (post Fable 5 review) | In progress |
 | [2026-07-06a](2026-07-06a-mcp-agent-transport-and-surfaces.md) | MCP as the Canonical Agent Transport (and the Surface Topology Around It) | Partially implemented |
 | [2026-07-06b](2026-07-06b-checkpointed-review-dialogue.md) | Checkpointed Review Dialogue | Implemented |


### PR DESCRIPTION
Rewritten 2026-07-25. The original draft led with sync topology and a bespoke
sync service, before the purpose had been thought through. The actual core idea
(project owner): **inside a closed group like a company, a few people take
responsibility for the quality of the learning content, and everyone else
benefits from that work.** Rewritten from that premise, then worked through
question by question with the owner — all ten decisions below are his.

## The substance

**Editorial workflow.** draft → in-review → published → deprecated. Anyone
proposes, only curators publish, nothing is deleted because `review_logs`
reference tokens. Content is authored and reviewed **in git** (as OKF already
works); the **Studio owns the release step**. "Is this text correct?" is a
question git answers; "what happens to people who learned the old version?" is
a scheduling question only ZAM can answer.

**Corrections reach people who learned the broken version.** Tokens carry a
`content_version`; the curator classifies every publish, with **no default**.
A material change **re-tests rather than resets**: the card becomes due now,
the learner sees what changed and who changed it, and their next rating
recalibrates FSRS. That avoids inventing a number — a hard reset discards
history the scheduler could use, a soft reset needs an unjustifiable penalty,
and FSRS already distinguishes "still knew it" from "did not".

**Assignments bind while they stand.** The learner cannot detach an active
assignment — that is what makes it an assignment. Once withdrawn, the cards and
full history stay with them to keep, detach, or delete. An assigner may
withdraw an assignment but never delete another person's learning.

**No aggregates about people, at all.** Beyond the privacy argument: FSRS only
works when a rating of 1 is safe to give. A learner who believes their failures
are visible rates generously, and the scheduler starts optimising against
fiction. Surveillance here costs accuracy, not just trust. Curators get
anonymous, thresholded *content*-level signals instead.

## Deployment

**A — unchanged and the default.** Local SQLite, libsql replica, Turso/`sqld`.
No forced migration for anyone.

**B — new and parallel.** Azure PostgreSQL Flexible Server + Microsoft Entra,
in a **company subscription in the `docuware.com` tenant from day one** (the
Visual Studio Professional subscription could not be activated — and going
straight to a company-owned one removes the migration entirely). Colleagues are
ordinary tenant members, sign-in is passwordless via an MSAL token in the
password field.

**Learning state lives in the shared database**, so progress follows a
colleague across machines. That makes RLS the load-bearing privacy boundary:
policies keyed to the mapped ULID, `FORCE ROW LEVEL SECURITY`, a schema owner
separate from any human admin, and an isolation test suite — a boundary nobody
tests is a claim, not a boundary. Reviews are consequently **online-only**;
whether an offline cache earns its sync complexity is a question the pilot
measures rather than a guess.

**ZAM discloses the residual exposure itself**, in-app and beside a working
local alternative: a superuser or Azure admin can read every row, and saying so
is part of the product rather than contingent on a works-council process.

**The database selection carries the knowledge context**, bound per device —
private DB on the phone at home, company DB on the work PC. This puts the
contexts ADR the right way round, since a context was never an authorization
boundary and the deployment is. Honest cost: no combined cross-world due view.

## Findings

- The dialect cost the draft feared is **tens of sites, not hundreds**:
  `datetime('now')`×21, `LIKE`×16 (needs `ILIKE`), `INSERT OR IGNORE`×4,
  `last_insert_rowid`×3, plus mechanical `?`→`$n`. ULIDs mean almost no
  autoincrement coupling.
- 32 GiB is Azure's storage floor, not oversizing — 100k tokens of embeddings
  ≈ 300 MB. Cost ~$20/month (B1ms) to ~$35 (B2s), flagged for verification.
- Azure is selected by the **Entra requirement**, not the database. Cheaper
  options exist; none offer "an admin grants Entra identities access in the
  database" without building the identity bridge. PostgreSQL 18's native OAuth
  is noted as the exit.
- Concurrent curation needed no design: it is a git merge conflict.

Also rebased onto main (the branch was 186 commits behind) so the ADR
cross-links resolve.

Status is **Proposed**. Every question for the project owner is answered — say
the word and I will flip it to Accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)