### PR TITLE
feat: question provenance, ephemeral review-time variation, snapshot-safe defaults

### DIFF
--- a/docs/adr/2026-06-15-kernel-polish-and-performance.md
+++ b/docs/adr/2026-06-15-kernel-polish-and-performance.md
@@ -1,8 +1,8 @@
 # Kernel Polish and Performance
 
-**Status:** Partially implemented (items 1–2 shipped 2026-07-08 with v0.9.3;
-item 5 had already shipped with v0.5.2; items 4, 6, 7 rejected 2026-07-08 —
-see item notes; item 3 open)
+**Status:** Implemented (items 1–2 shipped 2026-07-08 with v0.9.3; item 3
+shipped 2026-07-08 for v0.10.0 — revised, see item note; item 5 had already
+shipped with v0.5.2; items 4, 6, 7 rejected 2026-07-08 — see item notes)
 **Deciders:** Thomas (project owner)
 
 ---
@@ -28,6 +28,17 @@ Collect all unique token slugs from the merged patterns first, then run a single
 - `createToken()` and `updateToken()` accept an optional `question_source`.
 - `ensureHighQualityQuestion()` only overwrites when `question_source !== 'manual'`.
 - `generateQuestionViaLLM()` sets `question_source = 'llm'` when persisting.
+
+*Implemented 2026-07-08 for v0.10.0 (migration M013), with one revision
+decided during implementation: review-time question generation is
+**ephemeral**. `ensureHighQualityQuestion()` never persists generated
+questions — the stored question changes only through deliberate editing
+surfaces (Studio content editor, token CLI, imports). Manual questions are
+asked verbatim, without LLM variation. `question_source` is pure provenance
+for curation: `'manual'` for human-authored questions (API question edits
+without a declared source default to it), `'llm'` for agent- and
+curriculum-authored questions (also the column default, so pre-M013 rows and
+old snapshot restores classify as LLM-era), `'template'` reserved.*
 
 ### 4. `interleave()` performance
 Replace the inner loop with a priority-queue approach: maintain a min-heap of (domain, remaining-count) and pick from the domain with the most remaining items that does not violate `maxConsecutive`. This brings the complexity to O(n log n).

--- a/docs/adr/2026-06-15-kernel-polish-and-performance.md
+++ b/docs/adr/2026-06-15-kernel-polish-and-performance.md
@@ -29,16 +29,19 @@ Collect all unique token slugs from the merged patterns first, then run a single
 - `ensureHighQualityQuestion()` only overwrites when `question_source !== 'manual'`.
 - `generateQuestionViaLLM()` sets `question_source = 'llm'` when persisting.
 
-*Implemented 2026-07-08 for v0.10.0 (migration M013), with one revision
-decided during implementation: review-time question generation is
-**ephemeral**. `ensureHighQualityQuestion()` never persists generated
-questions — the stored question changes only through deliberate editing
-surfaces (Studio content editor, token CLI, imports). Manual questions are
-asked verbatim, without LLM variation. `question_source` is pure provenance
-for curation: `'manual'` for human-authored questions (API question edits
-without a declared source default to it), `'llm'` for agent- and
-curriculum-authored questions (also the column default, so pre-M013 rows and
-old snapshot restores classify as LLM-era), `'template'` reserved.*
+*Implemented 2026-07-08 for v0.10.0 (migration M013), revised during
+implementation: review-time question generation is **ephemeral**.
+`ensureHighQualityQuestion()` never persists generated questions — the
+stored question changes only through deliberate editing surfaces (Studio
+content editor, token CLI, imports). At review time the learner gets a fresh
+variation anchored on the stored question (same knowledge, different
+phrasing, so the wording cannot be memorized); the `llm.dynamic_questions`
+setting (default on) disables this per-review LLM roundtrip and serves the
+stored question verbatim. `question_source` is pure provenance for curation
+— it does not gate behavior: `'manual'` for human-authored questions (API
+question edits without a declared source default to it), `'llm'` for agent-
+and curriculum-authored questions (also the column default, so pre-M013 rows
+and old snapshot restores classify as LLM-era), `'template'` reserved.*
 
 ### 4. `interleave()` performance
 Replace the inner loop with a priority-queue approach: maintain a min-heap of (domain, remaining-count) and pick from the domain with the most remaining items that does not violate `maxConsecutive`. This brings the complexity to O(n log n).

--- a/docs/adr/2026-06-15-kernel-polish-and-performance.md
+++ b/docs/adr/2026-06-15-kernel-polish-and-performance.md
@@ -1,7 +1,7 @@
 # Kernel Polish and Performance
 
 **Status:** Implemented (items 1–2 shipped 2026-07-08 with v0.9.3; item 3
-shipped 2026-07-08 for v0.10.0 — revised, see item note; item 5 had already
+shipped 2026-07-08 with v0.9.4 — revised, see item note; item 5 had already
 shipped with v0.5.2; items 4, 6, 7 rejected 2026-07-08 — see item notes)
 **Deciders:** Thomas (project owner)
 
@@ -29,7 +29,7 @@ Collect all unique token slugs from the merged patterns first, then run a single
 - `ensureHighQualityQuestion()` only overwrites when `question_source !== 'manual'`.
 - `generateQuestionViaLLM()` sets `question_source = 'llm'` when persisting.
 
