### PR TITLE
fix: Bayern Realschule Physik 8-10 manifest coverage

### DIFF
--- a/docs/plans/2026-07-12-bayern-rs-gym-coverage-fix.md
+++ b/docs/plans/2026-07-12-bayern-rs-gym-coverage-fix.md
@@ -9,8 +9,8 @@ Audit: `npx tsx scripts/audit-bayern-manifest.ts`
 
 - [x] **Audit-Skript** — zählt OK-Pfade vs. Lücken im Manifest
 - [x] **RS Physik 8–10** — Tracks `wpfg1` / `wpfg2-3`, Lernbereiche + `contentUrls`
-- [ ] **RS übrige Lücken prüfen** — siehe Tabelle „erwartet leer“
-- [ ] **Gymnasium Lücken prüfen** — Wahlpflichtfächer, viele erwartet leer
+- [x] **RS übrige Lücken prüfen** — 37/37 N/A auf LehrplanPLUS (Probe 2026-07-12)
+- [x] **Gymnasium Lücken prüfen** — 159/159 N/A auf LehrplanPLUS (Probe 2026-07-12)
 - [ ] **CI-Gate** (optional) — Audit in Tests einbinden
 
 ## Realschule — Checkliste (178 Pfade gesamt)
@@ -23,10 +23,11 @@ Alle Kernfächer mit Lehrplan auf LehrplanPLUS für die jeweilige Stufe, inkl.:
 - **Physik 7** (einheitlich) + **Physik 8–10** mit `wpfg1` / `wpfg2-3` ← neu
 - Deutsch, Englisch, Biologie (wo angeboten), Chemie 8, …
 
-### Manifest-Lücken — erwartet leer (37)
+### Manifest-Lücken — erwartet leer (37) ✅
 
-Fach steht im Katalog, aber **kein Fachlehrplan** auf LehrplanPLUS für diese
-Jahrgangsstufe (Startseiten-Redirect). Verhalten wie Chemie 5 (bestehender Test).
+Live-Probe (`npx tsx scripts/probe-bayern-gaps.ts realschule`): **0 LIVE, 0 TRACKS,
+37 N/A**. Fach steht im Katalog, aber kein Fachlehrplan auf LehrplanPLUS für diese
+Jahrgangsstufe. Verhalten wie Chemie 5 (bestehender Test).
 
 | Pfad | Grund |
 |------|-------|
