### PR TITLE
feat: localize Windows setup.exe installer into 7 languages

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -38,7 +38,21 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "languages": [
+          "English",
+          "German",
+          "Spanish",
+          "French",
+          "Portuguese",
+          "SimpChinese",
+          "Japanese"
+        ],
+        "displayLanguageSelector": false
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/docs/specs/2026-07-08-multilingual-windows-installer-design.md
+++ b/docs/specs/2026-07-08-multilingual-windows-installer-design.md
@@ -1,0 +1,96 @@
+# Design: Multilingual Windows installer (`setup.exe`)
+
+- **Date:** 2026-07-08
+- **Status:** Accepted — config implemented + config-test; installer build-render verification pending (no local Rust/Tauri toolchain)
+- **Scope:** `desktop/src-tauri/tauri.conf.json`, `tests/desktop/installer-languages.test.ts`
+
+## Problem
+
+Consumer onboarding is: download the Windows **`setup.exe`** → install → launch
+the desktop Studio (already localized in all 7 languages). The NSIS `setup.exe`
+installer itself is **English-only**: `tauri.conf.json` has no
+`bundle.windows.nsis` block, so Tauri defaults `languages` to `["English"]`. A
+German/French/… user's very first screen is English.
+
+The `zam setup` CLI command is out of scope (it runs behind the app, not shown to
+users). The `zam init` terminal wizard localization is **deferred** (see below).
+
+## Decision
+
+Configure the Tauri NSIS bundler for ZAM's 7 standard languages, **auto-detecting
+the OS language with no picker** — consistent with how the desktop and CLI
+resolve locale.
+
+Add to `desktop/src-tauri/tauri.conf.json` under `bundle`:
+
+```json
+"windows": {
+  "nsis": {
+    "languages": ["English", "German", "Spanish", "French", "Portuguese", "SimpChinese", "Japanese"],
+    "displayLanguageSelector": false
+  }
+}
+```
+
+### Language mapping (kernel locale → NSIS identifier)
+
+| Locale | NSIS identifier |
+|---|---|
+| `en` | `English` |
+| `de` | `German` |
+| `es` | `Spanish` |
+| `fr` | `French` |
+| `pt` | `Portuguese` *(European; flip to `PortugueseBR` for Brazilian)* |
+| `zh` | `SimpChinese` |
+| `ja` | `Japanese` |
+
+All 7 are in Tauri's supported NSIS set (verified against
+`crates/tauri-bundler/src/bundle/windows/nsis/languages`), so both the base NSIS
+strings *and* Tauri's own added strings are translated for each. English is
+listed **first**: NSIS falls back to the first listed language when the OS
+language isn't among the seven.
+
+### Behavior
+
+- `displayLanguageSelector: false` → NSIS uses the OS default language, falling
+  back to English. No language dialog — matches the "auto-detect, no picker"
+  choice already made for the CLI. (Flip to `true` for a dropdown; trivial.)
+- Base installer chrome (Next/Back/Cancel, directory page, welcome/finish pages)
+  auto-translates per language; no custom language files needed for the 7.
+
+## Non-goals
+
+- The WiX **`.msi`** artifact stays English (`bundle.windows.wix.language` not
+  configured). `setup.exe` (NSIS) is the target; MSI localization is a separate
+  follow-up if that artifact is distributed.
+- macOS/Linux bundles (unaffected by `bundle.windows`).
+- Custom installer graphics or custom strings.
+
+## Testing & verification
+
+- **Automated (runs in CI `ci.yml` via vitest):**
+  `tests/desktop/installer-languages.test.ts` asserts
+  `bundle.windows.nsis.languages` equals the 7 expected identifiers in order,
+  each is a Tauri-supported NSIS identifier (guards typos), no duplicates,
+  `displayLanguageSelector === false`, and English is first (fallback).
+- **Build/render verification:** the NSIS `setup.exe` is produced by
+  `release.yml` (Windows `tauri-action` build). An invalid identifier fails that
+  build. Full visual confirmation = run the produced `setup.exe` (or a local
+  `tauri build` on a machine with Rust) under a non-English Windows language and
+  confirm the translated chrome. **Not performed in this environment** — it has
+  no Rust/Tauri toolchain.
+
+## Deferred: `zam init` CLI wizard localization
+
+The terminal onboarding wizard (`zam init`) remains English-only (~40 hardcoded
+strings). Localizing it through the kernel `t()` catalog was fully designed
+(auto-detect locale, extend `TRANSLATIONS`, TDD completeness test) but shelved in
+favor of the consumer installer path. Revisit if the developer/terminal
+onboarding needs language parity.
+
+## Risks
+
+- **pt-PT vs pt-BR** default (flagged above; one-word change).
+- Tauri issue [#13041](https://github.com/tauri-apps/tauri/issues/13041): some
+  custom component/checkbox strings can show the wrong language in multi-language
+  NSIS builds — cosmetic, upstream; monitor when render-verifying.

--- a/docs/specs/2026-07-08-multilingual-windows-installer-design.md
+++ b/docs/specs/2026-07-08-multilingual-windows-installer-design.md
@@ -1,7 +1,8 @@
 # Design: Multilingual Windows installer (`setup.exe`)
 
 - **Date:** 2026-07-08
-- **Status:** Accepted — config implemented + config-test; installer build-render verification pending (no local Rust/Tauri toolchain)
+- **Status:** Implemented & verified — config + parity test shipped; installer
+  built locally and rendering observed in en/de/ja (2026-07-08)
 - **Scope:** `desktop/src-tauri/tauri.conf.json`, `tests/desktop/installer-languages.test.ts`
 
 ## Problem
@@ -19,7 +20,8 @@ users). The `zam init` terminal wizard localization is **deferred** (see below).
 
 Configure the Tauri NSIS bundler for ZAM's 7 standard languages, **auto-detecting
 the OS language with no picker** — consistent with how the desktop and CLI
