### PR TITLE
docs: reject ADR 2026-06-15 items 4, 6, 7 with rationale

### DIFF
--- a/docs/adr/2026-06-15-kernel-polish-and-performance.md
+++ b/docs/adr/2026-06-15-kernel-polish-and-performance.md
@@ -1,7 +1,8 @@
 # Kernel Polish and Performance
 
-**Status:** Partially implemented (items 1–2 shipped 2026-07-08 for v0.9.3;
-item 5 had already shipped with v0.5.2; items 3, 4, 6, 7 open)
+**Status:** Partially implemented (items 1–2 shipped 2026-07-08 with v0.9.3;
+item 5 had already shipped with v0.5.2; items 4, 6, 7 rejected 2026-07-08 —
+see item notes; item 3 open)
 **Deciders:** Thomas (project owner)
 
 ---
@@ -31,6 +32,13 @@ Collect all unique token slugs from the merged patterns first, then run a single
 ### 4. `interleave()` performance
 Replace the inner loop with a priority-queue approach: maintain a min-heap of (domain, remaining-count) and pick from the domain with the most remaining items that does not violate `maxConsecutive`. This brings the complexity to O(n log n).
 
+*Rejected 2026-07-08. `interleave()` runs once per queue build on
+session-sized input (tens of cards, a handful of domains); the current
+O(n·d·log d) costs microseconds. A heap rewrite risks changing the
+user-visible tie-breaking of the review order for an imperceptible gain —
+and the open decision below already conceded a sorted array may beat the
+heap at these sizes. Revisit only if queues grow by orders of magnitude.*
+
 ### 5. Review-context caching
 Add a module-level `Map<string, { context: ReviewContext; expiresAt: number }>` cache with a configurable TTL. `resolveReviewContext()` checks the cache before fetching. Cache is keyed by the normalized `sourceLink`.
 
@@ -39,11 +47,29 @@ Add a module-level `Map<string, { context: ReviewContext; expiresAt: number }>` 
 ### 6. Goal-engine async migration
 Convert all file operations to their `fs/promises` equivalents (`readFile`, `writeFile`, `readdir`). Update function signatures to return `Promise<...>`. Update callers in `src/cli/commands/goal.ts`.
 
+*Rejected 2026-07-08 as standalone work. The goal engine is consumed only by
+the one-shot `zam goal` CLI command, where synchronous I/O blocks nobody; the
+value is consistency alone. Do it opportunistically when goals are touched
+anyway — mandatory before goals join a long-running surface (`zam mcp`,
+`bridge serve`), where sync I/O would stall the event loop.*
+
 ### 7. Incremental snapshot deltas
 Add `exportSnapshotDelta(db, since)` that only exports rows modified after a given timestamp. Requires adding `updated_at` columns to tables that lack them. The delta snapshot format uses the same SQL-text approach but includes only INSERT statements for changed rows and DELETE statements for removed rows.
+
+*Rejected 2026-07-08. Three reasons: (1) no observed pain — snapshots exclude
+the recomputable embeddings and run only on backup/machine-move, not in any
+hot path; (2) the sketch under-specifies deletions — `updated_at` cannot find
+rows that no longer exist, so deltas need tombstones or a change-log table, a
+multiple of the effort described here; (3) the multi-learner sync ADR will
+introduce a real sync protocol that would supersede hand-rolled deltas.
+Revisit only if snapshot size or export/import time hurts in practice, and
+then inside the multi-learner sync design.*
 
 ## Open decisions
 
 - **Item 4 (interleave):** Should we implement a custom min-heap or use a sorted-array approach? For the typical queue size (50–100 items), a simple sorted array may be faster than a heap due to cache locality.
+  *Moot — item rejected 2026-07-08.*
 - **Item 5 (cache TTL):** Should the TTL be configurable via settings or hardcoded at 5 minutes? Configurable adds complexity for a feature that rarely needs tuning.
+  *Resolved in practice — shipped hardcoded with v0.5.2; no tuning need has surfaced.*
 - **Item 7 (delta snapshots):** Should deltas be cumulative (each delta is self-contained) or incremental (each delta depends on the previous one)? Cumulative is simpler but larger; incremental is smaller but requires a chain of deltas for restore.
+  *Moot — item rejected 2026-07-08.*


### PR DESCRIPTION
## Summary

Marks items 4 (interleave heap), 6 (goal-engine async) and 7 (delta snapshots) of the kernel-polish ADR as rejected, each with an inline rationale and a revisit trigger, and resolves the now-moot open decisions. Item 3 (question_source) remains the only open item and is scheduled for 0.10.0.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)