@@ -54,21 +55,27 @@ Kein Manifest-Eintrag nötig — Wizard soll leere Themenliste zeigen (ggf. Trac
 Kernfächer inkl. Deutsch, Englisch (mit Fremdsprachen-Tracks), Mathematik,
 Physik/Chemie/Biologie wo unterrichtet, Geographie 5/7/10/11, NTG 5–7, …
 
-### Manifest-Lücken (159) — überwiegend erwartet leer
+### Manifest-Lücken (159) — alle erwartet leer ✅
 
-Wahlpflichtfächer, Seminarfächer (`w-seminar`, `instrumentalensemble`, …),
-`nt_gym` ab Jg. 8, `iu` in Oberstufe, etc. — im Fächerverzeichnis, aber kein
-eigener Fachlehrplan für diese Kombination auf LehrplanPLUS.
-
-**Nächster Schritt:** Stichproben mit alter URL-Form
-`/schulart/gymnasium/jgs/{n}/fach/{fach}/inhalt/fachlehrplaene` — nur echte
-Lücken (Live-Inhalt, kein Manifest) eintragen.
+Live-Probe (`npx tsx scripts/probe-bayern-gaps.ts gymnasium`): **0 LIVE, 0 TRACKS,
+159 N/A**. Wahlpflichtfächer, Seminarfächer, `nt_gym` ab Jg. 8, `iu` in
+Oberstufe usw. — im Fächerverzeichnis, aber kein Fachlehrplan auf LehrplanPLUS.
 
 ## Verifikation
 
 ```bash
 npx tsx scripts/audit-bayern-manifest.ts
+npx tsx scripts/probe-bayern-gaps.ts realschule   # erwartet: 0 live, 37 N/A
+npx tsx scripts/probe-bayern-gaps.ts gymnasium    # erwartet: 0 live, 159 N/A
 npm run test -- tests/cli/curriculum-lehrplanplus-bayern.test.ts
 npm run dev -- bridge curriculum-list-level --provider lehrplanplus-bayern \
   --level track --selection '{"schoolType":"realschule","grade":"9","subject":"physik"}'
 ```
+
+## Fazit
+
+Für **Realschule + Gymnasium Bayern** war nach dem Physik-Fix **keine weitere
+Manifest-Ergänzung nötig**: alle verbleibenden Audit-Lücken sind Fächer ohne
+Lehrplan auf LehrplanPLUS für die jeweilige Jahrgangsstufe. Die 0.10.6-Behauptung
+„vollständig abgedeckt“ galt nicht für Physik 8–10 RS; ansonsten deckt das
+Manifest alle **live vorhandenen** Pfade ab.

--- a/docs/plans/2026-07-12-bayern-rs-gym-coverage-fix.md
+++ b/docs/plans/2026-07-12-bayern-rs-gym-coverage-fix.md
@@ -1,0 +1,74 @@
+# Bayern Realschule + Gymnasium — Manifest-Coverage Fix
+
+Branch: `fix/bayern-rs-gym-curriculum-coverage`  
+Auslöser: Physik 9 Realschule lieferte im Wizard keine Themen (leeres `listTopics`).
+
+Audit: `npx tsx scripts/audit-bayern-manifest.ts`
+
+## Status
+
+- [x] **Audit-Skript** — zählt OK-Pfade vs. Lücken im Manifest
+- [x] **RS Physik 8–10** — Tracks `wpfg1` / `wpfg2-3`, Lernbereiche + `contentUrls`
+- [ ] **RS übrige Lücken prüfen** — siehe Tabelle „erwartet leer“
+- [ ] **Gymnasium Lücken prüfen** — Wahlpflichtfächer, viele erwartet leer
+- [ ] **CI-Gate** (optional) — Audit in Tests einbinden
+
+## Realschule — Checkliste (178 Pfade gesamt)
+
+### Abgedeckt (144 OK nach Physik-Fix)
+
+Alle Kernfächer mit Lehrplan auf LehrplanPLUS für die jeweilige Stufe, inkl.:
+
+- Mathematik 5–10 mit `wpfg1` / `wpfg2-3`
+- **Physik 7** (einheitlich) + **Physik 8–10** mit `wpfg1` / `wpfg2-3` ← neu
+- Deutsch, Englisch, Biologie (wo angeboten), Chemie 8, …
+
+### Manifest-Lücken — erwartet leer (37)
+
+Fach steht im Katalog, aber **kein Fachlehrplan** auf LehrplanPLUS für diese
+Jahrgangsstufe (Startseiten-Redirect). Verhalten wie Chemie 5 (bestehender Test).
+
+| Pfad | Grund |
+|------|-------|
+| `realschule\|5\|*` (11 Fächer) | Wahlfächer / nicht in Jg. 5 unterrichtet |
+| `realschule\|6\|*` (10 Fächer) | dito Jg. 6 |
+| `realschule\|7\|*` (5 Fächer) | BWL, Chemie, EUG, PuG, Soziallehre, WiR — nicht Jg. 7 |
+| `realschule\|8\|bwl-rechnungswesen`, `pug` | nicht Jg. 8 |
+| `realschule\|9\|biologie`, `chemie`, `pug`, `wirtschaft-und-recht` | nicht Jg. 9 |
+| `realschule\|10\|chemie`, `geographie`, `textiles-gestalten`, `wirtschaft-und-recht` | nicht Jg. 10 |
+
+Kein Manifest-Eintrag nötig — Wizard soll leere Themenliste zeigen (ggf. Track-Auswahl bei Physik).
+
+### Behoben in diesem Branch
+
+| Pfad | Tracks | Lernbereiche |
+|------|--------|--------------|
+| `realschule\|8\|physik` | wpfg1 (4 LB), wpfg2-3 (3 LB) | live verifiziert 2026-07-12 |
+| `realschule\|9\|physik` | wpfg1 (3 LB), wpfg2-3 (3 LB) | live verifiziert 2026-07-12 |
+| `realschule\|10\|physik` | wpfg1 (4 LB), wpfg2-3 (4 LB) | live verifiziert 2026-07-12 |
+
+## Gymnasium — Checkliste (500 Pfade gesamt)
+
+### Abgedeckt (341 OK)
+
+Kernfächer inkl. Deutsch, Englisch (mit Fremdsprachen-Tracks), Mathematik,
+Physik/Chemie/Biologie wo unterrichtet, Geographie 5/7/10/11, NTG 5–7, …
+
+### Manifest-Lücken (159) — überwiegend erwartet leer
+
+Wahlpflichtfächer, Seminarfächer (`w-seminar`, `instrumentalensemble`, …),
+`nt_gym` ab Jg. 8, `iu` in Oberstufe, etc. — im Fächerverzeichnis, aber kein
+eigener Fachlehrplan für diese Kombination auf LehrplanPLUS.
+
+**Nächster Schritt:** Stichproben mit alter URL-Form
+`/schulart/gymnasium/jgs/{n}/fach/{fach}/inhalt/fachlehrplaene` — nur echte
+Lücken (Live-Inhalt, kein Manifest) eintragen.
+
+## Verifikation
+
+```bash
+npx tsx scripts/audit-bayern-manifest.ts
+npm run test -- tests/cli/curriculum-lehrplanplus-bayern.test.ts
+npm run dev -- bridge curriculum-list-level --provider lehrplanplus-bayern \
+  --level track --selection '{"schoolType":"realschule","grade":"9","subject":"physik"}'
+```

--- a/scripts/audit-bayern-manifest.ts
+++ b/scripts/audit-bayern-manifest.ts
@@ -1,0 +1,48 @@
+import { LEHRPLANPLUS_BAYERN_MANIFEST as M } from "../src/cli/curriculum/providers/lehrplanplus-bayern/manifest.ts";
+
+type Gap = { key: string; issue: "no_topics" | "no_url" };
+
+function auditSchoolType(schoolType: "realschule" | "gymnasium"): {
+  ok: string[];
+  gaps: Gap[];
+} {
+  const grades = M.grades[schoolType] ?? [];
+  const subjects = M.subjects[schoolType] ?? [];
+  const ok: string[] = [];
+  const gaps: Gap[] = [];
+
+  for (const grade of grades) {
+    for (const sub of subjects) {
+      const base = `${schoolType}|${grade}|${sub.id}`;
+      const tracks = M.tracks[base] ?? [];
+
+      if (tracks.length > 0) {
+        for (const tr of tracks) {
+          const key = `${base}|${tr.id}`;
+          const topics = M.topics[key];
+          const url = M.contentUrls[key];
+          if (!topics?.length) gaps.push({ key, issue: "no_topics" });
+          else if (!url) gaps.push({ key, issue: "no_url" });
+          else ok.push(key);
+        }
+      } else {
+        const topics = M.topics[base];
+        const url = M.contentUrls[base];
+        if (!topics?.length) gaps.push({ key: base, issue: "no_topics" });
+        else if (!url) gaps.push({ key: base, issue: "no_url" });
+        else ok.push(base);
+      }
+    }
+  }
+
+  return { ok, gaps };
+}
+
+for (const schoolType of ["realschule", "gymnasium"] as const) {
+  const { ok, gaps } = auditSchoolType(schoolType);
+  console.log(`\n=== ${schoolType} ===`);
+  console.log(`OK: ${ok.length}  gaps: ${gaps.length}`);
+  for (const g of gaps) {
+    console.log(`  ${g.key} (${g.issue})`);
+  }
+}

--- a/scripts/probe-bayern-gaps.ts
+++ b/scripts/probe-bayern-gaps.ts
@@ -1,0 +1,119 @@
+import { LEHRPLANPLUS_BAYERN_MANIFEST as M } from "../src/cli/curriculum/providers/lehrplanplus-bayern/manifest.ts";
+
+type Gap = { key: string; issue: "no_topics" | "no_url" };
+
+function auditGaps(schoolType: "realschule" | "gymnasium"): Gap[] {
+  const grades = M.grades[schoolType] ?? [];
+  const subjects = M.subjects[schoolType] ?? [];
+  const gaps: Gap[] = [];
+
+  for (const grade of grades) {
+    for (const sub of subjects) {
+      const base = `${schoolType}|${grade}|${sub.id}`;
+      const tracks = M.tracks[base] ?? [];
+
+      if (tracks.length > 0) {
+        for (const tr of tracks) {
+          const key = `${base}|${tr.id}`;
+          const topics = M.topics[key];
+          const url = M.contentUrls[key];
+          if (!topics?.length) gaps.push({ key, issue: "no_topics" });
+          else if (!url) gaps.push({ key, issue: "no_url" });
+        }
+      } else {
+        const topics = M.topics[base];
+        const url = M.contentUrls[base];
+        if (!topics?.length) gaps.push({ key: base, issue: "no_topics" });
+        else if (!url) gaps.push({ key: base, issue: "no_url" });
+      }
+    }
+  }
+
+  return gaps;
+}
+
+function lehrplanUrl(key: string): string {
+  const [schoolType, grade, subject, track] = key.split("|");
+  const base = `https://www.lehrplanplus.bayern.de/schulart/${schoolType}/jgs/${grade}/fach/${subject}/inhalt/fachlehrplaene`;
+  if (!track) return base;
+  return `${base}?w_schulart=${schoolType}&wt_1=schulart&w_fach=${subject}&wt_2=fach&w_jgs=${grade}&wt_3=jgs&w_auspraegung=${track}`;
+}
+
+function extractTopics(html: string): Array<{ label: string; hours?: number }> {
+  const re = /head-absatz-title-short[^>]*>\s*([^<]+)/g;
+  const topics: Array<{ label: string; hours?: number }> = [];
+  let match: RegExpExecArray | null = re.exec(html);
+  while (match !== null) {
+    const raw = match[1]
+      .replace(/&nbsp;/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    const hoursMatch = raw.match(/\(ca\.\s*(\d+)\s*Std\.\)/);
+    topics.push({
+      label: raw.replace(/\s*\(ca\.\s*\d+\s*Std\.\)\s*/, "").trim(),
+      hours: hoursMatch ? Number(hoursMatch[1]) : undefined,
+    });
+    match = re.exec(html);
+  }
+  return topics;
+}
+
+const TRACK_CANDIDATES = ["wpfg1", "wpfg2-3"] as const;
+
+async function probeKey(key: string): Promise<{
+  status: "live" | "tracks" | "na";
+  topics: Array<{ label: string; hours?: number }>;
+  track?: string;
+  url?: string;
+}> {
+  const html = await fetch(lehrplanUrl(key), { redirect: "follow" }).then((r) =>
+    r.text(),
+  );
+  if (html.includes("<title>LehrplanPLUS - Startseite</title>")) {
+    const [schoolType, grade, subject] = key.split("|");
+    if (key.split("|").length === 3) {
+      for (const track of TRACK_CANDIDATES) {
+        const trackKey = `${schoolType}|${grade}|${subject}|${track}`;
+        const trackHtml = await fetch(lehrplanUrl(trackKey), {
+          redirect: "follow",
+        }).then((r) => r.text());
+        const topics = extractTopics(trackHtml);
+        if (
+          topics.length > 0 &&
+          !trackHtml.includes("<title>LehrplanPLUS - Startseite</title>")
+        ) {
+          return { status: "tracks", topics, track, url: lehrplanUrl(trackKey) };
+        }
+      }
+    }
+    return { status: "na", topics: [] };
+  }
+  return { status: "live", topics: extractTopics(html), url: lehrplanUrl(key) };
+}
+
+const schoolType = (process.argv[2] ?? "gymnasium") as "realschule" | "gymnasium";
+const gaps = auditGaps(schoolType);
+
+const live: string[] = [];
+const trackNeeded: string[] = [];
+const na: string[] = [];
+
+for (const gap of gaps) {
+  const result = await probeKey(gap.key);
+  if (result.status === "live" && result.topics.length > 0) {
+    live.push(gap.key);
+    console.log(`LIVE\t${gap.key}\t${result.topics.length}\t${result.topics.map((t) => t.label).join("; ")}`);
+  } else if (result.status === "tracks") {
+    trackNeeded.push(gap.key);
+    console.log(`TRACKS\t${gap.key}\t${result.track}\t${result.topics.length}\t${result.topics.map((t) => t.label).join("; ")}`);
+  } else {
+    na.push(gap.key);
+    console.log(`N/A\t${gap.key}`);
+  }
+  await new Promise((r) => setTimeout(r, 150));
+}
+
+console.log(`\n=== ${schoolType} summary ===`);
+console.log(`live fixes needed: ${live.length}`);
+console.log(`track fixes needed: ${trackNeeded.length}`);
+console.log(`expected empty: ${na.length}`);

--- a/src/cli/curriculum/providers/lehrplanplus-bayern/manifest.ts
+++ b/src/cli/curriculum/providers/lehrplanplus-bayern/manifest.ts
@@ -433,6 +433,16 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
         label: "Mathematik 8 (II/III)",
       },
     ],