-resolve locale.
+default their locale (both auto-detect; the Studio additionally offers a manual
+switcher, and `zam settings locale` overrides the CLI).
 
 Add to `desktop/src-tauri/tauri.conf.json` under `bundle`:
 
@@ -40,45 +42,54 @@ Add to `desktop/src-tauri/tauri.conf.json` under `bundle`:
 | `de` | `German` |
 | `es` | `Spanish` |
 | `fr` | `French` |
-| `pt` | `Portuguese` *(European; flip to `PortugueseBR` for Brazilian)* |
+| `pt` | `Portuguese` *(European; see Risks for pt-BR / zh-Hant variant behavior)* |
 | `zh` | `SimpChinese` |
 | `ja` | `Japanese` |
 
 All 7 are in Tauri's supported NSIS set (verified against
 `crates/tauri-bundler/src/bundle/windows/nsis/languages`), so both the base NSIS
-strings *and* Tauri's own added strings are translated for each. English is
-listed **first**: NSIS falls back to the first listed language when the OS
-language isn't among the seven.
+strings *and* Tauri's own added strings are translated for each.
 
 ### Behavior
 
-- `displayLanguageSelector: false` → NSIS uses the OS default language, falling
-  back to English. No language dialog — matches the "auto-detect, no picker"
-  choice already made for the CLI. (Flip to `true` for a dropdown; trivial.)
+- `displayLanguageSelector: false` → NSIS picks the installer language at
+  runtime with a three-pass match against the compiled tables (NSIS
+  `Source/exehead/Ui.c`, `set_language()`): exact LANGID → same **primary
+  language** → first-listed. So en-US gets English, de-DE German, pt-BR the
+  European-Portuguese chrome, zh-TW/zh-HK the Simplified-Chinese chrome — and
+  only language families outside the seven (e.g. Italian, Korean, Russian) fall
+  back to the first-listed English. (Flip to `true` for an explicit dropdown;
+  trivial.)
 - Base installer chrome (Next/Back/Cancel, directory page, welcome/finish pages)
   auto-translates per language; no custom language files needed for the 7.
 
 ## Non-goals
 
-- The WiX **`.msi`** artifact stays English (`bundle.windows.wix.language` not
-  configured). `setup.exe` (NSIS) is the target; MSI localization is a separate
-  follow-up if that artifact is distributed.
+- **The WiX `.msi` stays English-only.** Because `bundle.targets` is `"all"`,
+  `release.yml` builds and publishes an `.msi` beside `setup.exe`, and
+  `bundle.windows.wix.language` is unset. Localizing WiX (one `.msi` per
+  language) is a separate follow-up; `setup.exe` is the recommended consumer
+  artifact.
 - macOS/Linux bundles (unaffected by `bundle.windows`).
 - Custom installer graphics or custom strings.
 
 ## Testing & verification
 
 - **Automated (runs in CI `ci.yml` via vitest):**
