### PR TITLE
chore: bump source-reader User-Agent to 0.11.0

### DIFF
--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.10.11",
+          "User-Agent": "ZAM-Content-Studio/0.11.0",
         },
       });
 


### PR DESCRIPTION
The seventh version surface from the release checklist (User-Agent `ZAM-Content-Studio/x.y.z` in src/cli/adapters/source-reader.ts), missed in the 0.11.0 release prep. Cosmetic HTTP header only; released artifacts are otherwise fully versioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)