### PR TITLE
feat: ship GitHub Copilot MCP Apps in 0.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ your work, and guiding you step by step. ZAM connects to the agent apps you alre
 | **Codex** | `zam agent connect codex` |
 | **Antigravity** | `zam agent connect antigravity` |
 | **OpenCode** | `zam agent connect opencode` |
-| **GitHub Copilot** | `zam agent connect copilot` |
+| **GitHub Copilot** (CLI / app) | `zam agent connect copilot` |
 | **Goose** | `zam agent connect goose` |
 
-One command writes the MCP config (your agent may ask you to approve the server). Then
-just type **`/zam`** — or say "let's do this together with ZAM" — and work normally.
+One command writes the MCP config (your agent may ask you to approve the server). For
+GitHub Copilot, it also installs user-scoped Studio, Recall, Graph, and Settings canvases;
+restart Copilot or start a new session after connecting. Then just type **`/zam`** — or
+say "let's do this together with ZAM" — and work normally.
 
 ### 2. ZAM Desktop Studio — *setup, content & graph*
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.10.0"
+version = "0.10.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.10.0"
+version = "0.10.2"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/desktop/src/panel/graph-layout.ts
+++ b/desktop/src/panel/graph-layout.ts
@@ -1,0 +1,158 @@
+export interface GraphLabelSource {
+  slug: string;
+  title?: string | null;
+  display_title?: string | null;
+}
+
+export interface GraphNodeBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface GraphPoint {
+  x: number;
+  y: number;
+}
+
+export interface GraphEdgeEndpoints {
+  start: GraphPoint;
+  end: GraphPoint;
+}
+
+const ACRONYMS = new Map([
+  ["ai", "AI"],
+  ["api", "API"],
+  ["cli", "CLI"],
+  ["css", "CSS"],
+  ["fsrs", "FSRS"],
+  ["html", "HTML"],
+  ["http", "HTTP"],
+  ["https", "HTTPS"],
+  ["id", "ID"],
+  ["json", "JSON"],
+  ["llm", "LLM"],
+  ["mcp", "MCP"],
+  ["sdk", "SDK"],
+  ["sql", "SQL"],
+  ["svg", "SVG"],
+  ["ui", "UI"],
+  ["url", "URL"],
+  ["ux", "UX"],
+  ["zam", "ZAM"],
+]);
+
+export function humanizeTokenSlug(slug: string): string {
+  return slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => {
+      const lower = word.toLowerCase();
+      return (
+        ACRONYMS.get(lower) ?? `${lower[0].toUpperCase()}${lower.slice(1)}`
+      );
+    })
+    .join(" ");
+}
+
+export function graphNodeTitle(node: GraphLabelSource): string {
+  const title = node.title?.trim();
+  if (title) return title;
+
+  const displayTitle = node.display_title?.trim();
+  return humanizeTokenSlug(displayTitle || node.slug);
+}
+
+function rebalanceLines(lines: string[], maxChars: number): string[] {
+  const balanced = [...lines];
+  for (let i = balanced.length - 2; i >= 0; i--) {
+    const words = balanced[i].split(" ");
+    if (words.length < 2) continue;
+
+    const moved = words[words.length - 1];
+    const shorter = words.slice(0, -1).join(" ");
+    const longer = `${moved} ${balanced[i + 1]}`;
+    const oldDifference = Math.abs(balanced[i].length - balanced[i + 1].length);
+    const newDifference = Math.abs(shorter.length - longer.length);
+    if (longer.length <= maxChars && newDifference < oldDifference) {
+      balanced[i] = shorter;
+      balanced[i + 1] = longer;
+    }
+  }
+  return balanced;
+}
+
+function ellipsize(text: string, maxChars: number): string {
+  if (maxChars <= 1) return "…";
+  return `${text.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
+export function wrapGraphLabel(
+  label: string,
+  maxChars = 20,
+  maxLines = 3,
+): string[] {
+  const lineWidth = Math.max(2, Math.floor(maxChars));
+  const lineLimit = Math.max(1, Math.floor(maxLines));
+  const normalized = label.trim().replace(/\s+/g, " ");
+  if (!normalized) return [""];
+
+  const chunks: string[] = [];
+  for (const word of normalized.split(" ")) {
+    for (let offset = 0; offset < word.length; offset += lineWidth) {
+      chunks.push(word.slice(offset, offset + lineWidth));
+    }
+  }
+
+  const lines: string[] = [];
+  for (const chunk of chunks) {
+    const current = lines[lines.length - 1];
+    if (!current || current.length + 1 + chunk.length > lineWidth) {
+      lines.push(chunk);
+    } else {
+      lines[lines.length - 1] = `${current} ${chunk}`;
+    }
+  }
+
+  if (lines.length <= lineLimit) {
+    return rebalanceLines(lines, lineWidth);
+  }
+
+  const visible = lines.slice(0, lineLimit);
+  visible[lineLimit - 1] = ellipsize(
+    lines.slice(lineLimit - 1).join(" "),
+    lineWidth,
+  );
+  return visible;
+}
+
+function boundaryPoint(
+  node: GraphNodeBounds,
+  toward: GraphPoint,
+  gap: number,
+): GraphPoint {
+  const dx = toward.x - node.x;
+  const dy = toward.y - node.y;
+  if (dx === 0 && dy === 0) return { x: node.x, y: node.y };
+
+  const halfWidth = node.width / 2 + gap;
+  const halfHeight = node.height / 2 + gap;
+  const scale =
+    1 / Math.max(Math.abs(dx) / halfWidth, Math.abs(dy) / halfHeight);
+  return {
+    x: node.x + dx * scale,
+    y: node.y + dy * scale,
+  };
+}
+
+export function graphEdgeEndpoints(
+  from: GraphNodeBounds,
+  to: GraphNodeBounds,
+  gap = 4,
+): GraphEdgeEndpoints {
+  return {
+    start: boundaryPoint(from, to, gap),
+    end: boundaryPoint(to, from, gap),
+  };
+}

--- a/desktop/src/panel/graph-panel.html
+++ b/desktop/src/panel/graph-panel.html
@@ -186,8 +186,11 @@
         display: block;
       }
       .graph-edge {
-        stroke-width: 1.6;
-        opacity: 0.75;
+        stroke-width: 2;
+        stroke-linecap: round;
+        opacity: 0.58;
+        pointer-events: none;
+        vector-effect: non-scaling-stroke;
       }
       .graph-node-rect {
         stroke-width: 1.6;

--- a/desktop/src/panel/graph.ts
+++ b/desktop/src/panel/graph.ts
@@ -4,7 +4,7 @@
  * Renders the 1-hop neighborhood (prerequisites below, dependents above)
  * around a focus token as a plain SVG diagram — no Three.js, no libraries.
  * Clicking a neighbor re-centers the graph on it (click-to-recenter); a
- * breadcrumb of the last 5 focus slugs enables going back.
+ * breadcrumb of the last 5 focus titles enables going back.
  *
  * Standalone by design (tests/desktop/module-boundaries.test.ts): no Tauri,
  * no Three.js, no import from ./panel.ts or ./recall.ts. The result-parsing
@@ -13,6 +13,12 @@
  */
 
 import { App } from "@modelcontextprotocol/ext-apps";
+import {
+  type GraphNodeBounds,
+  graphEdgeEndpoints,
+  graphNodeTitle,
+  wrapGraphLabel,
+} from "./graph-layout.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -25,7 +31,10 @@ const DEPENDENT_RADIUS = 145;
 const NODE_HEIGHT = 38;
 const NODE_MIN_WIDTH = 64;
 const NODE_PAD_X = 14;
-const LABEL_MAX_CHARS = 20;
+const NODE_PAD_Y = 8;
+const LABEL_MAX_CHARS_PER_LINE = 20;
+const LABEL_MAX_LINES = 3;
+const LABEL_LINE_HEIGHT = 14;
 const HISTORY_LIMIT = 5;
 
 const statusEl = document.getElementById("zam-status");
@@ -87,8 +96,8 @@ let currentUser: string | null = null;
 let connected = false;
 let started = false;
 let initialFocus: string | null = null;
-/** Last up to HISTORY_LIMIT focus slugs, most-recent last (current focus). */
-let history: string[] = [];
+/** Last up to HISTORY_LIMIT focuses, most-recent last (current focus). */
+let history: Array<{ slug: string; title: string }> = [];
 
 /**
  * Parse a zam MCP tool result: success answers carry JSON on content[0].text
@@ -175,10 +184,6 @@ function renderError(message: string): void {
   renderMessage("⚠️", "Graph konnte nicht geladen werden", message);
 }
 
-function truncateLabel(text: string, max = LABEL_MAX_CHARS): string {
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
-}
-
 function bloomStep(level: number): number {
   return Math.min(5, Math.max(1, Math.round(level) || 1));
 }
@@ -188,14 +193,17 @@ function bloomStep(level: number): number {
  * rendered SVG document — callers must append it first. The character-width
  * fallback guards hosts where getBBox throws or returns zero before layout.
  */
-function measureTextWidth(text: SVGTextElement): number {
+function measureTextWidth(
+  text: SVGTextElement,
+  lines: readonly string[],
+): number {
   try {
     const box = text.getBBox();
     if (box.width > 0) return box.width;
   } catch {
     // Fall through to the estimate below.
   }
-  return (text.textContent?.length ?? 0) * 6.4;
+  return Math.max(...lines.map((line) => line.length)) * 6.4;
 }
 
 type NodeKind = "center" | "prereq" | "dependent";
@@ -207,7 +215,7 @@ function createNode(
   y: number,
   kind: NodeKind,
   onSelect: (slug: string) => void,
-): void {
+): GraphNodeBounds {
   const g = document.createElementNS(SVG_NS, "g");
   g.setAttribute("transform", `translate(${x}, ${y})`);
   g.setAttribute(
@@ -221,17 +229,37 @@ function createNode(
 
   const text = document.createElementNS(SVG_NS, "text");
   text.setAttribute("text-anchor", "middle");
-  text.setAttribute("dominant-baseline", "middle");
+  text.setAttribute("dominant-baseline", "central");
   text.setAttribute("class", "graph-node-label");
-  text.textContent = truncateLabel(node.display_title || node.slug);
+  const labelLines = wrapGraphLabel(
+    graphNodeTitle(node),
+    LABEL_MAX_CHARS_PER_LINE,
+    LABEL_MAX_LINES,
+  );
+  labelLines.forEach((line, index) => {
+    const tspan = document.createElementNS(SVG_NS, "tspan");
+    tspan.setAttribute("x", "0");
+    tspan.setAttribute(
+      "dy",
+      String(
+        index === 0
+          ? -((labelLines.length - 1) * LABEL_LINE_HEIGHT) / 2
+          : LABEL_LINE_HEIGHT,
+      ),
+    );
+    tspan.textContent = line;
+    text.appendChild(tspan);
+  });
   g.appendChild(text);
 
   // Attach before measuring (see measureTextWidth doc comment).
   container.appendChild(g);
-  const textWidth = measureTextWidth(text);
+  const textWidth = measureTextWidth(text, labelLines);
 
   const width = Math.max(NODE_MIN_WIDTH, textWidth + NODE_PAD_X * 2);
-  const height = kind === "center" ? NODE_HEIGHT * 1.15 : NODE_HEIGHT;
+  const contentHeight = labelLines.length * LABEL_LINE_HEIGHT + NODE_PAD_Y * 2;
+  const height =
+    Math.max(NODE_HEIGHT, contentHeight) * (kind === "center" ? 1.15 : 1);
   const step = bloomStep(node.bloomLevel);
 
   const rect = document.createElementNS(SVG_NS, "rect");
@@ -269,6 +297,8 @@ function createNode(
     g.style.cursor = "pointer";
     g.addEventListener("click", () => onSelect(node.slug));
   }
+
+  return { x, y, width, height };
 }
 
 /** Evenly fan `count` nodes across an arc above (-1) or below (+1) center. */
@@ -302,7 +332,7 @@ function renderGraph(nb: Neighborhood, onSelect: (slug: string) => void): void {
   svg.setAttribute("viewBox", `0 0 ${VIEW_W} ${VIEW_H}`);
   svg.setAttribute("class", "graph-svg");
   svg.setAttribute("role", "img");
-  const label = nb.center.display_title || nb.center.slug;
+  const label = graphNodeTitle(nb.center);
   svg.setAttribute("aria-label", `Knowledge graph centered on ${label}`);
   wrap.appendChild(svg);
 
@@ -314,17 +344,6 @@ function renderGraph(nb: Neighborhood, onSelect: (slug: string) => void): void {
   nodesGroup.setAttribute("class", "graph-nodes");
   svg.appendChild(nodesGroup);
 
-  function drawEdge(x: number, y: number, colorVar: string): void {
-    const line = document.createElementNS(SVG_NS, "line");
-    line.setAttribute("x1", String(CENTER_X));
-    line.setAttribute("y1", String(CENTER_Y));
-    line.setAttribute("x2", String(x));
-    line.setAttribute("y2", String(y));
-    line.setAttribute("class", "graph-edge");
-    line.style.stroke = colorVar;
-    edgesGroup.appendChild(line);
-  }
-
   const prereqPositions = nb.prerequisites.map((_, i) =>
     arcPosition(i, nb.prerequisites.length, PREREQ_RADIUS, 1),
   );
@@ -332,30 +351,49 @@ function renderGraph(nb: Neighborhood, onSelect: (slug: string) => void): void {
     arcPosition(i, nb.dependents.length, DEPENDENT_RADIUS, -1),
   );
 
-  prereqPositions.forEach(({ x, y }) => {
-    drawEdge(x, y, "var(--prereq)");
-  });
-  depPositions.forEach(({ x, y }) => {
-    drawEdge(x, y, "var(--dependent)");
-  });
-
-  nb.prerequisites.forEach((node, i) => {
+  const prerequisiteNodes = nb.prerequisites.map((node, i) => {
     const { x, y } = prereqPositions[i];
-    createNode(nodesGroup, node, x, y, "prereq", onSelect);
+    return createNode(nodesGroup, node, x, y, "prereq", onSelect);
   });
-  nb.dependents.forEach((node, i) => {
+  const dependentNodes = nb.dependents.map((node, i) => {
     const { x, y } = depPositions[i];
-    createNode(nodesGroup, node, x, y, "dependent", onSelect);
+    return createNode(nodesGroup, node, x, y, "dependent", onSelect);
   });
-  // Center drawn last so it renders above any crossing edges.
-  createNode(nodesGroup, nb.center, CENTER_X, CENTER_Y, "center", onSelect);
+  const centerNode = createNode(
+    nodesGroup,
+    nb.center,
+    CENTER_X,
+    CENTER_Y,
+    "center",
+    onSelect,
+  );
+
+  function drawEdge(target: GraphNodeBounds, colorVar: string): void {
+    const { start, end } = graphEdgeEndpoints(centerNode, target);
+    const line = document.createElementNS(SVG_NS, "line");
+    line.setAttribute("x1", String(start.x));
+    line.setAttribute("y1", String(start.y));
+    line.setAttribute("x2", String(end.x));
+    line.setAttribute("y2", String(end.y));
+    line.setAttribute("class", "graph-edge");
+    line.setAttribute("aria-hidden", "true");
+    line.style.stroke = colorVar;
+    edgesGroup.appendChild(line);
+  }
+
+  prerequisiteNodes.forEach((node) => {
+    drawEdge(node, "var(--prereq)");
+  });
+  dependentNodes.forEach((node) => {
+    drawEdge(node, "var(--dependent)");
+  });
 }
 
 function renderBreadcrumb(onSelect: (slug: string) => void): void {
   if (!breadcrumbEl) return;
   breadcrumbEl.replaceChildren();
   if (history.length <= 1) return; // nothing to go back to yet
-  history.forEach((slug, i) => {
+  history.forEach((entry, i) => {
     if (i > 0) {
       const sep = document.createElement("span");
       sep.className = "graph-crumb-sep";
@@ -365,22 +403,25 @@ function renderBreadcrumb(onSelect: (slug: string) => void): void {
     if (i === history.length - 1) {
       const current = document.createElement("span");
       current.className = "graph-crumb-current";
-      current.textContent = slug;
+      current.textContent = entry.title;
       breadcrumbEl.appendChild(current);
     } else {
       const btn = document.createElement("button");
       btn.type = "button";
       btn.className = "graph-crumb-link";
-      btn.textContent = slug;
-      btn.addEventListener("click", () => onSelect(slug));
+      btn.textContent = entry.title;
+      btn.addEventListener("click", () => onSelect(entry.slug));
       breadcrumbEl.appendChild(btn);
     }
   });
 }
 
-function pushHistory(slug: string): void {
-  if (history[history.length - 1] === slug) return;
-  history = [...history, slug].slice(-HISTORY_LIMIT);
+function pushHistory(slug: string, title: string): void {
+  if (history[history.length - 1]?.slug === slug) {
+    history[history.length - 1] = { slug, title };
+    return;
+  }
+  history = [...history, { slug, title }].slice(-HISTORY_LIMIT);
 }
 
 async function navigateTo(slug: string): Promise<void> {
@@ -391,7 +432,7 @@ async function navigateTo(slug: string): Promise<void> {
       cmd: "get-neighborhood",
       args,
     })) as Neighborhood;
-    pushHistory(data.focus);
+    pushHistory(data.focus, graphNodeTitle(data.center));
     renderBreadcrumb((s) => void navigateTo(s));
     renderGraph(data, (s) => void navigateTo(s));
     pushContext(data);

--- a/docs/plans/2026-07-08-mcp-apps-studio-panel.md
+++ b/docs/plans/2026-07-08-mcp-apps-studio-panel.md
@@ -302,6 +302,17 @@ the usual flow: release/x.y.z branch, 7-file version bump, merge commit
 follow-ups list above; the locale decision (mixed de/en on non-de
 hosts) is accepted for 0.10.0.
 
+**GitHub Copilot app resolution (2026-07-11, v0.10.2):** Copilot connects
+the ZAM MCP server but does not mount the advertised `ui://` resources when
+the opening tools are called directly. `zam agent connect copilot` now also
+installs a user-scoped Copilot canvas extension that hosts the original four
+MCP Apps through the official `AppBridge`; it does not duplicate their UI or
+enter the repository as a project extension. The installer respects
+`COPILOT_HOME` and records an absolute Node + CLI-entry launch on packaged
+installs, avoiding npm `.cmd` process-launch issues on Windows. The 2D Graph
+also uses explicit/readable titles and clips relationship lines to measured
+node boundaries so they cannot cross labels.
+
 ## Verification
 
 - `tests/cli/mcp.test.ts`: `resources/list` contains `ui://zam/studio`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "zam": "dist/cli/index.js"
   },
   "scripts": {
-    "build": "tsup && npm run build:panel",
+    "build": "tsup && npm run build:panel && npm run build:copilot-extension",
+    "build:copilot-extension": "tsup --config tsup.config.copilot-extension.ts && vite build --config vite.config.copilot-extension.mts && node scripts/prepare-copilot-extension.mjs",
     "build:panel": "vite build --config vite.config.panel.mts && vite build --config vite.config.panel.mts --mode recall && vite build --config vite.config.panel.mts --mode graph && vite build --config vite.config.panel.mts --mode settings",
     "prepare": "npm run build",
     "dev": "tsx src/cli/index.ts",

--- a/scripts/prepare-copilot-extension.mjs
+++ b/scripts/prepare-copilot-extension.mjs
@@ -1,0 +1,49 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = join(repoRoot, "src", "copilot-extension");
+const destinationDir = join(repoRoot, "dist", "copilot-extension");
+const packageJson = JSON.parse(
+  readFileSync(join(repoRoot, "package.json"), "utf8"),
+);
+const version = packageJson.version;
+
+mkdirSync(destinationDir, { recursive: true });
+
+for (const bundle of ["host.bundle.js", "mcp-client.bundle.mjs"]) {
+  if (!existsSync(join(destinationDir, bundle))) {
+    throw new Error(`Copilot extension bundle is missing: ${bundle}`);
+  }
+}
+
+for (const file of [
+  "extension.mjs",
+  "host.bundle.js",
+  "mcp-client.bundle.mjs",
+]) {
+  const source =
+    file === "extension.mjs"
+      ? join(sourceDir, file)
+      : join(destinationDir, file);
+  const content = readFileSync(source, "utf8").replaceAll(
+    "__ZAM_VERSION__",
+    version,
+  );
+  writeFileSync(join(destinationDir, file), content, "utf8");
+}
+
+writeFileSync(
+  join(destinationDir, "manifest.json"),
+  `${JSON.stringify(
+    {
+      name: "zam-mcp-apps",
+      version,
+      files: ["extension.mjs", "host.bundle.js", "mcp-client.bundle.mjs"],
+    },
+    null,
+    2,
+  )}\n`,
+  "utf8",
+);

--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -226,6 +226,7 @@ export function connectHarnessMcp(
     zamPath: string;
     cwd: string;
     home: string;
+    copilotHome?: string;
     readFile?: (path: string) => string;
     platform?: NodeJS.Platform;
   },
@@ -396,9 +397,12 @@ approval_mode = "prompt"
       content = `extensions:\n${zamExtension}\n`;
     }
   } else if (harnessId === "copilot") {
-    targetPath = join(opts.home, ".copilot", "mcp-config.json");
+    targetPath = join(
+      opts.copilotHome ?? join(opts.home, ".copilot"),
+      "mcp-config.json",
+    );
     hint =
-      "GitHub Copilot CLI will load the 'zam' MCP server on next session. Use '/mcp show' in Copilot CLI to verify.";
+      "Restart GitHub Copilot or start a new session to load the 'zam' MCP server and its Studio, Recall, Graph, and Settings canvases.";
     let existing: McpJsonConfig = {};
     if (exists(targetPath)) {
       existing = parseMcpJsonConfig(targetPath, read(targetPath));

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -28,6 +28,10 @@ import {
   launchHarness,
   resolveHarnessExecutable,
 } from "../agent-harness.js";
+import {
+  type CopilotExtensionInstallResult,
+  installCopilotExtension,
+} from "../copilot-extension.js";
 import { findExecutable, normalizeShell } from "../terminal-open.js";
 
 const C = {
@@ -228,6 +232,7 @@ const connectCmd = new Command("connect")
         zamPath,
         cwd: process.cwd(),
         home: homedir(),
+        copilotHome: process.env.COPILOT_HOME,
       });
     } catch (error) {
       console.error(
@@ -236,9 +241,31 @@ const connectCmd = new Command("connect")
       process.exit(1);
     }
 
+    let copilotExtension: CopilotExtensionInstallResult | undefined;
+    if (harnessArg === "copilot") {
+      try {
+        copilotExtension = installCopilotExtension({
+          home: homedir(),
+          zamPath,
+          dryRun: Boolean(opts.print),
+        });
+      } catch (error) {
+        console.error(
+          `Error preparing Copilot MCP Apps extension: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    }
+
     if (opts.print) {
       console.log(`Path: ${result.path}`);
       console.log(`Content:\n${result.content}`);
+      if (copilotExtension) {
+        console.log(`Extension: ${copilotExtension.destinationDir}`);
+        console.log(
+          `Launch: ${copilotExtension.launch.command} ${copilotExtension.launch.args.join(" ")}`,
+        );
+      }
       return;
     }
 
@@ -246,6 +273,12 @@ const connectCmd = new Command("connect")
       console.log(
         `${C.green}✓${C.reset} MCP server 'zam' already configured in ${result.path}`,
       );
+      if (copilotExtension) {
+        console.log(
+          `${C.green}✓${C.reset} MCP Apps extension ${copilotExtension.action} at ${copilotExtension.destinationDir}`,
+        );
+      }
+      console.log(`  ${C.dim}${result.hint}${C.reset}`);
       return;
     }
 
@@ -255,6 +288,11 @@ const connectCmd = new Command("connect")
       console.log(
         `${C.green}✓${C.reset} Wrote MCP configuration to ${result.path}`,
       );
+      if (copilotExtension) {
+        console.log(
+          `${C.green}✓${C.reset} MCP Apps extension ${copilotExtension.action} at ${copilotExtension.destinationDir}`,
+        );
+      }
       console.log(`  ${C.dim}${result.hint}${C.reset}`);
     } catch (error) {
       console.error(

--- a/src/cli/copilot-extension.ts
+++ b/src/cli/copilot-extension.ts
@@ -1,0 +1,182 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const EXTENSION_NAME = "zam-mcp-apps";
+const EXTENSION_FILES = [
+  "extension.mjs",
+  "host.bundle.js",
+  "mcp-client.bundle.mjs",
+  "manifest.json",
+] as const;
+
+const packageRoot =
+  [
+    fileURLToPath(new URL("../..", import.meta.url)),
+    fileURLToPath(new URL("../../..", import.meta.url)),
+  ].find((candidate) => existsSync(join(candidate, "package.json"))) ??
+  fileURLToPath(new URL("../..", import.meta.url));
+
+export interface CopilotExtensionLaunch {
+  command: string;
+  args: string[];
+}
+
+export interface CopilotExtensionPlan {
+  sourceDir: string;
+  destinationDir: string;
+  launch: CopilotExtensionLaunch;
+  files: readonly string[];
+}
+
+export type CopilotExtensionInstallAction =
+  | "installed"
+  | "updated"
+  | "unchanged"
+  | "planned";
+
+export interface CopilotExtensionInstallResult extends CopilotExtensionPlan {
+  action: CopilotExtensionInstallAction;
+  changedFiles: string[];
+}
+
+export interface CopilotExtensionOptions {
+  home?: string;
+  copilotHome?: string;
+  assetsDir?: string;
+  zamPath: string;
+  nodePath?: string;
+  cliEntry?: string;
+  dryRun?: boolean;
+}
+
+function defaultCliEntry(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "index.js");
+}
+
+export function resolveCopilotHome(
+  home = homedir(),
+  configuredHome = process.env.COPILOT_HOME,
+): string {
+  return configuredHome?.trim()
+    ? resolve(configuredHome)
+    : join(home, ".copilot");
+}
+
+export function resolveCopilotZamLaunch(
+  zamPath: string,
+  options: Pick<CopilotExtensionOptions, "cliEntry" | "nodePath"> = {},
+): CopilotExtensionLaunch {
+  const cliEntry = options.cliEntry ?? defaultCliEntry();
+  if (existsSync(cliEntry)) {
+    return {
+      command: options.nodePath ?? process.execPath,
+      args: [cliEntry, "mcp"],
+    };
+  }
+  return {
+    command: zamPath,
+    args: ["mcp"],
+  };
+}
+
+export function planCopilotExtensionInstall(
+  options: CopilotExtensionOptions,
+): CopilotExtensionPlan {
+  const sourceDir =
+    options.assetsDir ?? join(packageRoot, "dist", "copilot-extension");
+  for (const file of EXTENSION_FILES) {
+    if (!existsSync(join(sourceDir, file))) {
+      throw new Error(
+        `Copilot MCP Apps asset is missing: ${join(sourceDir, file)}. Run \`npm run build\` and retry.`,
+      );
+    }
+  }
+
+  const manifest = JSON.parse(
+    readFileSync(join(sourceDir, "manifest.json"), "utf8"),
+  ) as { name?: unknown; version?: unknown };
+  if (
+    manifest.name !== EXTENSION_NAME ||
+    typeof manifest.version !== "string" ||
+    !manifest.version
+  ) {
+    throw new Error(
+      `Invalid Copilot MCP Apps manifest: ${join(sourceDir, "manifest.json")}`,
+    );
+  }
+
+  const copilotHome = resolveCopilotHome(
+    options.home,
+    options.copilotHome ?? process.env.COPILOT_HOME,
+  );
+  return {
+    sourceDir,
+    destinationDir: join(copilotHome, "extensions", EXTENSION_NAME),
+    launch: resolveCopilotZamLaunch(options.zamPath, options),
+    files: EXTENSION_FILES,
+  };
+}
+
+function writeIfChanged(path: string, content: Buffer | string): boolean {
+  const next = Buffer.isBuffer(content) ? content : Buffer.from(content);
+  if (existsSync(path) && readFileSync(path).equals(next)) return false;
+  writeFileSync(path, next);
+  return true;
+}
+
+export function installCopilotExtension(
+  options: CopilotExtensionOptions,
+): CopilotExtensionInstallResult {
+  const plan = planCopilotExtensionInstall(options);
+  if (options.dryRun) {
+    return { ...plan, action: "planned", changedFiles: [] };
+  }
+
+  const destinationExisted = existsSync(plan.destinationDir);
+  if (destinationExisted && lstatSync(plan.destinationDir).isSymbolicLink()) {
+    throw new Error(
+      `Refusing to replace symlinked Copilot extension directory: ${plan.destinationDir}`,
+    );
+  }
+  mkdirSync(plan.destinationDir, { recursive: true });
+
+  const changedFiles: string[] = [];
+  for (const file of plan.files) {
+    const source = join(plan.sourceDir, file);
+    const destination = join(plan.destinationDir, file);
+    if (writeIfChanged(destination, readFileSync(source))) {
+      changedFiles.push(file);
+    }
+  }
+
+  const launchContent = `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      command: plan.launch.command,
+      args: plan.launch.args,
+    },
+    null,
+    2,
+  )}\n`;
+  if (writeIfChanged(join(plan.destinationDir, "launch.json"), launchContent)) {
+    changedFiles.push("launch.json");
+  }
+
+  return {
+    ...plan,
+    action: !destinationExisted
+      ? "installed"
+      : changedFiles.length > 0
+        ? "updated"
+        : "unchanged",
+    changedFiles,
+  };
+}

