### PR TITLE
fix: MCP rating validation + add goose and copilot agent support

### DIFF
--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -331,44 +331,40 @@ approval_mode = "prompt"
     targetPath = join(opts.home, ".config", "goose", "config.yaml");
     hint =
       "goose will load the 'zam' extension on next session start. Run 'goose configure' to manage extensions.";
+    // The `zam` entry, indented for placement directly under the `extensions:` map.
+    const zamExtension = [
+      "  zam:",
+      "    name: ZAM",
+      `    cmd: ${opts.zamPath}`,
+      "    args:",
+      "      - mcp",
+      "    enabled: true",
+      "    type: stdio",
+      "    timeout: 300",
+      "    description: Symbiotic learning agent with spaced repetition",
+    ].join("\n");
     let existingStr = "";
     if (exists(targetPath)) {
       existingStr = read(targetPath);
     }
-    // Check if already configured
-    if (existingStr.includes("zam:") && existingStr.includes("zam mcp")) {
+    if (/^\s+zam:\s*$/m.test(existingStr) && existingStr.includes("- mcp")) {
+      // An indented `zam:` extension wired to `zam mcp` is already present.
       alreadyConfigured = true;
       content = existingStr;
+    } else if (/^extensions:[ \t]*$/m.test(existingStr)) {
+      // Insert as the first child of the existing `extensions:` map. Appending at
+      // end-of-file is wrong: goose configs carry top-level keys (providers, model,
+      // …) after `extensions:`, so an appended block lands outside the map — or
+      // under a trailing scalar — producing YAML that goose silently drops.
+      content = existingStr.replace(
+        /^extensions:[ \t]*$/m,
+        (line) => `${line}\n${zamExtension}`,
+      );
+    } else if (existingStr.trim()) {
+      // Config exists but has no `extensions:` map yet — add one.
+      content = `${existingStr.trimEnd()}\nextensions:\n${zamExtension}\n`;
     } else {
-      // Build the extension block in YAML
-      const extensionBlock = `
-extensions:
-  zam:
-    name: ZAM
-    cmd: ${opts.zamPath}
-    args:
-      - mcp
-    enabled: true
-    type: stdio
-    timeout: 300
-    description: Symbiotic learning agent with spaced repetition
-`;
-      // If there's existing content, try to merge
-      if (existingStr) {
-        // Check if extensions key exists
-        if (existingStr.includes("extensions:")) {
-          // Append zam under existing extensions
-          content =
-            existingStr.trimEnd() +
-            "\n  zam:\n    name: ZAM\n    cmd: " +
-            opts.zamPath +
-            "\n    args:\n      - mcp\n    enabled: true\n    type: stdio\n    timeout: 300\n    description: Symbiotic learning agent with spaced repetition\n";
-        } else {
-          content = existingStr.trimEnd() + extensionBlock;
-        }
-      } else {
-        content = extensionBlock.trimStart();
-      }
+      content = `extensions:\n${zamExtension}\n`;
     }
   } else if (harnessId === "copilot") {
     targetPath = join(opts.home, ".copilot", "mcp-config.json");

--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -30,7 +30,8 @@ export type AgentHarnessId =
   | "opencode"
   | "cursor"
   | "copilot"
-  | "antigravity";
+  | "antigravity"
+  | "goose";
 
 export interface AgentHarness {
   id: AgentHarnessId;
@@ -71,6 +72,7 @@ export const AGENT_HARNESSES: AgentHarness[] = [
     kind: "app",
     command: "antigravity",
   },
+  { id: "goose", label: "goose", kind: "cli", command: "goose" },
 ];
 
 export function getHarness(id: string): AgentHarness | undefined {
@@ -179,7 +181,9 @@ export type ConnectHarnessId =
   | "claude-code"
   | "antigravity"
   | "codex"
-  | "opencode";
+  | "opencode"
+  | "goose"
+  | "copilot";
 
 interface McpJsonConfig {
   mcpServers?: Record<string, unknown>;
@@ -323,6 +327,67 @@ approval_mode = "prompt"
 `;
       content = existingStr ? `${existingStr.trimEnd()}\n${block}` : block;
     }
+  } else if (harnessId === "goose") {
+    targetPath = join(opts.home, ".config", "goose", "config.yaml");
+    hint =
+      "goose will load the 'zam' extension on next session start. Run 'goose configure' to manage extensions.";
+    let existingStr = "";
+    if (exists(targetPath)) {
+      existingStr = read(targetPath);
+    }
+    // Check if already configured
+    if (existingStr.includes("zam:") && existingStr.includes("zam mcp")) {
+      alreadyConfigured = true;
+      content = existingStr;
+    } else {
+      // Build the extension block in YAML
+      const extensionBlock = `
+extensions:
+  zam:
+    name: ZAM
+    cmd: ${opts.zamPath}
+    args:
+      - mcp
+    enabled: true
+    type: stdio
+    timeout: 300
+    description: Symbiotic learning agent with spaced repetition
+`;
+      // If there's existing content, try to merge
+      if (existingStr) {
+        // Check if extensions key exists
+        if (existingStr.includes("extensions:")) {
+          // Append zam under existing extensions
+          content =
+            existingStr.trimEnd() +
+            "\n  zam:\n    name: ZAM\n    cmd: " +
+            opts.zamPath +
+            "\n    args:\n      - mcp\n    enabled: true\n    type: stdio\n    timeout: 300\n    description: Symbiotic learning agent with spaced repetition\n";
+        } else {
+          content = existingStr.trimEnd() + extensionBlock;
+        }
+      } else {
+        content = extensionBlock.trimStart();
+      }
+    }
+  } else if (harnessId === "copilot") {
+    targetPath = join(opts.home, ".copilot", "mcp-config.json");
+    hint =
+      "GitHub Copilot CLI will load the 'zam' MCP server on next session. Use '/mcp show' in Copilot CLI to verify.";
+    let existing: McpJsonConfig = {};
+    if (exists(targetPath)) {
+      existing = parseMcpJsonConfig(targetPath, read(targetPath));
+    }
+    if (!existing.mcpServers) {
+      existing.mcpServers = {};
+    }
+    existing.mcpServers.zam = {
+      type: "local",
+      command: opts.zamPath,
+      args: ["mcp"],
+      tools: ["*"],
+    };
+    content = JSON.stringify(existing, null, 2);
   }
 
   return {

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -45,6 +45,8 @@ const CONNECT_HARNESSES: ConnectHarnessId[] = [
   "antigravity",
   "codex",
   "opencode",
+  "goose",
+  "copilot",
 ];
 
 function isConnectHarnessId(value: string): value is ConnectHarnessId {
@@ -197,7 +199,7 @@ const connectCmd = new Command("connect")
   .description("Configure the ZAM MCP server for an agent harness")
   .argument(
     "<harness>",
-    "Harness to connect: claude-code | antigravity | codex | opencode",
+    "Harness to connect: claude-code | antigravity | codex | opencode | goose | copilot",
   )
   .option(
     "--print",

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -243,10 +243,15 @@ export function createMcpServer(db: Database): McpServer {
           .string()
           .optional()
           .describe("Token ULID for a confirmed synthesis without a card yet"),
-        rating: z
-          .union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)])
+        rating: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(4)
           .optional()
-          .describe("User FSRS rating; omit when doneBy is agent"),
+          .describe(
+            "User FSRS rating (1=Again, 2=Hard, 3=Good, 4=Easy); omit when doneBy is agent",
+          ),
         sessionId: z
           .string()
           .optional()
@@ -294,10 +299,15 @@ export function createMcpServer(db: Database): McpServer {
             "stop",
           ])
           .describe("The action type"),
-        rating: z
-          .union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)])
+        rating: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(4)
           .optional()
-          .describe("Rating (required for rate)"),
+          .describe(
+            "Rating (1=Again, 2=Hard, 3=Good, 4=Easy; required for rate)",
+          ),
         concept: z
           .string()
           .optional()

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -268,6 +268,95 @@ describe("connectHarnessMcp", () => {
     expect(res.content).toBe(existing);
   });
 
+  it("goose fresh write creates a valid extensions map", () => {
+    const res = connectHarnessMcp("goose", mockDeps);
+    expect(res.path).toBe("/home/user/.config/goose/config.yaml");
+    expect(res.alreadyConfigured).toBe(false);
+    expect(res.content).toBe(
+      "extensions:\n" +
+        "  zam:\n" +
+        "    name: ZAM\n" +
+        "    cmd: /usr/local/bin/zam\n" +
+        "    args:\n" +
+        "      - mcp\n" +
+        "    enabled: true\n" +
+        "    type: stdio\n" +
+        "    timeout: 300\n" +
+        "    description: Symbiotic learning agent with spaced repetition\n",
+    );
+  });
+
+  it("goose inserts zam inside extensions when top-level keys follow it", () => {
+    // Regression: the merge must nest zam under `extensions:`, not append it at
+    // end-of-file where trailing top-level keys would push it out of the map.
+    mockFiles["/home/user/.config/goose/config.yaml"] =
+      "GOOSE_TELEMETRY_ENABLED: true\n" +
+      "extensions:\n" +
+      "  developer:\n" +
+      "    enabled: true\n" +
+      "    type: platform\n" +
+      "    name: developer\n" +
+      "active_provider: openrouter\n";
+    const res = connectHarnessMcp("goose", mockDeps);
+    expect(res.alreadyConfigured).toBe(false);
+    const lines = res.content.split("\n");
+    // zam is the first child of the extensions map...
+    expect(lines[lines.indexOf("extensions:") + 1]).toBe("  zam:");
+    // ...the sibling extension is preserved...
+    expect(res.content).toContain("  developer:");
+    // ...and the trailing top-level key stays top-level (not swallowed by zam).
+    expect(res.content).toContain("\nactive_provider: openrouter\n");
+  });
+
+  it("goose no-ops when a zam extension already runs zam mcp", () => {
+    const existing =
+      "extensions:\n" +
+      "  zam:\n" +
+      "    name: ZAM\n" +
+      "    cmd: /usr/local/bin/zam\n" +
+      "    args:\n" +
+      "      - mcp\n" +
+      "    enabled: true\n" +
+      "    type: stdio\n";
+    mockFiles["/home/user/.config/goose/config.yaml"] = existing;
+    const res = connectHarnessMcp("goose", mockDeps);
+    expect(res.alreadyConfigured).toBe(true);
+    expect(res.content).toBe(existing);
+  });
+
+  it("goose still installs when only an unrelated providers.zam entry exists", () => {
+    // A `zam:` key under `providers:` (no `- mcp`) must not be mistaken for the
+    // MCP extension being already configured.
+    mockFiles["/home/user/.config/goose/config.yaml"] =
+      "extensions:\n" +
+      "  developer:\n" +
+      "    enabled: true\n" +
+      "providers:\n" +
+      "  zam:\n" +
+      "    enabled: true\n" +
+      "    configured: false\n";
+    const res = connectHarnessMcp("goose", mockDeps);
+    expect(res.alreadyConfigured).toBe(false);
+    const lines = res.content.split("\n");
+    expect(lines[lines.indexOf("extensions:") + 1]).toBe("  zam:");
+  });
+
+  it("copilot fresh write", () => {
+    const res = connectHarnessMcp("copilot", mockDeps);
+    expect(res.path).toBe("/home/user/.copilot/mcp-config.json");
+    expect(res.alreadyConfigured).toBe(false);
+    expect(JSON.parse(res.content)).toEqual({
+      mcpServers: {
+        zam: {
+          type: "local",
+          command: "/usr/local/bin/zam",
+          args: ["mcp"],
+          tools: ["*"],
+        },
+      },
+    });
+  });
+
   it("refuses to overwrite malformed JSON configuration", () => {
     mockFiles["/work/.mcp.json"] = "{ definitely not JSON";
 


### PR DESCRIPTION
- Fix MCP rating validation: use z.coerce.number() instead of z.union([z.literal(1)...]) so opencode sends string ratings correctly
- Add goose agent harness (CLI, ~/.config/goose/config.yaml)
- Add GitHub Copilot CLI agent harness (~/.copilot/mcp-config.json)