-*Implemented 2026-07-08 for v0.10.0 (migration M013), revised during
+*Implemented 2026-07-08 with v0.9.4 (migration M013), revised during
 implementation: review-time question generation is **ephemeral**.
 `ensureHighQualityQuestion()` never persists generated questions — the
 stored question changes only through deliberate editing surfaces (Studio

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,7 +23,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-06-09](2026-06-09-async-database-providers.md) | Async Database Providers | Implemented |
 | [2026-06-13a](2026-06-13a-automatic-session-synthesis.md) | Automatic Session Synthesis | Implemented |
 | [2026-06-13b](2026-06-13b-approachable-setup-and-self-update.md) | Approachable Setup and Self-Update | Partially implemented |
-| [2026-06-15](2026-06-15-kernel-polish-and-performance.md) | Kernel Polish and Performance | Partially implemented |
+| [2026-06-15](2026-06-15-kernel-polish-and-performance.md) | Kernel Polish and Performance | Implemented |
 | [2026-06-20](2026-06-20-observer-permission-model.md) | Configurable Observer permission model (`ObserverPolicy`) and two-layer consent | Accepted |
 | [2026-06-21](2026-06-21-code-signing-and-trusted-installers.md) | Code Signing and Trusted Installers | Proposed |
 | [2026-06-22](2026-06-22-screen-recording-observer.md) | Screen Recording Observer and Local/Cloud Vision Fallbacks | Proposed |