-  `tests/desktop/installer-languages.test.ts` asserts
-  `bundle.windows.nsis.languages` equals the 7 expected identifiers in order,
-  each is a Tauri-supported NSIS identifier (guards typos), no duplicates,
-  `displayLanguageSelector === false`, and English is first (fallback).
-- **Build/render verification:** the NSIS `setup.exe` is produced by
-  `release.yml` (Windows `tauri-action` build). An invalid identifier fails that
-  build. Full visual confirmation = run the produced `setup.exe` (or a local
-  `tauri build` on a machine with Rust) under a non-English Windows language and
-  confirm the translated chrome. **Not performed in this environment** — it has
-  no Rust/Tauri toolchain.
+  `tests/desktop/installer-languages.test.ts` derives the expected language list
+  from the app's canonical `LOCALES` (`desktop/src/i18n.ts`) through an NSIS
+  mapping typed `Record<Locale, string>` — adding an app locale fails
+  compilation until an installer mapping exists. It further asserts the
+  English-first fallback, no duplicate tables, `displayLanguageSelector ===
+  false`, and that every identifier is in Tauri's shipped NSIS vocabulary — the
+  pipeline's only pre-release spelling check, since PR CI runs vitest but never
+  makensis.
+- **Build/render verification (performed 2026-07-08):** built `setup.exe`
+  locally (Rust/Tauri toolchain; `makensis` compiled all seven language tables),
+  ran the installer, and observed rendering: **English** (auto-detected on an
+  en-US OS), **German** (full wizard flow, native-verified), **Japanese** (CJK).
+  Release builds re-validate the config on every `v*` tag (`release.yml`,
+  Windows `tauri-action` legs).
 
 ## Deferred: `zam init` CLI wizard localization
 
@@ -90,7 +101,11 @@ onboarding needs language parity.
 
 ## Risks
 
