### PR TITLE
fix: spawn VS Code .cmd shim via shell to avoid EINVAL on Windows

### DIFF
--- a/src/cli/vscode-extension.ts
+++ b/src/cli/vscode-extension.ts
@@ -87,6 +87,28 @@ export function resolveVscodeExecutable(
   return candidates.find((candidate) => exists(candidate)) ?? null;
 }
 
+export interface VscodeCliInvocation {
+  command: string;
+  args: string[];
+  shell: boolean;
+}
+
+/**
+ * Windows refuses to spawn .cmd/.bat shims without a shell (Node's
+ * CVE-2024-27980 hardening throws EINVAL), and with a shell the command
+ * line is concatenated, so paths with spaces must be quoted.
+ */
+export function buildVscodeCliInvocation(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): VscodeCliInvocation {
+  const needsShell = platform === "win32" && /\.(cmd|bat)$/i.test(command);
+  if (!needsShell) return { command, args, shell: false };
+  const quote = (value: string) => `"${value}"`;
+  return { command: quote(command), args: args.map(quote), shell: true };
+}
+
 function packageVersion(): string {
   const parsed = JSON.parse(
     readFileSync(join(packageRoot, "package.json"), "utf8"),
@@ -155,7 +177,11 @@ export function installVscodeExtension(
   const run =
     options.run ??
     ((command: string, args: string[]) => {
-      execFileSync(command, args, { stdio: "pipe" });
+      const invocation = buildVscodeCliInvocation(command, args);
+      execFileSync(invocation.command, invocation.args, {
+        stdio: "pipe",
+        shell: invocation.shell,
+      });
     });
   run(plan.codePath, ["--install-extension", plan.vsixPath, "--force"]);
 

--- a/tests/cli/vscode-extension.test.ts
+++ b/tests/cli/vscode-extension.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildVscodeCliInvocation,
   installVscodeExtension,
   planVscodeExtensionInstall,
   resolveVscodeExecutable,
@@ -32,6 +33,61 @@ function fixture() {
   writeFileSync(vsixPath, "fixture");
   return { root, home, assetsDir, vsixPath };
 }
+
+describe("buildVscodeCliInvocation", () => {
+  it("wraps Windows .cmd shims in a shell with quoted command and args", () => {
+    const invocation = buildVscodeCliInvocation(
+      "C:\\Users\\test\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code.cmd",
+      ["--install-extension", "C:\\assets\\ZAM Companion.vsix", "--force"],
+      "win32",
+    );
+    expect(invocation).toEqual({
+      command:
+        '"C:\\Users\\test\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code.cmd"',
+      args: [
+        '"--install-extension"',
+        '"C:\\assets\\ZAM Companion.vsix"',
+        '"--force"',
+      ],
+      shell: true,
+    });
+  });
+
+  it("matches .CMD and .bat case-insensitively", () => {
+    expect(
+      buildVscodeCliInvocation("C:\\bin\\code.CMD", [], "win32").shell,
+    ).toBe(true);
+    expect(buildVscodeCliInvocation("C:\\bin\\code.BAT", [], "win32").shell).toBe(
+      true,
+    );
+  });
+
+  it("spawns Windows .exe targets directly without a shell", () => {
+    const invocation = buildVscodeCliInvocation(
+      "C:\\bin\\code.exe",
+      ["--version"],
+      "win32",
+    );
+    expect(invocation).toEqual({
+      command: "C:\\bin\\code.exe",
+      args: ["--version"],
+      shell: false,
+    });
+  });
+
+  it("spawns directly on non-Windows platforms", () => {
+    const invocation = buildVscodeCliInvocation(
+      "/usr/local/bin/code",
+      ["--install-extension", "/tmp/a.vsix"],
+      "linux",
+    );
+    expect(invocation).toEqual({
+      command: "/usr/local/bin/code",
+      args: ["--install-extension", "/tmp/a.vsix"],
+      shell: false,
+    });
+  });
+});
 
 describe("VS Code Companion installation", () => {
   it("resolves the standard macOS CLI when code is not on PATH", () => {


### PR DESCRIPTION
Node's CVE-2024-27980 hardening makes `spawnSync` throw `EINVAL` for `.cmd`/`.bat` targets unless a shell is used. The VS Code companion install (`zam agent connect vscode`) spawned `bin\code.cmd` directly and failed on Windows with current Node.

- New `buildVscodeCliInvocation()`: on win32, `.cmd`/`.bat` targets run via `shell: true` with the command and each argument double-quoted (the shell concatenates the command line, and 'Microsoft VS Code' contains spaces). `.exe` and non-Windows paths spawn directly, unchanged.
- 4 new unit tests (TDD); verified end-to-end on Windows: `zam agent connect vscode` installs the companion and writes the MCP config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)