--- a/src/cli/bridge-handlers.ts
+++ b/src/cli/bridge-handlers.ts
@@ -184,7 +184,6 @@ export async function getReview(db: Database, params: GetReviewParams) {
         bloomLevel: item.bloomLevel as BloomLevel,
         sourceLink: item.sourceLink,
         question: item.question,
-        questionSource: item.questionSource,
       });
       if (healed) {
         resolvedQuestion = healed.question;
@@ -288,7 +287,6 @@ export async function getReviewsBatch(
             bloomLevel: token.bloom_level as BloomLevel,
             sourceLink: token.source_link,
             question: token.question,
-            questionSource: token.question_source,
           });
           if (healed) {
             resolvedQuestion = healed.question;

--- a/src/cli/bridge-handlers.ts
+++ b/src/cli/bridge-handlers.ts
@@ -184,6 +184,7 @@ export async function getReview(db: Database, params: GetReviewParams) {
         bloomLevel: item.bloomLevel as BloomLevel,
         sourceLink: item.sourceLink,
         question: item.question,
+        questionSource: item.questionSource,
       });
       if (healed) {
         resolvedQuestion = healed.question;
@@ -287,6 +288,7 @@ export async function getReviewsBatch(
             bloomLevel: token.bloom_level as BloomLevel,
             sourceLink: token.source_link,
             question: token.question,
+            questionSource: token.question_source,
           });
           if (healed) {
             resolvedQuestion = healed.question;
@@ -642,6 +644,9 @@ export async function addToken(db: Database, params: AddTokenParams) {
     symbiosis_mode: params.symbiosisMode,
     source_link: params.sourceLink ?? null,
     question: params.question ?? null,
+    // Bridge/MCP callers are agents: their questions are LLM-authored and
+    // stay refreshable. Humans author questions via the token CLI instead.
+    question_source: params.question ? "llm" : undefined,
   });
 
   for (const context of assignedContexts) {

--- a/src/cli/commands/learn.ts
+++ b/src/cli/commands/learn.ts
@@ -125,7 +125,6 @@ export const learnCommand = new Command("learn")
               bloomLevel: item.bloomLevel as BloomLevel,
               sourceLink: item.sourceLink,
               question: item.question,
-              questionSource: item.questionSource,
             });
             if (healed) {
               resolvedQuestion = healed.question;

--- a/src/cli/commands/learn.ts
+++ b/src/cli/commands/learn.ts
@@ -125,6 +125,7 @@ export const learnCommand = new Command("learn")
               bloomLevel: item.bloomLevel as BloomLevel,
               sourceLink: item.sourceLink,
               question: item.question,
+              questionSource: item.questionSource,
             });
             if (healed) {
               resolvedQuestion = healed.question;

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -487,6 +487,8 @@ export async function generateQuestionViaLLM(
     bloomLevel: number;
     context?: string;
     sourceLinkContent?: string | null;
+    /** Stored question to vary — same knowledge, fresh phrasing. */
+    existingQuestion?: string | null;
   },
 ): Promise<LlmTextResult> {
   const cfg = await getProviderForRole(db, "recall");
@@ -499,6 +501,12 @@ export async function generateQuestionViaLLM(
 
   const langName = LANGUAGE_NAMES[cfg.locale] || "English";
 
+  const existingQuestion = input.existingQuestion?.trim();
+  const variationGuideline = existingQuestion
+    ? `
+5. A canonical question for this token already exists. Generate a fresh VARIATION of it: test the same knowledge, but with different wording or from a different angle, so the learner cannot memorize the exact phrasing. Never repeat the canonical question verbatim.`
+    : "";
+
   const systemPrompt = `You are ZAM, a highly precise agentic skills trainer.
 Your task is to generate a single, clear, conceptual active-recall question (flashcard front) in ${langName} for a knowledge token.
 
@@ -506,13 +514,13 @@ Guidelines:
 1. The question MUST match the Bloom level: ${verb} (Level ${bloom}).
 2. CRITICAL: The question MUST NOT contain or reveal the concept text itself! The concept is the answer (flashcard back) that the learner needs to recall.
 3. Keep the question concise, highly specific, and clear. Avoid generic prompts like "What is the concept of..." if possible, and ask about the core mechanism, function, or purpose of the slug/concept without giving the answer away.
-4. Output ONLY the raw question text in ${langName}. Do not include any preamble, headers, markdown fences, or conversational filler.`;
+4. Output ONLY the raw question text in ${langName}. Do not include any preamble, headers, markdown fences, or conversational filler.${variationGuideline}`;
 
   const userPrompt = `Domain: ${input.domain}
 Slug: ${input.slug}
 Concept to Recall (DO NOT REVEAL IN QUESTION): ${input.concept}
 Context: ${input.context || "(none)"}
-${input.sourceLinkContent ? `Source Reference:\n${input.sourceLinkContent}` : ""}
+${existingQuestion ? `Canonical Question (vary, do not repeat verbatim): ${existingQuestion}\n` : ""}${input.sourceLinkContent ? `Source Reference:\n${input.sourceLinkContent}` : ""}
 
 Active-Recall Question:`;
 
@@ -2060,12 +2068,13 @@ export async function fetchWithInteractiveTimeout(
 /**
  * Resolve the active-recall question to ask for a token.
  *
- * Manual questions are authoritative and returned verbatim. For everything
- * else, when LLM is enabled, a fresh question is generated for THIS review
- * only — it is never persisted; the stored question changes exclusively
- * through deliberate editing surfaces (Studio content editor, token CLI,
- * imports). Falls back to the stored question when generation is off or
- * fails.
+ * When LLM is enabled (and `llm.dynamic_questions` is not disabled), a fresh
+ * question is generated for THIS review only — anchored on the stored
+ * question when one exists, so the learner cannot memorize its exact
+ * phrasing. The result is never persisted; the stored question changes
+ * exclusively through deliberate editing surfaces (Studio content editor,
+ * token CLI, imports). Falls back to the stored question verbatim when
+ * variation is disabled, generation is off, or it fails.
  */
 export async function ensureHighQualityQuestion(
   db: Database,
@@ -2077,21 +2086,15 @@ export async function ensureHighQualityQuestion(
     bloomLevel: number;
     sourceLink?: string | null;
     question?: string | null;
-    questionSource?: string | null;
   },
 ): Promise<QuestionResolution | null> {
-  // A human-authored question is authoritative: never regenerate or
-  // overwrite it (ADR 2026-06-15 item 3).
-  if (token.questionSource === "manual" && token.question?.trim()) {
-    return {
-      question: token.question.trim(),
-      source: "original",
-    };
-  }
-
   const { enabled } = await getLlmConfig(db);
+  // Opt-out for review latency/cost: disabling dynamic questions serves the
+  // stored question verbatim instead of generating a per-review variation.
+  const variationEnabled =
+    (await getSetting(db, "llm.dynamic_questions")) !== "false";
 
-  if (enabled) {
+  if (enabled && variationEnabled) {
     try {
       let sourceLinkContent: string | null = null;
       if (token.sourceLink) {
@@ -2109,6 +2112,7 @@ export async function ensureHighQualityQuestion(
         domain: token.domain,
         bloomLevel: token.bloomLevel,
         sourceLinkContent,
+        existingQuestion: token.question,
       });
 
       if (generated.text.trim().length > 0) {

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -26,7 +26,6 @@ import {
   normalizeLocale,
   resolveReviewContext,
   t,
-  updateToken,
 } from "../../kernel/index.js";
 
 /** Single source of truth for connection defaults (easy to bump as models evolve). */
@@ -2059,9 +2058,14 @@ export async function fetchWithInteractiveTimeout(
 }
 
 /**
- * Ensures a token has a high-quality active-recall question.
- * When LLM is enabled, generates a fresh question on the fly, self-heals it into
- * the database, and returns it. Otherwise falls back to the stored question.
+ * Resolve the active-recall question to ask for a token.
+ *
+ * Manual questions are authoritative and returned verbatim. For everything
+ * else, when LLM is enabled, a fresh question is generated for THIS review
+ * only — it is never persisted; the stored question changes exclusively
+ * through deliberate editing surfaces (Studio content editor, token CLI,
+ * imports). Falls back to the stored question when generation is off or
+ * fails.
  */
 export async function ensureHighQualityQuestion(
   db: Database,
@@ -2073,8 +2077,18 @@ export async function ensureHighQualityQuestion(
     bloomLevel: number;
     sourceLink?: string | null;
     question?: string | null;
+    questionSource?: string | null;
   },
 ): Promise<QuestionResolution | null> {
+  // A human-authored question is authoritative: never regenerate or
+  // overwrite it (ADR 2026-06-15 item 3).
+  if (token.questionSource === "manual" && token.question?.trim()) {
+    return {
+      question: token.question.trim(),
+      source: "original",
+    };
+  }
+
   const { enabled } = await getLlmConfig(db);
 
   if (enabled) {
@@ -2098,8 +2112,8 @@ export async function ensureHighQualityQuestion(
       });
 
       if (generated.text.trim().length > 0) {
-        // Persist the latest high-quality question as the offline fallback.
-        await updateToken(db, token.slug, { question: generated.text });
+        // Ephemeral by design: the generated question is used for this
+        // review only and never written back to the token.
         return {
           question: generated.text,
           source: "llm",

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -513,4 +513,18 @@ async function runMigrations(db: Database): Promise<void> {
   await db.exec(`
     CREATE INDEX IF NOT EXISTS idx_token_contexts_context ON token_contexts(context_id)
   `);
+
+  // M013: add question provenance to tokens (ADR 2026-06-15 item 3).
+  // The column default 'llm' doubles as the backfill: pre-provenance rows
+  // (and rows from old snapshots, which INSERT without this column) count
+  // as LLM-era content. Human-authored questions are marked 'manual' by the
+  // API layer (createToken/updateToken) from now on.
+  if (
+    tokenCols.length > 0 &&
+    !tokenCols.some((c) => c.name === "question_source")
+  ) {
+    await db.exec(
+      `ALTER TABLE tokens ADD COLUMN question_source TEXT NOT NULL DEFAULT 'llm'`,
+    );
+  }
 }

--- a/src/kernel/db/schema.ts
+++ b/src/kernel/db/schema.ts
@@ -29,7 +29,12 @@ CREATE TABLE IF NOT EXISTS tokens (
   deprecated_at TEXT,
   question      TEXT,
   provider      TEXT,
-  topic_id      TEXT
+  topic_id      TEXT,
+  -- Who authored the current question ('manual' | 'llm' | 'template');
+  -- validated in code, not via CHECK. Column default is 'llm' so unlabeled
+  -- writes (pre-M013 rows, old snapshot restores) count as LLM-era content;
+  -- createToken() defaults to 'manual' for API callers instead.
+  question_source TEXT NOT NULL DEFAULT 'llm'
 );
 
 -- Prerequisite dependency graph: "to learn A, first know B"

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -173,6 +173,7 @@ export type {
   ImportCurriculumResult,
   ListTokensOptions,
   PersonalCard,
+  QuestionSource,
   SourceProposalInput,
   SplitProposalInput,
   SymbiosisMode,

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -16,6 +16,12 @@ export type BloomLevel = 1 | 2 | 3 | 4 | 5;
 
 export type SymbiosisMode = "shadowing" | "copilot" | "autonomy";
 
+/**
+ * Who authored a token's current recall question. LLM healing only
+ * overwrites questions whose source is not 'manual'.
+ */
+export type QuestionSource = "manual" | "llm" | "template";
+
 export interface Token {
   id: string;
   slug: string;
@@ -27,6 +33,7 @@ export interface Token {
   symbiosis_mode: SymbiosisMode | null;
   source_link: string | null;
   question: string | null;
+  question_source: QuestionSource;
   created_at: string;
   updated_at: string;
   deprecated_at: string | null;
@@ -44,6 +51,7 @@ export interface CreateTokenInput {
   symbiosis_mode?: SymbiosisMode | null;
   source_link?: string | null;
   question?: string | null;
+  question_source?: QuestionSource;
   provider?: string | null;
   topic_id?: string | null;
 }
@@ -57,6 +65,7 @@ export interface UpdateTokenInput {
   symbiosis_mode?: SymbiosisMode | null;
   source_link?: string | null;
   question?: string | null;
+  question_source?: QuestionSource;
   provider?: string | null;
   topic_id?: string | null;
 }
@@ -97,6 +106,16 @@ export interface ScoredToken extends Token {
 
 // ── Functions ────────────────────────────────────────────────────────────────
 
+const VALID_QUESTION_SOURCES: QuestionSource[] = ["manual", "llm", "template"];
+
+function validateQuestionSource(value: QuestionSource): void {
+  if (!VALID_QUESTION_SOURCES.includes(value)) {
+    throw new Error(
+      `Invalid question_source: ${value} (expected one of ${VALID_QUESTION_SOURCES.join(", ")})`,
+    );
+  }
+}
+
 /**
  * Create a new knowledge token.
  * Throws if a token with the same slug already exists.
@@ -114,11 +133,13 @@ export async function createToken(
   }
 
   const title = input.title ?? "";
+  const questionSource = input.question_source ?? "manual";
+  validateQuestionSource(questionSource);
 
   await db
     .prepare(`
-    INSERT INTO tokens (id, slug, title, concept, domain, bloom_level, context, symbiosis_mode, source_link, question, provider, topic_id, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO tokens (id, slug, title, concept, domain, bloom_level, context, symbiosis_mode, source_link, question, question_source, provider, topic_id, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
     .run(
       id,
@@ -131,6 +152,7 @@ export async function createToken(
       input.symbiosis_mode ?? null,
       input.source_link ?? null,
       input.question ?? null,
+      questionSource,
       input.provider ?? null,
       input.topic_id ?? null,
       now,
@@ -267,6 +289,17 @@ export async function updateToken(
   if (updates.question !== undefined) {
     fields.push("question = ?");
     values.push(updates.question);
+  }
+  // A question edit without a declared source is a human edit: default to
+  // 'manual' so LLM healing stops overwriting it. Automated writers (the
+  // heal path) must declare question_source explicitly.
+  const questionSource =
+    updates.question_source ??
+    (updates.question !== undefined ? "manual" : undefined);
+  if (questionSource !== undefined) {
+    validateQuestionSource(questionSource);
+    fields.push("question_source = ?");
+    values.push(questionSource);
   }
   if (updates.provider !== undefined) {
     fields.push("provider = ?");
@@ -827,6 +860,9 @@ export async function importCurriculumCards(
           symbiosis_mode: symbiosisMode,
           source_link: card.source_link || null,
           question: card.question || null,
+          // Curriculum cards are LLM-extracted; their questions are LLM
+          // inventions, not human-authored content.
+          question_source: "llm",
           provider: card.provider || null,
           topic_id: card.topic_id || null,
         });

--- a/src/kernel/scheduler/queue.ts
+++ b/src/kernel/scheduler/queue.ts
@@ -31,6 +31,7 @@ export interface ReviewQueueItem {
   dueAt: string;
   sourceLink: string | null;
   question: string | null;
+  questionSource: string;
 }
 
 export interface ReviewQueue {
@@ -55,6 +56,7 @@ interface CardRow {
   due_at: string;
   source_link: string | null;
   question: string | null;
+  question_source: string;
 }
 
 // ── Functions ────────────────────────────────────────────────────────────────
@@ -95,7 +97,8 @@ export async function buildReviewQueue(
          c.state    AS state,
          c.due_at   AS due_at,
          t.source_link AS source_link,
-         t.question AS question
+         t.question AS question,
+         t.question_source AS question_source
        FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.user_id = ?
@@ -131,7 +134,8 @@ export async function buildReviewQueue(
          c.state    AS state,
          c.due_at   AS due_at,
          t.source_link AS source_link,
-         t.question AS question
+         t.question AS question,
+         t.question_source AS question_source
        FROM cards c
        JOIN tokens t ON t.id = c.token_id
        WHERE c.user_id = ?
@@ -221,6 +225,7 @@ function rowToItem(row: CardRow): ReviewQueueItem {
     dueAt: row.due_at,
     sourceLink: row.source_link,
     question: row.question,
+    questionSource: row.question_source,
   };
 }
 

--- a/tests/cli/bridge-handlers.test.ts
+++ b/tests/cli/bridge-handlers.test.ts
@@ -24,10 +24,15 @@ describe("bridge-handlers unit tests", () => {
   let tempDir: string;
   let dbPath: string;
   let db: any;
+  let previousConfigPath: string | undefined;
 
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), "zam-bridge-handlers-test-"));
     dbPath = join(tempDir, "test.db");
+    // Isolate from the developer's machine config (~/.zam/config.json) so an
+    // active workspace knowledge context on the host cannot leak into tests.
+    previousConfigPath = process.env.ZAM_CONFIG_PATH;
+    process.env.ZAM_CONFIG_PATH = join(tempDir, "machine-config.json");
     db = await openDatabase({
       dbPath,
       initialize: true,
@@ -42,6 +47,11 @@ describe("bridge-handlers unit tests", () => {
   });
 
   afterEach(async () => {
+    if (previousConfigPath === undefined) {
+      delete process.env.ZAM_CONFIG_PATH;
+    } else {
+      process.env.ZAM_CONFIG_PATH = previousConfigPath;
+    }
     if (db) {
       await db.close();
     }
@@ -264,6 +274,79 @@ describe("bridge-handlers unit tests", () => {
       }),
     ).rejects.toThrow("Prerequisite token not found");
     expect(await getTokenBySlug(db, "invalid-advanced")).toBeUndefined();
+  });
+
+  it("addToken marks agent-provided questions as llm", async () => {
+    await addToken(db, {
+      user: "thomas",
+      slug: "agent-authored",
+      concept: "A concept whose question the agent wrote",
+      domain: "testing",
+      question: "What did the agent ask?",
+    });
+
+    const token = await getTokenBySlug(db, "agent-authored");
+    expect(token?.question_source).toBe("llm");
+  });
+
+  it("getReviewsBatch asks manual questions verbatim and llm ones with a fresh, unpersisted variation", async () => {
+    const { setSetting } = await import("../../src/kernel/index.js");
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(db, "llm.url", "http://dummy/v1");
+
+    const manual = await createToken(db, {
+      slug: "manual-question",
+      concept: "Human-authored question",
+      domain: "testing",
+      question: "What did the human write?",
+      // createToken defaults to question_source 'manual'
+    });
+    const generated = await createToken(db, {
+      slug: "generated-question",
+      concept: "LLM-authored question",
+      domain: "testing",
+      question: "Old generated question?",
+      question_source: "llm",
+    });
+    await ensureCard(db, manual.id, "thomas");
+    await ensureCard(db, generated.id, "thomas");
+    await db
+      .prepare("UPDATE cards SET due_at = '2000-01-01T00:00:00.000Z'")
+      .run();
+
+    const originalFetch = global.fetch;
+    global.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "Fresh generated question?" } }],
+        }),
+      )) as typeof fetch;
+
+    try {
+      const res = await getReviewsBatch(db, {
+        user: "thomas",
+        includeQuestions: true,
+        noResolve: true,
+      });
+
+      const manualCard = res.cards.find((c: any) => c.slug === manual.slug);
+      const generatedCard = res.cards.find(
+        (c: any) => c.slug === generated.slug,
+      );
+      expect(manualCard?.question).toBe("What did the human write?");
+      expect(generatedCard?.question).toBe("Fresh generated question?");
+
+      // Reviews never mutate content: both stored questions are untouched.
+      const storedManual = await getTokenBySlug(db, manual.slug);
+      expect(storedManual?.question).toBe("What did the human write?");
+      expect(storedManual?.question_source).toBe("manual");
+
+      const storedGenerated = await getTokenBySlug(db, generated.slug);
+      expect(storedGenerated?.question).toBe("Old generated question?");
+      expect(storedGenerated?.question_source).toBe("llm");
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 
   it("endSession can return synthesis candidates and the final summary", async () => {

--- a/tests/cli/bridge-handlers.test.ts
+++ b/tests/cli/bridge-handlers.test.ts
@@ -289,7 +289,7 @@ describe("bridge-handlers unit tests", () => {
     expect(token?.question_source).toBe("llm");
   });
 
-  it("getReviewsBatch asks manual questions verbatim and llm ones with a fresh, unpersisted variation", async () => {
+  it("getReviewsBatch serves fresh question variations and never mutates stored questions", async () => {
     const { setSetting } = await import("../../src/kernel/index.js");
     await setSetting(db, "llm.enabled", "true");
     await setSetting(db, "llm.url", "http://dummy/v1");
@@ -333,7 +333,9 @@ describe("bridge-handlers unit tests", () => {
       const generatedCard = res.cards.find(
         (c: any) => c.slug === generated.slug,
       );
-      expect(manualCard?.question).toBe("What did the human write?");
+      // Both get an ephemeral variation — manual questions too, so the
+      // learner cannot memorize the exact phrasing.
+      expect(manualCard?.question).toBe("Fresh generated question?");
       expect(generatedCard?.question).toBe("Fresh generated question?");
 
       // Reviews never mutate content: both stored questions are untouched.

--- a/tests/cli/llm.test.ts
+++ b/tests/cli/llm.test.ts
@@ -435,7 +435,7 @@ describe("LLM client utilities (CLI layer)", () => {
     }
   });
 
-  it("ensureHighQualityQuestion preserves manual questions without calling the LLM", async () => {
+  it("ensureHighQualityQuestion varies a stored question ephemerally, anchored on its text", async () => {
     const db = await openDatabase({
       dbPath: ":memory:",
       initialize: true,
@@ -453,12 +453,12 @@ describe("LLM client utilities (CLI layer)", () => {
     });
 
     const originalFetch = global.fetch;
-    let fetchCalls = 0;
-    global.fetch = (async () => {
-      fetchCalls++;
+    const requestBodies: string[] = [];
+    global.fetch = (async (_url: unknown, init?: RequestInit) => {
+      if (typeof init?.body === "string") requestBodies.push(init.body);
       return new Response(
         JSON.stringify({
-          choices: [{ message: { content: "Generated replacement?" } }],
+          choices: [{ message: { content: "A varied phrasing of the ask?" } }],
         }),
       );
     }) as typeof fetch;
@@ -472,18 +472,74 @@ describe("LLM client utilities (CLI layer)", () => {
         bloomLevel: token.bloom_level,
         sourceLink: token.source_link,
         question: token.question,
-        questionSource: token.question_source,
       });
 
+      // The learner gets a fresh variation so the exact phrasing cannot be
+      // memorized — generated from the stored question as anchor.
       expect(resolution).toMatchObject({
-        question: "What exactly did the human ask?",
-        source: "original",
+        question: "A varied phrasing of the ask?",
+        source: "llm",
       });
-      expect(fetchCalls).toBe(0);
+      expect(
+        requestBodies.some((body) =>
+          body.includes("What exactly did the human ask?"),
+        ),
+      ).toBe(true);
 
+      // The stored question and its provenance are untouched.
       const stored = await getTokenBySlug(db, token.slug);
       expect(stored?.question).toBe("What exactly did the human ask?");
       expect(stored?.question_source).toBe("manual");
+    } finally {
+      global.fetch = originalFetch;
+      await db.close();
+    }
+  });
+
+  it("ensureHighQualityQuestion serves the stored question verbatim when dynamic questions are disabled", async () => {
+    const db = await openDatabase({
+      dbPath: ":memory:",
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(db, "llm.url", "http://dummy/v1");
+    await setSetting(db, "llm.dynamic_questions", "false");
+
+    const token = await createToken(db, {
+      slug: "no-variation",
+      concept: "A concept reviewed without question variation",
+      domain: "testing",
+      question: "The stored question, asked as-is?",
+    });
+
+    const originalFetch = global.fetch;
+    let fetchCalls = 0;
+    global.fetch = (async () => {
+      fetchCalls++;
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "Should never be requested" } }],
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const resolution = await ensureHighQualityQuestion(db, {
+        id: token.id,
+        slug: token.slug,
+        concept: token.concept,
+        domain: token.domain,
+        bloomLevel: token.bloom_level,
+        sourceLink: token.source_link,
+        question: token.question,
+      });
+
+      expect(resolution).toMatchObject({
+        question: "The stored question, asked as-is?",
+        source: "original",
+      });
+      expect(fetchCalls).toBe(0);
     } finally {
       global.fetch = originalFetch;
       await db.close();

--- a/tests/cli/llm.test.ts
+++ b/tests/cli/llm.test.ts
@@ -376,7 +376,7 @@ describe("LLM client utilities (CLI layer)", () => {
     });
   });
 
-  it("ensureHighQualityQuestion dynamically generates and self-heals a missing question when LLM is enabled", async () => {
+  it("ensureHighQualityQuestion generates a review-only question without persisting it", async () => {
     const db = await openDatabase({
       dbPath: ":memory:",
       initialize: true,
@@ -425,11 +425,65 @@ describe("LLM client utilities (CLI layer)", () => {
         source: "llm",
       });
 
-      // Verify that it self-healed in the database!
+      // The generated question is ephemeral: the stored token must be
+      // untouched — content changes only through deliberate editing surfaces.
       const updated = await getTokenBySlug(db, slug);
-      expect(updated?.question).toBe(
-        "How do you securely store Azure DevOps HTTPS credentials on macOS?",
+      expect(updated?.question).toBeNull();
+    } finally {
+      global.fetch = originalFetch;
+      await db.close();
+    }
+  });
+
+  it("ensureHighQualityQuestion preserves manual questions without calling the LLM", async () => {
+    const db = await openDatabase({
+      dbPath: ":memory:",
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    await setSetting(db, "llm.enabled", "true");
+    await setSetting(db, "llm.url", "http://dummy/v1");
+
+    const token = await createToken(db, {
+      slug: "manual-question",
+      concept: "A concept with a hand-written question",
+      domain: "testing",
+      question: "What exactly did the human ask?",
+      // createToken defaults to question_source 'manual'
+    });
+
+    const originalFetch = global.fetch;
+    let fetchCalls = 0;
+    global.fetch = (async () => {
+      fetchCalls++;
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "Generated replacement?" } }],
+        }),
       );
+    }) as typeof fetch;
+
+    try {
+      const resolution = await ensureHighQualityQuestion(db, {
+        id: token.id,
+        slug: token.slug,
+        concept: token.concept,
+        domain: token.domain,
+        bloomLevel: token.bloom_level,
+        sourceLink: token.source_link,
+        question: token.question,
+        questionSource: token.question_source,
+      });
+
+      expect(resolution).toMatchObject({
+        question: "What exactly did the human ask?",
+        source: "original",
+      });
+      expect(fetchCalls).toBe(0);
+
+      const stored = await getTokenBySlug(db, token.slug);
+      expect(stored?.question).toBe("What exactly did the human ask?");
+      expect(stored?.question_source).toBe("manual");
     } finally {
       global.fetch = originalFetch;
       await db.close();

--- a/tests/kernel/question-source.test.ts
+++ b/tests/kernel/question-source.test.ts
@@ -1,0 +1,180 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildReviewQueue,
+  createToken,
+  type Database,
+  ensureCard,
+  getTokenBySlug,
+  openDatabase,
+  updateToken,
+} from "../../src/kernel/index.js";
+
+describe("question_source provenance", () => {
+  let db: Database;
+  let tempDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-question-source-"));
+    dbPath = join(tempDir, "zam-test.db");
+    db = await openDatabase({
+      dbPath,
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("createToken defaults question_source to manual", async () => {
+    const token = await createToken(db, {
+      slug: "hand-written",
+      concept: "A concept with a hand-written question",
+      domain: "testing",
+      question: "What did the human ask?",
+    });
+
+    expect(token.question_source).toBe("manual");
+  });
+
+  it("createToken honors an explicit question_source", async () => {
+    const token = await createToken(db, {
+      slug: "agent-written",
+      concept: "A concept whose question came from an agent",
+      domain: "testing",
+      question: "What did the agent ask?",
+      question_source: "llm",
+    });
+
+    expect(token.question_source).toBe("llm");
+  });
+
+  it("createToken rejects an invalid question_source", async () => {
+    await expect(
+      createToken(db, {
+        slug: "bad-source",
+        concept: "Invalid provenance value",
+        // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid input
+        question_source: "robot" as any,
+      }),
+    ).rejects.toThrow(/question_source/);
+  });
+
+  it("updateToken marks question edits as manual when no source is given", async () => {
+    await createToken(db, {
+      slug: "refreshable",
+      concept: "Question was LLM-generated",
+      question: "Generated question?",
+      question_source: "llm",
+    });
+
+    const updated = await updateToken(db, "refreshable", {
+      question: "A better, hand-written question?",
+    });
+
+    expect(updated.question_source).toBe("manual");
+  });
+
+  it("updateToken honors an explicit question_source alongside a question", async () => {
+    await createToken(db, {
+      slug: "healed",
+      concept: "Question will be LLM-healed",
+      question: "Original?",
+    });
+
+    const updated = await updateToken(db, "healed", {
+      question: "Freshly generated?",
+      question_source: "llm",
+    });
+
+    expect(updated.question_source).toBe("llm");
+  });
+
+  it("updateToken leaves question_source untouched when question is not updated", async () => {
+    await createToken(db, {
+      slug: "unrelated-edit",
+      concept: "Provenance must survive unrelated edits",
+      question: "Generated?",
+      question_source: "llm",
+    });
+
+    const updated = await updateToken(db, "unrelated-edit", {
+      title: "A new title",
+    });
+
+    expect(updated.question_source).toBe("llm");
+  });
+
+  it("updateToken can reclassify provenance without touching the question", async () => {
+    await createToken(db, {
+      slug: "keep-this-one",
+      concept: "User wants to pin the current LLM question",
+      question: "A great generated question?",
+      question_source: "llm",
+    });
+
+    const updated = await updateToken(db, "keep-this-one", {
+      question_source: "manual",
+    });
+
+    expect(updated.question_source).toBe("manual");
+    expect(updated.question).toBe("A great generated question?");
+  });
+
+  it("migration backfills pre-provenance tokens as llm", async () => {
+    // Emulate a pre-M013 database: drop the column, then reopen so the
+    // migration re-adds it and backfills.
+    await createToken(db, {
+      slug: "legacy-token",
+      concept: "Existed before provenance tracking",
+      question: "A question of unknown origin?",
+    });
+    await db.exec("ALTER TABLE tokens DROP COLUMN question_source");
+    await db.close();
+
+    db = await openDatabase({
+      dbPath,
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+
+    const legacy = await getTokenBySlug(db, "legacy-token");
+    expect(legacy?.question_source).toBe("llm");
+  });
+
+  it("treats raw inserts without provenance as llm (old snapshot restores)", async () => {
+    // Old snapshots INSERT with an explicit column list that predates
+    // question_source, so restored rows must fall back to 'llm', not
+    // 'manual' — mirroring the migration backfill.
+    await db
+      .prepare(
+        `INSERT INTO tokens (id, slug, title, concept, domain, bloom_level, context, created_at, updated_at)
+         VALUES ('01LEGACY', 'restored-token', '', 'Restored from an old backup', 'testing', 1, '', '2026-01-01', '2026-01-01')`,
+      )
+      .run();
+
+    const restored = await getTokenBySlug(db, "restored-token");
+    expect(restored?.question_source).toBe("llm");
+  });
+
+  it("review queue items carry the question source", async () => {
+    const token = await createToken(db, {
+      slug: "queued",
+      concept: "Appears in the review queue",
+      domain: "testing",
+      question: "Hand-written question?",
+    });
+    await ensureCard(db, token.id, "thomas");
+
+    const queue = await buildReviewQueue(db, { userId: "thomas" });
+
+    expect(queue.items).toHaveLength(1);
+    expect(queue.items[0].questionSource).toBe("manual");
+  });
+});


### PR DESCRIPTION
## Summary

ADR 2026-06-15 item 3, with two design revisions decided during review. Ships as patch release 0.9.4: the core of the change corrects review-time behavior that misread the original intent (reviews persisting generated questions into the token).

- **Reviews never mutate content.** `ensureHighQualityQuestion()` no longer persists generated questions (the old "self-heal" write is removed). The stored question changes only through deliberate editing surfaces — Studio content editor, token CLI, imports.
- **Every review asks an ephemeral variation.** Generation is anchored on the stored question when one exists (same knowledge, fresh phrasing, so the wording cannot be memorized). The new `llm.dynamic_questions` setting (default on) disables the per-review LLM roundtrip for performance and serves the stored question verbatim.
- **`question_source` (migration M013) is pure provenance for curation** — it does not gate behavior. `manual` for human-authored questions (API question edits without a declared source default to it), `llm` for agent- (bridge/MCP `add-token`) and curriculum-authored questions, `template` reserved. The column default is `llm`, so pre-M013 rows and old snapshot restores classify as LLM-era content.
- Review queue items expose `questionSource` for future surfaces (e.g. a provenance badge on the check-in card).

Also isolates `tests/cli/bridge-handlers.test.ts` from the developer machine config via `ZAM_CONFIG_PATH` — it no longer depends on the host workspace knowledge context.

## Test plan

- `tests/kernel/question-source.test.ts` (10 tests): create/update provenance semantics, reclassification, migration backfill via drop-column round trip, raw-insert default (old-snapshot restore path), queue projection.
- `tests/cli/llm.test.ts`: variation is anchored on the stored question (request body assertion), never persisted; disabled setting serves the stored question verbatim without any LLM call.
- `tests/cli/bridge-handlers.test.ts`: end-to-end `getReviewsBatch` — fresh variations served, stored questions untouched; `addToken` marks agent questions as `llm`.
- Full suite: 616 passing; the 14 failing `tests/cli/{agent-harness,mcp}` tests fail identically on `main` (pre-existing environment issues). Biome clean, DTS build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)