-- **pt-PT vs pt-BR** default (flagged above; one-word change).
+- **Regional variants:** NSIS primary-language matching sends pt-BR systems to
+  the European **Portuguese** chrome and zh-TW/zh-HK systems to **SimpChinese**
+  chrome (a Hans/Hant script mismatch). NSIS supports compiling `PortugueseBR`
+  and `TradChinese` **in addition** (not instead) — a cheap follow-up if
+  variant-exact chrome is wanted.
 - Tauri issue [#13041](https://github.com/tauri-apps/tauri/issues/13041): some
   custom component/checkbox strings can show the wrong language in multi-language
-  NSIS builds — cosmetic, upstream; monitor when render-verifying.
+  NSIS builds — cosmetic, upstream; none observed in the en/de/ja verification.

--- a/tests/desktop/installer-languages.test.ts
+++ b/tests/desktop/installer-languages.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// ZAM's 7 standard languages (src/kernel/system/locale.ts) mapped to the NSIS
+// language identifiers Tauri ships translations for. English is first: NSIS
+// falls back to the first listed language when the OS language isn't included.
+const EXPECTED_NSIS_LANGUAGES = [
+  "English", // en
+  "German", // de
+  "Spanish", // es
+  "French", // fr
+  "Portuguese", // pt
+  "SimpChinese", // zh
+  "Japanese", // ja
+];
+
+// The NSIS languages Tauri bundles translations for, verified against
+// crates/tauri-bundler/src/bundle/windows/nsis/languages on the dev branch.
+const TAURI_SUPPORTED_NSIS_LANGUAGES = new Set([
+  "Arabic",
+  "Bulgarian",
+  "Dutch",
+  "English",
+  "French",
+  "German",
+  "Hebrew",
+  "Italian",
+  "Japanese",
+  "Korean",
+  "Norwegian",
+  "Persian",
+  "Portuguese",
+  "PortugueseBR",
+  "Russian",
+  "SimpChinese",
+  "Spanish",
+  "SpanishInternational",
+  "Swedish",
+  "TradChinese",
+  "Turkish",
+  "Ukrainian",
+  "Vietnamese",
+]);
+
+interface TauriConfig {
+  bundle?: {
+    windows?: {
+      nsis?: {
+        languages?: string[];
+        displayLanguageSelector?: boolean;
+      };
+    };
+  };
+}
+
+function readTauriConfig(): TauriConfig {
+  const path = join(process.cwd(), "desktop", "src-tauri", "tauri.conf.json");
+  return JSON.parse(readFileSync(path, "utf8")) as TauriConfig;
+}
+
+describe("Windows NSIS installer localization", () => {
+  it("configures all 7 ZAM languages in order (English first as fallback)", () => {
+    const nsis = readTauriConfig().bundle?.windows?.nsis;
+    expect(nsis?.languages).toEqual(EXPECTED_NSIS_LANGUAGES);
+  });
+
+  it("uses only NSIS identifiers Tauri ships translations for", () => {
+    const langs = readTauriConfig().bundle?.windows?.nsis?.languages ?? [];
+    for (const lang of langs) {
+      expect(TAURI_SUPPORTED_NSIS_LANGUAGES.has(lang)).toBe(true);
+    }
+  });
+
+  it("covers exactly one installer language per supported locale (7, no duplicates)", () => {
+    const langs = readTauriConfig().bundle?.windows?.nsis?.languages ?? [];
+    expect(langs).toHaveLength(7);
+    expect(new Set(langs).size).toBe(7);
+  });
+
+  it("auto-detects the OS language without showing a picker", () => {
+    const nsis = readTauriConfig().bundle?.windows?.nsis;
+    expect(nsis?.displayLanguageSelector).toBe(false);
+    expect(nsis?.languages?.[0]).toBe("English");
+  });
+});

--- a/tests/desktop/installer-languages.test.ts
+++ b/tests/desktop/installer-languages.test.ts
@@ -1,22 +1,26 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { LOCALES, type Locale } from "../../desktop/src/i18n.js";
 
-// ZAM's 7 standard languages (src/kernel/system/locale.ts) mapped to the NSIS
-// language identifiers Tauri ships translations for. English is first: NSIS
-// falls back to the first listed language when the OS language isn't included.
-const EXPECTED_NSIS_LANGUAGES = [
-  "English", // en
-  "German", // de
-  "Spanish", // es
-  "French", // fr
-  "Portuguese", // pt
-  "SimpChinese", // zh
-  "Japanese", // ja
-];
+// NSIS identifier for each ZAM locale. Keyed as Record<Locale, string> so that
+// adding a locale to LOCALES (desktop/src/i18n.ts) fails compilation here until
+// an installer mapping exists — keeping setup.exe in parity with the app.
+const NSIS_LANGUAGE_BY_LOCALE: Record<Locale, string> = {
+  en: "English",
+  de: "German",
+  es: "Spanish",
+  fr: "French",
+  pt: "Portuguese",
+  zh: "SimpChinese",
+  ja: "Japanese",
+};
 
-// The NSIS languages Tauri bundles translations for, verified against
-// crates/tauri-bundler/src/bundle/windows/nsis/languages on the dev branch.
+// The NSIS languages Tauri ships translations for — hand-checked against
+// crates/tauri-bundler/src/bundle/windows/nsis/languages (dev branch and the
+// resolved @tauri-apps/cli 2.11.x, 2026-07-08). PR CI never runs makensis (only
+// the tag-triggered release build does), so this membership check is the
+// pipeline's pre-release guard against typo'd identifiers.
 const TAURI_SUPPORTED_NSIS_LANGUAGES = new Set([
   "Arabic",
   "Bulgarian",
@@ -43,44 +47,41 @@ const TAURI_SUPPORTED_NSIS_LANGUAGES = new Set([
   "Vietnamese",
 ]);
 
-interface TauriConfig {
-  bundle?: {
-    windows?: {
-      nsis?: {
-        languages?: string[];
-        displayLanguageSelector?: boolean;
-      };
-    };
-  };
+interface NsisConfig {
+  languages?: string[];
+  displayLanguageSelector?: boolean;
 }
 
-function readTauriConfig(): TauriConfig {
-  const path = join(process.cwd(), "desktop", "src-tauri", "tauri.conf.json");
-  return JSON.parse(readFileSync(path, "utf8")) as TauriConfig;
+/** The `bundle.windows.nsis` block exactly as the Tauri bundler reads it. */
+function readNsisConfig(): NsisConfig {
+  const raw = readFileSync(
+    join(process.cwd(), "desktop", "src-tauri", "tauri.conf.json"),
+    "utf8",
+  );
+  return JSON.parse(raw).bundle?.windows?.nsis ?? {};
 }
 
 describe("Windows NSIS installer localization", () => {
-  it("configures all 7 ZAM languages in order (English first as fallback)", () => {
-    const nsis = readTauriConfig().bundle?.windows?.nsis;
-    expect(nsis?.languages).toEqual(EXPECTED_NSIS_LANGUAGES);
+  const nsis = readNsisConfig();
+
+  it("configures one NSIS language per ZAM locale, English first as fallback", () => {
+    expect(nsis.languages).toEqual(
+      LOCALES.map((locale) => NSIS_LANGUAGE_BY_LOCALE[locale]),
+    );
+    expect(nsis.languages?.[0]).toBe("English");
+    // Distinct entries — catches a copy-paste duplicate inside the mapping.
+    expect(new Set(nsis.languages).size).toBe(LOCALES.length);
   });
 
   it("uses only NSIS identifiers Tauri ships translations for", () => {
-    const langs = readTauriConfig().bundle?.windows?.nsis?.languages ?? [];
-    for (const lang of langs) {
+    const languages = nsis.languages ?? [];
+    expect(languages.length).toBeGreaterThan(0);
+    for (const lang of languages) {
       expect(TAURI_SUPPORTED_NSIS_LANGUAGES.has(lang)).toBe(true);
     }
   });
 
-  it("covers exactly one installer language per supported locale (7, no duplicates)", () => {
-    const langs = readTauriConfig().bundle?.windows?.nsis?.languages ?? [];
-    expect(langs).toHaveLength(7);
-    expect(new Set(langs).size).toBe(7);
-  });
-
   it("auto-detects the OS language without showing a picker", () => {
-    const nsis = readTauriConfig().bundle?.windows?.nsis;
-    expect(nsis?.displayLanguageSelector).toBe(false);
-    expect(nsis?.languages?.[0]).toBe("English");
+    expect(nsis.displayLanguageSelector).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Configures the Tauri **NSIS Windows installer** (`setup.exe`) for ZAM's 7 standard languages, so the consumer onboarding path is localized end to end (installer → the already-localized Desktop Studio).

`desktop/src-tauri/tauri.conf.json`:

```json
"windows": {
  "nsis": {
    "languages": ["English", "German", "Spanish", "French", "Portuguese", "SimpChinese", "Japanese"],
    "displayLanguageSelector": false
  }
}
```

- **Auto-detect, no picker:** `displayLanguageSelector: false` → NSIS uses the OS default language, falling back to English (first in the list). Consistent with how the desktop and CLI resolve locale.
- Locale → NSIS identifier: `en`→English, `de`→German, `es`→Spanish, `fr`→French, **`pt`→Portuguese (European)**, `zh`→SimpChinese, `ja`→Japanese. All seven ship Tauri `.nsh` translations, so base installer chrome and Tauri's own added strings are localized.

## Tests

- `tests/desktop/installer-languages.test.ts` — asserts the exact 7 identifiers in order, all valid Tauri-supported NSIS names (guards typos/drift), no duplicates, `displayLanguageSelector: false`, and English-first fallback.
- Design recorded in `docs/specs/2026-07-08-multilingual-windows-installer-design.md`.

## Verification

- ✅ Config test 4/4; `npm run typecheck` clean.
- ✅ No regressions — the suite's `agent-harness` / `mcp` / `bridge-handlers` failures reproduce on clean `main` (Windows file-locks + environment-specific), unrelated to this change.
- ✅ **Built and observed locally.** Installed the Rust/Tauri toolchain and built the NSIS `setup.exe`; `makensis` compiled **all 7 language tables** with no error (a bad identifier fails the build). Ran the installer and confirmed rendering in:
  - **English** — auto-detected on an English OS (the intended no-picker path);
  - **German** — full wizard, native-verified (*"Willkommen zur Installation von ZAM"*);
  - **Japanese** — CJK renders correctly (*「ZAM セットアップへようこそ」*).
- Note for local builds behind a corporate network: `cargo` needed `CARGO_HTTP_MULTIPLEXING=false` to fetch crates (HTTP/2 stall); CI (GitHub runners) is unaffected.

## Out of scope / follow-ups

- The WiX `.msi` artifact stays English (`bundle.windows.wix.language` not set) — separate follow-up if that artifact is distributed.
- `zam init` CLI-wizard localization is designed but **deferred** (documented in the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