--- a/src/copilot-extension/extension.mjs
+++ b/src/copilot-extension/extension.mjs
@@ -1,0 +1,520 @@
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CanvasError,
+  createCanvas,
+  joinSession,
+} from "@github/copilot-sdk/extension";
+import { connectZam } from "./mcp-client.bundle.mjs";
+
+const extensionDir = dirname(fileURLToPath(import.meta.url));
+const hostBundlePromise = readFile(
+  join(extensionDir, "host.bundle.js"),
+  "utf8",
+);
+
+const APP_CONFIG = {
+  studio: {
+    title: "ZAM Studio",
+    toolName: "zam_open_studio",
+    allowedTools: new Set(["zam_studio_bridge"]),
+  },
+  recall: {
+    title: "ZAM Recall",
+    toolName: "zam_open_recall",
+    allowedTools: new Set(["zam_get_reviews", "zam_submit_review"]),
+  },
+  graph: {
+    title: "ZAM Graph",
+    toolName: "zam_show_graph",
+    allowedTools: new Set(["zam_studio_bridge"]),
+  },
+  settings: {
+    title: "ZAM Settings",
+    toolName: "zam_open_settings",
+    allowedTools: new Set(["zam_studio_bridge"]),
+  },
+};
+
+const servers = new Map();
+const modelContexts = new Map();
+let mcpConnectionPromise;
+
+async function getLaunchConfig() {
+  if (process.env.ZAM_BIN) {
+    return { command: process.env.ZAM_BIN, args: ["mcp"] };
+  }
+
+  const path = join(extensionDir, "launch.json");
+  const config = JSON.parse(await readFile(path, "utf8"));
+  if (
+    !config ||
+    typeof config.command !== "string" ||
+    !Array.isArray(config.args) ||
+    !config.args.every((arg) => typeof arg === "string")
+  ) {
+    throw new Error(`Invalid ZAM launch configuration: ${path}`);
+  }
+  return { command: config.command, args: config.args };
+}
+
+async function getMcpClient() {
+  if (!mcpConnectionPromise) {
+    mcpConnectionPromise = getLaunchConfig()
+      .then(connectZam)
+      .catch((error) => {
+        mcpConnectionPromise = undefined;
+        throw error;
+      });
+  }
+  return (await mcpConnectionPromise).client;
+}
+
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
+}
+
+function buildToolArguments(kind, input) {
+  const common = { user: input?.user };
+  if (kind === "recall") {
+    return compactObject({ ...common, domain: input?.domain });
+  }
+  if (kind === "graph") {
+    return compactObject({ ...common, focus: input?.focus });
+  }
+  return compactObject(common);
+}
+
+function toolUiResourceUri(tool) {
+  const nested = tool?._meta?.ui?.resourceUri;
+  const legacy = tool?._meta?.["ui/resourceUri"];
+  return typeof nested === "string"
+    ? nested
+    : typeof legacy === "string"
+      ? legacy
+      : undefined;
+}
+
+async function prepareApp(kind, input) {
+  const config = APP_CONFIG[kind];
+  const client = await getMcpClient();
+  const { tools } = await client.listTools();
+  const tool = tools.find((candidate) => candidate.name === config.toolName);
+  if (!tool) {
+    throw new Error(`ZAM MCP tool not found: ${config.toolName}`);
+  }
+
+  const resourceUri = toolUiResourceUri(tool);
+  if (!resourceUri) {
+    throw new Error(
+      `${config.toolName} does not advertise an MCP App resource`,
+    );
+  }
+
+  const toolArguments = buildToolArguments(kind, input);
+  const [toolResult, resourceResult] = await Promise.all([
+    client.callTool({
+      name: config.toolName,
+      arguments: toolArguments,
+    }),
+    client.readResource({ uri: resourceUri }),
+  ]);
+
+  if (toolResult.isError) {
+    const text = toolResult.content?.find((item) => item.type === "text")?.text;
+    throw new Error(text || `${config.toolName} failed`);
+  }
+
+  const resource =
+    resourceResult.contents?.find((item) => item.uri === resourceUri) ??
+    resourceResult.contents?.[0];
+  const appHtml =
+    typeof resource?.text === "string"
+      ? resource.text
+      : typeof resource?.blob === "string"
+        ? Buffer.from(resource.blob, "base64").toString("utf8")
+        : "";
+  if (!appHtml) {
+    throw new Error(`MCP App resource is empty: ${resourceUri}`);
+  }
+
+  return {
+    appHtml,
+    config,
+    kind,
+    resourceUri,
+    tool,
+    toolArguments,
+    toolResult,
+  };
+}
+
+function send(response, status, contentType, body, headers = {}) {
+  response.writeHead(status, {
+    "Cache-Control": "no-store",
+    "Content-Type": contentType,
+    "X-Content-Type-Options": "nosniff",
+    ...headers,
+  });
+  response.end(body);
+}
+
+function sendJson(response, status, value) {
+  send(
+    response,
+    status,
+    "application/json; charset=utf-8",
+    JSON.stringify(value),
+  );
+}
+
+function sendError(response, error, status = 500) {
+  sendJson(response, status, {
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
+
+async function readJsonBody(request) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of request) {
+    size += chunk.length;
+    if (size > 1_000_000) {
+      throw new Error("Request body exceeds 1 MB");
+    }
+    chunks.push(chunk);
+  }
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text ? JSON.parse(text) : {};
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function renderHostHtml(title) {
+  const escapedTitle = escapeHtml(title);
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapedTitle}</title>
+    <style>
+      :root { color-scheme: light dark; }
+      * { box-sizing: border-box; }
+      html, body { width: 100%; height: 100%; margin: 0; }
+      body {
+        overflow: hidden;
+        background: var(--background-color-default, Canvas);
+        color: var(--text-color-default, CanvasText);
+        font-family: var(--font-sans, system-ui, sans-serif);
+      }
+      #status {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        color: var(--text-color-muted, #656d76);
+        font-size: var(--text-body-medium, 14px);
+      }
+      #app {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        background: transparent;
+      }
+      body.ready #status { display: none; }
+    </style>
+  </head>
+  <body>
+    <div id="status" role="status">Connecting MCP App...</div>
+    <iframe
+      id="app"
+      title="${escapedTitle}"
+      sandbox="allow-scripts allow-forms"
+    ></iframe>
+    <script type="module" src="/host.bundle.js"></script>
+  </body>
+</html>`;
+}
+
+async function startServer(instanceId, app) {
+  const hostBundle = await hostBundlePromise;
+  const client = await getMcpClient();
+  const hostStatus = { phase: "server-ready" };
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url || "/", "http://127.0.0.1");
+    try {
+      if (request.method === "GET" && url.pathname === "/") {
+        send(
+          response,
+          200,
+          "text/html; charset=utf-8",
+          renderHostHtml(app.config.title),
+          {
+            "Content-Security-Policy":
+              "default-src 'none'; script-src 'self'; frame-src 'self'; connect-src 'self'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'",
+          },
+        );
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/host.bundle.js") {
+        send(response, 200, "text/javascript; charset=utf-8", hostBundle);
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/app") {
+        send(response, 200, "text/html; charset=utf-8", app.appHtml);
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/api/bootstrap") {
+        sendJson(response, 200, {
+          resourceUri: app.resourceUri,
+          title: app.config.title,
+          tool: app.tool,
+          toolArguments: app.toolArguments,
+          toolResult: app.toolResult,
+        });
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/api/tool") {
+        const body = await readJsonBody(request);
+        if (
+          typeof body.name !== "string" ||
+          !app.config.allowedTools.has(body.name)
+        ) {
+          sendError(
+            response,
+            new Error(`Tool is not allowed for ${app.kind}: ${body.name}`),
+            403,
+          );
+          return;
+        }
+        const result = await client.callTool({
+          name: body.name,
+          arguments:
+            body.arguments &&
+            typeof body.arguments === "object" &&
+            !Array.isArray(body.arguments)
+              ? body.arguments
+              : {},
+        });
+        sendJson(response, 200, result);
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/api/model-context") {
+        const body = await readJsonBody(request);
+        modelContexts.set(instanceId, body);
+        sendJson(response, 200, {});
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/api/host-status") {
+        const body = await readJsonBody(request);
+        Object.assign(hostStatus, body, {
+          updatedAt: new Date().toISOString(),
+        });
+        sendJson(response, 200, {});
+        return;
+      }
+      sendJson(response, 404, { error: "Not found" });
+    } catch (error) {
+      sendError(response, error);
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    app,
+    hostStatus,
+    server,
+    url: `http://127.0.0.1:${port}/`,
+  };
+}
+
+async function openApp(kind, context) {
+  let entry = servers.get(context.instanceId);
+  if (!entry) {
+    try {
+      const app = await prepareApp(kind, context.input ?? {});
+      entry = await startServer(context.instanceId, app);
+      servers.set(context.instanceId, entry);
+    } catch (error) {
+      throw new CanvasError(
+        "zam_mcp_app_open_failed",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+  return {
+    title: APP_CONFIG[kind].title,
+    status: `Connected via ${entry.app.resourceUri}`,
+    url: entry.url,
+  };
+}
+
+async function closeApp(context) {
+  const entry = servers.get(context.instanceId);
+  if (!entry) return;
+  servers.delete(context.instanceId);
+  modelContexts.delete(context.instanceId);
+  await new Promise((resolve) => entry.server.close(resolve));
+}
+
+const commonInputProperties = {
+  user: {
+    type: "string",
+    description: "ZAM user ID; defaults to the configured ZAM identity.",
+  },
+};
+
+function connectionStatusAction() {
+  return {
+    name: "connection_status",
+    description:
+      "Report whether the embedded ZAM MCP App completed its host handshake.",
+    handler: (context) => {
+      const entry = servers.get(context.instanceId);
+      if (!entry) {
+        throw new CanvasError(
+          "zam_mcp_app_not_open",
+          "This ZAM MCP App canvas is not open.",
+        );
+      }
+      return {
+        ...entry.hostStatus,
+        resourceUri: entry.app.resourceUri,
+        toolName: entry.app.config.toolName,
+      };
+    },
+  };
+}
+
+let shutdownPromise;
+
+function shutdown() {
+  if (!shutdownPromise) {
+    shutdownPromise = (async () => {
+      const entries = [...servers.values()];
+      servers.clear();
+      modelContexts.clear();
+      await Promise.all(
+        entries.map(
+          (entry) => new Promise((resolve) => entry.server.close(resolve)),
+        ),
+      );
+      if (mcpConnectionPromise) {
+        const connection = await mcpConnectionPromise.catch(() => undefined);
+        await connection?.client.close().catch(() => {});
+      }
+    })();
+  }
+  return shutdownPromise;
+}
+
+function exitAfterShutdown() {
+  void shutdown().finally(() => process.exit(0));
+}
+
+process.once("SIGTERM", exitAfterShutdown);
+process.once("SIGINT", exitAfterShutdown);
+
+await joinSession({
+  canvases: [
+    createCanvas({
+      id: "zam-studio",
+      displayName: "ZAM Studio",
+      description:
+        "Open the original ZAM Studio MCP App in a hosted Copilot canvas.",
+      inputSchema: {
+        type: "object",
+        properties: commonInputProperties,
+        additionalProperties: false,
+      },
+      actions: [connectionStatusAction()],
+      open: (context) => openApp("studio", context),
+      onClose: closeApp,
+    }),
+    createCanvas({
+      id: "zam-recall",
+      displayName: "ZAM Recall",
+      description:
+        "Open the original spoiler-free ZAM Recall MCP App in a hosted Copilot canvas.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ...commonInputProperties,
+          domain: {
+            type: "string",
+            description: "Optional domain prefix for the recall queue.",
+          },
+        },
+        additionalProperties: false,
+      },
+      actions: [connectionStatusAction()],
+      open: (context) => openApp("recall", context),
+      onClose: closeApp,
+    }),
+    createCanvas({
+      id: "zam-graph",
+      displayName: "ZAM Graph",
+      description:
+        "Open the original interactive ZAM knowledge-graph MCP App in a hosted Copilot canvas.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ...commonInputProperties,
+          focus: {
+            type: "string",
+            description: "Token slug to center the graph on.",
+          },
+        },
+        additionalProperties: false,
+      },
+      actions: [connectionStatusAction()],
+      open: (context) => openApp("graph", context),
+      onClose: closeApp,
+    }),
+    createCanvas({
+      id: "zam-settings",
+      displayName: "ZAM Settings",
+      description:
+        "Open the original ZAM Settings MCP App in a hosted Copilot canvas.",
+      inputSchema: {
+        type: "object",
+        properties: commonInputProperties,
+        additionalProperties: false,
+      },
+      actions: [connectionStatusAction()],
+      open: (context) => openApp("settings", context),
+      onClose: closeApp,
+    }),
+  ],
+  hooks: {
+    onUserPromptSubmitted: async () => {
+      if (modelContexts.size === 0) return;
+      const context = [...modelContexts.values()]
+        .map((value) => JSON.stringify(value))
+        .join("\n");
+      return {
+        additionalContext: `Current state from open ZAM MCP Apps:\n${context}`,
+      };
+    },
+  },
+});