+    "realschule|8|physik": [
+      {
+        id: "wpfg1",
+        label: "Physik 8 (I)",
+      },
+      {
+        id: "wpfg2-3",
+        label: "Physik 8 (II/III)",
+      },
+    ],
     "realschule|8|sport": [
       {
         id: "basis_sport",
@@ -453,6 +463,16 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
         label: "Mathematik 9 (II/III)",
       },
     ],
+    "realschule|9|physik": [
+      {
+        id: "wpfg1",
+        label: "Physik 9 (I)",
+      },
+      {
+        id: "wpfg2-3",
+        label: "Physik 9 (II/III)",
+      },
+    ],
     "realschule|9|sport": [
       {
         id: "basis_sport",
@@ -471,6 +491,16 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
       {
         id: "wpfg2-3",
         label: "Mathematik 10 (II/III)",
+      },
+    ],
+    "realschule|10|physik": [
+      {
+        id: "wpfg1",
+        label: "Physik 10 (I)",
+      },
+      {
+        id: "wpfg2-3",
+        label: "Physik 10 (II/III)",
       },
     ],
     "realschule|10|sport": [
@@ -3541,6 +3571,45 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
         hours: 8,
       },
     ],
+    "realschule|8|physik|wpfg1": [
+      {
+        id: "lb1",
+        label: "Mechanik und Energie",
+        hours: 20,
+      },
+      {
+        id: "lb2",
+        label: "Wärmelehre",
+        hours: 15,
+      },
+      {
+        id: "lb3",
+        label: "Elektrizitätslehre",
+        hours: 15,
+      },
+      {
+        id: "lb4",
+        label: "Wahlbereich: Astronomie oder Akustik",
+        hours: 6,
+      },
+    ],
+    "realschule|8|physik|wpfg2-3": [
+      {
+        id: "lb1",
+        label: "Mechanik",
+        hours: 22,
+      },
+      {
+        id: "lb2",
+        label: "Optik",
+        hours: 14,
+      },
+      {
+        id: "lb3",
+        label: "Magnetismus und Elektrizitätslehre",
+        hours: 20,
+      },
+    ],
     "realschule|8|musik": [
       {
         id: "lb1",
@@ -4313,6 +4382,40 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
         hours: 9,
       },
     ],
