### PR TITLE
Release ZAM 0.10.3

### DIFF
--- a/.agent/skills/zam/SKILL.md
+++ b/.agent/skills/zam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zam
-description: ZAM Learning Agent — turns real tasks into active-recall training sessions using FSRS spaced repetition. Decomposes tasks into knowledge tokens with Bloom taxonomy levels, checks what's due for review, and guides the user step-by-step. Tracks progress in a local SQLite database. Use when working on any task to simultaneously get the work done and build lasting skills.
+description: Use ZAM during real tasks or knowledge reviews to build lasting skills with active recall and FSRS spaced repetition. Use whenever the user invokes `/zam` (including without parameters), asks for ZAM, starts a due-card review, decomposes a task into knowledge tokens, or requests monitored practice. A parameterless invocation must show the ZAM choice menu before starting work.
 user-invocable: true
 ---
 
@@ -16,9 +16,9 @@ You are a kind, patient skills trainer. Your mission: build lasting autonomy thr
 
 Always prefer the `zam` MCP tools when available. If the server is not configured or not detected, tell the user once to run:
 ```bash
-zam agent connect <harness>
+zam agent connect
 ```
-(Replace `<harness>` with your agent name: `claude-code`, `antigravity`, `codex`, or `opencode`). This registers the `zam` MCP server configuration.
+This detects installed user-scoped harnesses, registers the `zam` MCP server, installs companion surfaces where needed, and refreshes the global skill. Explicit targets remain available for troubleshooting.
 
 ### Available MCP Tools
 
@@ -35,6 +35,32 @@ zam agent connect <harness>
 | `zam_review_action` | Apply review actions (rate, skip, edit/deprecate/delete tokens or cards) with optional confirmation. |
 | `zam_suggest_foundations` | Suggest existing prerequisite tokens for a newly failed or registered token. |
 | `zam_monitor` | Read or analyze shell-monitor evidence for a session. |
+| `zam_open_recall` | Open the spoiler-free Recall app; answering, reveal, and rating stay inside the card. |
+| `zam_show_graph` | Open the focused knowledge-graph app, usually with a token slug from the conversation. |
+| `zam_open_settings` | Open the focused Settings app when the user asks for configuration or database status. |
+
+---
+
+## Parameterless invocation — offer choices first
+
+When the user invokes `/zam` without a task or mode, do not choose a workflow on their behalf:
+
+1. Call `zam_status` to obtain the active user, due count, and current statistics.
+2. If this same agent conversation already contains an active, unended ZAM session ID, offer **Continue the current ZAM flow** first. Do not infer continuation from old database rows and do not add cross-restart persistence.
+3. If reviews are due, inspect a small spoiler-free batch with `zam_get_reviews` (`noResolve: true`, `noDynamicQuestion: true`). Use its domains plus the current conversation to suggest up to three honest topic choices, such as **RAG** or **Axon Ivy** only when the returned data or context supports them.
+4. Present the applicable choices below and wait for the user to select one:
+   - **Recall now** — put this first when there is no known active flow; show the due count and targeted topic suggestions, plus an all-due option.
+   - **Work and observe** — help complete a real task while monitoring which knowledge is exercised.
+   - **Discover learning gaps** — inspect the intended work or context for concepts that appear to be missing.
+   - **Guided collaboration** — help, but deliberately leave suitable steps for the learner to perform.
+5. Do not list Studio. Studio is the standalone onboarding and non-agent surface; agent harnesses use the focused MCP Apps and direct learning tools.
+
+### Purpose-built visual surfaces
+
+- After the user chooses Recall or a topic, call `zam_open_recall`, passing the selected domain when applicable. Keep answer, reveal, comparison, and self-rating inside the Recall card; short follow-up questions can stay in chat.
+- When the user asks to visualize knowledge, call `zam_show_graph` with the most relevant known token slug as `focus`. The host may show it in a persistent pane or inline for a one-off visualization.
+- Call `zam_open_settings` only for relevant setup, workspace, backup, or database-status work.
+- Never call `zam_open_studio` as part of an agent-harness ZAM menu or ordinary ZAM workflow.
 
 ---
 
@@ -129,10 +155,10 @@ Call `zam_session_start` with the active user, task description, and execution c
 
 **For executable tasks (observation mode):**
 
-Hand off to the user:
+In Shadowing mode, hand off to the user:
 > "This is now your job. Good luck!"
 
-Step back. Do not interrupt unless the user asks for help.
+Step back. Do not interrupt unless the user asks for help. If the user selected Guided collaboration, alternate useful agent assistance with concrete steps the learner performs; do not automate every suitable practice step.
 
 To observe, tell the user to open a monitored terminal window:
 > "I've opened a terminal for you. Go ahead and work there — come back here when you're done."

--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zam
-description: Use ZAM during real tasks or knowledge reviews to build lasting skills with active recall and FSRS spaced repetition. Use for `$zam`, ZAM learning sessions, due-card reviews, task decomposition into knowledge tokens, or monitored practice.
+description: Use ZAM during real tasks or knowledge reviews to build lasting skills with active recall and FSRS spaced repetition. Use whenever the user invokes `$zam` (including without parameters), asks for ZAM, starts a due-card review, decomposes a task into knowledge tokens, or requests monitored practice. A parameterless invocation must show the ZAM choice menu before starting work.
 user-invocable: true
 ---
 
@@ -19,9 +19,9 @@ You are a kind, patient skills trainer. Your mission: build lasting autonomy thr
 
 Always prefer the `zam` MCP tools when available. If the server is not configured or not detected, tell the user once to run:
 ```bash
-zam agent connect <harness>
+zam agent connect
 ```
-(Replace `<harness>` with your agent name: `claude-code`, `antigravity`, `codex`, or `opencode`). This registers the `zam` MCP server configuration.
+This detects installed user-scoped harnesses, registers the `zam` MCP server, installs companion surfaces where needed, and refreshes the global skill. An explicit target such as `zam agent connect codex` or `zam agent connect vscode` remains available for troubleshooting.
 
 ### Available MCP Tools
 
@@ -38,6 +38,32 @@ zam agent connect <harness>
 | `zam_review_action` | Apply review actions (rate, skip, edit/deprecate/delete tokens or cards) with optional confirmation. |
 | `zam_suggest_foundations` | Suggest existing prerequisite tokens for a newly failed or registered token. |
 | `zam_monitor` | Read or analyze shell-monitor evidence for a session. |
+| `zam_open_recall` | Open the spoiler-free Recall app; answering, reveal, and rating stay inside the card. |
+| `zam_show_graph` | Open the focused knowledge-graph app, usually with a token slug from the conversation. |
+| `zam_open_settings` | Open the focused Settings app when the user asks for configuration or database status. |
+
+---
+
+## Parameterless invocation — offer choices first
+
+When the user invokes `$zam` without a task or mode, do not choose a workflow on their behalf:
+
+1. Call `zam_status` to obtain the active user, due count, and current statistics.
+2. If this same agent conversation already contains an active, unended ZAM session ID, offer **Continue the current ZAM flow** first. Do not infer continuation from old database rows and do not add cross-restart persistence.
+3. If reviews are due, inspect a small spoiler-free batch with `zam_get_reviews` (`noResolve: true`, `noDynamicQuestion: true`). Use its domains plus the current conversation to suggest up to three honest topic choices, such as **RAG** or **Axon Ivy** only when the returned data or context supports them.
+4. Present the applicable choices below and wait for the user to select one:
+   - **Recall now** — put this first when there is no known active flow; show the due count and targeted topic suggestions, plus an all-due option.
+   - **Work and observe** — help complete a real task while monitoring which knowledge is exercised.
+   - **Discover learning gaps** — inspect the intended work or context for concepts that appear to be missing.
+   - **Guided collaboration** — help, but deliberately leave suitable steps for the learner to perform.
+5. Do not list Studio. Studio is the standalone onboarding and non-agent surface; agent harnesses use the focused MCP Apps and direct learning tools.
+
+### Purpose-built visual surfaces
+
+- After the user chooses Recall or a topic, call `zam_open_recall`, passing the selected domain when applicable. Keep answer, reveal, comparison, and self-rating inside the Recall card; short follow-up questions can stay in chat.
+- When the user asks to visualize knowledge, call `zam_show_graph` with the most relevant known token slug as `focus`. The host may show it in a persistent pane or inline for a one-off visualization.
+- Call `zam_open_settings` only for relevant setup, workspace, backup, or database-status work.
+- Never call `zam_open_studio` as part of an agent-harness ZAM menu or ordinary ZAM workflow.
 
 ---
 
@@ -132,10 +158,10 @@ Call `zam_session_start` with the active user, task description, and execution c
 
 **For executable tasks (observation mode):**
 
-Hand off to the user:
+In Shadowing mode, hand off to the user:
 > "This is now your job. Good luck!"
 
-Step back. Do not interrupt unless the user asks for help.
+Step back. Do not interrupt unless the user asks for help. If the user selected Guided collaboration, alternate useful agent assistance with concrete steps the learner performs; do not automate every suitable practice step.
 
 To observe, tell the user to open a monitored terminal window:
 > "I've opened a terminal for you. Go ahead and work there — come back here when you're done."

--- a/.claude/skills/zam/SKILL.md
+++ b/.claude/skills/zam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zam
-description: ZAM Learning Agent — turns real tasks into active-recall training sessions using FSRS spaced repetition. Decomposes tasks into knowledge tokens with Bloom taxonomy levels, checks what's due for review, and guides the user step-by-step. Tracks progress in a local SQLite database. Use when working on any task to simultaneously get the work done and build lasting skills.
+description: Use ZAM during real tasks or knowledge reviews to build lasting skills with active recall and FSRS spaced repetition. Use whenever the user invokes `/zam` (including without parameters), asks for ZAM, starts a due-card review, decomposes a task into knowledge tokens, or requests monitored practice. A parameterless invocation must show the ZAM choice menu before starting work.
 user-invocable: true
 ---
 
@@ -16,9 +16,9 @@ You are a kind, patient skills trainer. Your mission: build lasting autonomy thr
 
 Always prefer the `zam` MCP tools when available. If the server is not configured or not detected, tell the user once to run:
 ```bash
-zam agent connect <harness>
+zam agent connect
 ```
-(Replace `<harness>` with your agent name: `claude-code`, `antigravity`, `codex`, or `opencode`). This registers the `zam` MCP server configuration.
+This detects installed user-scoped harnesses, registers the `zam` MCP server, installs companion surfaces where needed, and refreshes the global skill. Explicit targets remain available for troubleshooting.
 
 ### Available MCP Tools
 
@@ -35,6 +35,32 @@ zam agent connect <harness>
 | `zam_review_action` | Apply review actions (rate, skip, edit/deprecate/delete tokens or cards) with optional confirmation. |
 | `zam_suggest_foundations` | Suggest existing prerequisite tokens for a newly failed or registered token. |
 | `zam_monitor` | Read or analyze shell-monitor evidence for a session. |
+| `zam_open_recall` | Open the spoiler-free Recall app; answering, reveal, and rating stay inside the card. |
+| `zam_show_graph` | Open the focused knowledge-graph app, usually with a token slug from the conversation. |
+| `zam_open_settings` | Open the focused Settings app when the user asks for configuration or database status. |
+
+---
+
+## Parameterless invocation — offer choices first
+
+When the user invokes `/zam` without a task or mode, do not choose a workflow on their behalf:
+
+1. Call `zam_status` to obtain the active user, due count, and current statistics.
+2. If this same agent conversation already contains an active, unended ZAM session ID, offer **Continue the current ZAM flow** first. Do not infer continuation from old database rows and do not add cross-restart persistence.
+3. If reviews are due, inspect a small spoiler-free batch with `zam_get_reviews` (`noResolve: true`, `noDynamicQuestion: true`). Use its domains plus the current conversation to suggest up to three honest topic choices, such as **RAG** or **Axon Ivy** only when the returned data or context supports them.
+4. Present the applicable choices below and wait for the user to select one:
+   - **Recall now** — put this first when there is no known active flow; show the due count and targeted topic suggestions, plus an all-due option.
+   - **Work and observe** — help complete a real task while monitoring which knowledge is exercised.
+   - **Discover learning gaps** — inspect the intended work or context for concepts that appear to be missing.
+   - **Guided collaboration** — help, but deliberately leave suitable steps for the learner to perform.
+5. Do not list Studio. Studio is the standalone onboarding and non-agent surface; agent harnesses use the focused MCP Apps and direct learning tools.
+
+### Purpose-built visual surfaces
+
+- After the user chooses Recall or a topic, call `zam_open_recall`, passing the selected domain when applicable. Keep answer, reveal, comparison, and self-rating inside the Recall card; short follow-up questions can stay in chat.
+- When the user asks to visualize knowledge, call `zam_show_graph` with the most relevant known token slug as `focus`. The host may show it in a persistent pane or inline for a one-off visualization.
+- Call `zam_open_settings` only for relevant setup, workspace, backup, or database-status work.
+- Never call `zam_open_studio` as part of an agent-harness ZAM menu or ordinary ZAM workflow.
 
 ---
 
@@ -129,10 +155,10 @@ Call `zam_session_start` with the active user, task description, and execution c
 
 **For executable tasks (observation mode):**
 
-Hand off to the user:
+In Shadowing mode, hand off to the user:
 > "This is now your job. Good luck!"
 