--- a/src/copilot-extension/host.ts
+++ b/src/copilot-extension/host.ts
@@ -1,0 +1,163 @@
+/// <reference lib="dom" />
+
+import {
+  AppBridge,
+  PostMessageTransport,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+
+function requiredElement<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`ZAM MCP App host element is missing: ${selector}`);
+  }
+  return element;
+}
+
+const frame = requiredElement<HTMLIFrameElement>("#app");
+const status = requiredElement<HTMLElement>("#status");
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(url, options);
+  const body = (await response.json()) as T & { error?: string };
+  if (!response.ok) {
+    throw new Error(body.error || `HTTP ${response.status}`);
+  }
+  return body;
+}
+
+async function reportStatus(
+  phase: string,
+  details: Record<string, unknown> = {},
+): Promise<void> {
+  await fetchJson("/api/host-status", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ phase, ...details }),
+  });
+}
+
+function currentTheme(): "dark" | "light" {
+  const value =
+    document.documentElement.dataset.colorMode ??
+    document.body.dataset.colorMode;
+  if (value === "dark" || value === "light") return value;
+  return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+async function start(): Promise<void> {
+  const bootstrap = await fetchJson<{
+    tool: Tool;
+    toolArguments: Record<string, unknown>;
+    toolResult: CallToolResult;
+  }>("/api/bootstrap");
+
+  const bridge = new AppBridge(
+    null,
+    { name: "GitHub Copilot Canvas", version: "__ZAM_VERSION__" },
+    {
+      openLinks: {},
+      serverTools: {},
+      logging: {},
+      updateModelContext: { text: {}, structuredContent: {} },
+    },
+    {
+      hostContext: {
+        toolInfo: {
+          id: `canvas-${bootstrap.tool.name}`,
+          tool: bootstrap.tool,
+        },
+        theme: currentTheme(),
+        displayMode: "inline",
+        availableDisplayModes: ["inline"],
+        containerDimensions: {
+          width: window.innerWidth,
+          height: window.innerHeight,
+        },
+        locale: navigator.language,
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        userAgent: navigator.userAgent,
+        platform: "desktop",
+        deviceCapabilities: {
+          touch: navigator.maxTouchPoints > 0,
+          hover: matchMedia("(hover: hover)").matches,
+        },
+      },
+    },
+  );
+
+  bridge.oncalltool = async (params) =>
+    fetchJson("/api/tool", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+
+  bridge.onupdatemodelcontext = async (params) =>
+    fetchJson("/api/model-context", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+
+  bridge.onopenlink = async ({ url }) => {
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    return opened ? {} : { isError: true };
+  };
+
+  bridge.onrequestdisplaymode = async () => ({ mode: "inline" });
+
+  bridge.onsizechange = ({ height }) => {
+    if (typeof height === "number" && Number.isFinite(height)) {
+      frame.style.height = `${Math.max(240, Math.min(height, window.innerHeight))}px`;
+    }
+  };
+
+  bridge.oninitialized = async () => {
+    await bridge.sendToolInput({ arguments: bootstrap.toolArguments });
+    await bridge.sendToolResult(bootstrap.toolResult);
+    await reportStatus("ready", { app: bootstrap.tool.name });
+    document.body.classList.add("ready");
+  };
+
+  const targetWindow = frame.contentWindow;
+  if (!targetWindow) {
+    throw new Error("ZAM MCP App iframe is unavailable");
+  }
+  const transport = new PostMessageTransport(targetWindow, targetWindow);
+  await bridge.connect(transport);
+  await reportStatus("bridge-connected");
+  frame.src = "/app";
+
+  const updateContext = () => {
+    bridge.setHostContext({
+      theme: currentTheme(),
+      containerDimensions: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      },
+    });
+  };
+  window.addEventListener("resize", updateContext);
+
+  const themeObserver = new MutationObserver(updateContext);
+  themeObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-color-mode", "data-dark-theme", "data-light-theme"],
+  });
+
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      themeObserver.disconnect();
+      void bridge.teardownResource({}).catch(() => {});
+    },
+    { once: true },
+  );
+}
+
+start().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  status.textContent = `MCP App konnte nicht gestartet werden: ${message}`;
+  void reportStatus("error", { message }).catch(() => {});
+});

