### PR TITLE
fix: eliminate N+1 queries in unblockReady and prepareSessionSynthesis

### DIFF
--- a/docs/adr/2026-06-15-kernel-polish-and-performance.md
+++ b/docs/adr/2026-06-15-kernel-polish-and-performance.md
@@ -1,6 +1,7 @@
 # Kernel Polish and Performance
 
-**Status:** Proposed
+**Status:** Partially implemented (items 1–2 shipped 2026-07-08 for v0.9.3;
+item 5 had already shipped with v0.5.2; items 3, 4, 6, 7 open)
 **Deciders:** Thomas (project owner)
 
 ---
@@ -22,7 +23,7 @@ Replace the per-card loop with a single JOIN query that returns all blocked card
 Collect all unique token slugs from the merged patterns first, then run a single `SELECT * FROM tokens WHERE slug IN (...)` query, and build the pattern map from the result.
 
 ### 3. Question-source provenance (`question_source`)
-- Add `question_source TEXT NOT NULL DEFAULT 'manual'` column to the `tokens` table (migration M007). Valid values: `'manual'`, `'llm'`, `'template'`.
+- Add `question_source TEXT NOT NULL DEFAULT 'manual'` column to the `tokens` table (next free migration slot — M007–M012 have since been taken by other features). Valid values: `'manual'`, `'llm'`, `'template'`.
 - `createToken()` and `updateToken()` accept an optional `question_source`.
 - `ensureHighQualityQuestion()` only overwrites when `question_source !== 'manual'`.
 - `generateQuestionViaLLM()` sets `question_source = 'llm'` when persisting.
