### PR TITLE
fix: keep ZAM usable through cloud DB outages (#162, #163, #164)

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -41,6 +41,7 @@
     ],
     "windows": {
       "nsis": {
+        "installerHooks": "./windows/installer-hooks.nsh",
         "languages": [
           "English",
           "German",

--- a/desktop/src-tauri/windows/installer-hooks.nsh
+++ b/desktop/src-tauri/windows/installer-hooks.nsh
@@ -1,0 +1,21 @@
+; NSIS installer hooks for the ZAM desktop bundle (issue #164).
+;
+; A running ZAM process keeps the native libsql module
+; (resources\zam-cli\node_modules\@libsql\...\index.node) open, which makes
+; the installer fail with "Error opening file for writing". The desktop app
+; is not the only holder: agent harnesses (Claude Code, VS Code, Copilot)
+; spawn `zam mcp` servers via node.exe from this install's resources, and
+; those outlive the app window. Stop them all before files are written.
+
+!macro NSIS_HOOK_PREINSTALL
+  DetailPrint "Closing running ZAM processes..."
+  ; The desktop app itself (and its child processes).
+  nsExec::Exec "taskkill /F /T /IM zam-app.exe"
+  Pop $0
+  ; MCP server / CLI processes launched from an installed zam-cli. Matched by
+  ; command line so unrelated node.exe processes are left untouched.
+  nsExec::Exec "powershell -NoProfile -ExecutionPolicy Bypass -Command $\"Get-CimInstance Win32_Process | Where-Object { $$_.CommandLine -like '*zam-cli*' } | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }$\""
+  Pop $0
+  ; Give Windows a moment to release the file handles.
+  Sleep 500
+!macroend

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -203,7 +203,10 @@ import {
   removeWorkspaceAndResolveActive,
 } from "../workspaces/active.js";
 import { backupDatabaseTo } from "../workspaces/backup.js";
-import { withDb as sharedWithDb } from "./shared/db.js";
+import {
+  withDb as sharedWithDb,
+  withOptionalDb as sharedWithOptionalDb,
+} from "./shared/db.js";
 
 let isServeMode = false;
 let serveStdinPayload: string | undefined;
@@ -271,6 +274,18 @@ async function withDb(
   fn: (db: Database) => void | Promise<void>,
 ): Promise<void> {
   await sharedWithDb(fn, jsonError);
+}
+
+/**
+ * For commands over machine-local state (workspaces, active knowledge
+ * context): when the database cannot be opened — e.g. the configured cloud
+ * database is unreachable — fn receives `null` and degrades gracefully
+ * instead of failing the whole command (issue #162).
+ */
+async function withOptionalDb(
+  fn: (db: Database | null) => void | Promise<void>,
+): Promise<void> {
+  await sharedWithOptionalDb(fn, jsonError);
 }
 
 interface ReviewTargetRow {
@@ -456,7 +471,7 @@ bridgeCommand
   .command("workspace-info")
   .description("Report the workspace dir, its default, and the data dir (JSON)")
   .action(async () => {
-    await withDb(async (db) => {
+    await withOptionalDb(async (db) => {
       const activeWorkspace = await ensureActiveWorkspace(db);
       jsonOut({
         activeWorkspaceId: activeWorkspace.id,
@@ -522,7 +537,7 @@ bridgeCommand
   .command("workspace-list")
   .description("List configured ZAM workspaces (JSON)")
   .action(async () => {
-    await withDb(async (db) => {
+    await withOptionalDb(async (db) => {
       const activeWorkspace = await ensureActiveWorkspace(db);
       const workspaces = getConfiguredWorkspaces();
       jsonOut({
@@ -609,7 +624,7 @@ bridgeCommand
     if (opts.id && !id) jsonError("A non-empty --id is required");
     const kind = parseBridgeWorkspaceKind(opts.kind);
     const skillLinks = wireSkills(path, parseSetupAgents(), { quiet: true });
-    await withDb(async (db) => {
+    await withOptionalDb(async (db) => {
       const workspace = await activateWorkspacePath(db, path, {
         ...(id ? { id } : {}),
         ...(opts.label ? { label: opts.label } : {}),
@@ -637,7 +652,7 @@ bridgeCommand
     const workspace = getConfiguredWorkspaces().find((item) => item.id === id);
     if (!workspace) jsonError(`Workspace "${id}" is not configured`);
 
-    await withDb(async (db) => {
+    await withOptionalDb(async (db) => {
       const { activeWorkspace, workspaces } =
         await removeWorkspaceAndResolveActive(db, id);
       const skillLinks = provisionConfiguredWorkspaces();
@@ -664,7 +679,7 @@ bridgeCommand
     const dir = resolve(raw);
     if (!existsSync(dir)) jsonError(`Workspace path does not exist: ${dir}`);
     const skillLinks = wireSkills(dir, parseSetupAgents(), { quiet: true });
-    await withDb(async (db) => {
+    await withOptionalDb(async (db) => {
       const workspace = await activateWorkspacePath(db, dir);
       jsonOut({
         ok: true,
@@ -5242,8 +5257,19 @@ bridgeCommand
   .command("get-active-knowledge-context")
   .description("Get the active knowledge context name (JSON)")
   .action(async () => {
-    await withDb(async (db) => {
+    await withOptionalDb(async (db) => {
       const configured = getActiveWorkspaceContext();
+      if (!db) {
+        // The name is machine-local; without a database it is reported
+        // as-is instead of hiding the machine's configuration (issue #162).
+        jsonOut({
+          success: true,
+          activeContext: configured ?? null,
+          staleContext: null,
+          validated: false,
+        });
+        return;
+      }
       const active = configured
         ? await getKnowledgeContextByName(db, configured)
         : undefined;
@@ -5262,12 +5288,21 @@ bridgeCommand
   .description("Set the active knowledge context name (JSON)")
   .argument("[name]", "Context name to use (use empty/none to clear)")
   .action(async (name) => {
-    await withDb(async (db) => {
+    await withOptionalDb(async (db) => {
       if (!name || name === "none" || name === "null" || name === "undefined") {
         if (!setActiveWorkspaceContext(undefined)) {
           jsonError("No active workspace configured");
         }
         jsonOut({ success: true, activeContext: null });
+        return;
+      }
+      if (!db) {
+        // Without a database the name cannot be validated; it is still
+        // stored machine-locally so the choice survives an outage (#162).
+        if (!setActiveWorkspaceContext(name)) {
+          jsonError("No active workspace configured");
+        }
+        jsonOut({ success: true, activeContext: name, validated: false });
         return;
       }
       const context = await getKnowledgeContextByName(db, name);

--- a/src/cli/commands/shared/db.ts
+++ b/src/cli/commands/shared/db.ts
@@ -32,6 +32,31 @@ export async function withDb(
 }
 
 /**
+ * Like `withDb`, but for commands whose data is machine-local (workspaces,
+ * active knowledge context): when the database cannot be opened — e.g. the
+ * configured cloud database is unreachable — fn receives `null` and must
+ * degrade gracefully instead of failing the whole command (issue #162).
+ */
+export async function withOptionalDb(
+  fn: (db: Database | null) => void | Promise<void>,
+  onError: ErrorHandler = defaultErrorHandler,
+): Promise<void> {
+  let db: Database | null = null;
+  try {
+    db = await openDatabase();
+  } catch {
+    db = null;
+  }
+  try {
+    await fn(db);
+  } catch (err) {
+    onError((err as Error).message);
+  } finally {
+    await db?.close();
+  }
+}
+
+/**
  * JSON output helper — used by commands that support --json.
  */
 export function jsonOut(data: unknown): void {

--- a/src/cli/workspaces/active.ts
+++ b/src/cli/workspaces/active.ts
@@ -53,13 +53,21 @@ function findWorkspaceByPath(dir: string): WorkspaceConfig | undefined {
   );
 }
 
-async function clearLegacyWorkspaceDir(db: Database): Promise<void> {
+async function clearLegacyWorkspaceDir(db: Database | null): Promise<void> {
+  if (!db) return;
   await deleteSetting(db, LEGACY_WORKSPACE_DIR_KEY);
 }
 
+/**
+ * Migrate the legacy `personal.workspace_dir` DB setting into the machine-local
+ * workspace registry. Best-effort: without a database connection (`db` null)
+ * the migration is skipped — machine-local workspace state must stay available
+ * when the cloud database is unreachable (issue #162).
+ */
 export async function migrateLegacyWorkspaceDir(
-  db: Database,
+  db: Database | null,
 ): Promise<WorkspaceConfig | undefined> {
+  if (!db) return undefined;
   const legacyDir = await getSetting(db, LEGACY_WORKSPACE_DIR_KEY);
   if (!legacyDir) return undefined;
 
@@ -89,7 +97,7 @@ export async function migrateLegacyWorkspaceDir(
 }
 
 export async function ensureActiveWorkspace(
-  db: Database,
+  db: Database | null,
 ): Promise<WorkspaceConfig> {
   await migrateLegacyWorkspaceDir(db);
 
@@ -120,7 +128,7 @@ export async function ensureActiveWorkspace(
 }
 
 export async function activateWorkspace(
-  db: Database,
+  db: Database | null,
   workspace: WorkspaceConfig,
 ): Promise<WorkspaceConfig> {
   upsertConfiguredWorkspace(workspace);
@@ -130,7 +138,7 @@ export async function activateWorkspace(
 }
 
 export async function activateWorkspacePath(
-  db: Database,
+  db: Database | null,
   dir: string,
   opts: {
     id?: string;
@@ -157,7 +165,7 @@ export async function activateWorkspacePath(
 }
 
 export async function removeWorkspaceAndResolveActive(
-  db: Database,
+  db: Database | null,
   id: string,
 ): Promise<{
   activeWorkspace: WorkspaceConfig;

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -181,6 +181,28 @@ function loadLibsql(): LibsqlConstructor {
   }
 }
 
+const TRANSIENT_REMOTE_ERROR_PATTERNS = [
+  /status=5\d\d/i,
+  /websocket/i,
+  /stream closed/i,
+  /connection (?:closed|reset|refused)/i,
+  /fetch failed/i,
+  /\b(?:ETIMEDOUT|ENOTFOUND|ECONNREFUSED|ECONNRESET|EAI_AGAIN|EPIPE)\b/,
+];
+
+/**
+ * True for server/network failures that say nothing about the SQL itself —
+ * e.g. Turso's intermittent `Hrana(Api("status=502 ...upstream forward
+ * failed"))` on the websocket path. These justify retrying the connection
+ * over the HTTP provider (issue #163); real SQL errors never match.
+ */
+export function isTransientRemoteDatabaseError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : "";
+  return TRANSIENT_REMOTE_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(message),
+  );
+}
+
 /**
  * Open (or create) the ZAM database.
  * Uses configured Turso credentials for the default database when present.
@@ -196,14 +218,7 @@ export async function openDatabase(
     options.initialize === true ||
     (!isRemote && !isEmbeddedReplica && !existsSync(dbPath));
 
-  if (provider === "remote") {
-    const url = isRemote ? dbPath : options.syncUrl;
-    if (!url) {
-      throw new Error(
-        "The remote database provider is selected but no Turso URL is " +
-          "configured. Run: zam connector setup turso",
-      );
-    }
+  const openViaHttpProvider = async (url: string): Promise<Database> => {
     const db = openRemoteDatabase({
       url,
       authToken: configuredCloud?.token ?? options.authToken,
@@ -213,6 +228,17 @@ export async function openDatabase(
     }
     await runMigrations(db);
     return db;
+  };
+
+  if (provider === "remote") {
+    const url = isRemote ? dbPath : options.syncUrl;
+    if (!url) {
+      throw new Error(
+        "The remote database provider is selected but no Turso URL is " +
+          "configured. Run: zam connector setup turso",
+      );
+    }
+    return openViaHttpProvider(url);
   }
 
   if (shouldInitialize && !isRemote) {
@@ -282,17 +308,8 @@ export async function openDatabase(
       // remote database we transparently fall back to the HTTP provider, which
       // needs no native bindings. Embedded replicas require the native driver,
       // so those still surface the original error.
-      const fallbackUrl = isRemote ? dbPath : options.syncUrl;
-      if (isRemote && !isEmbeddedReplica && fallbackUrl) {
-        const db = openRemoteDatabase({
-          url: fallbackUrl,
-          authToken: configuredCloud?.token ?? options.authToken,
-        });
-        if (options.initialize) {
-          await db.exec(SCHEMA);
-        }
-        await runMigrations(db);
-        return db;
+      if (isRemote && !isEmbeddedReplica) {
+        return openViaHttpProvider(dbPath);
       }
       throw nativeErr;
     }
@@ -300,31 +317,50 @@ export async function openDatabase(
     driver = openLocalSqlite(dbPath);
   }
 
-  // Enable WAL mode and foreign keys for local SQLite.
-  // Remote Turso databases and embedded replicas manage their own journaling.
-  if (!isRemote && !isEmbeddedReplica) {
-    driver.pragma("journal_mode = WAL");
+  const finishOpen = async (): Promise<Database> => {
+    // Enable WAL mode and foreign keys for local SQLite.
+    // Remote Turso databases and embedded replicas manage their own journaling.
+    if (!isRemote && !isEmbeddedReplica) {
+      driver.pragma("journal_mode = WAL");
+    }
+    driver.pragma("foreign_keys = ON");
+    if (!isRemote) {
+      driver.pragma("busy_timeout = 5000");
+    }
+
+    const db = wrapSyncDatabase(driver);
+
+    // For embedded replicas: sync from cloud FIRST so the local file has the
+    // primary's schema before we try to run migrations or create tables.
+    if (isEmbeddedReplica) {
+      await db.sync?.();
+    }
+
+    if (shouldInitialize) {
+      await db.exec(SCHEMA);
+    }
+
+    await runMigrations(db);
+
+    return db;
+  };
+
+  if (isRemote && !isEmbeddedReplica) {
+    try {
+      return await finishOpen();
+    } catch (err) {
+      // Autorepair (issue #163): the native websocket path can hit transient
+      // Turso failures (e.g. status=502 "upstream forward failed") that the
+      // HTTP path does not share. Retry over the HTTP provider before
+      // surfacing the error.
+      if (isTransientRemoteDatabaseError(err)) {
+        return openViaHttpProvider(dbPath);
+      }
+      throw err;
+    }
   }
-  driver.pragma("foreign_keys = ON");
-  if (!isRemote) {
-    driver.pragma("busy_timeout = 5000");
-  }
 
-  const db = wrapSyncDatabase(driver);
-
-  // For embedded replicas: sync from cloud FIRST so the local file has the
-  // primary's schema before we try to run migrations or create tables.
-  if (isEmbeddedReplica) {
-    await db.sync?.();
-  }
-
-  if (shouldInitialize) {
-    await db.exec(SCHEMA);
-  }
-
-  await runMigrations(db);
-
-  return db;
+  return finishOpen();
 }
 
 function resolveProvider(

--- a/tests/cli/bridge-offline-config.test.ts
+++ b/tests/cli/bridge-offline-config.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * Machine-local configuration (workspaces, active knowledge context) lives in
+ * ~/.zam/config.json and must stay readable and writable when the configured
+ * cloud database is unreachable (issue #162). These tests point the bridge at
+ * a Turso URL that refuses connections and expect the machine-local commands
+ * to keep working.
+ */
+describe("bridge machine-local config with unreachable cloud DB", () => {
+  let tempHome: string;
+  let tempCwd: string;
+  let workspaceDir: string;
+  let cliPath: string;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "zam-bridge-offline-home-"));
+    tempCwd = mkdtempSync(join(tmpdir(), "zam-bridge-offline-cwd-"));
+    cliPath = join(process.cwd(), "dist", "cli", "index.js");
+    const dataDir = join(tempHome, ".zam");
+    mkdirSync(dataDir, { recursive: true });
+    workspaceDir = join(tempHome, "workspace");
+    mkdirSync(workspaceDir, { recursive: true });
+
+    // Cloud DB that always refuses connections (nothing listens on port 9).
+    writeFileSync(
+      join(dataDir, "credentials.json"),
+      `${JSON.stringify({
+        turso: {
+          url: "https://127.0.0.1:9",
+          token: "unreachable-fixture-token",
+          mode: "remote",
+        },
+      })}\n`,
+    );
+
+    writeFileSync(
+      join(dataDir, "config.json"),
+      `${JSON.stringify({
+        workspaces: [
+          {
+            id: "w1",
+            label: "Workspace One",
+            kind: "personal",
+            path: workspaceDir,
+            activeKnowledgeContext: "work",
+          },
+        ],
+        activeWorkspaceId: "w1",
+      })}\n`,
+    );
+  });
+
+  afterEach(() => {
+    for (const dir of [tempHome, tempCwd]) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function runBridge(args: string[]): unknown {
+    const output = execFileSync("node", [cliPath, "bridge", ...args], {
+      cwd: tempCwd,
+      env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+      encoding: "utf8",
+    });
+    return JSON.parse(output);
+  }
+
+  it("lists configured workspaces without a database connection", () => {
+    const result = runBridge(["workspace-list"]) as {
+      workspaces: Array<{ id: string }>;
+      activeWorkspaceId: string;
+      workspaceDir: string;
+    };
+    expect(result.activeWorkspaceId).toBe("w1");
+    expect(result.workspaceDir).toBe(workspaceDir);
+    expect(result.workspaces).toEqual([
+      expect.objectContaining({ id: "w1", label: "Workspace One" }),
+    ]);
+  });
+
+  it("returns the machine-local active knowledge context without validation", () => {
+    expect(runBridge(["get-active-knowledge-context"])).toMatchObject({
+      success: true,
+      activeContext: "work",
+    });
+  });
+
+  it("clears the active knowledge context without a database connection", () => {
+    expect(runBridge(["set-active-knowledge-context", "none"])).toMatchObject({
+      success: true,
+      activeContext: null,
+    });
+    expect(runBridge(["get-active-knowledge-context"])).toMatchObject({
+      success: true,
+      activeContext: null,
+    });
+  });
+});

--- a/tests/cli/workspace-active.test.ts
+++ b/tests/cli/workspace-active.test.ts
@@ -8,7 +8,9 @@ import {
   getConfiguredWorkspaces,
   getSetting,
   openDatabase,
+  setActiveWorkspaceId,
   setSetting,
+  upsertConfiguredWorkspace,
 } from "../../src/kernel/index.js";
 
 const tempDirs: string[] = [];
@@ -29,6 +31,43 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe("active workspace without a database", () => {
+  it("resolves the configured active workspace when db is null", async () => {
+    const root = tempDir();
+    const workspaceDir = join(root, "workspace");
+    mkdirSync(workspaceDir, { recursive: true });
+    process.env.ZAM_CONFIG_PATH = join(root, "config.json");
+    upsertConfiguredWorkspace({
+      id: "w1",
+      kind: "personal",
+      path: workspaceDir,
+    });
+    setActiveWorkspaceId("w1");
+
+    const active = await ensureActiveWorkspace(null);
+
+    expect(active).toMatchObject({ id: "w1", path: workspaceDir });
+    expect(getActiveWorkspaceId()).toBe("w1");
+  });
+
+  it("promotes the first configured workspace when none is active and db is null", async () => {
+    const root = tempDir();
+    const workspaceDir = join(root, "workspace");
+    mkdirSync(workspaceDir, { recursive: true });
+    process.env.ZAM_CONFIG_PATH = join(root, "config.json");
+    upsertConfiguredWorkspace({
+      id: "w1",
+      kind: "personal",
+      path: workspaceDir,
+    });
+
+    const active = await ensureActiveWorkspace(null);
+
+    expect(active).toMatchObject({ id: "w1", path: workspaceDir });
+    expect(getActiveWorkspaceId()).toBe("w1");
+  });
 });
 
 describe("active workspace migration", () => {

--- a/tests/kernel/connection-fallback.test.ts
+++ b/tests/kernel/connection-fallback.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { isTransientRemoteDatabaseError } from "../../src/kernel/db/connection.js";
+
+/**
+ * Classifier behind the native→HTTP autorepair fallback (issue #163): a
+ * native libsql websocket connection that hits a transient server/network
+ * failure should be retried over the HTTP provider, while real SQL errors
+ * must keep surfacing unchanged.
+ */
+describe("transient remote database error classification", () => {
+  it("classifies the Turso websocket 502 as transient", () => {
+    expect(
+      isTransientRemoteDatabaseError(
+        new Error(
+          'Hrana: `api error: `status=502 Bad Gateway, body={"error":"upstream forward failed"}``',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("classifies Hrana(Api(...)) debug-formatted errors as transient", () => {
+    expect(
+      isTransientRemoteDatabaseError(
+        new Error(
+          'Hrana(Api("status=502 Bad Gateway, body={\\"error\\":\\"upstream forward failed\\"}"))',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("classifies websocket/stream failures as transient", () => {
+    expect(
+      isTransientRemoteDatabaseError(new Error("websocket connection closed")),
+    ).toBe(true);
+    expect(
+      isTransientRemoteDatabaseError(new Error("stream closed by server")),
+    ).toBe(true);
+  });
+
+  it("classifies network-level failures as transient", () => {
+    expect(
+      isTransientRemoteDatabaseError(
+        new Error("connect ETIMEDOUT 1.2.3.4:443"),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientRemoteDatabaseError(new Error("getaddrinfo ENOTFOUND x.y")),
+    ).toBe(true);
+  });
+
+  it("does not classify SQL and constraint errors as transient", () => {
+    expect(
+      isTransientRemoteDatabaseError(
+        new Error("UNIQUE constraint failed: tokens.slug"),
+      ),
+    ).toBe(false);
+    expect(
+      isTransientRemoteDatabaseError(new Error("no such table: tokens")),
+    ).toBe(false);
+    expect(
+      isTransientRemoteDatabaseError(
+        new Error("status=401 Unauthorized, body=..."),
+      ),
+    ).toBe(false);
+  });
+
+  it("handles non-Error values without throwing", () => {
+    expect(isTransientRemoteDatabaseError("boom")).toBe(false);
+    expect(isTransientRemoteDatabaseError(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
Three fixes from the 2026-07-15 Turso outage (`Hrana(Api("status=502 Bad Gateway..."))`):

- **#162 — Settings without DB**: workspaces and the active knowledge context are machine-local (`~/.zam/config.json`), but the bridge commands serving them required a DB connection, so the Settings panel looked unconfigured during the outage. Machine-local commands now use a new `withOptionalDb` and degrade gracefully (`validated: false` where DB validation is skipped).
- **#163 — HTTP autorepair**: pure-remote native libsql connections (Hrana over websocket) now retry over the existing HTTP provider when they hit a transient server/network failure (`status=5xx`, websocket/stream drops, DNS/socket errors). SQL errors surface unchanged. New exported classifier `isTransientRemoteDatabaseError` with unit tests.
- **#164 — Installer file lock**: NSIS pre-install hook terminates `zam-app.exe` and harness-spawned `zam mcp` node processes (matched by `zam-cli` in the command line) so the native libsql module can be overwritten during updates.

Tests: 2 new kernel/CLI unit test groups + an e2e bridge test that drives the built CLI against an unreachable Turso URL. Full suite green except the two known environment-dependent failures (Copilot detection, VS Code ui-intent) that also fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)