--- a/src/copilot-extension/mcp-client.ts
+++ b/src/copilot-extension/mcp-client.ts
@@ -1,0 +1,23 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+export interface ZamLaunchConfig {
+  command: string;
+  args: string[];
+}
+
+export async function connectZam(launch: ZamLaunchConfig): Promise<{
+  client: Client;
+  transport: StdioClientTransport;
+}> {
+  const transport = new StdioClientTransport({
+    command: launch.command,
+    args: launch.args,
+  });
+  const client = new Client({
+    name: "github-copilot-zam-mcp-app-host",
+    version: "__ZAM_VERSION__",
+  });
+  await client.connect(transport);
+  return { client, transport };
+}

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -362,6 +362,14 @@ describe("connectHarnessMcp", () => {
     });
   });
 
+  it("copilot honors an explicit Copilot home", () => {
+    const res = connectHarnessMcp("copilot", {
+      ...mockDeps,
+      copilotHome: "/custom/copilot",
+    });
+    expect(posix(res.path)).toBe("/custom/copilot/mcp-config.json");
+  });
+
   it("claude-desktop fresh write targets the platform config", () => {
     const res = connectHarnessMcp("claude-desktop", {
       ...mockDeps,

--- a/tests/cli/copilot-extension.test.ts
+++ b/tests/cli/copilot-extension.test.ts
@@ -1,0 +1,168 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  installCopilotExtension,
+  resolveCopilotHome,
+  resolveCopilotZamLaunch,
+} from "../../src/cli/copilot-extension.js";
+
+const ASSET_FILES = [
+  "extension.mjs",
+  "host.bundle.js",
+  "mcp-client.bundle.mjs",
+] as const;
+
+function withFixture(
+  run: (fixture: {
+    root: string;
+    home: string;
+    assetsDir: string;
+    cliEntry: string;
+  }) => void,
+): void {
+  const root = mkdtempSync(join(tmpdir(), "zam-copilot-extension-"));
+  const home = join(root, "home");
+  const assetsDir = join(root, "assets");
+  const cliEntry = join(root, "package", "dist", "cli", "index.js");
+  mkdirSync(assetsDir, { recursive: true });
+  mkdirSync(dirname(cliEntry), { recursive: true });
+  for (const file of ASSET_FILES) {
+    writeFileSync(join(assetsDir, file), `fixture:${file}\n`, "utf8");
+  }
+  writeFileSync(
+    join(assetsDir, "manifest.json"),
+    `${JSON.stringify({ name: "zam-mcp-apps", version: "0.10.2" })}\n`,
+    "utf8",
+  );
+  writeFileSync(cliEntry, "// cli fixture\n", "utf8");
+
+  try {
+    run({ root, home, assetsDir, cliEntry });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("Copilot MCP Apps extension provisioning", () => {
+  it("resolves the default and configured Copilot homes", () => {
+    const home = join(tmpdir(), "zam-home");
+    const custom = join(tmpdir(), "zam-copilot-home");
+    expect(resolveCopilotHome(home, undefined)).toBe(join(home, ".copilot"));
+    expect(resolveCopilotHome(home, custom)).toBe(custom);
+  });
+
+  it("launches the built CLI through Node instead of an npm shim", () => {
+    withFixture(({ cliEntry }) => {
+      expect(
+        resolveCopilotZamLaunch("C:\\Users\\thomas\\bin\\zam.cmd", {
+          cliEntry,
+          nodePath: "C:\\Program Files\\nodejs\\node.exe",
+        }),
+      ).toEqual({
+        command: "C:\\Program Files\\nodejs\\node.exe",
+        args: [cliEntry, "mcp"],
+      });
+    });
+  });
+
+  it("falls back to the resolved ZAM executable outside a built package", () => {
+    expect(
+      resolveCopilotZamLaunch("/usr/local/bin/zam", {
+        cliEntry: "/missing/zam/dist/cli/index.js",
+      }),
+    ).toEqual({
+      command: "/usr/local/bin/zam",
+      args: ["mcp"],
+    });
+  });
+
+  it("installs assets and a machine-specific launch configuration", () => {
+    withFixture(({ home, assetsDir, cliEntry }) => {
+      const result = installCopilotExtension({
+        home,
+        assetsDir,
+        cliEntry,
+        nodePath: "/runtime/node",
+        zamPath: "/usr/local/bin/zam",
+      });
+
+      expect(result.action).toBe("installed");
+      expect(result.destinationDir).toBe(
+        join(home, ".copilot", "extensions", "zam-mcp-apps"),
+      );
+      expect(result.changedFiles).toEqual([
+        ...ASSET_FILES,
+        "manifest.json",
+        "launch.json",
+      ]);
+      for (const file of [...ASSET_FILES, "manifest.json"]) {
+        expect(readFileSync(join(result.destinationDir, file), "utf8")).toBe(
+          readFileSync(join(assetsDir, file), "utf8"),
+        );
+      }
+      expect(
+        JSON.parse(
+          readFileSync(join(result.destinationDir, "launch.json"), "utf8"),
+        ),
+      ).toEqual({
+        schemaVersion: 1,
+        command: "/runtime/node",
+        args: [cliEntry, "mcp"],
+      });
+    });
+  });
+
+  it("is idempotent and only updates changed assets", () => {
+    withFixture(({ home, assetsDir, cliEntry }) => {
+      const options = {
+        home,
+        assetsDir,
+        cliEntry,
+        zamPath: "/usr/local/bin/zam",
+      };
+      installCopilotExtension(options);
+
+      const unchanged = installCopilotExtension(options);
+      expect(unchanged.action).toBe("unchanged");
+      expect(unchanged.changedFiles).toEqual([]);
+
+      writeFileSync(
+        join(assetsDir, "host.bundle.js"),
+        "fixture:host.bundle.js:v2\n",
+        "utf8",
+      );
+      const updated = installCopilotExtension(options);
+      expect(updated.action).toBe("updated");
+      expect(updated.changedFiles).toEqual(["host.bundle.js"]);
+    });
+  });
+
+  it("keeps dry runs write-free and honors COPILOT_HOME", () => {
+    withFixture(({ root, home, assetsDir, cliEntry }) => {
+      const copilotHome = join(root, "custom-copilot");
+      const result = installCopilotExtension({
+        home,
+        copilotHome,
+        assetsDir,
+        cliEntry,
+        zamPath: "/usr/local/bin/zam",
+        dryRun: true,
+      });
+
+      expect(result.action).toBe("planned");
+      expect(result.destinationDir).toBe(
+        join(copilotHome, "extensions", "zam-mcp-apps"),
+      );
+      expect(existsSync(result.destinationDir)).toBe(false);
+    });
+  });
+});

--- a/tests/desktop/graph-layout.test.ts
+++ b/tests/desktop/graph-layout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  graphEdgeEndpoints,
+  graphNodeTitle,
+  humanizeTokenSlug,
+  wrapGraphLabel,
+} from "../../desktop/src/panel/graph-layout.js";
+
+describe("2D graph presentation", () => {
+  it("prefers an explicit token title", () => {
+    expect(
+      graphNodeTitle({
+        slug: "zam-mcp-server-architecture",
+        title: "MCP server architecture",
+        display_title: "zam-mcp-server-architecture",
+      }),
+    ).toBe("MCP server architecture");
+  });
+
+  it("turns legacy slugs into readable title labels", () => {
+    expect(humanizeTokenSlug("zam-mcp-server-architecture")).toBe(
+      "ZAM MCP Server Architecture",
+    );
+    expect(
+      graphNodeTitle({
+        slug: "agent-skill-installation-scope-tradeoff",
+        title: "",
+        display_title: "agent-skill-installation-scope-tradeoff",
+      }),
+    ).toBe("Agent Skill Installation Scope Tradeoff");
+  });
+
+  it("balances readable titles across up to three lines", () => {
+    expect(wrapGraphLabel("Agent Skill Installation Scope Tradeoff")).toEqual([
+      "Agent Skill",
+      "Installation",
+      "Scope Tradeoff",
+    ]);
+    expect(wrapGraphLabel("ZAM MCP Server Architecture")).toEqual([
+      "ZAM MCP Server",
+      "Architecture",
+    ]);
+  });
+
+  it("ellipsizes only after the multiline budget is exhausted", () => {
+    const lines = wrapGraphLabel(
+      "One two three four five six seven eight nine ten eleven",
+      10,
+      3,
+    );
+    expect(lines).toHaveLength(3);
+    expect(lines.every((line) => line.length <= 10)).toBe(true);
+    expect(lines[2].endsWith("…")).toBe(true);
+  });
+
+  it("terminates horizontal edges outside both node rectangles", () => {
+    const edge = graphEdgeEndpoints(
+      { x: 0, y: 0, width: 100, height: 40 },
+      { x: 200, y: 0, width: 80, height: 40 },
+    );
+    expect(edge).toEqual({
+      start: { x: 54, y: 0 },
+      end: { x: 156, y: 0 },
+    });
+  });
+
+  it("clips diagonal edges against the first rectangle boundary hit", () => {
+    const edge = graphEdgeEndpoints(
+      { x: 0, y: 0, width: 100, height: 40 },
+      { x: 100, y: 100, width: 60, height: 60 },
+      0,
+    );
+    expect(edge.start).toEqual({ x: 20, y: 20 });
+    expect(edge.end).toEqual({ x: 70, y: 70 });
+  });
+});

--- a/tests/desktop/module-boundaries.test.ts
+++ b/tests/desktop/module-boundaries.test.ts
@@ -91,21 +91,23 @@ describe("desktop module boundaries", () => {
     }
   });
 
-  it("graph.ts stays Tauri-free and Three-free", () => {
-    const specifiers = importSpecifiers(read("panel/graph.ts"));
-    for (const specifier of specifiers) {
-      expect(
-        specifier.startsWith("@tauri-apps"),
-        `graph.ts must not import Tauri APIs (found "${specifier}")`,
-      ).toBe(false);
-      expect(
-        specifier === "three" || specifier.startsWith("three/"),
-        `graph.ts must not import Three.js (found "${specifier}")`,
-      ).toBe(false);
-      expect(
-        specifier.startsWith("./main") || specifier.startsWith("../main"),
-        `graph.ts must not import main.js (found "${specifier}")`,
-      ).toBe(false);
+  it("graph modules stay Tauri-free and Three-free", () => {
+    for (const file of ["panel/graph.ts", "panel/graph-layout.ts"]) {
+      const specifiers = importSpecifiers(read(file));
+      for (const specifier of specifiers) {
+        expect(
+          specifier.startsWith("@tauri-apps"),
+          `${file} must not import Tauri APIs (found "${specifier}")`,
+        ).toBe(false);
+        expect(
+          specifier === "three" || specifier.startsWith("three/"),
+          `${file} must not import Three.js (found "${specifier}")`,
+        ).toBe(false);
+        expect(
+          specifier.startsWith("./main") || specifier.startsWith("../main"),
+          `${file} must not import main.js (found "${specifier}")`,
+        ).toBe(false);
+      }
     }
   });
 

--- a/tsup.config.copilot-extension.ts
+++ b/tsup.config.copilot-extension.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "copilot-extension/mcp-client.bundle":
+      "src/copilot-extension/mcp-client.ts",
+  },
+  outDir: "dist",
+  format: ["esm"],
+  target: "node22",
+  platform: "node",
+  splitting: false,
+  sourcemap: false,
+  dts: false,
+  clean: false,
+  minify: true,
+  noExternal: [/.*/],
+  outExtension: () => ({ js: ".mjs" }),
+  banner: {
+    js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);',
+  },
+});

--- a/vite.config.copilot-extension.mts
+++ b/vite.config.copilot-extension.mts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    outDir: resolve(import.meta.dirname, "dist/copilot-extension"),
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(import.meta.dirname, "src/copilot-extension/host.ts"),
+      formats: ["es"],
+      fileName: () => "host.bundle.js",
+    },
+    minify: true,
+    sourcemap: false,
+  },
+});


### PR DESCRIPTION
## Summary

- ship a user-scoped GitHub Copilot canvas host for the existing Studio, Recall, Graph, and Settings MCP Apps
- install/update the host through `zam agent connect copilot`, with `COPILOT_HOME` support and a Windows-safe Node + CLI launch
- make the 2D graph readable with human titles, balanced multiline labels, and relationship lines clipped outside measured nodes
- bump all package metadata to 0.10.2 and document the Copilot host path

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 669 passed
- `npm run build`
- desktop TypeScript check
- npm package-content check
- live Copilot canvas handshakes and read-only data proxy calls for all four apps
- Graph allowlist rejection for an unrelated tool

## Release

The tag workflow will publish npm plus Windows/Linux packages. The Apple Silicon macOS app will be built locally and uploaded separately, matching recent ZAM releases. GitHub release notes are hand-written.
