### PR TITLE
fix: treat empty MCP config stub as {} in agent connect

### DIFF
--- a/src/cli/agent-harness.ts
+++ b/src/cli/agent-harness.ts
@@ -358,6 +358,11 @@ interface McpJsonConfig {
 }
 
 function parseMcpJsonConfig(path: string, content: string): McpJsonConfig {
+  // Editors (e.g. VS Code) auto-create the config as an empty stub — often a
+  // lone newline. Treat a blank file as {} so the connect proceeds instead of
+  // aborting on "Unexpected end of JSON input"; genuine garbage still throws.
+  if (content.trim() === "") return {};
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -556,6 +556,33 @@ describe("connectHarnessMcp", () => {
     });
   });
 
+  it("treats an empty stub file as a fresh config", () => {
+    // VS Code auto-creates mcp.json as a single newline on first launch; that
+    // empty stub must be treated as {}, not rejected as invalid JSON.
+    mockFiles["/home/user/.config/Code/User/mcp.json"] = "\n";
+    const res = connectHarnessMcp("vscode", {
+      ...mockDeps,
+      platform: "linux",
+    });
+    expect(JSON.parse(res.content)).toEqual({
+      servers: {
+        zam: { command: "/usr/local/bin/zam", args: ["mcp"] },
+      },
+      inputs: [],
+    });
+    expect(res.alreadyConfigured).toBe(false);
+  });
+
+  it("treats a whitespace-only stub as an empty object", () => {
+    mockFiles["/work/.mcp.json"] = "   \n\t\n";
+    const res = connectHarnessMcp("claude-code", mockDeps);
+    expect(JSON.parse(res.content)).toEqual({
+      mcpServers: {
+        zam: { command: "/usr/local/bin/zam", args: ["mcp"] },
+      },
+    });
+  });
+
   it("refuses to overwrite malformed JSON configuration", () => {
     mockFiles["/work/.mcp.json"] = "{ definitely not JSON";
 


### PR DESCRIPTION
## Problem

`zam agent connect` (and the ZAM VS Code panel's connect button, which shares the code path) failed when the target MCP config file existed but was **empty or whitespace-only**:

> Cannot update C:\Users\<user>\AppData\Roaming\Code\User\mcp.json: existing file is not valid JSON (Unexpected end of JSON input)

VS Code auto-creates `%APPDATA%\Code\User\mcp.json` as an empty stub (a single newline) on first launch. `parseMcpJsonConfig` ran a strict `JSON.parse` on that content, which threw, so the connect aborted instead of merging in the `zam` server.

Because `parseMcpJsonConfig` is the shared choke point for every JSON-based harness, this affected **claude-code, claude-desktop, antigravity, opencode, vscode, and copilot** whenever their config file existed but was blank.

## Fix

Treat a blank (empty or whitespace-only) file as an empty object `{}`, so the connect proceeds and writes a valid merged config. Genuinely malformed JSON (e.g. `{ definitely not JSON`) still throws — that test is unchanged and still passes.

## Tests

Added two TDD tests to `connectHarnessMcp` (verified failing before the fix, passing after):
- `treats an empty stub file as a fresh config` — vscode with a lone-newline stub → merged `servers.zam` + `inputs`.
- `treats a whitespace-only stub as an empty object` — claude-code with whitespace-only content → merged `mcpServers.zam`.

## Test notes

`tests/cli/agent-harness.test.ts` `connectHarnessMcp` suite: all green. The unrelated `detectInstalledConnectHarnesses` / `bridge-agent-connect` failures on this branch are **pre-existing on `main`** (those tests run real harness detection against the local machine's installed tools without dependency injection) and are untouched by this change.

Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)