-Step back. Do not interrupt unless the user asks for help.
+Step back. Do not interrupt unless the user asks for help. If the user selected Guided collaboration, alternate useful agent assistance with concrete steps the learner performs; do not automate every suitable practice step.
 
 To observe, tell the user to open a monitored terminal window:
 > "I've opened a terminal for you. Go ahead and work there — come back here when you're done."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,3 +166,40 @@ jobs:
           prerelease: false
           projectPath: './desktop'
           args: ${{ matrix.args }}
+
+  publish-vscode-extension:
+    name: 'Upload ZAM Companion VSIX'
+    needs: publish-tauri
+    if: ${{ always() && needs.publish-tauri.result != 'cancelled' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build VS Code Companion
+        run: npm run build:vscode-extension
+
+      - name: Guard tag/package version match
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Upload VSIX to draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" "dist/vscode-extension/ZAM_Companion_${GITHUB_REF_NAME#v}.vsix" --clobber

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.10.2"
+version = "0.10.3"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/adr/2026-07-11-codex-and-vscode-companion-surfaces.md
+++ b/docs/adr/2026-07-11-codex-and-vscode-companion-surfaces.md
@@ -1,0 +1,97 @@
+# Codex and VS Code Companion Surfaces
+
+**Status:** Accepted
+**Date:** 2026-07-11
+**Deciders:** Thomas (project owner)
+**Related:**
+[2026-07-06a-mcp-agent-transport-and-surfaces.md](2026-07-06a-mcp-agent-transport-and-surfaces.md) ·
+[2026-06-30-learning-content-studio.md](2026-06-30-learning-content-studio.md)
+
+---
+
+## Context
+
+ZAM 0.10.0 introduced purpose-built MCP Apps for Recall, Graph, Settings, and
+learning-content curation. ZAM 0.10.2 proved that the same `ui://` resources can
+also be hosted in GitHub Copilot through a thin canvas adapter. Codex Desktop
+can use the MCP server and app resources directly, while VS Code needs a visual
+surface whose lifetime is independent from the scrolling agent transcript.
+
+An earlier, unmerged VS Code proposal treated a VS Code extension as the
+primary host for the complete Studio and an agent terminal. That scope is now
+too broad. MCP remains the canonical agent transport, and the standalone ZAM
+App remains the easiest onboarding and agent-free surface. Agent harnesses need
+the focused learning cards, not another copy of Studio.
+
+## Decision
+
+ZAM 0.10.3 supports two complementary visual mounts over the same MCP server:
+
+1. **Codex Desktop uses the native MCP App result.** The app can appear wherever
+   Codex places custom app UI; ZAM does not implement a Codex-specific copy.
+2. **VS Code gets one host-neutral ZAM Companion WebviewView.** It is contributed
+   to the VS Code Panel by default and can be moved by the user to the Primary
+   Sidebar, Secondary Sidebar, or another panel location. Its lifetime is
+   independent from the chat transcript.
+
+The VS Code extension starts its own local `zam mcp` client and mounts the same
+self-contained Recall, Graph, and Settings resources through the official MCP
+Apps `AppBridge`. An opening tool publishes a small, local, best-effort UI
+intent. The extension observes that intent, focuses its view, loads the original
+resource, and proxies only the tools allowed for that card.
+
+The intent contains only the requested app and its opening parameters. It is
+not a second database, a learning-session persistence mechanism, or a message
+bus for answers. Recall answers, reveal, and ratings remain inside the Recall
+card. Short or complex follow-up questions remain in the user's chosen agent
+chat. One-off requests such as “visualize this” may still render an inline MCP
+App when the host supports it.
+
+There is one ZAM Companion extension, not separate Codex, Copilot, or Claude
+variants. Users normally run one agent harness at a time. Concurrent ownership
+and cross-harness session synchronization are out of scope.
+
+## Setup
+
+`zam agent connect` without a harness auto-detects installed hosts and applies
+the supported user setup idempotently. Explicit forms such as
+`zam agent connect codex`, `zam agent connect vscode`, and
+`zam agent connect copilot` remain available.
+
+For Codex, setup installs the user-level MCP entry and global ZAM skill. For VS
+Code, setup installs the user-level MCP entry and the packaged ZAM Companion
+`.vsix`. Existing unrelated configuration is preserved.
+
+The parameterless ZAM skill invocation presents choices before acting:
+
+1. continue a session only when the current agent conversation already knows
+   its active session ID;
+2. Recall first, including relevant due-domain suggestions such as RAG or
+   Axon Ivy;
+3. work while ZAM observes;
+4. discover likely missing learning content;
+5. collaborate while deliberately leaving suitable steps to the learner.
+
+Studio is not an agent-harness menu option. The standalone ZAM App remains the
+onboarding and non-agent experience.
+
+## Consequences
+
+- The persistent learning UI no longer scrolls away with agent messages.
+- Codex, Copilot, and future harnesses can share one VS Code surface.
+- ZAM reuses the existing app HTML, kernel, database, and MCP tool contracts.
+- VS Code gains a small extension package and `.vsix` release asset.
+- A running VS Code extension is required for detached-pane behavior; hosts
+  without it retain their native inline or text fallback.
+- Cross-restart session discovery remains future work. Database session rows
+  already persist, but 0.10.3 does not add an MCP resume/list contract.
+
+## 0.10.3 acceptance scope
+
+- Full automated verification on macOS.
+- Live Codex Desktop MCP App test.
+- Live VS Code test with the official Codex extension and the detached ZAM
+  Companion view.
+- A brief GitHub Copilot regression smoke test.
+- Claude and Windows end-to-end testing are deferred to a later Windows
+  polishing release.

--- a/docs/adr/2026-07-11-codex-and-vscode-companion-surfaces.md
+++ b/docs/adr/2026-07-11-codex-and-vscode-companion-surfaces.md
@@ -62,6 +62,11 @@ For Codex, setup installs the user-level MCP entry and global ZAM skill. For VS
 Code, setup installs the user-level MCP entry and the packaged ZAM Companion
 `.vsix`. Existing unrelated configuration is preserved.
 
+The same VSIX is installed for `zam agent connect antigravity` when the
+VS Code-compatible `antigravity-ide` CLI is detected. Antigravity CLI and
+legacy app installations retain MCP setup without being treated as extension
+hosts.
+
 The parameterless ZAM skill invocation presents choices before acting:
 
 1. continue a session only when the current agent conversation already knows
@@ -93,5 +98,7 @@ onboarding and non-agent experience.
 - Live VS Code test with the official Codex extension and the detached ZAM
   Companion view.
 - A brief GitHub Copilot regression smoke test.
+- A targeted Antigravity IDE 1.107 compatibility smoke for VSIX installation
+  and detached Recall rendering.
 - Claude and Windows end-to-end testing are deferred to a later Windows
   polishing release.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-06b](2026-07-06b-checkpointed-review-dialogue.md) | Checkpointed Review Dialogue | Proposed |
 | [2026-07-06](../plans/2026-07-06-mcp-agent-transport-plan.md) | MCP agent transport implementation plan (ADR 2026-07-06a, items 1–5) | Implemented |
 | [2026-07-07](2026-07-07-resilient-self-update-and-dependency-isolation.md) | Resilient Self-Update and Dependency-Failure Isolation | Implemented |
+| [2026-07-11](2026-07-11-codex-and-vscode-companion-surfaces.md) | Codex and VS Code Companion Surfaces | Accepted |

--- a/docs/plans/2026-07-11-codex-vscode-integration.md
+++ b/docs/plans/2026-07-11-codex-vscode-integration.md
@@ -1,0 +1,36 @@
+# ZAM 0.10.3 Codex and VS Code integration plan
+
+**Status:** In progress
+**Scope:** Integration and setup hardening only. No new learning features.
+
+## Phase 1 — Contracts and packaging
+
+- [x] Add a tested local UI-intent contract for Recall, Graph, and Settings.
+- [x] Package a dependency-free VS Code extension that hosts the existing MCP
+  App resources in a movable WebviewView.
+- [x] Produce a `.vsix` in every root build without adding dependencies.
+
+## Phase 2 — Setup
+
+- [x] Add user-scoped VS Code MCP configuration support.
+- [x] Make `zam agent connect` parameterless, auto-detecting, idempotent, and
+  non-destructive while retaining explicit harness arguments.
+- [x] Install or refresh the global ZAM skill and VS Code extension from the
+  same command.
+
+## Phase 3 — Skill behavior
+
+- [x] Document the dedicated MCP Apps in every packaged skill flavor.
+- [x] Make parameterless ZAM invocation show the agreed choice menu, with
+  Recall and relevant due topics first.
+- [x] Keep Studio out of agent-harness choices and route visualization requests
+  to focused app surfaces.
+
+## Phase 4 — Verification and release
+
+- [x] Pass format, lint, typecheck, full tests, and build.
+- [x] Verify Codex Desktop and VS Code with the Codex extension; smoke-test
+  Copilot without broadening scope.
+- [x] Build and verify the Apple Silicon macOS application package.
+- [ ] Publish npm, `.vsix`, desktop assets, and the 0.10.3 GitHub release using
+  the established “What's new” structure.

--- a/docs/plans/2026-07-11-codex-vscode-integration.md
+++ b/docs/plans/2026-07-11-codex-vscode-integration.md
@@ -31,6 +31,8 @@
 - [x] Pass format, lint, typecheck, full tests, and build.
 - [x] Verify Codex Desktop and VS Code with the Codex extension; smoke-test
   Copilot without broadening scope.
+- [x] Verify the shared Companion VSIX in Antigravity IDE 1.107 after the
+  compatibility review.
 - [x] Build and verify the Apple Silicon macOS application package.
 - [ ] Publish npm, `.vsix`, desktop assets, and the 0.10.3 GitHub release using
   the established “What's new” structure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "zam": "dist/cli/index.js"
   },
   "scripts": {
-    "build": "tsup && npm run build:panel && npm run build:copilot-extension",
+    "build": "tsup && npm run build:panel && npm run build:copilot-extension && npm run build:vscode-extension",
     "build:copilot-extension": "tsup --config tsup.config.copilot-extension.ts && vite build --config vite.config.copilot-extension.mts && node scripts/prepare-copilot-extension.mjs",
+    "build:vscode-extension": "tsup --config tsup.config.vscode-extension.ts && vite build --config vite.config.vscode-extension.mts && node scripts/prepare-vscode-extension.mjs",
     "build:panel": "vite build --config vite.config.panel.mts && vite build --config vite.config.panel.mts --mode recall && vite build --config vite.config.panel.mts --mode graph && vite build --config vite.config.panel.mts --mode settings",
     "prepare": "npm run build",
     "dev": "tsx src/cli/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/scripts/prepare-vscode-extension.mjs
+++ b/scripts/prepare-vscode-extension.mjs
@@ -1,8 +1,8 @@
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -19,6 +19,7 @@ const packageJson = JSON.parse(
   readFileSync(join(repoRoot, "package.json"), "utf8"),
 );
 const version = packageJson.version;
+const vscodeEngine = "^1.100.0";
 const extensionBundle = join(distDir, "extension.cjs");
 const hostBundle = join(distDir, "host.bundle.js");
 const vsixName = `ZAM_Companion_${version}.vsix`;
@@ -55,7 +56,7 @@ const extensionPackage = {
     type: "git",
     url: "https://github.com/zam-os/zam.git",
   },
-  engines: { vscode: "^1.109.0" },
+  engines: { vscode: vscodeEngine },
   categories: ["Other"],
   keywords: ["zam", "learning", "recall", "mcp", "codex"],
   main: "./out/extension.cjs",
@@ -157,7 +158,7 @@ writeFileSync(
     <Categories>Other</Categories>
     <GalleryFlags>Public</GalleryFlags>
     <Properties>
-      <Property Id="Microsoft.VisualStudio.Code.Engine" Value="^1.109.0" />
+      <Property Id="Microsoft.VisualStudio.Code.Engine" Value="${vscodeEngine}" />
       <Property Id="Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown" Value="true" />
       <Property Id="Microsoft.VisualStudio.Services.Content.Pricing" Value="Free" />
     </Properties>

--- a/scripts/prepare-vscode-extension.mjs
+++ b/scripts/prepare-vscode-extension.mjs
@@ -1,0 +1,300 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { deflateRawSync } from "node:zlib";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = join(repoRoot, "dist", "vscode-extension");
+const stagingDir = join(distDir, "vsix-staging");
+const extensionDir = join(stagingDir, "extension");
+const packageJson = JSON.parse(
+  readFileSync(join(repoRoot, "package.json"), "utf8"),
+);
+const version = packageJson.version;
+const extensionBundle = join(distDir, "extension.cjs");
+const hostBundle = join(distDir, "host.bundle.js");
+const vsixName = `ZAM_Companion_${version}.vsix`;
+const vsixPath = join(distDir, vsixName);
+
+for (const file of [extensionBundle, hostBundle]) {
+  if (!existsSync(file)) throw new Error(`VS Code bundle is missing: ${file}`);
+}
+
+rmSync(stagingDir, { recursive: true, force: true });
+mkdirSync(join(extensionDir, "out"), { recursive: true });
+mkdirSync(join(extensionDir, "media"), { recursive: true });
+
+writeFileSync(
+  join(extensionDir, "out", "extension.cjs"),
+  readFileSync(extensionBundle, "utf8").replaceAll("__ZAM_VERSION__", version),
+  "utf8",
+);
+writeFileSync(
+  join(extensionDir, "media", "host.bundle.js"),
+  readFileSync(hostBundle, "utf8").replaceAll("__ZAM_VERSION__", version),
+  "utf8",
+);
+
+const extensionPackage = {
+  name: "zam-companion",
+  displayName: "ZAM Companion",
+  description:
+    "Persistent Recall, Graph, and Settings surfaces for ZAM agent workflows.",
+  version,
+  publisher: "zam-os",
+  license: "Apache-2.0",
+  repository: {
+    type: "git",
+    url: "https://github.com/zam-os/zam.git",
+  },
+  engines: { vscode: "^1.109.0" },
+  categories: ["Other"],
+  keywords: ["zam", "learning", "recall", "mcp", "codex"],
+  main: "./out/extension.cjs",
+  extensionKind: ["ui"],
+  activationEvents: [
+    "onStartupFinished",
+    "onView:zam.companion",
+    "onCommand:zam.openRecall",
+    "onCommand:zam.showGraph",
+    "onCommand:zam.openSettings",
+  ],
+  contributes: {
+    viewsContainers: {
+      panel: [
+        {
+          id: "zamCompanion",
+          title: "ZAM",
+          icon: "media/zam.svg",
+        },
+      ],
+    },
+    views: {
+      zamCompanion: [
+        {
+          id: "zam.companion",
+          type: "webview",
+          name: "Companion",
+          contextualTitle: "ZAM Companion",
+          visibility: "visible",
+        },
+      ],
+    },
+    commands: [
+      {
+        command: "zam.openRecall",
+        title: "Open Recall",
+        category: "ZAM",
+        icon: "$(book)",
+      },
+      {
+        command: "zam.showGraph",
+        title: "Open Knowledge Graph",
+        category: "ZAM",
+        icon: "$(type-hierarchy)",
+      },
+      {
+        command: "zam.openSettings",
+        title: "Open Settings",
+        category: "ZAM",
+        icon: "$(gear)",
+      },
+    ],
+    menus: {
+      "view/title": [
+        {
+          command: "zam.openRecall",
+          when: "view == zam.companion",
+          group: "navigation@1",
+        },
+        {
+          command: "zam.showGraph",
+          when: "view == zam.companion",
+          group: "navigation@2",
+        },
+        {
+          command: "zam.openSettings",
+          when: "view == zam.companion",
+          group: "navigation@3",
+        },
+      ],
+    },
+  },
+};
+
+writeFileSync(
+  join(extensionDir, "package.json"),
+  `${JSON.stringify(extensionPackage, null, 2)}\n`,
+  "utf8",
+);
+writeFileSync(
+  join(extensionDir, "README.md"),
+  `# ZAM Companion\n\nThis extension keeps ZAM Recall, Graph, and Settings in a movable VS Code view that does not scroll away with agent chat.\n\nInstall and configure it with:\n\n\`\`\`sh\nzam agent connect vscode\n\`\`\`\n\nThe extension hosts the existing MCP App resources from your local \`zam mcp\` server. It contains no second learning engine or database.\n`,
+  "utf8",
+);
+writeFileSync(
+  join(extensionDir, "media", "zam.svg"),
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"><path d="M5 5h14L7 19h12" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6" cy="18" r="2" fill="currentColor"/></svg>\n`,
+  "utf8",
+);
+
+writeFileSync(
+  join(stagingDir, "extension.vsixmanifest"),
+  `<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+  <Metadata>
+    <Identity Language="en-US" Id="zam-companion" Version="${version}" Publisher="zam-os" />
+    <DisplayName>ZAM Companion</DisplayName>
+    <Description xml:space="preserve">Persistent ZAM MCP App surfaces for VS Code agent workflows.</Description>
+    <Categories>Other</Categories>
+    <GalleryFlags>Public</GalleryFlags>
+    <Properties>
+      <Property Id="Microsoft.VisualStudio.Code.Engine" Value="^1.109.0" />
+      <Property Id="Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown" Value="true" />
+      <Property Id="Microsoft.VisualStudio.Services.Content.Pricing" Value="Free" />
+    </Properties>
+  </Metadata>
+  <Installation><InstallationTarget Id="Microsoft.VisualStudio.Code" /></Installation>
+  <Dependencies />
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.Code.Manifest" Path="extension/package.json" Addressable="true" />
+    <Asset Type="Microsoft.VisualStudio.Services.Content.Details" Path="extension/README.md" Addressable="true" />
+  </Assets>
+</PackageManifest>
+`,
+  "utf8",
+);
+writeFileSync(
+  join(stagingDir, "[Content_Types].xml"),
+  `<?xml version="1.0" encoding="utf-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="json" ContentType="application/json" />
+  <Default Extension="cjs" ContentType="application/octet-stream" />
+  <Default Extension="js" ContentType="application/javascript" />
+  <Default Extension="svg" ContentType="image/svg+xml" />
+  <Default Extension="md" ContentType="text/markdown" />
+  <Override PartName="/extension.vsixmanifest" ContentType="text/xml" />
+</Types>
+`,
+  "utf8",
+);
+
+const crcTable = Array.from({ length: 256 }, (_, index) => {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function dosTimestamp(date) {
+  const year = Math.max(1980, date.getFullYear());
+  const time =
+    (date.getHours() << 11) |
+    (date.getMinutes() << 5) |
+    Math.floor(date.getSeconds() / 2);
+  const day =
+    ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate();
+  return { time, day };
+}
+
+function collectFiles(root, current = root) {
+  return readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(current, entry.name);
+    return entry.isDirectory() ? collectFiles(root, path) : [path];
+  });
+}
+
+function createVsix(sourceDir, target) {
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+  const files = collectFiles(sourceDir).sort();
+
+  for (const file of files) {
+    const name = relative(sourceDir, file).replaceAll("\\", "/");
+    const nameBuffer = Buffer.from(name, "utf8");
+    const contents = readFileSync(file);
+    const compressed = deflateRawSync(contents, { level: 9 });
+    const checksum = crc32(contents);
+    const { time, day } = dosTimestamp(statSync(file).mtime);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0x0800, 6);
+    local.writeUInt16LE(8, 8);
+    local.writeUInt16LE(time, 10);
+    local.writeUInt16LE(day, 12);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(contents.length, 22);
+    local.writeUInt16LE(nameBuffer.length, 26);
+    local.writeUInt16LE(0, 28);
+    localParts.push(local, nameBuffer, compressed);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(0x0314, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0x0800, 8);
+    central.writeUInt16LE(8, 10);
+    central.writeUInt16LE(time, 12);
+    central.writeUInt16LE(day, 14);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(contents.length, 24);
+    central.writeUInt16LE(nameBuffer.length, 28);
+    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(0, 32);
+    central.writeUInt16LE(0, 34);
+    central.writeUInt16LE(0, 36);
+    central.writeUInt32LE((0o100644 << 16) >>> 0, 38);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, nameBuffer);
+    offset += local.length + nameBuffer.length + compressed.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(files.length, 8);
+  end.writeUInt16LE(files.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+  writeFileSync(target, Buffer.concat([...localParts, centralDirectory, end]));
+}
+
+createVsix(stagingDir, vsixPath);
+rmSync(stagingDir, { recursive: true, force: true });
+writeFileSync(
+  join(distDir, "manifest.json"),
+  `${JSON.stringify(
+    {
+      name: "zam-companion",
+      version,
+      vsix: vsixName,
+    },
+    null,
+    2,
+  )}\n`,
+  "utf8",
+);
+
+console.log(`Prepared ${relative(repoRoot, vsixPath)}`);

--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -43,6 +43,21 @@ export interface AgentHarness {
   candidatePaths?: Partial<Record<NodeJS.Platform, string[]>>;
 }
 
+const ANTIGRAVITY_IDE_CANDIDATE_PATHS: Partial<
+  Record<NodeJS.Platform, string[]>
+> = {
+  darwin: [
+    join(
+      homedir(),
+      ".antigravity-ide",
+      "antigravity-ide",
+      "bin",
+      "antigravity-ide",
+    ),
+    "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide",
+  ],
+};
+
 /**
  * Known harnesses. CLI-first ones (Claude Code, Codex, opencode) launch in a
  * terminal; GUI apps (Cursor, Copilot, Antigravity) launch as a process. The
@@ -71,6 +86,12 @@ export const AGENT_HARNESSES: AgentHarness[] = [
     label: "Antigravity",
     kind: "app",
     command: "antigravity",
+    candidatePaths: {
+      darwin: [
+        ...(ANTIGRAVITY_IDE_CANDIDATE_PATHS.darwin ?? []),
+        "/Applications/Antigravity.app/Contents/MacOS/Antigravity",
+      ],
+    },
   },
   { id: "goose", label: "goose", kind: "cli", command: "goose" },
 ];
@@ -83,6 +104,21 @@ export interface ResolveDeps {
   find?: (command: string) => string | null;
   exists?: (path: string) => boolean;
   platform?: NodeJS.Platform;
+}
+
+/** Resolve only the VS Code-compatible Antigravity IDE CLI. */
+export function resolveAntigravityIdeExecutable(
+  deps: ResolveDeps = {},
+): string | null {
+  const find = deps.find ?? findExecutable;
+  const exists = deps.exists ?? existsSync;
+  const platform = deps.platform ?? process.platform;
+  const found = find("antigravity-ide");
+  if (found) return found;
+  return (
+    ANTIGRAVITY_IDE_CANDIDATE_PATHS[platform]?.find((path) => exists(path)) ??
+    null
+  );
 }
 
 /**
@@ -102,6 +138,15 @@ export function resolveHarnessExecutable(
 
   const found = find(overrideCommand || harness.command);
   if (found) return found;
+
+  if (!overrideCommand && harness.id === "antigravity") {
+    const foundIde = resolveAntigravityIdeExecutable({
+      find,
+      exists,
+      platform,
+    });
+    if (foundIde) return foundIde;
+  }
 
   if (harness.kind === "app") {
     for (const candidate of harness.candidatePaths?.[platform] ?? []) {
@@ -274,8 +319,21 @@ export function detectInstalledConnectHarnesses(
   if (
     hasCommandOrPath("antigravity", [
       join(home, ".gemini", "config"),
-      ...(platform === "darwin" ? ["/Applications/Antigravity.app"] : []),
-    ])
+      ...(platform === "darwin"
+        ? [
+            join(
+              home,
+              ".antigravity-ide",
+              "antigravity-ide",
+              "bin",
+              "antigravity-ide",
+            ),
+            "/Applications/Antigravity.app",
+            "/Applications/Antigravity IDE.app",
+          ]
+        : []),
+    ]) ||
+    find("antigravity-ide")
   ) {
     detected.push("antigravity");
   }

--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -182,9 +182,113 @@ export type ConnectHarnessId =
   | "claude-desktop"
   | "antigravity"
   | "codex"
+  | "vscode"
   | "opencode"
   | "goose"
   | "copilot";
+
+export interface DetectConnectHarnessesOptions {
+  home?: string;
+  platform?: NodeJS.Platform;
+  find?: (command: string) => string | null;
+  exists?: (path: string) => boolean;
+  copilotHome?: string;
+}
+
+/**
+ * Detect user-scoped harness targets for parameterless `zam agent connect`.
+ * Claude Code is deliberately excluded because its existing MCP target is the
+ * current workspace; users can still configure it explicitly.
+ */
+export function detectInstalledConnectHarnesses(
+  options: DetectConnectHarnessesOptions = {},
+): ConnectHarnessId[] {
+  const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
+  const find = options.find ?? findExecutable;
+  const exists = options.exists ?? existsSync;
+  const detected: ConnectHarnessId[] = [];
+
+  const hasCommandOrPath = (command: string, paths: string[] = []) =>
+    Boolean(find(command)) || paths.some((path) => exists(path));
+
+  if (
+    hasCommandOrPath("codex", [
+      join(home, ".codex"),
+      ...(platform === "darwin"
+        ? ["/Applications/Codex.app"]
+        : platform === "win32"
+          ? [join(home, "AppData", "Local", "Programs", "Codex")]
+          : []),
+    ])
+  ) {
+    detected.push("codex");
+  }
+
+  const vscodePaths =
+    platform === "darwin"
+      ? [
+          "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+          join(
+            home,
+            "Applications",
+            "Visual Studio Code.app",
+            "Contents",
+            "Resources",
+            "app",
+            "bin",
+            "code",
+          ),
+        ]
+      : platform === "win32"
+        ? [
+            join(
+              home,
+              "AppData",
+              "Local",
+              "Programs",
+              "Microsoft VS Code",
+              "bin",
+              "code.cmd",
+            ),
+          ]
+        : ["/usr/bin/code", "/usr/local/bin/code", "/snap/bin/code"];
+  if (hasCommandOrPath("code", vscodePaths)) detected.push("vscode");
+
+  const copilotHome = options.copilotHome ?? join(home, ".copilot");
+  if (
+    hasCommandOrPath("copilot", [
+      copilotHome,
+      ...(platform === "darwin" ? ["/Applications/GitHub Copilot.app"] : []),
+    ])
+  ) {
+    detected.push("copilot");
+  }
+
+  if (hasCommandOrPath("opencode", [join(home, ".config", "opencode")])) {
+    detected.push("opencode");
+  }
+  if (hasCommandOrPath("goose", [join(home, ".config", "goose")])) {
+    detected.push("goose");
+  }
+  if (
+    hasCommandOrPath("antigravity", [
+      join(home, ".gemini", "config"),
+      ...(platform === "darwin" ? ["/Applications/Antigravity.app"] : []),
+    ])
+  ) {
+    detected.push("antigravity");
+  }
+  const claudeDesktopPath =
+    platform === "darwin"
+      ? "/Applications/Claude.app"
+      : platform === "win32"
+        ? join(home, "AppData", "Local", "AnthropicClaude")
+        : join(home, ".config", "Claude");
+  if (exists(claudeDesktopPath)) detected.push("claude-desktop");
+
+  return detected;
+}
 
 interface McpJsonConfig {
   mcpServers?: Record<string, unknown>;
@@ -357,6 +461,52 @@ approval_mode = "prompt"
 `;
       content = existingStr ? `${existingStr.trimEnd()}\n${block}` : block;
     }
+  } else if (harnessId === "vscode") {
+    const platform = opts.platform ?? process.platform;
+    targetPath =
+      platform === "win32"
+        ? join(opts.home, "AppData", "Roaming", "Code", "User", "mcp.json")
+        : platform === "darwin"
+          ? join(
+              opts.home,
+              "Library",
+              "Application Support",
+              "Code",
+              "User",
+              "mcp.json",
+            )
+          : join(opts.home, ".config", "Code", "User", "mcp.json");
+    hint =
+      "Reload VS Code after setup. ZAM Companion stays separate from the Codex chat and can be moved to any panel or sidebar.";
+    let existing: McpJsonConfig & { servers?: Record<string, unknown> } = {};
+    if (exists(targetPath)) {
+      existing = parseMcpJsonConfig(targetPath, read(targetPath));
+    }
+    if (
+      existing.servers !== undefined &&
+      (typeof existing.servers !== "object" ||
+        existing.servers === null ||
+        Array.isArray(existing.servers))
+    ) {
+      throw new Error(
+        `Cannot update ${targetPath}: servers must be a JSON object`,
+      );
+    }
+    if (existing.inputs !== undefined && !Array.isArray(existing.inputs)) {
+      throw new Error(`Cannot update ${targetPath}: inputs must be an array`);
+    }
+    if (!existing.servers) existing.servers = {};
+    const expectedServer = { command: opts.zamPath, args: ["mcp"] };
+    const currentServer = existing.servers.zam;
+    alreadyConfigured =
+      Array.isArray(existing.inputs) &&
+      typeof currentServer === "object" &&
+      currentServer !== null &&
+      !Array.isArray(currentServer) &&
+      JSON.stringify(currentServer) === JSON.stringify(expectedServer);
+    existing.servers.zam = expectedServer;
+    if (!existing.inputs) existing.inputs = [];
+    content = JSON.stringify(existing, null, 2);
   } else if (harnessId === "goose") {
     targetPath = join(opts.home, ".config", "goose", "config.yaml");
     hint =
@@ -402,7 +552,7 @@ approval_mode = "prompt"
       "mcp-config.json",
     );
     hint =
-      "Restart GitHub Copilot or start a new session to load the 'zam' MCP server and its Studio, Recall, Graph, and Settings canvases.";
+      "Restart GitHub Copilot or start a new session to load the 'zam' MCP server and its focused Recall, Graph, and Settings canvases.";
     let existing: McpJsonConfig = {};
     if (exists(targetPath)) {
       existing = parseMcpJsonConfig(targetPath, read(targetPath));

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -28,6 +28,7 @@ import {
   detectInstalledConnectHarnesses,
   getHarness,
   launchHarness,
+  resolveAntigravityIdeExecutable,
   resolveHarnessExecutable,
 } from "../agent-harness.js";
 import {
@@ -285,6 +286,16 @@ const connectCmd = new Command("connect")
             zamPath,
             dryRun: Boolean(opts.print),
           });
+        } else if (harness === "antigravity") {
+          const antigravityPath = resolveAntigravityIdeExecutable();
+          if (antigravityPath) {
+            vscodeExtension = installVscodeExtension({
+              home,
+              zamPath,
+              codePath: antigravityPath,
+              dryRun: Boolean(opts.print),
+            });
+          }
         }
       } catch (error) {
         console.error(
@@ -335,7 +346,7 @@ const connectCmd = new Command("connect")
       }
       if (vscodeExtension) {
         console.log(
-          `${C.green}✓${C.reset} VS Code Companion ${vscodeExtension.action} from ${vscodeExtension.vsixPath}`,
+          `${C.green}✓${C.reset} ZAM Companion ${vscodeExtension.action} from ${vscodeExtension.vsixPath}`,
         );
       }
       console.log(`  ${C.dim}${result.hint}${C.reset}`);

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -14,6 +14,7 @@ import { dirname, join } from "node:path";
 import { Command } from "commander";
 import type { Database } from "../../kernel/index.js";
 import {
+  distributeGlobalSkills,
   getSetting,
   hasCommand,
   installOpenCode,
@@ -24,6 +25,7 @@ import {
   type ConnectHarnessId,
   type ConnectResult,
   connectHarnessMcp,
+  detectInstalledConnectHarnesses,
   getHarness,
   launchHarness,
   resolveHarnessExecutable,
@@ -33,6 +35,10 @@ import {
   installCopilotExtension,
 } from "../copilot-extension.js";
 import { findExecutable, normalizeShell } from "../terminal-open.js";
+import {
+  installVscodeExtension,
+  type VscodeExtensionInstallResult,
+} from "../vscode-extension.js";
 
 const C = {
   reset: "\x1b[0m",
@@ -49,6 +55,7 @@ const CONNECT_HARNESSES: ConnectHarnessId[] = [
   "claude-desktop",
   "antigravity",
   "codex",
+  "vscode",
   "opencode",
   "goose",
   "copilot",
@@ -201,19 +208,40 @@ const openCmd = new Command("open")
   });
 
 const connectCmd = new Command("connect")
-  .description("Configure the ZAM MCP server for an agent harness")
+  .description(
+    "Configure ZAM for detected user agent harnesses, or one explicit harness",
+  )
   .argument(
-    "<harness>",
-    "Harness to connect: claude-code | claude-desktop | antigravity | codex | opencode | goose | copilot",
+    "[harness]",
+    "Optional harness: claude-code | claude-desktop | antigravity | codex | vscode | opencode | goose | copilot",
   )
   .option(
     "--print",
     "Print configuration changes instead of writing them to disk",
   )
-  .action(async (harnessArg, opts: { print?: boolean }) => {
-    if (!isConnectHarnessId(harnessArg)) {
+  .action(async (harnessArg: string | undefined, opts: { print?: boolean }) => {
+    let explicitHarness: ConnectHarnessId | undefined;
+    if (harnessArg) {
+      if (!isConnectHarnessId(harnessArg)) {
+        console.error(
+          `Unsupported harness: ${harnessArg}. Supported: ${CONNECT_HARNESSES.join(", ")}.`,
+        );
+        process.exit(1);
+      } else {
+        explicitHarness = harnessArg;
+      }
+    }
+
+    const home = homedir();
+    const harnesses: ConnectHarnessId[] = explicitHarness
+      ? [explicitHarness]
+      : detectInstalledConnectHarnesses({
+          home,
+          copilotHome: process.env.COPILOT_HOME,
+        });
+    if (harnesses.length === 0) {
       console.error(
-        `Unsupported harness: ${harnessArg}. Supported: ${CONNECT_HARNESSES.join(", ")}.`,
+        "No supported user-scoped agent harness was detected. Install Codex, VS Code, or another supported host, or pass a harness explicitly.",
       );
       process.exit(1);
     }
@@ -226,79 +254,99 @@ const connectCmd = new Command("connect")
       zamPath = "zam";
     }
 
-    let result: ConnectResult;
-    try {
-      result = connectHarnessMcp(harnessArg, {
-        zamPath,
-        cwd: process.cwd(),
-        home: homedir(),
-        copilotHome: process.env.COPILOT_HOME,
-      });
-    } catch (error) {
-      console.error(
-        `Error preparing MCP configuration: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      process.exit(1);
-    }
-
-    let copilotExtension: CopilotExtensionInstallResult | undefined;
-    if (harnessArg === "copilot") {
+    for (const harness of harnesses) {
+      let result: ConnectResult;
       try {
-        copilotExtension = installCopilotExtension({
-          home: homedir(),
+        result = connectHarnessMcp(harness, {
           zamPath,
-          dryRun: Boolean(opts.print),
+          cwd: process.cwd(),
+          home,
+          copilotHome: process.env.COPILOT_HOME,
         });
       } catch (error) {
         console.error(
-          `Error preparing Copilot MCP Apps extension: ${error instanceof Error ? error.message : String(error)}`,
+          `Error preparing ${harness} MCP configuration: ${error instanceof Error ? error.message : String(error)}`,
         );
         process.exit(1);
       }
-    }
 
-    if (opts.print) {
-      console.log(`Path: ${result.path}`);
-      console.log(`Content:\n${result.content}`);
-      if (copilotExtension) {
-        console.log(`Extension: ${copilotExtension.destinationDir}`);
+      let copilotExtension: CopilotExtensionInstallResult | undefined;
+      let vscodeExtension: VscodeExtensionInstallResult | undefined;
+      try {
+        if (harness === "copilot") {
+          copilotExtension = installCopilotExtension({
+            home,
+            zamPath,
+            dryRun: Boolean(opts.print),
+          });
+        } else if (harness === "vscode") {
+          vscodeExtension = installVscodeExtension({
+            home,
+            zamPath,
+            dryRun: Boolean(opts.print),
+          });
+        }
+      } catch (error) {
+        console.error(
+          `Error preparing ${harness} companion extension: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+
+      if (opts.print) {
+        if (harnesses.length > 1) console.log(`${C.bold}${harness}${C.reset}`);
+        console.log(`Path: ${result.path}`);
+        console.log(`Content:\n${result.content}`);
+        if (copilotExtension) {
+          console.log(`Extension: ${copilotExtension.destinationDir}`);
+          console.log(
+            `Launch: ${copilotExtension.launch.command} ${copilotExtension.launch.args.join(" ")}`,
+          );
+        }
+        if (vscodeExtension) {
+          console.log(`Extension: ${vscodeExtension.vsixPath}`);
+          console.log(`Launch config: ${vscodeExtension.launchConfigPath}`);
+        }
+        continue;
+      }
+
+      if (result.alreadyConfigured) {
         console.log(
-          `Launch: ${copilotExtension.launch.command} ${copilotExtension.launch.args.join(" ")}`,
+          `${C.green}✓${C.reset} ${harness}: MCP server 'zam' already configured in ${result.path}`,
+        );
+      } else {
+        try {
+          mkdirSync(dirname(result.path), { recursive: true });
+          writeFileSync(result.path, result.content, "utf-8");
+          console.log(
+            `${C.green}✓${C.reset} ${harness}: wrote MCP configuration to ${result.path}`,
+          );
+        } catch (error) {
+          console.error(
+            `Error writing ${harness} MCP configuration: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          process.exit(1);
+        }
+      }
+      if (copilotExtension) {
+        console.log(
+          `${C.green}✓${C.reset} Copilot MCP Apps extension ${copilotExtension.action} at ${copilotExtension.destinationDir}`,
         );
       }
-      return;
-    }
-
-    if (result.alreadyConfigured) {
-      console.log(
-        `${C.green}✓${C.reset} MCP server 'zam' already configured in ${result.path}`,
-      );
-      if (copilotExtension) {
+      if (vscodeExtension) {
         console.log(
-          `${C.green}✓${C.reset} MCP Apps extension ${copilotExtension.action} at ${copilotExtension.destinationDir}`,
+          `${C.green}✓${C.reset} VS Code Companion ${vscodeExtension.action} from ${vscodeExtension.vsixPath}`,
         );
       }
       console.log(`  ${C.dim}${result.hint}${C.reset}`);
-      return;
     }
 
-    try {
-      mkdirSync(dirname(result.path), { recursive: true });
-      writeFileSync(result.path, result.content, "utf-8");
+    if (!opts.print) {
+      const skills = distributeGlobalSkills(home);
+      const installed = skills.filter((result) => result.success).length;
       console.log(
-        `${C.green}✓${C.reset} Wrote MCP configuration to ${result.path}`,
+        `${C.green}✓${C.reset} Refreshed ${installed}/${skills.length} global ZAM skill installations`,
       );
-      if (copilotExtension) {
-        console.log(
-          `${C.green}✓${C.reset} MCP Apps extension ${copilotExtension.action} at ${copilotExtension.destinationDir}`,
-        );
-      }
-      console.log(`  ${C.dim}${result.hint}${C.reset}`);
-    } catch (error) {
-      console.error(
-        `Error writing MCP configuration: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      process.exit(1);
     }
   });
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -25,6 +25,7 @@ import {
   submitReview as handleSubmitReview,
   suggestFoundations as handleSuggestFoundations,
 } from "../bridge-handlers.js";
+import { publishUiIntent } from "../ui-intent.js";
 import { executeBridgeCommandJson } from "./bridge.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -653,7 +654,7 @@ export function createMcpServer(db: Database): McpServer {
     {
       title: "ZAM Studio",
       description:
-        "Open the ZAM Studio panel (content editor, knowledge graph, settings) inline",
+        "Open the legacy all-in-one ZAM Studio panel for standalone onboarding and content curation. Agent harness workflows should use the focused Recall, Graph, and Settings apps instead.",
       inputSchema: {},
       annotations: {
         ...commonAnnotations,
@@ -726,6 +727,7 @@ export function createMcpServer(db: Database): McpServer {
         // Mirror zam_open_studio: resolve to the signed-in user, but never
         // fail to open the panel — fall back to null when no default is set.
         const userId = await getUserId(user).catch(() => null);
+        await publishUiIntent("recall", { user, domain });
         return {
           recall: "zam",
           version: pkg.version,
@@ -786,6 +788,7 @@ export function createMcpServer(db: Database): McpServer {
       // Mirror zam_open_recall: resolve to the signed-in user, but never
       // fail to open the panel — fall back to null when no default is set.
       const userId = await getUserId(user).catch(() => null);
+      await publishUiIntent("graph", { user, focus });
       return {
         graph: "zam",
         focus: focus ?? null,
@@ -839,6 +842,7 @@ export function createMcpServer(db: Database): McpServer {
       // Mirror zam_open_recall/zam_show_graph: resolve to the signed-in user,
       // but never fail to open the panel — fall back to null when unset.
       const userId = await getUserId(user).catch(() => null);
+      await publishUiIntent("settings", { user });
       return {
         settings: "zam",
         version: pkg.version,

--- a/src/cli/ui-intent.ts
+++ b/src/cli/ui-intent.ts
@@ -1,0 +1,114 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { ulid } from "ulid";
+
+export type UiIntentApp = "recall" | "graph" | "settings";
+
+export interface UiIntent {
+  version: 1;
+  id: string;
+  app: UiIntentApp;
+  input: Record<string, string>;
+  createdAt: string;
+}
+
+export interface WriteUiIntentOptions {
+  path?: string;
+  id?: string;
+  now?: () => Date;
+  hostRegistrationPath?: string;
+}
+
+interface UiHostRegistration {
+  version: 1;
+  intentPath: string;
+  updatedAt: string;
+}
+
+export function getUiIntentPath(home: string = homedir()): string {
+  return join(home, ".zam", "ui-intent.json");
+}
+
+export function getUiHostRegistrationPath(home: string = homedir()): string {
+  return join(home, ".zam", "vscode-host.json");
+}
+
+function compactStringInput(
+  input: Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(input).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+/**
+ * Atomically hand one purpose-built MCP App request to a local visual host.
+ * The file is deliberately a last-intent snapshot rather than a queue: users
+ * operate one harness at a time, and a newer request supersedes an older one.
+ */
+export async function writeUiIntent(
+  app: UiIntentApp,
+  input: Record<string, string | undefined> = {},
+  opts: WriteUiIntentOptions = {},
+): Promise<UiIntent> {
+  const path = opts.path ?? process.env.ZAM_UI_INTENT_PATH ?? getUiIntentPath();
+  const id = opts.id ?? ulid();
+  const intent: UiIntent = {
+    version: 1,
+    id,
+    app,
+    input: compactStringInput(input),
+    createdAt: (opts.now ?? (() => new Date()))().toISOString(),
+  };
+  const tempPath = join(dirname(path), `.ui-intent-${process.pid}-${id}.tmp`);
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tempPath, `${JSON.stringify(intent, null, 2)}\n`, "utf8");
+  await rename(tempPath, path);
+  return intent;
+}
+
+/**
+ * Opening an MCP App must still succeed in hosts that do not run the VS Code
+ * companion, or when its optional local handoff cannot be written.
+ */
+export async function publishUiIntent(
+  app: UiIntentApp,
+  input: Record<string, string | undefined> = {},
+  opts: WriteUiIntentOptions = {},
+): Promise<UiIntent | undefined> {
+  try {
+    if (process.env.ZAM_DISABLE_UI_INTENT === "1") return undefined;
+    const explicitPath = opts.path ?? process.env.ZAM_UI_INTENT_PATH;
+    if (explicitPath) {
+      return await writeUiIntent(app, input, { ...opts, path: explicitPath });
+    }
+
+    const now = (opts.now ?? (() => new Date()))();
+    const registrationPath =
+      opts.hostRegistrationPath ?? getUiHostRegistrationPath();
+    const registration = JSON.parse(
+      await readFile(registrationPath, "utf8"),
+    ) as Partial<UiHostRegistration>;
+    const updatedAt = Date.parse(registration.updatedAt ?? "");
+    if (
+      registration.version !== 1 ||
+      typeof registration.intentPath !== "string" ||
+      !Number.isFinite(updatedAt) ||
+      now.getTime() - updatedAt > 15_000
+    ) {
+      return undefined;
+    }
+
+    return await writeUiIntent(app, input, {
+      ...opts,
+      path: registration.intentPath,
+      now: () => now,
+    });
+  } catch {
+    return undefined;
+  }
+}

--- a/src/cli/vscode-extension.ts
+++ b/src/cli/vscode-extension.ts
@@ -107,7 +107,7 @@ export function planVscodeExtensionInstall(
   const vsixPath = join(assetsDir, `ZAM_Companion_${version}.vsix`);
   if (!existsSync(vsixPath)) {
     throw new Error(
-      `VS Code Companion asset is missing: ${vsixPath}. Run \`npm run build\` and retry.`,
+      `ZAM Companion VSIX asset is missing: ${vsixPath}. Run \`npm run build\` and retry.`,
     );
   }
   const codePath =

--- a/src/cli/vscode-extension.ts
+++ b/src/cli/vscode-extension.ts
@@ -1,0 +1,171 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findExecutable } from "./terminal-open.js";
+
+const packageRoot =
+  [
+    fileURLToPath(new URL("../..", import.meta.url)),
+    fileURLToPath(new URL("../../..", import.meta.url)),
+  ].find((candidate) => existsSync(join(candidate, "package.json"))) ??
+  fileURLToPath(new URL("../..", import.meta.url));
+
+export type VscodeExtensionInstallAction =
+  | "installed"
+  | "updated"
+  | "unchanged"
+  | "planned";
+
+export interface VscodeExtensionPlan {
+  version: string;
+  vsixPath: string;
+  codePath: string;
+  launchConfigPath: string;
+  launch: { command: string; args: string[] };
+}
+
+export interface VscodeExtensionInstallResult extends VscodeExtensionPlan {
+  action: VscodeExtensionInstallAction;
+}
+
+export interface VscodeExtensionOptions {
+  home?: string;
+  platform?: NodeJS.Platform;
+  assetsDir?: string;
+  version?: string;
+  zamPath: string;
+  codePath?: string;
+  dryRun?: boolean;
+  find?: (command: string) => string | null;
+  exists?: (path: string) => boolean;
+  run?: (command: string, args: string[]) => void;
+}
+
+export function resolveVscodeExecutable(
+  options: Pick<
+    VscodeExtensionOptions,
+    "home" | "platform" | "find" | "exists"
+  > = {},
+): string | null {
+  const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
+  const find = options.find ?? findExecutable;
+  const exists = options.exists ?? existsSync;
+  const found = find("code");
+  if (found) return found;
+
+  const candidates =
+    platform === "darwin"
+      ? [
+          "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+          join(
+            home,
+            "Applications",
+            "Visual Studio Code.app",
+            "Contents",
+            "Resources",
+            "app",
+            "bin",
+            "code",
+          ),
+        ]
+      : platform === "win32"
+        ? [
+            join(
+              home,
+              "AppData",
+              "Local",
+              "Programs",
+              "Microsoft VS Code",
+              "bin",
+              "code.cmd",
+            ),
+          ]
+        : ["/usr/bin/code", "/usr/local/bin/code", "/snap/bin/code"];
+  return candidates.find((candidate) => exists(candidate)) ?? null;
+}
+
+function packageVersion(): string {
+  const parsed = JSON.parse(
+    readFileSync(join(packageRoot, "package.json"), "utf8"),
+  ) as { version?: unknown };
+  if (typeof parsed.version !== "string" || !parsed.version) {
+    throw new Error("Cannot determine the ZAM package version");
+  }
+  return parsed.version;
+}
+
+export function planVscodeExtensionInstall(
+  options: VscodeExtensionOptions,
+): VscodeExtensionPlan {
+  const home = options.home ?? homedir();
+  const version = options.version ?? packageVersion();
+  const assetsDir =
+    options.assetsDir ?? join(packageRoot, "dist", "vscode-extension");
+  const vsixPath = join(assetsDir, `ZAM_Companion_${version}.vsix`);
+  if (!existsSync(vsixPath)) {
+    throw new Error(
+      `VS Code Companion asset is missing: ${vsixPath}. Run \`npm run build\` and retry.`,
+    );
+  }
+  const codePath =
+    options.codePath ??
+    resolveVscodeExecutable({
+      home,
+      platform: options.platform,
+      find: options.find,
+      exists: options.exists,
+    });
+  if (!codePath) {
+    throw new Error(
+      "Visual Studio Code was not detected. Install VS Code or add its 'code' command to PATH.",
+    );
+  }
+  return {
+    version,
+    vsixPath,
+    codePath,
+    launchConfigPath: join(home, ".zam", "vscode-launch.json"),
+    launch: { command: options.zamPath, args: ["mcp"] },
+  };
+}
+
+export function installVscodeExtension(
+  options: VscodeExtensionOptions,
+): VscodeExtensionInstallResult {
+  const plan = planVscodeExtensionInstall(options);
+  if (options.dryRun) return { ...plan, action: "planned" };
+
+  const launchContent = `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      version: plan.version,
+      command: plan.launch.command,
+      args: plan.launch.args,
+    },
+    null,
+    2,
+  )}\n`;
+  const existed = existsSync(plan.launchConfigPath);
+  const changed =
+    !existed || readFileSync(plan.launchConfigPath, "utf8") !== launchContent;
+
+  const run =
+    options.run ??
+    ((command: string, args: string[]) => {
+      execFileSync(command, args, { stdio: "pipe" });
+    });
+  run(plan.codePath, ["--install-extension", plan.vsixPath, "--force"]);
+
+  if (changed) {
+    mkdirSync(dirname(plan.launchConfigPath), { recursive: true });
+    writeFileSync(plan.launchConfigPath, launchContent, "utf8");
+  }
+
+  return {
+    ...plan,
+    action: !existed ? "installed" : changed ? "updated" : "unchanged",
+  };
+}

--- a/src/vscode-extension/extension.ts
+++ b/src/vscode-extension/extension.ts
@@ -1,0 +1,478 @@
+import { unwatchFile, watchFile } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import * as vscode from "vscode";
+import {
+  buildOpeningArguments,
+  COMPANION_APPS,
+  type CompanionApp,
+  type CompanionAppConfig,
+  parseCompanionIntent,
+  toolUiResourceUri,
+} from "./protocol.js";
+
+interface LaunchConfig {
+  command: string;
+  args: string[];
+}
+
+interface PreparedApp {
+  appHtml: string;
+  config: CompanionAppConfig;
+  kind: CompanionApp;
+  resourceUri: string;
+  tool: Tool;
+  toolArguments: Record<string, string>;
+  toolResult: CallToolResult;
+}
+
+interface HostMessage {
+  type?: unknown;
+  id?: unknown;
+  payload?: unknown;
+}
+
+const VIEW_CONTAINER_ID = "zamCompanion";
+const VIEW_ID = "zam.companion";
+const DEFAULT_EMPTY_MESSAGE =
+  "ZAM wartet auf eine Auswahl im Agent-Chat. Starte mit $zam oder öffne Recall, Graph oder Settings über die Befehlspalette.";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function childEnvironment(): Record<string, string> {
+  return {
+    ...Object.fromEntries(
+      Object.entries(process.env).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      ),
+    ),
+    ZAM_DISABLE_UI_INTENT: "1",
+  };
+}
+
+async function readLaunchConfig(path: string): Promise<LaunchConfig> {
+  try {
+    const parsed = JSON.parse(
+      await readFile(path, "utf8"),
+    ) as Partial<LaunchConfig>;
+    if (
+      typeof parsed.command === "string" &&
+      Array.isArray(parsed.args) &&
+      parsed.args.every((arg) => typeof arg === "string")
+    ) {
+      return { command: parsed.command, args: parsed.args };
+    }
+  } catch {
+    // Manual VSIX installs may not have run `zam agent connect vscode` yet.
+  }
+  return { command: process.env.ZAM_BIN ?? "zam", args: ["mcp"] };
+}
+
+class ZamMcpHost {
+  private connectionPromise:
+    | Promise<{ client: Client; transport: StdioClientTransport }>
+    | undefined;
+
+  public constructor(
+    private readonly launchConfigPath: string,
+    private readonly output: vscode.OutputChannel,
+  ) {}
+
+  private async connect(): Promise<{
+    client: Client;
+    transport: StdioClientTransport;
+  }> {
+    if (!this.connectionPromise) {
+      this.connectionPromise = (async () => {
+        const launch = await readLaunchConfig(this.launchConfigPath);
+        const transport = new StdioClientTransport({
+          command: launch.command,
+          args: launch.args,
+          env: childEnvironment(),
+          stderr: "pipe",
+        });
+        transport.stderr?.on("data", (chunk: Buffer | string) => {
+          this.output.appendLine(
+            `[zam mcp] ${(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk).trimEnd()}`,
+          );
+        });
+        const client = new Client({
+          name: "vscode-zam-companion",
+          version: "__ZAM_VERSION__",
+        });
+        await client.connect(transport);
+        return { client, transport };
+      })().catch((error) => {
+        this.connectionPromise = undefined;
+        throw error;
+      });
+    }
+    return this.connectionPromise;
+  }
+
+  public async client(): Promise<Client> {
+    return (await this.connect()).client;
+  }
+
+  public async prepare(
+    kind: CompanionApp,
+    input: Record<string, string>,
+  ): Promise<PreparedApp> {
+    const config = COMPANION_APPS[kind];
+    const client = await this.client();
+    const { tools } = await client.listTools();
+    const tool = tools.find((candidate) => candidate.name === config.toolName);
+    if (!tool) throw new Error(`ZAM MCP tool not found: ${config.toolName}`);
+
+    const resourceUri = toolUiResourceUri(tool);
+    if (!resourceUri) {
+      throw new Error(`${config.toolName} does not advertise an MCP App`);
+    }
+    const toolArguments = buildOpeningArguments(kind, input);
+    const [rawToolResult, resourceResult] = await Promise.all([
+      client.callTool({ name: config.toolName, arguments: toolArguments }),
+      client.readResource({ uri: resourceUri }),
+    ]);
+    const toolResult = rawToolResult as CallToolResult;
+    if (toolResult.isError) {
+      const message = toolResult.content?.find((item) => item.type === "text");
+      throw new Error(
+        message && "text" in message
+          ? message.text
+          : `${config.toolName} failed`,
+      );
+    }
+
+    const resource =
+      resourceResult.contents.find((item) => item.uri === resourceUri) ??
+      resourceResult.contents[0];
+    const appHtml =
+      resource && "text" in resource && typeof resource.text === "string"
+        ? resource.text
+        : resource && "blob" in resource && typeof resource.blob === "string"
+          ? Buffer.from(resource.blob, "base64").toString("utf8")
+          : "";
+    if (!appHtml) throw new Error(`MCP App resource is empty: ${resourceUri}`);
+
+    return {
+      appHtml,
+      config,
+      kind,
+      resourceUri,
+      tool,
+      toolArguments,
+      toolResult: toolResult as CallToolResult,
+    };
+  }
+
+  public async close(): Promise<void> {
+    const connection = await this.connectionPromise?.catch(() => undefined);
+    this.connectionPromise = undefined;
+    await connection?.client.close().catch(() => {});
+  }
+}
+
+class CompanionViewProvider implements vscode.WebviewViewProvider {
+  private view: vscode.WebviewView | undefined;
+  private hostReady = false;
+  private prepared: PreparedApp | undefined;
+
+  public constructor(
+    private readonly extensionUri: vscode.Uri,
+    private readonly mcp: ZamMcpHost,
+    private readonly output: vscode.OutputChannel,
+  ) {}
+
+  public resolveWebviewView(view: vscode.WebviewView): void {
+    this.view = view;
+    this.hostReady = false;
+    view.webview.options = { enableScripts: true };
+    view.webview.html = this.renderHostHtml(view.webview);
+    view.webview.onDidReceiveMessage((message: unknown) => {
+      void this.handleMessage(message as HostMessage);
+    });
+    view.onDidDispose(() => {
+      this.view = undefined;
+      this.hostReady = false;
+    });
+  }
+
+  public async open(
+    kind: CompanionApp,
+    input: Record<string, string> = {},
+  ): Promise<void> {
+    await vscode.commands.executeCommand(
+      `workbench.view.extension.${VIEW_CONTAINER_ID}`,
+    );
+    this.view?.show(true);
+    this.setEmpty(`${COMPANION_APPS[kind].title} wird geladen …`);
+    try {
+      this.prepared = await this.mcp.prepare(kind, input);
+      this.sendBootstrap();
+      this.output.appendLine(
+        `[${new Date().toISOString()}] opened ${kind} via ${this.prepared.resourceUri}`,
+      );
+    } catch (error) {
+      const message = errorMessage(error);
+      this.setEmpty(`ZAM konnte nicht geöffnet werden: ${message}`);
+      this.output.appendLine(
+        `[${new Date().toISOString()}] failed to open ${kind}: ${message}`,
+      );
+      void vscode.window.showErrorMessage(`ZAM Companion: ${message}`);
+    }
+  }
+
+  private async handleMessage(message: HostMessage): Promise<void> {
+    if (message.type === "ready") {
+      this.hostReady = true;
+      this.output.appendLine(
+        `[${new Date().toISOString()}] webview host ready`,
+      );
+      if (this.prepared) this.sendBootstrap();
+      else this.setEmpty(DEFAULT_EMPTY_MESSAGE);
+      return;
+    }
+
+    const id = typeof message.id === "number" ? message.id : undefined;
+    if (id === undefined) return;
+    try {
+      let result: unknown = {};
+      if (message.type === "callTool") {
+        result = await this.callTool(message.payload);
+      } else if (message.type === "openLink") {
+        result = await this.openLink(message.payload);
+      } else if (message.type === "modelContext") {
+        result = {};
+      } else if (message.type === "status") {
+        this.output.appendLine(
+          `[${new Date().toISOString()}] webview ${JSON.stringify(message.payload)}`,
+        );
+      } else {
+        throw new Error(
+          `Unknown ZAM Companion message: ${String(message.type)}`,
+        );
+      }
+      await this.view?.webview.postMessage({ type: "response", id, result });
+    } catch (error) {
+      await this.view?.webview.postMessage({
+        type: "response",
+        id,
+        error: errorMessage(error),
+      });
+    }
+  }
+
+  private async callTool(payload: unknown): Promise<CallToolResult> {
+    if (!this.prepared || !payload || typeof payload !== "object") {
+      throw new Error("No active ZAM MCP App");
+    }
+    const value = payload as { name?: unknown; arguments?: unknown };
+    if (
+      typeof value.name !== "string" ||
+      !this.prepared.config.allowedTools.has(value.name)
+    ) {
+      throw new Error(
+        `Tool is not allowed for ${this.prepared.kind}: ${String(value.name)}`,
+      );
+    }
+    const args =
+      value.arguments &&
+      typeof value.arguments === "object" &&
+      !Array.isArray(value.arguments)
+        ? (value.arguments as Record<string, unknown>)
+        : {};
+    return (await (
+      await this.mcp.client()
+    ).callTool({ name: value.name, arguments: args })) as CallToolResult;
+  }
+
+  private async openLink(payload: unknown): Promise<Record<string, unknown>> {
+    if (!payload || typeof payload !== "object") {
+      throw new Error("Invalid link request");
+    }
+    const url = (payload as { url?: unknown }).url;
+    if (typeof url !== "string") throw new Error("Invalid link URL");
+    const uri = vscode.Uri.parse(url, true);
+    if (uri.scheme !== "https" && uri.scheme !== "http") {
+      throw new Error(`Blocked link scheme: ${uri.scheme}`);
+    }
+    const opened = await vscode.env.openExternal(uri);
+    return opened ? {} : { isError: true };
+  }
+
+  private sendBootstrap(): void {
+    if (!this.hostReady || !this.prepared || !this.view) return;
+    this.output.appendLine(
+      `[${new Date().toISOString()}] sending ${this.prepared.kind} bootstrap`,
+    );
+    void this.view.webview.postMessage({
+      type: "bootstrap",
+      payload: {
+        appHtml: this.prepared.appHtml,
+        title: this.prepared.config.title,
+        tool: this.prepared.tool,
+        toolArguments: this.prepared.toolArguments,
+        toolResult: this.prepared.toolResult,
+      },
+    });
+  }
+
+  private setEmpty(message: string): void {
+    if (!this.hostReady || !this.view) return;
+    void this.view.webview.postMessage({ type: "empty", message });
+  }
+
+  private renderHostHtml(webview: vscode.Webview): string {
+    const hostBundle = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, "media", "host.bundle.js"),
+    );
+    // Blob documents inherit the creator's CSP in Electron. The MCP App is a
+    // self-contained HTML resource with an inline module bundle, so the outer
+    // policy must allow inline script execution inside the sandboxed iframe.
+    // The VS Code host itself still loads only the extension-owned script URI.
+    return `<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webview.cspSource} 'unsafe-inline' blob:; style-src 'unsafe-inline'; frame-src blob:; img-src data: blob:;" />
+    <title>ZAM Companion</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { width: 100%; height: 100%; margin: 0; }
+      body {
+        overflow: hidden;
+        color: var(--vscode-foreground);
+        background: var(--vscode-panel-background, var(--vscode-sideBar-background));
+        font-family: var(--vscode-font-family, system-ui, sans-serif);
+      }
+      #status {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        color: var(--vscode-descriptionForeground);
+        text-align: center;
+        line-height: 1.45;
+      }
+      #app { width: 100%; height: 100%; border: 0; background: transparent; }
+      body.ready #status { display: none; }
+    </style>
+  </head>
+  <body>
+    <div id="status" role="status">${DEFAULT_EMPTY_MESSAGE}</div>
+    <iframe id="app" title="ZAM Companion" sandbox="allow-scripts allow-forms"></iframe>
+    <script type="module" src="${hostBundle}"></script>
+  </body>
+</html>`;
+  }
+}
+
+async function writeHostRegistration(
+  registrationPath: string,
+  intentPath: string,
+): Promise<void> {
+  const tempPath = join(
+    dirname(registrationPath),
+    `.vscode-host-${process.pid}.tmp`,
+  );
+  await mkdir(dirname(registrationPath), { recursive: true });
+  await writeFile(
+    tempPath,
+    `${JSON.stringify(
+      {
+        version: 1,
+        intentPath,
+        updatedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  await rename(tempPath, registrationPath);
+}
+
+let activeMcpHost: ZamMcpHost | undefined;
+
+export async function activate(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const zamDir = join(homedir(), ".zam");
+  const intentPath =
+    process.env.ZAM_UI_INTENT_PATH ?? join(zamDir, "ui-intent.json");
+  const registrationPath = join(zamDir, "vscode-host.json");
+  const launchConfigPath = join(zamDir, "vscode-launch.json");
+  const output = vscode.window.createOutputChannel("ZAM Companion", {
+    log: true,
+  });
+  const mcp = new ZamMcpHost(launchConfigPath, output);
+  activeMcpHost = mcp;
+  const provider = new CompanionViewProvider(context.extensionUri, mcp, output);
+
+  context.subscriptions.push(
+    output,
+    vscode.window.registerWebviewViewProvider(VIEW_ID, provider),
+    vscode.commands.registerCommand("zam.openRecall", () =>
+      provider.open("recall"),
+    ),
+    vscode.commands.registerCommand("zam.showGraph", () =>
+      provider.open("graph"),
+    ),
+    vscode.commands.registerCommand("zam.openSettings", () =>
+      provider.open("settings"),
+    ),
+  );
+
+  let lastIntentId: string | undefined;
+  const consumeIntent = async () => {
+    if (!vscode.window.state.focused) return;
+    try {
+      const intent = parseCompanionIntent(
+        JSON.parse(await readFile(intentPath, "utf8")),
+      );
+      if (!intent || intent.id === lastIntentId) return;
+      lastIntentId = intent.id;
+      await provider.open(intent.app, intent.input);
+    } catch {
+      // The handoff file is optional and may not exist before the first call.
+    }
+  };
+  const watchListener = () => void consumeIntent();
+  watchFile(intentPath, { interval: 300 }, watchListener);
+  context.subscriptions.push({
+    dispose: () => unwatchFile(intentPath, watchListener),
+  });
+
+  const heartbeat = () => {
+    if (!vscode.window.state.focused) return;
+    void writeHostRegistration(registrationPath, intentPath).catch((error) => {
+      output.warn(
+        `Could not publish VS Code host registration: ${errorMessage(error)}`,
+      );
+    });
+  };
+  heartbeat();
+  const heartbeatTimer = setInterval(heartbeat, 5_000);
+  context.subscriptions.push(
+    { dispose: () => clearInterval(heartbeatTimer) },
+    vscode.window.onDidChangeWindowState((state) => {
+      if (state.focused) {
+        heartbeat();
+        void consumeIntent();
+      }
+    }),
+  );
+}
+
+export async function deactivate(): Promise<void> {
+  await activeMcpHost?.close();
+  activeMcpHost = undefined;
+}

--- a/src/vscode-extension/host.ts
+++ b/src/vscode-extension/host.ts
@@ -1,0 +1,206 @@
+/// <reference lib="dom" />
+
+import {
+  AppBridge,
+  PostMessageTransport,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+
+declare function acquireVsCodeApi(): {
+  postMessage(message: unknown): void;
+};
+
+interface BootstrapPayload {
+  appHtml: string;
+  title: string;
+  tool: Tool;
+  toolArguments: Record<string, unknown>;
+  toolResult: CallToolResult;
+}
+
+type HostRequestType = "callTool" | "modelContext" | "openLink" | "status";
+
+function requiredElement<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector);
+  if (!element)
+    throw new Error(`ZAM Companion element is missing: ${selector}`);
+  return element;
+}
+
+const vscode = acquireVsCodeApi();
+const frame = requiredElement<HTMLIFrameElement>("#app");
+const status = requiredElement<HTMLElement>("#status");
+const pending = new Map<
+  number,
+  { resolve: (value: unknown) => void; reject: (error: Error) => void }
+>();
+let requestId = 0;
+let activeBridge: AppBridge | undefined;
+let activeBlobUrl: string | undefined;
+
+function request<T>(type: HostRequestType, payload: unknown): Promise<T> {
+  const id = ++requestId;
+  return new Promise<T>((resolve, reject) => {
+    pending.set(id, {
+      resolve: (value) => resolve(value as T),
+      reject,
+    });
+    vscode.postMessage({ type, id, payload });
+  });
+}
+
+function currentTheme(): "dark" | "light" {
+  return document.body.classList.contains("vscode-dark") ||
+    document.body.classList.contains("vscode-high-contrast")
+    ? "dark"
+    : "light";
+}
+
+function hostContext(tool: Tool) {
+  return {
+    toolInfo: { id: `vscode-${tool.name}`, tool },
+    theme: currentTheme(),
+    displayMode: "inline" as const,
+    availableDisplayModes: ["inline" as const],
+    containerDimensions: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    },
+    locale: navigator.language,
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    userAgent: navigator.userAgent,
+    platform: "desktop" as const,
+    deviceCapabilities: {
+      touch: navigator.maxTouchPoints > 0,
+      hover: matchMedia("(hover: hover)").matches,
+    },
+  };
+}
+
+async function teardownActiveBridge(): Promise<void> {
+  if (activeBridge) {
+    await activeBridge.teardownResource({}).catch(() => {});
+    activeBridge = undefined;
+  }
+  if (activeBlobUrl) {
+    URL.revokeObjectURL(activeBlobUrl);
+    activeBlobUrl = undefined;
+  }
+  frame.removeAttribute("src");
+  document.body.classList.remove("ready");
+}
+
+async function mount(payload: BootstrapPayload): Promise<void> {
+  await teardownActiveBridge();
+  status.textContent = `${payload.title} wird verbunden …`;
+
+  const bridge = new AppBridge(
+    null,
+    { name: "VS Code ZAM Companion", version: "__ZAM_VERSION__" },
+    {
+      openLinks: {},
+      serverTools: {},
+      logging: {},
+      updateModelContext: { text: {}, structuredContent: {} },
+    },
+    { hostContext: hostContext(payload.tool) },
+  );
+  activeBridge = bridge;
+
+  bridge.oncalltool = async (params) =>
+    request<CallToolResult>("callTool", params);
+  bridge.onupdatemodelcontext = async (params) =>
+    request<Record<string, never>>("modelContext", params);
+  bridge.onopenlink = async ({ url }) =>
+    request<Record<string, unknown>>("openLink", { url });
+  bridge.onrequestdisplaymode = async () => ({ mode: "inline" });
+  bridge.onsizechange = () => {
+    frame.style.height = "100%";
+  };
+  bridge.oninitialized = async () => {
+    await bridge.sendToolInput({ arguments: payload.toolArguments });
+    await bridge.sendToolResult(payload.toolResult);
+    document.body.classList.add("ready");
+    void request("status", {
+      phase: "ready",
+      app: payload.tool.name,
+    }).catch(() => {});
+  };
+
+  const targetWindow = frame.contentWindow;
+  if (!targetWindow) throw new Error("ZAM Companion iframe is unavailable");
+  const transport = new PostMessageTransport(targetWindow, targetWindow);
+  await bridge.connect(transport);
+
+  activeBlobUrl = URL.createObjectURL(
+    new Blob([payload.appHtml], { type: "text/html" }),
+  );
+  frame.title = payload.title;
+  frame.src = activeBlobUrl;
+}
+
+window.addEventListener("message", (event: MessageEvent<unknown>) => {
+  const message = event.data;
+  if (!message || typeof message !== "object") return;
+  const value = message as Record<string, unknown>;
+
+  if (value.type === "bootstrap") {
+    void mount(value.payload as BootstrapPayload).catch((error) => {
+      status.textContent = `MCP App konnte nicht gestartet werden: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+      void request("status", {
+        phase: "error",
+        message: error instanceof Error ? error.message : String(error),
+      }).catch(() => {});
+    });
+    return;
+  }
+
+  if (value.type === "empty") {
+    void teardownActiveBridge();
+    status.textContent =
+      typeof value.message === "string"
+        ? value.message
+        : "ZAM wartet auf eine Auswahl im Agent-Chat.";
+    return;
+  }
+
+  if (value.type === "response" && typeof value.id === "number") {
+    const entry = pending.get(value.id);
+    if (!entry) return;
+    pending.delete(value.id);
+    if (typeof value.error === "string") {
+      entry.reject(new Error(value.error));
+    } else {
+      entry.resolve(value.result);
+    }
+  }
+});
+
+const refreshHostContext = () => {
+  if (!activeBridge) return;
+  activeBridge.setHostContext({
+    theme: currentTheme(),
+    containerDimensions: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    },
+  });
+};
+window.addEventListener("resize", refreshHostContext);
+const themeObserver = new MutationObserver(refreshHostContext);
+themeObserver.observe(document.body, {
+  attributes: true,
+  attributeFilter: ["class"],
+});
+window.addEventListener(
+  "beforeunload",
+  () => {
+    themeObserver.disconnect();
+    void teardownActiveBridge();
+  },
+  { once: true },
+);
+
+vscode.postMessage({ type: "ready" });

--- a/src/vscode-extension/protocol.ts
+++ b/src/vscode-extension/protocol.ts
@@ -1,0 +1,110 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export type CompanionApp = "recall" | "graph" | "settings";
+
+export interface CompanionIntent {
+  version: 1;
+  id: string;
+  app: CompanionApp;
+  input: Record<string, string>;
+  createdAt: string;
+}
+
+export interface CompanionAppConfig {
+  title: string;
+  toolName: string;
+  allowedTools: ReadonlySet<string>;
+}
+
+export const COMPANION_APPS: Record<CompanionApp, CompanionAppConfig> = {
+  recall: {
+    title: "ZAM Recall",
+    toolName: "zam_open_recall",
+    allowedTools: new Set(["zam_get_reviews", "zam_submit_review"]),
+  },
+  graph: {
+    title: "ZAM Graph",
+    toolName: "zam_show_graph",
+    allowedTools: new Set(["zam_studio_bridge"]),
+  },
+  settings: {
+    title: "ZAM Settings",
+    toolName: "zam_open_settings",
+    allowedTools: new Set(["zam_studio_bridge"]),
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseCompanionIntent(
+  value: unknown,
+  now: number = Date.now(),
+  maxAgeMs = 30_000,
+): CompanionIntent | undefined {
+  if (!isRecord(value) || value.version !== 1) return undefined;
+  if (
+    typeof value.id !== "string" ||
+    typeof value.app !== "string" ||
+    !(value.app in COMPANION_APPS)
+  ) {
+    return undefined;
+  }
+  if (typeof value.createdAt !== "string" || !isRecord(value.input)) {
+    return undefined;
+  }
+  const createdAt = Date.parse(value.createdAt);
+  if (
+    !Number.isFinite(createdAt) ||
+    createdAt > now + 5_000 ||
+    now - createdAt > maxAgeMs
+  ) {
+    return undefined;
+  }
+  const input = Object.fromEntries(
+    Object.entries(value.input).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  return {
+    version: 1,
+    id: value.id,
+    app: value.app as CompanionApp,
+    input,
+    createdAt: value.createdAt,
+  };
+}
+
+export function buildOpeningArguments(
+  app: CompanionApp,
+  input: Record<string, string>,
+): Record<string, string> {
+  const allowed =
+    app === "recall"
+      ? ["user", "domain"]
+      : app === "graph"
+        ? ["user", "focus"]
+        : ["user"];
+  return Object.fromEntries(
+    allowed.flatMap((key) =>
+      typeof input[key] === "string" ? [[key, input[key]]] : [],
+    ),
+  );
+}
+
+export function toolUiResourceUri(tool: Tool): string | undefined {
+  const meta = tool._meta as
+    | {
+        ui?: { resourceUri?: unknown };
+        "ui/resourceUri"?: unknown;
+      }
+    | undefined;
+  const nested = meta?.ui?.resourceUri;
+  const legacy = meta?.["ui/resourceUri"];
+  return typeof nested === "string"
+    ? nested
+    : typeof legacy === "string"
+      ? legacy
+      : undefined;
+}

--- a/src/vscode-extension/vscode.d.ts
+++ b/src/vscode-extension/vscode.d.ts
@@ -1,0 +1,76 @@
+declare module "vscode" {
+  export interface Disposable {
+    dispose(): unknown;
+  }
+
+  export class Uri {
+    readonly scheme: string;
+    static parse(value: string, strict?: boolean): Uri;
+    static joinPath(base: Uri, ...pathSegments: string[]): Uri;
+    toString(): string;
+  }
+
+  export interface Webview {
+    options: { enableScripts?: boolean };
+    html: string;
+    readonly cspSource: string;
+    asWebviewUri(localResource: Uri): Uri;
+    postMessage(message: unknown): PromiseLike<boolean>;
+    onDidReceiveMessage(listener: (message: unknown) => unknown): Disposable;
+  }
+
+  export interface WebviewView {
+    readonly webview: Webview;
+    show(preserveFocus?: boolean): void;
+    onDidDispose(listener: () => unknown): Disposable;
+  }
+
+  export interface WebviewViewProvider {
+    resolveWebviewView(view: WebviewView): unknown;
+  }
+
+  export interface OutputChannel extends Disposable {
+    appendLine(value: string): void;
+    warn(value: string): void;
+  }
+
+  export interface WindowState {
+    readonly focused: boolean;
+  }
+
+  export interface ExtensionContext {
+    readonly extensionUri: Uri;
+    readonly subscriptions: Disposable[];
+  }
+
+  export const commands: {
+    executeCommand<T = unknown>(
+      command: string,
+      ...rest: unknown[]
+    ): Promise<T>;
+    registerCommand(
+      command: string,
+      callback: (...args: unknown[]) => unknown,
+    ): Disposable;
+  };
+
+  export const env: {
+    openExternal(uri: Uri): Promise<boolean>;
+  };
+
+  export const window: {
+    readonly state: WindowState;
+    createOutputChannel(
+      name: string,
+      options?: { log?: boolean },
+    ): OutputChannel;
+    registerWebviewViewProvider(
+      viewId: string,
+      provider: WebviewViewProvider,
+    ): Disposable;
+    showErrorMessage(message: string): PromiseLike<unknown>;
+    onDidChangeWindowState(
+      listener: (state: WindowState) => unknown,
+    ): Disposable;
+  };
+}

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -4,12 +4,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AGENT_HARNESSES,
   type AgentHarness,
+  connectHarnessMcp,
+  detectInstalledConnectHarnesses,
   getHarness,
   launchHarness,
   planHarnessLaunch,
+  resolveAntigravityIdeExecutable,
   resolveHarnessExecutable,
-  connectHarnessMcp,
-  detectInstalledConnectHarnesses,
 } from "../../src/cli/agent-harness.js";
 
 afterEach(() => {
@@ -83,6 +84,54 @@ describe("resolveHarnessExecutable", () => {
     ).toBe("/opt/x/x");
   });
 
+  it("resolves antigravity-ide on PATH for antigravity harness", () => {
+    const antigravity = getHarness("antigravity") as AgentHarness;
+    expect(
+      resolveHarnessExecutable(antigravity, undefined, {
+        find: (c) =>
+          c === "antigravity-ide" ? "/usr/local/bin/antigravity-ide" : null,
+      }),
+    ).toBe("/usr/local/bin/antigravity-ide");
+  });
+
+  it("resolves antigravity candidate paths on macOS", () => {
+    const antigravity = getHarness("antigravity") as AgentHarness;
+    expect(
+      resolveHarnessExecutable(antigravity, undefined, {
+        find: () => null,
+        exists: (p) =>
+          p ===
+          "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide",
+        platform: "darwin",
+      }),
+    ).toBe(
+      "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide",
+    );
+  });
+
+  it("resolves only the VS Code-compatible Antigravity IDE for extensions", () => {
+    expect(
+      resolveAntigravityIdeExecutable({
+        find: () => null,
+        exists: (path) =>
+          path ===
+          "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide",
+        platform: "darwin",
+      }),
+    ).toBe(
+      "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide",
+    );
+
+    expect(
+      resolveAntigravityIdeExecutable({
+        find: () => null,
+        exists: (path) =>
+          path === "/Applications/Antigravity.app/Contents/MacOS/Antigravity",
+        platform: "darwin",
+      }),
+    ).toBeNull();
+  });
+
   it("does not probe candidate paths for CLI harnesses", () => {
     expect(
       resolveHarnessExecutable(claude, undefined, {
@@ -121,6 +170,18 @@ describe("detectInstalledConnectHarnesses", () => {
         exists: () => false,
       }),
     ).toEqual([]);
+  });
+
+  it("detects Antigravity IDE by its CLI name", () => {
+    expect(
+      detectInstalledConnectHarnesses({
+        home: "/home/user",
+        platform: "linux",
+        find: (command) =>
+          command === "antigravity-ide" ? "/usr/bin/antigravity-ide" : null,
+        exists: () => false,
+      }),
+    ).toEqual(["antigravity"]);
   });
 });
 

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -9,6 +9,7 @@ import {
   planHarnessLaunch,
   resolveHarnessExecutable,
   connectHarnessMcp,
+  detectInstalledConnectHarnesses,
 } from "../../src/cli/agent-harness.js";
 
 afterEach(() => {
@@ -89,6 +90,37 @@ describe("resolveHarnessExecutable", () => {
         exists: () => true,
       }),
     ).toBeNull();
+  });
+});
+
+describe("detectInstalledConnectHarnesses", () => {
+  it("detects user-scoped Codex, VS Code, and Copilot targets", () => {
+    const detected = detectInstalledConnectHarnesses({
+      home: "/home/user",
+      platform: "darwin",
+      find: (command) =>
+        command === "codex" || command === "claude"
+          ? `/usr/local/bin/${command}`
+          : null,
+      exists: (path) =>
+        path ===
+          "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ||
+        path === "/home/user/.copilot",
+    });
+
+    expect(detected).toEqual(["codex", "vscode", "copilot"]);
+    expect(detected).not.toContain("claude-code");
+  });
+
+  it("returns no targets when no supported user host is installed", () => {
+    expect(
+      detectInstalledConnectHarnesses({
+        home: "/home/user",
+        platform: "linux",
+        find: () => null,
+        exists: () => false,
+      }),
+    ).toEqual([]);
   });
 });
 
@@ -271,6 +303,58 @@ describe("connectHarnessMcp", () => {
     const res = connectHarnessMcp("codex", mockDeps);
     expect(res.alreadyConfigured).toBe(true);
     expect(res.content).toBe(existing);
+  });
+
+  it("vscode merges the user config and preserves servers and inputs", () => {
+    mockFiles["/home/user/Library/Application Support/Code/User/mcp.json"] =
+      JSON.stringify({
+        servers: { other: { command: "other-mcp" } },
+        inputs: [{ id: "token", type: "promptString" }],
+        custom: true,
+      });
+    const res = connectHarnessMcp("vscode", {
+      ...mockDeps,
+      platform: "darwin",
+    });
+
+    expect(posix(res.path)).toBe(
+      "/home/user/Library/Application Support/Code/User/mcp.json",
+    );
+    expect(JSON.parse(res.content)).toEqual({
+      servers: {
+        other: { command: "other-mcp" },
+        zam: { command: "/usr/local/bin/zam", args: ["mcp"] },
+      },
+      inputs: [{ id: "token", type: "promptString" }],
+      custom: true,
+    });
+    expect(res.alreadyConfigured).toBe(false);
+  });
+
+  it("vscode reports an existing complete setup as configured", () => {
+    mockFiles["/home/user/.config/Code/User/mcp.json"] = JSON.stringify({
+      servers: {
+        zam: { command: "/usr/local/bin/zam", args: ["mcp"] },
+      },
+      inputs: [],
+    });
+    const res = connectHarnessMcp("vscode", {
+      ...mockDeps,
+      platform: "linux",
+    });
+    expect(res.alreadyConfigured).toBe(true);
+  });
+
+  it("vscode refuses to replace malformed server configuration", () => {
+    mockFiles["/home/user/.config/Code/User/mcp.json"] = JSON.stringify({
+      servers: [],
+    });
+    expect(() =>
+      connectHarnessMcp("vscode", {
+        ...mockDeps,
+        platform: "linux",
+      }),
+    ).toThrow("servers must be a JSON object");
   });
 
   it("goose fresh write creates a valid extensions map", () => {

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -295,8 +295,13 @@ describe("setup command helpers", () => {
     );
 
     expect(content).toContain("In Codex, invoke this workflow as `$zam`");
-    expect(content).toContain("zam agent connect <harness>");
+    expect(content).toContain("zam agent connect\n");
     expect(content).toContain("`zam_monitor`");
+    expect(content).toContain(
+      "## Parameterless invocation — offer choices first",
+    );
+    expect(content).toContain("`zam_open_recall`");
+    expect(content).not.toContain("- **Studio");
     expect(content).not.toContain("Codex Execution Notes");
     expect(content).not.toContain("WindowsPowerShell");
   });

--- a/tests/cli/ui-intent.test.ts
+++ b/tests/cli/ui-intent.test.ts
@@ -1,0 +1,126 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getUiIntentPath,
+  getUiHostRegistrationPath,
+  publishUiIntent,
+  writeUiIntent,
+} from "../../src/cli/ui-intent.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempHome(): string {
+  const dir = mkdtempSync(join(tmpdir(), "zam-ui-intent-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("VS Code UI intent", () => {
+  it("uses one user-scoped handoff file", () => {
+    expect(getUiIntentPath("/home/thomas")).toBe(
+      join("/home/thomas", ".zam", "ui-intent.json"),
+    );
+  });
+
+  it("atomically writes a focused MCP App request", async () => {
+    const path = getUiIntentPath(tempHome());
+    const intent = await writeUiIntent(
+      "recall",
+      { domain: "rag", user: undefined },
+      {
+        path,
+        id: "01KX87ZQBE4QGDVJCBFX5PVWGW",
+        now: () => new Date("2026-07-11T09:26:24.878Z"),
+      },
+    );
+
+    expect(intent).toEqual({
+      version: 1,
+      id: "01KX87ZQBE4QGDVJCBFX5PVWGW",
+      app: "recall",
+      input: { domain: "rag" },
+      createdAt: "2026-07-11T09:26:24.878Z",
+    });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(intent);
+  });
+
+  it("keeps UI publication best-effort for hosts without the companion", async () => {
+    const intent = await publishUiIntent(
+      "graph",
+      { focus: "zam-mcp-server-architecture" },
+      { path: "/dev/null/not-a-directory/ui-intent.json" },
+    );
+
+    expect(intent).toBeUndefined();
+  });
+
+  it("publishes through a fresh VS Code host registration", async () => {
+    const home = tempHome();
+    const path = getUiIntentPath(home);
+    const registrationPath = getUiHostRegistrationPath(home);
+    mkdirSync(join(home, ".zam"), { recursive: true });
+    writeFileSync(
+      registrationPath,
+      JSON.stringify({
+        version: 1,
+        intentPath: path,
+        updatedAt: "2026-07-11T09:26:20.000Z",
+      }),
+      "utf8",
+    );
+
+    const intent = await publishUiIntent(
+      "settings",
+      {},
+      {
+        hostRegistrationPath: registrationPath,
+        id: "01KX87ZQBE4QGDVJCBFX5PVWGW",
+        now: () => new Date("2026-07-11T09:26:24.878Z"),
+      },
+    );
+
+    expect(intent?.app).toBe("settings");
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(intent);
+  });
+
+  it("ignores a stale VS Code host registration", async () => {
+    const home = tempHome();
+    const path = getUiIntentPath(home);
+    const registrationPath = getUiHostRegistrationPath(home);
+    mkdirSync(join(home, ".zam"), { recursive: true });
+    writeFileSync(
+      registrationPath,
+      JSON.stringify({
+        version: 1,
+        intentPath: path,
+        updatedAt: "2026-07-11T09:25:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const intent = await publishUiIntent(
+      "recall",
+      {},
+      {
+        hostRegistrationPath: registrationPath,
+        now: () => new Date("2026-07-11T09:26:24.878Z"),
+      },
+    );
+
+    expect(intent).toBeUndefined();
+  });
+});

--- a/tests/cli/vscode-companion-protocol.test.ts
+++ b/tests/cli/vscode-companion-protocol.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOpeningArguments,
+  COMPANION_APPS,
+  parseCompanionIntent,
+  toolUiResourceUri,
+} from "../../src/vscode-extension/protocol.js";
+
+describe("VS Code companion protocol", () => {
+  const now = Date.parse("2026-07-11T09:26:30.000Z");
+
+  it("accepts a fresh purpose-built app intent", () => {
+    expect(
+      parseCompanionIntent(
+        {
+          version: 1,
+          id: "01KX87ZQBE4QGDVJCBFX5PVWGW",
+          app: "recall",
+          input: { domain: "rag", ignored: 42 },
+          createdAt: "2026-07-11T09:26:24.878Z",
+        },
+        now,
+      ),
+    ).toEqual({
+      version: 1,
+      id: "01KX87ZQBE4QGDVJCBFX5PVWGW",
+      app: "recall",
+      input: { domain: "rag" },
+      createdAt: "2026-07-11T09:26:24.878Z",
+    });
+  });
+
+  it("rejects stale and unknown intents", () => {
+    expect(
+      parseCompanionIntent(
+        {
+          version: 1,
+          id: "old",
+          app: "recall",
+          input: {},
+          createdAt: "2026-07-11T09:25:00.000Z",
+        },
+        now,
+      ),
+    ).toBeUndefined();
+    expect(
+      parseCompanionIntent(
+        {
+          version: 1,
+          id: "studio",
+          app: "studio",
+          input: {},
+          createdAt: "2026-07-11T09:26:24.878Z",
+        },
+        now,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps host arguments and tool access purpose-specific", () => {
+    expect(
+      buildOpeningArguments("recall", {
+        user: "thomas",
+        domain: "rag",
+        focus: "ignore-me",
+      }),
+    ).toEqual({ user: "thomas", domain: "rag" });
+    expect(COMPANION_APPS.recall.allowedTools).toEqual(
+      new Set(["zam_get_reviews", "zam_submit_review"]),
+    );
+    expect(COMPANION_APPS).not.toHaveProperty("studio");
+  });
+
+  it("accepts current and legacy MCP Apps resource metadata", () => {
+    expect(
+      toolUiResourceUri({
+        name: "current",
+        inputSchema: { type: "object" },
+        _meta: { ui: { resourceUri: "ui://zam/recall" } },
+      }),
+    ).toBe("ui://zam/recall");
+    expect(
+      toolUiResourceUri({
+        name: "legacy",
+        inputSchema: { type: "object" },
+        _meta: { "ui/resourceUri": "ui://zam/graph" },
+      }),
+    ).toBe("ui://zam/graph");
+  });
+});

--- a/tests/cli/vscode-extension.test.ts
+++ b/tests/cli/vscode-extension.test.ts
@@ -1,0 +1,122 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  installVscodeExtension,
+  planVscodeExtensionInstall,
+  resolveVscodeExecutable,
+} from "../../src/cli/vscode-extension.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "zam-vscode-extension-"));
+  tempDirs.push(root);
+  const home = join(root, "home");
+  const assetsDir = join(root, "assets");
+  mkdirSync(assetsDir, { recursive: true });
+  const vsixPath = join(assetsDir, "ZAM_Companion_0.10.3.vsix");
+  writeFileSync(vsixPath, "fixture");
+  return { root, home, assetsDir, vsixPath };
+}
+
+describe("VS Code Companion installation", () => {
+  it("resolves the standard macOS CLI when code is not on PATH", () => {
+    expect(
+      resolveVscodeExecutable({
+        home: "/Users/test",
+        platform: "darwin",
+        find: () => null,
+        exists: (path) =>
+          path ===
+          "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+      }),
+    ).toBe(
+      "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+    );
+  });
+
+  it("plans the packaged VSIX and user launch configuration", () => {
+    const { home, assetsDir, vsixPath } = fixture();
+    const plan = planVscodeExtensionInstall({
+      home,
+      assetsDir,
+      version: "0.10.3",
+      zamPath: "/usr/local/bin/zam",
+      codePath: "/usr/local/bin/code",
+    });
+    expect(plan.vsixPath).toBe(vsixPath);
+    expect(plan.launchConfigPath).toBe(
+      join(home, ".zam", "vscode-launch.json"),
+    );
+    expect(plan.launch).toEqual({
+      command: "/usr/local/bin/zam",
+      args: ["mcp"],
+    });
+  });
+
+  it("installs idempotently and records the exact ZAM launch", () => {
+    const { home, assetsDir, vsixPath } = fixture();
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const options = {
+      home,
+      assetsDir,
+      version: "0.10.3",
+      zamPath: "/usr/local/bin/zam",
+      codePath: "/usr/local/bin/code",
+      run: (command: string, args: string[]) => calls.push({ command, args }),
+    };
+
+    const first = installVscodeExtension(options);
+    const second = installVscodeExtension(options);
+    expect(first.action).toBe("installed");
+    expect(second.action).toBe("unchanged");
+    expect(calls).toEqual([
+      {
+        command: "/usr/local/bin/code",
+        args: ["--install-extension", vsixPath, "--force"],
+      },
+      {
+        command: "/usr/local/bin/code",
+        args: ["--install-extension", vsixPath, "--force"],
+      },
+    ]);
+    expect(JSON.parse(readFileSync(first.launchConfigPath, "utf8"))).toEqual({
+      schemaVersion: 1,
+      version: "0.10.3",
+      command: "/usr/local/bin/zam",
+      args: ["mcp"],
+    });
+  });
+
+  it("does not execute or write during a dry run", () => {
+    const { home, assetsDir } = fixture();
+    let ran = false;
+    const result = installVscodeExtension({
+      home,
+      assetsDir,
+      version: "0.10.3",
+      zamPath: "zam",
+      codePath: "code",
+      dryRun: true,
+      run: () => {
+        ran = true;
+      },
+    });
+    expect(result.action).toBe("planned");
+    expect(ran).toBe(false);
+  });
+});

--- a/tsup.config.vscode-extension.ts
+++ b/tsup.config.vscode-extension.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "vscode-extension/extension": "src/vscode-extension/extension.ts",
+  },
+  outDir: "dist",
+  format: ["cjs"],
+  target: "node22",
+  platform: "node",
+  splitting: false,
+  sourcemap: false,
+  dts: false,
+  clean: false,
+  minify: true,
+  external: ["vscode"],
+  noExternal: [/^(?!vscode$).*/],
+  outExtension: () => ({ js: ".cjs" }),
+});

--- a/vite.config.vscode-extension.mts
+++ b/vite.config.vscode-extension.mts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    outDir: resolve(import.meta.dirname, "dist/vscode-extension"),
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(import.meta.dirname, "src/vscode-extension/host.ts"),
+      formats: ["es"],
+      fileName: () => "host.bundle.js",
+    },
+    minify: true,
+    sourcemap: false,
+  },
+});


### PR DESCRIPTION
## Summary

- add native MCP App intents plus a detached, movable ZAM Companion surface for VS Code
- make `zam agent connect` parameterless, user-scoped, auto-detecting, and idempotent
- guide parameterless `/zam` usage through Recall-first MCP App choices without exposing Studio
- package and upload the Companion VSIX with release builds
- support the same Companion in Antigravity IDE 1.107 through its `antigravity-ide` CLI
- bump CLI and desktop packages to 0.10.3

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 75 files, 691 tests
- `npm run build`
- `npm pack --dry-run`
- live Codex Desktop MCP App smoke
- live VS Code smoke with the official Codex extension and detached Recall pane
- brief GitHub Copilot MCP regression smoke
- live Antigravity IDE 1.107 VSIX install and detached Recall smoke
- Apple Silicon macOS app build, ad-hoc signature verification, first-run bootstrap, and archive integrity check

## Scope

Claude and Windows end-to-end polishing remain deferred to a later release.