+    "realschule|9|physik|wpfg1": [
+      {
+        id: "lb1",
+        label: "Mechanik von Flüssigkeiten und Gasen",
+        hours: 18,
+      },
+      {
+        id: "lb2",
+        label: "Wärmelehre",
+        hours: 28,
+      },
+      {
+        id: "lb3",
+        label: "Elektrizitätslehre",
+        hours: 38,
+      },
+    ],
+    "realschule|9|physik|wpfg2-3": [
+      {
+        id: "lb1",
+        label: "Mechanik und Energie",
+        hours: 22,
+      },
+      {
+        id: "lb2",
+        label: "Wärmelehre",
+        hours: 15,
+      },
+      {
+        id: "lb3",
+        label: "Elektrizitätslehre",
+        hours: 19,
+      },
+    ],
     "realschule|9|musik": [
       {
         id: "lb1",
@@ -4982,6 +5085,50 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
         id: "lb5",
         label: "Daten und Zufall",
         hours: 10,
+      },
+    ],
+    "realschule|10|physik|wpfg1": [
+      {
+        id: "lb1",
+        label: "Mechanik",
+        hours: 17,
+      },
+      {
+        id: "lb2",
+        label: "Elektrizitätslehre",
+        hours: 29,
+      },
+      {
+        id: "lb3",
+        label: "Atom- und Kernphysik",
+        hours: 14,
+      },
+      {
+        id: "lb4",
+        label: "Energieversorgung",
+        hours: 12,
+      },
+    ],
+    "realschule|10|physik|wpfg2-3": [
+      {
+        id: "lb1",
+        label: "Mechanik",
+        hours: 10,
+      },
+      {
+        id: "lb2",
+        label: "Elektrizitätslehre",
+        hours: 19,
+      },
+      {
+        id: "lb3",
+        label: "Atom- und Kernphysik",
+        hours: 7,
+      },
+      {
+        id: "lb4",
+        label: "Energieversorgung",
+        hours: 12,
       },
     ],
     "realschule|10|musik": [
@@ -13932,6 +14079,10 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/8/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=8&wt_3=jgs&w_auspraegung=wpfg1",
     "realschule|8|mathematik|wpfg2-3":
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/8/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=8&wt_3=jgs&w_auspraegung=wpfg2-3",
+    "realschule|8|physik|wpfg1":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/8/fach/physik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=physik&wt_2=fach&w_jgs=8&wt_3=jgs&w_auspraegung=wpfg1",
+    "realschule|8|physik|wpfg2-3":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/8/fach/physik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=physik&wt_2=fach&w_jgs=8&wt_3=jgs&w_auspraegung=wpfg2-3",
     "realschule|8|musik":
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/8/fach/musik/inhalt/fachlehrplaene",
     "realschule|8|or":
@@ -13984,6 +14135,10 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=9&wt_3=jgs&w_auspraegung=wpfg1",
     "realschule|9|mathematik|wpfg2-3":
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=9&wt_3=jgs&w_auspraegung=wpfg2-3",
+    "realschule|9|physik|wpfg1":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/physik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=physik&wt_2=fach&w_jgs=9&wt_3=jgs&w_auspraegung=wpfg1",
+    "realschule|9|physik|wpfg2-3":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/physik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=physik&wt_2=fach&w_jgs=9&wt_3=jgs&w_auspraegung=wpfg2-3",
     "realschule|9|musik":
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/9/fach/musik/inhalt/fachlehrplaene",
     "realschule|9|or":
@@ -14034,6 +14189,10 @@ export const LEHRPLANPLUS_BAYERN_MANIFEST: LehrplanPlusBayernManifest = {
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/10/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=10&wt_3=jgs&w_auspraegung=wpfg1",
     "realschule|10|mathematik|wpfg2-3":
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/10/fach/mathematik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=mathematik&wt_2=fach&w_jgs=10&wt_3=jgs&w_auspraegung=wpfg2-3",
+    "realschule|10|physik|wpfg1":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/10/fach/physik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=physik&wt_2=fach&w_jgs=10&wt_3=jgs&w_auspraegung=wpfg1",
+    "realschule|10|physik|wpfg2-3":
+      "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/10/fach/physik/inhalt/fachlehrplaene?w_schulart=realschule&wt_1=schulart&w_fach=physik&wt_2=fach&w_jgs=10&wt_3=jgs&w_auspraegung=wpfg2-3",
     "realschule|10|musik":
       "https://www.lehrplanplus.bayern.de/schulart/realschule/jgs/10/fach/musik/inhalt/fachlehrplaene",
     "realschule|10|or":

--- a/tests/cli/curriculum-lehrplanplus-bayern.test.ts
+++ b/tests/cli/curriculum-lehrplanplus-bayern.test.ts
@@ -170,6 +170,28 @@ describe("LehrplanPLUS Bayern provider — navigation (real, agent-captured data
     ).toEqual([]);
   });
 
