### PR TITLE
chore: gitignore per-machine .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ scratch/
 .claude/worktrees/
 .antigravitycli/
 
+# Per-machine Claude Code MCP config (generate with: zam agent connect claude-code)
+.mcp.json
+
 # Tauri / Rust build output
 desktop/src-tauri/target/
 desktop/src-tauri/resources/zam-cli/


### PR DESCRIPTION
`zam agent connect claude-code` generates a project `.mcp.json` with an absolute, machine-specific path to the local `zam` binary — so it should not be committed. Contributors regenerate it locally via the connect command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)