@@ -32,6 +33,8 @@ Replace the inner loop with a priority-queue approach: maintain a min-heap of (d
 
 ### 5. Review-context caching
 Add a module-level `Map<string, { context: ReviewContext; expiresAt: number }>` cache with a configurable TTL. `resolveReviewContext()` checks the cache before fetching. Cache is keyed by the normalized `sourceLink`.
+
+*Already shipped with v0.5.2 (`reviewContextCache` in `src/kernel/recall/reference-resolver.ts`, keyed by link + max length).*
 
 ### 6. Goal-engine async migration
 Convert all file operations to their `fs/promises` equivalents (`readFile`, `writeFile`, `readdir`). Update function signatures to return `Promise<...>`. Update callers in `src/cli/commands/goal.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,7 +23,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-06-09](2026-06-09-async-database-providers.md) | Async Database Providers | Implemented |
 | [2026-06-13a](2026-06-13a-automatic-session-synthesis.md) | Automatic Session Synthesis | Implemented |
 | [2026-06-13b](2026-06-13b-approachable-setup-and-self-update.md) | Approachable Setup and Self-Update | Partially implemented |
-| [2026-06-15](2026-06-15-kernel-polish-and-performance.md) | Kernel Polish and Performance | Proposed |
+| [2026-06-15](2026-06-15-kernel-polish-and-performance.md) | Kernel Polish and Performance | Partially implemented |
 | [2026-06-20](2026-06-20-observer-permission-model.md) | Configurable Observer permission model (`ObserverPolicy`) and two-layer consent | Accepted |
 | [2026-06-21](2026-06-21-code-signing-and-trusted-installers.md) | Code Signing and Trusted Installers | Proposed |
 | [2026-06-22](2026-06-22-screen-recording-observer.md) | Screen Recording Observer and Local/Cloud Vision Fallbacks | Proposed |
@@ -36,7 +36,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-02](2026-07-02-lehrplanplus-import-wizard.md) | LehrplanPLUS Curriculum Import Wizard | Partially implemented |
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
-| [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Accepted |
+| [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
 | [2026-07-05](../plans/2026-07-05-titles-doctor-adaptation.md) | Human-friendly Titles + `zam doctor` adaptation plan (post Fable 5 review) | In progress |
 | [2026-07-06a](2026-07-06a-mcp-agent-transport-and-surfaces.md) | MCP as the Canonical Agent Transport (and the Surface Topology Around It) | Partially implemented |
 | [2026-07-06b](2026-07-06b-checkpointed-review-dialogue.md) | Checkpointed Review Dialogue | Proposed |

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -168,6 +168,29 @@ export async function getTokenBySlug(
 }
 
 /**
+ * Look up many tokens by slug in a single query.
+ * Returns a map keyed by slug; slugs without a token are simply absent.
+ */
+export async function getTokensBySlugs(
+  db: Database,
+  slugs: string[],
+): Promise<Map<string, Token>> {
+  const tokens = new Map<string, Token>();
+  const unique = [...new Set(slugs)];
+  if (unique.length === 0) return tokens;
+
+  const placeholders = unique.map(() => "?").join(",");
+  const rows = (await db
+    .prepare(`SELECT * FROM tokens WHERE slug IN (${placeholders})`)
+    .all(...unique)) as Token[];
+  for (const token of rows) {
+    parseTokenFallback(token);
+    tokens.set(token.slug, token);
+  }
+  return tokens;
+}
+
+/**
  * Look up a token by its ULID.
  * Returns undefined if not found.
  */

--- a/src/kernel/observation/session-synthesis.ts
+++ b/src/kernel/observation/session-synthesis.ts
@@ -14,7 +14,7 @@ import { getPrerequisites } from "../models/prerequisite.js";
 import type { Session } from "../models/session.js";
 import { logStep } from "../models/session.js";
 import type { Token } from "../models/token.js";
-import { getTokenBySlug } from "../models/token.js";
+import { getTokenBySlug, getTokensBySlugs } from "../models/token.js";
 import { evaluateRatingWithinTransaction } from "../recall/evaluator.js";
 import { cascadeBlock } from "../scheduler/blocker.js";
 import type { Rating } from "../scheduler/fsrs.js";
@@ -200,10 +200,14 @@ export async function prepareSessionSynthesis(
     input.explicitPatterns ?? [],
   );
 
+  const patternTokens = await getTokensBySlugs(
+    db,
+    patterns.map((pattern) => pattern.slug),
+  );
   const validPatterns: TokenPattern[] = [];
   const tokens = new Map<string, Token>();
   for (const pattern of patterns) {
-    const token = await getTokenBySlug(db, pattern.slug);
+    const token = patternTokens.get(pattern.slug);
     if (!token || token.deprecated_at) continue;
     validPatterns.push(pattern);
     tokens.set(pattern.slug, token);
@@ -218,13 +222,16 @@ export async function prepareSessionSynthesis(
 
   if (session.execution_context === "ui") {
     const reports = readUiObservationLog(input.sessionId);
-    for (const report of reports) {
-      for (const candidate of report.candidateTokens) {
-        if (tokens.has(candidate.slug)) continue;
-        const token = await getTokenBySlug(db, candidate.slug);
-        if (token && !token.deprecated_at) {
-          tokens.set(candidate.slug, token);
-        }
+    const candidateTokens = await getTokensBySlugs(
+      db,
+      reports
+        .flatMap((report) => report.candidateTokens)
+        .map((candidate) => candidate.slug)
+        .filter((slug) => !tokens.has(slug)),
+    );
+    for (const [slug, token] of candidateTokens) {
+      if (!token.deprecated_at) {
+        tokens.set(slug, token);
       }
     }
 

--- a/src/kernel/scheduler/blocker.ts
+++ b/src/kernel/scheduler/blocker.ts
@@ -109,6 +109,9 @@ export async function cascadeBlock(
  * If a blocked card has no prerequisites at all, it is unblocked immediately
  * (it was likely blocked in error or its prerequisites were removed).
  *
+ * Unblocking cascades: when unblocking a card satisfies the last unmet
+ * prerequisite of another blocked card, that card unblocks in the same call.
+ *
  * @param db - Database connection
  * @param userId - The user whose blocked cards to check
  * @returns List of cards that were unblocked
@@ -117,42 +120,46 @@ export async function unblockReady(
   db: Database,
   userId: string,
 ): Promise<UnblockResult> {
-  const blockedCards = (await db
-    .prepare(
-      `SELECT c.token_id, t.slug, t.concept
-       FROM cards c
-       JOIN tokens t ON t.id = c.token_id
-       WHERE c.user_id = ? AND c.blocked = 1`,
-    )
-    .all(userId)) as Array<{
-    token_id: string;
-    slug: string;
-    concept: string;
-  }>;
-
   const unblocked: Array<{ slug: string; concept: string }> = [];
 
-  for (const card of blockedCards) {
-    const totalPrereqs = (await db
-      .prepare("SELECT COUNT(*) as n FROM prerequisites WHERE token_id = ?")
-      .get(card.token_id)) as { n: number };
-
-    const metPrereqs = (await db
+  // Fixpoint loop: unblocking a card can satisfy another blocked card's
+  // prerequisite, so repeat until a pass unblocks nothing. Each pass is one
+  // SELECT (correlated prerequisite counts, no per-card round trips) plus
+  // one batched UPDATE; passes are bounded by the prerequisite chain depth,
+  // not the card count.
+  for (;;) {
+    const readyCards = (await db
       .prepare(
-        `SELECT COUNT(*) as n FROM cards c
-         JOIN prerequisites p ON p.requires_id = c.token_id
-         WHERE p.token_id = ? AND c.user_id = ? AND c.reps >= 1 AND c.blocked = 0`,
+        `SELECT c.token_id, t.slug, t.concept
+         FROM cards c
+         JOIN tokens t ON t.id = c.token_id
+         WHERE c.user_id = ? AND c.blocked = 1
+           AND (SELECT COUNT(*) FROM prerequisites p
+                WHERE p.token_id = c.token_id) =
+               (SELECT COUNT(*) FROM prerequisites p
+                JOIN cards pc ON pc.token_id = p.requires_id
+                  AND pc.user_id = c.user_id
+                WHERE p.token_id = c.token_id
+                  AND pc.reps >= 1 AND pc.blocked = 0)`,
       )
-      .get(card.token_id, userId)) as { n: number };
+      .all(userId)) as Array<{
+      token_id: string;
+      slug: string;
+      concept: string;
+    }>;
 
-    if (totalPrereqs.n === 0 || metPrereqs.n === totalPrereqs.n) {
-      const now = new Date().toISOString();
-      await db
-        .prepare(
-          "UPDATE cards SET blocked = 0, due_at = ? WHERE token_id = ? AND user_id = ?",
-        )
-        .run(now, card.token_id, userId);
+    if (readyCards.length === 0) break;
 
+    const now = new Date().toISOString();
+    const placeholders = readyCards.map(() => "?").join(",");
+    await db
+      .prepare(
+        `UPDATE cards SET blocked = 0, due_at = ?
+         WHERE user_id = ? AND token_id IN (${placeholders})`,
+      )
+      .run(now, userId, ...readyCards.map((card) => card.token_id));
+
+    for (const card of readyCards) {
       unblocked.push({ slug: card.slug, concept: card.concept });
     }
   }

--- a/tests/kernel/blocker.test.ts
+++ b/tests/kernel/blocker.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  addPrerequisite,
+  createToken,
+  type Database,
+  ensureCard,
+  getCard,
+  openDatabase,
+  type Token,
+  unblockReady,
+} from "../../src/kernel/index.js";
+
+/** Wrap a Database so every prepare() call is counted. */
+function countPrepares(db: Database, counter: { count: number }): Database {
+  return {
+    prepare(sql: string) {
+      counter.count++;
+      return db.prepare(sql);
+    },
+    exec: (sql: string) => db.exec(sql),
+    pragma: (source: string) => db.pragma(source),
+    transaction: <T>(fn: (tx: Database) => Promise<T>) => db.transaction(fn),
+    close: () => db.close(),
+  };
+}
+
+describe("unblockReady", () => {
+  let db: Database;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-blocker-"));
+    db = await openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function makeToken(slug: string): Promise<Token> {
+    return createToken(db, {
+      slug,
+      concept: `Concept for ${slug}`,
+      domain: "testing",
+      bloom_level: 2,
+    });
+  }
+
+  async function blockCard(tokenId: string, userId: string): Promise<void> {
+    await ensureCard(db, tokenId, userId);
+    await db
+      .prepare(
+        "UPDATE cards SET blocked = 1 WHERE token_id = ? AND user_id = ?",
+      )
+      .run(tokenId, userId);
+  }
+
+  async function learnCard(tokenId: string, userId: string): Promise<void> {
+    await ensureCard(db, tokenId, userId);
+    await db
+      .prepare("UPDATE cards SET reps = 1 WHERE token_id = ? AND user_id = ?")
+      .run(tokenId, userId);
+  }
+
+  it("unblocks a blocked card once all prerequisites are learned", async () => {
+    const prereq = await makeToken("prereq");
+    const target = await makeToken("target");
+    await addPrerequisite(db, target.id, prereq.id);
+    await learnCard(prereq.id, "thomas");
+    await blockCard(target.id, "thomas");
+
+    const result = await unblockReady(db, "thomas");
+
+    expect(result.unblocked).toEqual([
+      { slug: target.slug, concept: target.concept },
+    ]);
+    const card = await getCard(db, target.id, "thomas");
+    expect(card?.blocked).toBe(0);
+    expect(card?.due_at).toBeTruthy();
+  });
+
+  it("keeps a card blocked while any prerequisite is unmet", async () => {
+    const met = await makeToken("met-prereq");
+    const unmet = await makeToken("unmet-prereq");
+    const target = await makeToken("target");
+    await addPrerequisite(db, target.id, met.id);
+    await addPrerequisite(db, target.id, unmet.id);
+    await learnCard(met.id, "thomas");
+    await ensureCard(db, unmet.id, "thomas"); // card exists but reps = 0
+    await blockCard(target.id, "thomas");
+
+    const result = await unblockReady(db, "thomas");
+
+    expect(result.unblocked).toEqual([]);
+    expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(1);
+  });
+
+  it("does not treat a missing prerequisite card as met", async () => {
+    const prereq = await makeToken("cardless-prereq");
+    const target = await makeToken("target");
+    await addPrerequisite(db, target.id, prereq.id);
+    await blockCard(target.id, "thomas");
+
+    const result = await unblockReady(db, "thomas");
+
+    expect(result.unblocked).toEqual([]);
+    expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(1);
+  });
+
+  it("does not unblock a card whose prerequisite remains blocked", async () => {
+    const root = await makeToken("root-prereq"); // never gets a card
+    const mid = await makeToken("mid-prereq");
+    const target = await makeToken("target");
+    await addPrerequisite(db, mid.id, root.id);
+    await addPrerequisite(db, target.id, mid.id);
+    await learnCard(mid.id, "thomas");
+    await blockCard(mid.id, "thomas"); // stays blocked: root is unmet
+    await blockCard(target.id, "thomas");
+
+    const result = await unblockReady(db, "thomas");
+
+    expect(result.unblocked).toEqual([]);
+    expect((await getCard(db, mid.id, "thomas"))?.blocked).toBe(1);
+    expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(1);
+  });
+
+  it("cascades through a blocked prerequisite in a single call", async () => {
+    const prereq = await makeToken("blocked-prereq");
+    const target = await makeToken("target");
+    await addPrerequisite(db, target.id, prereq.id);
+    await learnCard(prereq.id, "thomas");
+    await blockCard(prereq.id, "thomas");
+    await blockCard(target.id, "thomas");
+
+    const result = await unblockReady(db, "thomas");
+
+    // The prerequisite has no prerequisites of its own, so it unblocks;
+    // that makes it a met prerequisite (reps >= 1, unblocked), so the
+    // target unblocks in the same call — regardless of row order.
+    expect(result.unblocked).toEqual(
+      expect.arrayContaining([
+        { slug: prereq.slug, concept: prereq.concept },
+        { slug: target.slug, concept: target.concept },
+      ]),
+    );
+    expect(result.unblocked).toHaveLength(2);
+    expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(0);
+  });
+
+  it("unblocks a blocked card that has no prerequisites", async () => {
+    const orphan = await makeToken("orphan");
+    await blockCard(orphan.id, "thomas");
+
+    const result = await unblockReady(db, "thomas");
+
+    expect(result.unblocked).toEqual([
+      { slug: orphan.slug, concept: orphan.concept },
+    ]);
+    expect((await getCard(db, orphan.id, "thomas"))?.blocked).toBe(0);
+  });
+
+  it("only unblocks cards of the requested user", async () => {
+    const prereq = await makeToken("shared-prereq");
+    const target = await makeToken("shared-target");
+    await addPrerequisite(db, target.id, prereq.id);
+    await learnCard(prereq.id, "thomas");
+    await blockCard(target.id, "thomas");
+    await blockCard(target.id, "bob"); // bob has not learned the prerequisite
+
+    const result = await unblockReady(db, "thomas");
+
+    expect(result.unblocked).toEqual([
+      { slug: target.slug, concept: target.concept },
+    ]);
+    expect((await getCard(db, target.id, "thomas"))?.blocked).toBe(0);
+    expect((await getCard(db, target.id, "bob"))?.blocked).toBe(1);
+  });
+
+  it("issues a constant number of queries regardless of blocked-card count", async () => {
+    const makeUnmetBlockedTarget = async (i: number) => {
+      const prereq = await makeToken(`scale-prereq-${i}`);
+      const target = await makeToken(`scale-target-${i}`);
+      await addPrerequisite(db, target.id, prereq.id);
+      await blockCard(target.id, "thomas");
+    };
+
+    for (let i = 0; i < 2; i++) await makeUnmetBlockedTarget(i);
+    const counter = { count: 0 };
+    const counted = countPrepares(db, counter);
+    await unblockReady(counted, "thomas");
+    const queriesForTwoCards = counter.count;
+
+    for (let i = 2; i < 7; i++) await makeUnmetBlockedTarget(i);
+    counter.count = 0;
+    await unblockReady(counted, "thomas");
+
+    expect(counter.count).toBe(queriesForTwoCards);
+  });
+});

--- a/tests/kernel/session-synthesis.test.ts
+++ b/tests/kernel/session-synthesis.test.ts
@@ -39,6 +39,20 @@ function command(
   };
 }
 
+/** Wrap a Database so every prepare() call is counted. */
+function countPrepares(db: Database, counter: { count: number }): Database {
+  return {
+    prepare(sql: string) {
+      counter.count++;
+      return db.prepare(sql);
+    },
+    exec: (sql: string) => db.exec(sql),
+    pragma: (source: string) => db.pragma(source),
+    transaction: <T>(fn: (tx: Database) => Promise<T>) => db.transaction(fn),
+    close: () => db.close(),
+  };
+}
+
 const cleanEvidence = {
   matchedCommands: 2,
   helpSeeking: false,
@@ -139,6 +153,46 @@ describe("automatic session synthesis", () => {
     });
     expect(high.candidates).toHaveLength(1);
     expect(high.candidates[0].confidence).toBe("high");
+  });
+
+  it("issues a constant number of queries regardless of pattern count", async () => {
+    const makeSkillToken = async (i: number) => {
+      const token = await createToken(db, {
+        slug: `pattern-token-${i}`,
+        concept: `pattern command ${i} does something useful`,
+        domain: "testing",
+        bloom_level: 3,
+      });
+      await createAgentSkill(db, {
+        slug: `pattern-skill-${i}`,
+        description: `Skill ${i}`,
+        steps: [`Run \`pattern-command-${i}\``],
+        token_slugs: [token.slug],
+      });
+    };
+
+    for (let i = 0; i < 2; i++) await makeSkillToken(i);
+    const session = await startSession(db, {
+      user_id: "tester",
+      task: "Count queries",
+    });
+
+    const counter = { count: 0 };
+    const counted = countPrepares(db, counter);
+    await prepareSessionSynthesis(counted, {
+      sessionId: session.id,
+      commands: [command(1, "pattern-command-0")],
+    });
+    const queriesForTwoPatterns = counter.count;
+
+    for (let i = 2; i < 8; i++) await makeSkillToken(i);
+    counter.count = 0;
+    await prepareSessionSynthesis(counted, {
+      sessionId: session.id,
+      commands: [command(1, "pattern-command-0")],
+    });
+
+    expect(counter.count).toBe(queriesForTwoPatterns);
   });
 
   it("requires explicit patterns for skills linked to multiple tokens", async () => {


### PR DESCRIPTION
## Summary

Implements ADR 2026-06-15 items 1–2 (kernel polish: N+1 query fixes):

- **`unblockReady()`** now evaluates prerequisite counts with a single correlated SELECT plus one batched UPDATE per pass, looping to a fixpoint. Chains of blocked prerequisites now cascade deterministically in one call instead of depending on accidental row order; query count is bounded by chain depth, not card count.
- **`prepareSessionSynthesis()`** batch-loads tokens through the new `getTokensBySlugs()` (single `IN` query) for both skill patterns and UI observation candidates, replacing per-slug `getTokenBySlug` loops.
- ADR/docs hygiene: ADR 2026-06-15 marked partially implemented (item 5 had already shipped with v0.5.2, the M007 slot named for item 3 is taken), and two stale README index rows aligned.

## Test plan

- New `tests/kernel/blocker.test.ts`: six behavior guards (met/unmet/missing/blocked prerequisites, no-prereq unblock, per-user isolation, deterministic cascade) plus a scaling test pinning constant query count.
- `tests/kernel/session-synthesis.test.ts` gains the same scaling pin for pattern lookups.
- Full suite: kernel tests green; the failing `tests/cli/*` files fail identically on `main` (environment: user-global active knowledge context + Windows temp-file locking) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)