+  it("lists the two Wahlpflichtfächergruppe tracks for Realschule Physik 9", () => {
+    expect(provider.listTracks("realschule", "9", "physik")).toEqual([
+      { id: "wpfg1", label: "Physik 9 (I)" },
+      { id: "wpfg2-3", label: "Physik 9 (II/III)" },
+    ]);
+  });
+
+  it("lists Physik 9 (I)'s three Lernbereiche", () => {
+    const topics = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "physik",
+      track: "wpfg1",
+    });
+    expect(topics).toHaveLength(3);
+    expect(topics.map((t) => t.label)).toEqual([
+      "Mechanik von Flüssigkeiten und Gasen",
+      "Wärmelehre",
+      "Elektrizitätslehre",
+    ]);
+  });
+
   it("resolves a topic to its stable LehrplanPLUS source URL", () => {
     const [topic] = provider.listTopics({
       schoolType: "realschule",
@@ -210,9 +232,30 @@ describe("LehrplanPLUS Bayern provider — navigation (real, agent-captured data
       provider.resolveTopic({
         id: "lb1",
         label: "Fake",
-        sourceRef: "realschule|9|physik",
+        sourceRef: "realschule|9|biologie",
       }),
     ).toThrow(/no resolvable source URL/i);
+  });
+
+  it("resolves Physik 9 tracks to their distinct Ausprägung URLs", () => {
+    const [track1Topic] = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "physik",
+      track: "wpfg1",
+    });
+    const [track23Topic] = provider.listTopics({
+      schoolType: "realschule",
+      grade: "9",
+      subject: "physik",
+      track: "wpfg2-3",
+    });
+    expect(provider.resolveTopic(track1Topic).uri).toContain(
+      "w_auspraegung=wpfg1",
+    );
+    expect(provider.resolveTopic(track23Topic).uri).toContain(
+      "w_auspraegung=wpfg2-3",
+    );
   });
 
   it("lists Gymnasium grades 5 through 13", () => {


### PR DESCRIPTION
## Problem

Physik 9 Realschule (und 8/10) lieferte im Curriculum-Wizard keine Themen — das Manifest listete das Fach, hatte aber keine `tracks`, `topics` oder `contentUrls` für die Wahlpflichtfächergruppen `wpfg1` / `wpfg2-3` (analog Mathematik).

## Änderungen

- **Manifest:** Realschule Physik 8–10 mit Ausprägungen, Lernbereichen und LehrplanPLUS-URLs
- **Tests:** Provider-Tests für Physik-9-Tracks und Topic-Auflistung
- **Audit/Probe:** `scripts/audit-bayern-manifest.ts` und `scripts/probe-bayern-gaps.ts`
- **Plan:** `docs/plans/2026-07-12-bayern-rs-gym-coverage-fix.md` mit vollständiger Checkliste

## Verifikation

Live-Probe aller verbleibenden Audit-Lücken:
- Realschule: 37/37 erwartet leer (kein Lehrplan auf LehrplanPLUS)
- Gymnasium: 159/159 erwartet leer

Einziger echter Bug: Physik 8–10 RS.

```bash
npx tsx scripts/audit-bayern-manifest.ts
npm run test -- tests/cli/curriculum-lehrplanplus-bayern.test.ts
```