### PR TITLE
feat: OKF knowledge base with MCP authoring tools

### DIFF
--- a/.agent/skills/okf/SKILL.md
+++ b/.agent/skills/okf/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: okf
+description: Author and maintain the OKF knowledge base in docs/okf — living repo reference articles that ZAM cards cite as learning sources. Use whenever the user invokes `/okf`, asks to document current repo behavior as reference knowledge, when a code change alters behavior an OKF article describes, or when a learning token about this repo needs a source_link.
+user-invocable: true
+---
+
+# OKF — Repo Knowledge Base Authoring
+
+`docs/okf/` is an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+v0.1 bundle: the living, current-truth reference for this repository.
+Learners' ZAM cards cite these articles as `source_link`, so **a stale or
+wrong article actively teaches wrong knowledge**. Treat every edit with
+release-level care. Contract: ADR 2026-07-17.
+
+## The one hard rule
+
+**Never edit files in `docs/okf/` by hand.** The only sanctioned write
+path is the `zam_okf_upsert` MCP tool (server: `zam mcp`): it validates
+the frontmatter contract, regenerates `index.md`, and appends the `log.md`
+entry. `zam_okf_catalog` lists articles plus conformance problems;
+`zam_okf_read` returns one article. CI enforces bundle conformance
+(`tests/cli/okf-conformance.test.ts`).
+
+## ADR vs OKF
+
+OKF states **what is true today**; ADRs record **why it was decided**.
+Never restate decision rationale in an article — any sentence shaped like
+"we chose X because…" belongs in an ADR. Reference ADRs (and code paths)
+in the article's `# Citations` section instead. Every article must have
+one.
+
+## Article contract
+
+- File name: kebab-case `*.md`, flat (no subdirectories). Names are
+  **permanent IDs** — learners' stored source links break on rename, so
+  never rename; supersede with a new article and a `log.md` note instead.
+- Frontmatter (the validated subset — scalars and block string lists
+  only, no nested maps):
+  - `type` (required): short kind, e.g. `architecture`, `algorithm`,
+    `data-model`, `protocol` — reuse existing types before inventing one
+  - `description` (required here): one sentence; it becomes the index line
+  - `title`, `tags` (at least one), `timestamp` (ISO 8601)
+  - `resource`: the canonical URL
+    `https://github.com/zam-os/zam/blob/main/docs/okf/<file>` — exactly
+    this shape, CI-pinned
+- Body: current truth in plain prose, links to related articles as
+  ordinary markdown links, then `# Citations` with ADRs and code paths.
+  English only.
+
+## Staleness duty
+
+If a PR changes behavior that an OKF article describes, update the
+article via `zam_okf_upsert` **in the same PR**. Check
+`zam_okf_catalog` when touching kernel scheduling, the token/card model,
+prerequisite blocking, the bridge protocol, or MCP surfaces.
+
+## Articles as learning sources
+
+When creating ZAM tokens about this repo (e.g. via `zam_add_token`), set
+the token's `source_link` to the article's `resource` URL. The article —
+not the chat — is the durable source a learner returns to.

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: okf
+description: Author and maintain the OKF knowledge base in docs/okf — living repo reference articles that ZAM cards cite as learning sources. Use whenever the user invokes `$okf`, asks to document current repo behavior as reference knowledge, when a code change alters behavior an OKF article describes, or when a learning token about this repo needs a source_link.
+user-invocable: true
+---
+
+# OKF — Repo Knowledge Base Authoring
+
+In Codex, invoke this workflow as `$okf` or select `okf` through `/skills`.
+Codex does not expose repository skills as custom `/okf` slash commands.
+
+`docs/okf/` is an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+v0.1 bundle: the living, current-truth reference for this repository.
+Learners' ZAM cards cite these articles as `source_link`, so **a stale or
+wrong article actively teaches wrong knowledge**. Treat every edit with
+release-level care. Contract: ADR 2026-07-17.
+
+## The one hard rule
+
+**Never edit files in `docs/okf/` by hand.** The only sanctioned write
+path is the `zam_okf_upsert` MCP tool (server: `zam mcp`): it validates
+the frontmatter contract, regenerates `index.md`, and appends the `log.md`
+entry. `zam_okf_catalog` lists articles plus conformance problems;
+`zam_okf_read` returns one article. CI enforces bundle conformance
+(`tests/cli/okf-conformance.test.ts`).
+
+## ADR vs OKF
+
+OKF states **what is true today**; ADRs record **why it was decided**.
+Never restate decision rationale in an article — any sentence shaped like
+"we chose X because…" belongs in an ADR. Reference ADRs (and code paths)
+in the article's `# Citations` section instead. Every article must have
+one.
+
+## Article contract
+
+- File name: kebab-case `*.md`, flat (no subdirectories). Names are
+  **permanent IDs** — learners' stored source links break on rename, so
+  never rename; supersede with a new article and a `log.md` note instead.
+- Frontmatter (the validated subset — scalars and block string lists
+  only, no nested maps):
+  - `type` (required): short kind, e.g. `architecture`, `algorithm`,
+    `data-model`, `protocol` — reuse existing types before inventing one
+  - `description` (required here): one sentence; it becomes the index line
+  - `title`, `tags` (at least one), `timestamp` (ISO 8601)
+  - `resource`: the canonical URL
+    `https://github.com/zam-os/zam/blob/main/docs/okf/<file>` — exactly
+    this shape, CI-pinned
+- Body: current truth in plain prose, links to related articles as
+  ordinary markdown links, then `# Citations` with ADRs and code paths.
+  English only.
+
+## Staleness duty
+
+If a PR changes behavior that an OKF article describes, update the
+article via `zam_okf_upsert` **in the same PR**. Check
+`zam_okf_catalog` when touching kernel scheduling, the token/card model,
+prerequisite blocking, the bridge protocol, or MCP surfaces.
+
+## Articles as learning sources
+
+When creating ZAM tokens about this repo (e.g. via `zam_add_token`), set
+the token's `source_link` to the article's `resource` URL. The article —
+not the chat — is the durable source a learner returns to.

--- a/.claude/skills/okf/SKILL.md
+++ b/.claude/skills/okf/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: okf
+description: Author and maintain the OKF knowledge base in docs/okf — living repo reference articles that ZAM cards cite as learning sources. Use whenever the user invokes `/okf`, asks to document current repo behavior as reference knowledge, when a code change alters behavior an OKF article describes, or when a learning token about this repo needs a source_link.
+user-invocable: true
+---
+
+# OKF — Repo Knowledge Base Authoring
+
+`docs/okf/` is an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+v0.1 bundle: the living, current-truth reference for this repository.
+Learners' ZAM cards cite these articles as `source_link`, so **a stale or
+wrong article actively teaches wrong knowledge**. Treat every edit with
+release-level care. Contract: ADR 2026-07-17.
+
+## The one hard rule
+
+**Never edit files in `docs/okf/` by hand.** The only sanctioned write
+path is the `zam_okf_upsert` MCP tool (server: `zam mcp`): it validates
+the frontmatter contract, regenerates `index.md`, and appends the `log.md`
+entry. `zam_okf_catalog` lists articles plus conformance problems;
+`zam_okf_read` returns one article. CI enforces bundle conformance
+(`tests/cli/okf-conformance.test.ts`).
+
+## ADR vs OKF
+
+OKF states **what is true today**; ADRs record **why it was decided**.
+Never restate decision rationale in an article — any sentence shaped like
+"we chose X because…" belongs in an ADR. Reference ADRs (and code paths)
+in the article's `# Citations` section instead. Every article must have
+one.
+
+## Article contract
+
+- File name: kebab-case `*.md`, flat (no subdirectories). Names are
+  **permanent IDs** — learners' stored source links break on rename, so
+  never rename; supersede with a new article and a `log.md` note instead.
+- Frontmatter (the validated subset — scalars and block string lists
+  only, no nested maps):
+  - `type` (required): short kind, e.g. `architecture`, `algorithm`,
+    `data-model`, `protocol` — reuse existing types before inventing one
+  - `description` (required here): one sentence; it becomes the index line
+  - `title`, `tags` (at least one), `timestamp` (ISO 8601)
+  - `resource`: the canonical URL
+    `https://github.com/zam-os/zam/blob/main/docs/okf/<file>` — exactly
+    this shape, CI-pinned
+- Body: current truth in plain prose, links to related articles as
+  ordinary markdown links, then `# Citations` with ADRs and code paths.
+  English only.
+
+## Staleness duty
+
+If a PR changes behavior that an OKF article describes, update the
+article via `zam_okf_upsert` **in the same PR**. Check
+`zam_okf_catalog` when touching kernel scheduling, the token/card model,
+prerequisite blocking, the bridge protocol, or MCP surfaces.
+
+## Articles as learning sources
+
+When creating ZAM tokens about this repo (e.g. via `zam_add_token`), set
+the token's `source_link` to the article's `resource` URL. The article —
+not the chat — is the durable source a learner returns to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ the kernel; new HTTP goes in the CLI layer.
 - **Token vs card**: a token is shared knowledge; a card is per-user FSRS
   state. A concept only appears in a user's queue if a card exists.
 - New kernel API must be re-exported from `src/kernel/index.ts`.
+- **`docs/okf/` is not hand-editable.** It is an OKF knowledge bundle whose
+  articles are learning sources (ADR 2026-07-17): write only through the
+  `zam_okf_upsert` MCP tool, update the covering article in the same PR
+  that changes described behavior, and keep decision rationale in ADRs —
+  articles reference them under `# Citations`.
 
 ## Verification — required before every commit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Bridge responses are always JSON, including errors. Treat `protocol.ts` types as
 - **Token metadata drives behavior**: Bloom levels drive prompt generation; `symbiosis_mode` is load-bearing.
 - **FSRS tests are the source of truth** for scheduling behavior — check `tests/kernel/fsrs.test.ts` when changing scheduling or rating semantics.
 - **Semantic search**: kernel stores embeddings (`token_embeddings`) and ranks (`searchTokensHybrid`); the CLI layer embeds (role `embedding`, `src/cli/llm/embedder.ts`). Never import HTTP/LLM code into the kernel.
+- **OKF knowledge base (`docs/okf/`)**: living current-truth reference articles that ZAM cards cite as `source_link` (ADR 2026-07-17). Never edit bundle files by hand — write through the `zam_okf_upsert` MCP tool (it validates and regenerates `index.md`/`log.md`); a PR that changes behavior an article describes updates that article in the same PR. Decision rationale stays in ADRs; articles only reference them (`# Citations`).
 
 ## Commit format
 

--- a/docs/adr/2026-07-17-okf-knowledge-base.md
+++ b/docs/adr/2026-07-17-okf-knowledge-base.md
@@ -1,0 +1,88 @@
+# OKF Knowledge Base — Living Repo Knowledge as Learning Sources
+
+**Status:** Implemented (2026-07-17, same PR)
+**Date:** 2026-07-17
+**Deciders:** Thomas (project owner), designed with Fable 5
+**Related:**
+[2026-07-06a-mcp-agent-transport-and-surfaces.md](2026-07-06a-mcp-agent-transport-and-surfaces.md) (MCP as canonical transport) ·
+[2026-03-23-kernel-and-shell-observation.md](2026-03-23-kernel-and-shell-observation.md) (kernel/CLI split)
+
+---
+
+## Context
+
+ZAM's repo documentation had three genres with only two homes. ADRs record
+*why* something was decided — immutable, point-in-time. Plans are working
+documents — deleted once implemented. What was missing is the third genre:
+**current-truth reference knowledge** ("how does FSRS scheduling behave
+*today*?") that stays maintained as the code evolves.
+
+That genre has a product-shaped opportunity: ZAM cards carry a
+`source_link`, and learners studying this repo (its owner and contributors)
+need trustworthy sources for repo concepts. A wiki written for LLM and human
+consumption alike can be that source — if it has a defined format, a
+guarded write path, and a staleness strategy.
+
+[Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+(Apache 2.0) is a vendor-neutral convention for exactly this: markdown files
+with YAML frontmatter (only `type` is mandatory; `title`, `description`,
+`resource`, `tags`, `timestamp` recommended), a reserved `index.md` for
+progressive disclosure (frontmatter only in the root index, carrying
+`okf_version`) and a reserved `log.md` update history. Links are ordinary
+markdown links treated as untyped graph edges; consumers must tolerate
+unknown types and broken links.
+
+## Decision
+
+1. **Living repo knowledge lives in an OKF v0.1 bundle at `docs/okf/`.**
+   Articles are English, one concept per file, flat directory (no
+   subfolders in v1). File names are permanent IDs — renames break
+   learners' stored `source_link`s, so moves require an explicit stub and
+   `log.md` entry.
+2. **OKF complements ADRs, never duplicates them.** An OKF article states
+   what is true today; every "we chose X because…" sentence belongs in an
+   ADR. Articles reference ADRs (and code) in a `# Citations` section.
+3. **`docs/okf/` is not freely editable.** The sanctioned write path is the
+   `zam_okf_upsert` MCP tool: it validates the frontmatter contract,
+   refuses reserved files, regenerates `index.md`, and appends the `log.md`
+   entry. A conformance test (`tests/cli/okf-conformance.test.ts`) gates CI
+   on bundle validity. The rule is mirrored in CLAUDE.md and AGENTS.md;
+   the `okf` skill teaches agents the authoring discipline.
+4. **Articles are addressable as learning sources.** Each article's
+   `resource` field carries its canonical GitHub blob URL on `main`; ZAM
+   tokens use that URL as `source_link`, which the existing source-reader
+   pipeline can already ingest. No kernel change is needed.
+5. **The implementation is generic CLI-layer code** (`src/cli/okf/`): a
+   dependency-free frontmatter-subset parser, validator, catalog and
+   index/log generators, exposed as three MCP tools
+   (`zam_okf_catalog`, `zam_okf_read`, `zam_okf_upsert`) that operate on
+   any bundle directory (default `docs/okf` under the server's working
+   directory). Nothing enters the kernel — this is documentation
+   plumbing, not learning logic.
+
+## Options considered
+
+- **Keep free-form specs in `docs/specs/`** — rejected; the two existing
+  documents were ADRs in disguise (folded into `docs/adr/`, PR #171), and
+  free-form prose gives agents no contract to validate against.
+- **Skill only, no MCP tools** — rejected by Thomas: other agents should
+  author articles through a validated write path, which a skill alone
+  cannot enforce.
+- **Full YAML dependency for frontmatter** — rejected (AGENTS.md: no new
+  dependencies). The parser accepts the documented subset: scalar
+  `key: value` pairs and block string lists; authors stay inside it.
+- **Bridge-command parity from day one** — deferred, matching the
+  `zam_companion_sample` precedent; `zam bridge` remains the fallback for
+  the pre-existing surface.
+
+## Consequences
+
+- Staleness is the primary risk: an outdated article actively teaches
+  wrong knowledge through recall cards. Mitigations: a deliberately small
+  seed bundle of low-churn concepts, the CI conformance gate, the CLAUDE.md/
+  AGENTS.md rule that behavior changes update the covering article in the
+  same PR (plus `log.md` entry), and `timestamp` on every article.
+- The frontmatter subset is a contract: articles that need richer YAML
+  must extend the parser first (with tests), not hand-edit around it.
+- Consumers of the bundle outside this repo (an LLM `cat`-ing a file, a
+  future central sync service) get plain markdown — no ZAM dependency.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,5 +45,6 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-10](2026-07-10-recall-card-ux.md) | Recall Card UX — Adaptive Button, Finish/Summary, Domain Focus | Implemented |
 | [2026-07-11](2026-07-11-codex-and-vscode-companion-surfaces.md) | Codex and VS Code Companion Surfaces | Accepted |
 | [2026-07-12](2026-07-12-unified-capability-model-registry.md) | Unified Capability-Based Model Registry | Implemented |
-| [2026-07-16](2026-07-16-companion-context-and-harness-affinity.md) | Companion Context Bar and Harness Affinity | Proposed |
-| [2026-07-16b](2026-07-16b-in-recall-card-management.md) | In-Recall Card Management: Stop, Fix, and Remove | Accepted |
+| [2026-07-16](2026-07-16-companion-context-and-harness-affinity.md) | Companion Context Bar and Harness Affinity | Implemented |
+| [2026-07-16b](2026-07-16b-in-recall-card-management.md) | In-Recall Card Management: Stop, Fix, and Remove | Implemented |
+| [2026-07-17](2026-07-17-okf-knowledge-base.md) | OKF Knowledge Base — Living Repo Knowledge as Learning Sources | Implemented |

--- a/docs/okf/bridge-protocol.md
+++ b/docs/okf/bridge-protocol.md
@@ -1,0 +1,42 @@
+---
+type: protocol
+title: Bridge CLI Protocol
+description: zam bridge is the machine-facing JSON fallback transport for agents; responses are always JSON, and the protocol types are the stable contract.
+tags:
+  - cli
+  - bridge
+  - agents
+resource: "https://github.com/zam-os/zam/blob/main/docs/okf/bridge-protocol.md"
+timestamp: 2026-07-17T00:00:00Z
+---
+
+`zam bridge <command>` is ZAM's machine-facing CLI transport: an agent
+shells out, passes flags, and reads a JSON response from stdout. It is the
+**fallback** transport — MCP is the preferred connection (see
+[mcp-surfaces.md](mcp-surfaces.md)) — but it remains fully supported and
+is what embedded surfaces (for example the desktop app's bundled runtime)
+drive.
+
+The hard contract:
+
+- **JSON only.** Every bridge response is JSON, including errors — all
+  output goes through the `jsonOut`/`jsonError` helpers in
+  `src/cli/commands/bridge.ts`; a stray `console.log` is a bug. (This is
+  stricter than the `--json` flag other commands offer.)
+- **`src/bridge/protocol.ts` types are the stable contract.** Agents and
+  the desktop panels program against these shapes; breaking them breaks
+  external callers.
+
+Representative commands: `next` (pull the next queue card), `submit`
+(apply a rating), `add-token` (register a token *and* create the calling
+user's card — see [token-card-model.md](token-card-model.md)),
+`personal-card-update` (partial update by slug), and the destructive pair
+`personal-card-remove` / `personal-card-delete`, each a preview→confirm
+handshake: without `--confirm` they return an impact preview (affected
+cards, review logs, session steps, agent skills); with `--confirm` they
+execute.
+
+# Citations
+
+- [ADR 2026-07-06a — MCP as the Canonical Agent Transport](../adr/2026-07-06a-mcp-agent-transport-and-surfaces.md)
+- Code: `src/cli/commands/bridge.ts`, `src/bridge/protocol.ts`

--- a/docs/okf/fsrs-scheduling.md
+++ b/docs/okf/fsrs-scheduling.md
@@ -1,0 +1,48 @@
+---
+type: algorithm
+title: FSRS-5 Scheduling
+description: ZAM schedules reviews with a pure-function FSRS-5 implementation; ratings 1-4 update stability and difficulty, and the FSRS test suite is the source of truth for scheduling behavior.
+tags:
+  - kernel
+  - fsrs
+  - scheduling
+resource: "https://github.com/zam-os/zam/blob/main/docs/okf/fsrs-scheduling.md"
+timestamp: 2026-07-17T00:00:00Z
+---
+
+ZAM's spaced repetition uses **FSRS-5** (Free Spaced Repetition Scheduler,
+v5), implemented as pure functions in `src/kernel/scheduler/fsrs.ts`.
+
+A review takes a **rating** on a four-point scale: `1` Again (forgot),
+`2` Hard, `3` Good, `4` Easy. Each card carries FSRS state per user:
+**stability** (expected recall half-life in days), **difficulty** (1–10),
+elapsed/scheduled days, repetition and lapse counts, a **state** of
+`new`, `learning`, `review`, or `relearning`, and the next due date.
+
+`evaluateRating()` in `src/kernel/recall/evaluator.ts` applies a rating: it
+runs FSRS scheduling, updates the card, and appends an immutable entry to
+`review_logs`. Rating is deliberately separate from prerequisite blocking —
+`evaluateRating()` never blocks or unblocks anything; callers decide
+whether to invoke the blocker after a rating of `1` (see
+[prerequisite-blocking.md](prerequisite-blocking.md)).
+
+# Review queue
+
+`src/kernel/scheduler/queue.ts` builds each session's queue from due cards
+plus new cards: it interleaves cards by domain (so one topic doesn't
+monopolize a session) and inserts new cards at every 5th position.
+
+# Examples
+
+```ts
+import { evaluateRating } from "zam-core";
+// rating: 1 | 2 | 3 | 4 — updates FSRS state and appends to review_logs
+await evaluateRating(db, { cardId, tokenId, userId, rating: 3 });
+```
+
+# Citations
+
+- [ADR 2026-05-30a — Standalone Learning Session](../adr/2026-05-30a-standalone-learning-session.md)
+- Tests as source of truth for scheduling semantics: `tests/kernel/fsrs.test.ts`
+- Code: `src/kernel/scheduler/fsrs.ts`, `src/kernel/scheduler/queue.ts`, `src/kernel/recall/evaluator.ts`
+- Algorithm reference: <https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm>

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -1,0 +1,29 @@
+---
+okf_version: "0.1"
+---
+
+# ZAM Knowledge Base
+
+Living reference knowledge for this repository in
+[Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog).
+Current truth only — the *why* behind it lives in [../adr/](../adr/)
+(ADR 2026-07-17). Do not edit by hand: write through the
+`zam_okf_upsert` MCP tool.
+
+## algorithm
+
+- [FSRS-5 Scheduling](fsrs-scheduling.md) — ZAM schedules reviews with a pure-function FSRS-5 implementation; ratings 1-4 update stability and difficulty, and the FSRS test suite is the source of truth for scheduling behavior.
+
+## architecture
+
+- [Kernel and CLI Architecture](kernel-architecture.md) — ZAM is split into an AI-agnostic learning kernel and a thin CLI orchestration layer; all learning logic lives in the kernel, all LLM/HTTP code in the CLI.
+- [MCP Transport and Surfaces](mcp-surfaces.md) — zam mcp is the preferred agent transport - a stdio MCP server exposing ZAM tools and MCP Apps panels; zam agent connect configures supported harnesses.
+
+## data-model
+
+- [Prerequisite Graph and Blocking](prerequisite-blocking.md) — Tokens form a directed prerequisite graph; blocking and unblocking of dependent cards is a separate mechanism from FSRS rating, invoked by callers after a failed review.
+- [Token and Card Model](token-card-model.md) — A token is a shared atomic knowledge concept; a card is one user's FSRS state for it — a concept only appears in a user's queue if a card exists.
+
+## protocol
+
+- [Bridge CLI Protocol](bridge-protocol.md) — zam bridge is the machine-facing JSON fallback transport for agents; responses are always JSON, and the protocol types are the stable contract.

--- a/docs/okf/kernel-architecture.md
+++ b/docs/okf/kernel-architecture.md
@@ -1,0 +1,48 @@
+---
+type: architecture
+title: Kernel and CLI Architecture
+description: ZAM is split into an AI-agnostic learning kernel and a thin CLI orchestration layer; all learning logic lives in the kernel, all LLM/HTTP code in the CLI.
+tags:
+  - kernel
+  - cli
+  - boundaries
+resource: "https://github.com/zam-os/zam/blob/main/docs/okf/kernel-architecture.md"
+timestamp: 2026-07-17T00:00:00Z
+---
+
+ZAM has exactly two code layers with a hard boundary between them.
+
+The **kernel** (`src/kernel/`) is the learning engine. It owns scheduling,
+recall, prerequisite blocking, sessions, analytics, and persistence, and it
+has **zero LLM dependencies**: no fetch to model endpoints, no embedding
+calls, ever. It stores vectors and ranks search results, but never produces
+embeddings itself. Its public API is `src/kernel/index.ts`; the package root
+`src/index.ts` re-exports it for programmatic use, and every new kernel
+function must be re-exported there to be usable.
+
+The **CLI** (`src/cli/`) is thin orchestration. Each command opens the
+database, calls kernel functions, renders output, and closes the
+connection. Everything that talks to an LLM or embedding endpoint lives in
+`src/cli/llm/`. Heavy optional surfaces (for example the MCP transport in
+`src/cli/commands/mcp.ts`) stay out of the CLI's eager module graph: the
+bootstrap registers stub commands that `await import()` the implementation.
+
+Two placement rules follow: new learning logic goes in the kernel, never in
+CLI commands; new HTTP goes in the CLI layer, never in the kernel.
+
+# Persistence
+
+The database is SQLite at `~/.zam/zam.db` (WAL mode, foreign keys on). All
+access goes through the async `Database` contract in
+`src/kernel/db/types.ts`; concrete drivers are imported only inside
+`src/kernel/db/`. IDs are ULIDs throughout. Schema changes require both
+`src/kernel/db/schema.ts` and an idempotent numbered migration.
+Machine-local state (config, selections) lives in `~/.zam/config.json`,
+never in the shareable database.
+
+# Citations
+
+- [ADR 2026-03-23 — Kernel and Shell Observation](../adr/2026-03-23-kernel-and-shell-observation.md)
+- [ADR 2026-06-09 — Async Database Providers](../adr/2026-06-09-async-database-providers.md)
+- [ADR 2026-07-07 — Resilient Self-Update and Dependency-Failure Isolation](../adr/2026-07-07-resilient-self-update-and-dependency-isolation.md)
+- Code: `src/kernel/index.ts`, `src/kernel/db/types.ts`, `src/cli/index.ts`

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,0 +1,10 @@
+# Log
+
+## 2026-07-17
+
+- **Creation** — [Token and Card Model](token-card-model.md)
+- **Creation** — [Prerequisite Graph and Blocking](prerequisite-blocking.md)
+- **Creation** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Creation** — [Kernel and CLI Architecture](kernel-architecture.md)
+- **Creation** — [FSRS-5 Scheduling](fsrs-scheduling.md)
+- **Creation** — [Bridge CLI Protocol](bridge-protocol.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -1,0 +1,43 @@
+---
+type: architecture
+title: MCP Transport and Surfaces
+description: zam mcp is the preferred agent transport - a stdio MCP server exposing ZAM tools and MCP Apps panels; zam agent connect configures supported harnesses.
+tags:
+  - mcp
+  - agents
+  - surfaces
+resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
+timestamp: 2026-07-17T00:00:00Z
+---
+
+`zam mcp` starts a stdio **Model Context Protocol** server
+(`src/cli/commands/mcp.ts`, lazily loaded so the CLI bootstrap stays
+light). It is the preferred way for agents to drive ZAM;
+[bridge-protocol.md](bridge-protocol.md) is the fallback.
+
+`zam agent connect <harness>` writes the MCP registration for a harness;
+supported: `claude-code`, `claude-desktop`, `antigravity`, `codex`,
+`opencode`, `goose`, `copilot`. Running it with no target auto-detects
+installed harnesses.
+
+The server exposes ZAM's tool surface (session start/end, queue and
+review actions, token search and registration, prerequisite linking,
+companion context and sampling, and the OKF knowledge-base tools
+`zam_okf_catalog` / `zam_okf_read` / `zam_okf_upsert`). The authoritative
+tool list with annotations is pinned by `tests/cli/mcp.test.ts`.
+
+# MCP Apps panels
+
+Four self-contained HTML panels ship as MCP Apps resources and open
+in hosts that support them: `ui://zam/studio`, `ui://zam/recall`,
+`ui://zam/graph`, `ui://zam/settings` (built by `npm run build:panel`,
+served from `dist/ui/`). The VS Code / Antigravity Companion extension
+(`src/vscode-extension/`) hosts the same panels in a webview and routes
+recall evaluation through per-IDE evaluator selections.
+
+# Citations
+
+- [ADR 2026-07-06a — MCP as the Canonical Agent Transport](../adr/2026-07-06a-mcp-agent-transport-and-surfaces.md)
+- [ADR 2026-07-16 — Companion Context Bar and Harness Affinity](../adr/2026-07-16-companion-context-and-harness-affinity.md)
+- [ADR 2026-07-17 — OKF Knowledge Base](../adr/2026-07-17-okf-knowledge-base.md)
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`

--- a/docs/okf/prerequisite-blocking.md
+++ b/docs/okf/prerequisite-blocking.md
@@ -1,0 +1,42 @@
+---
+type: data-model
+title: Prerequisite Graph and Blocking
+description: Tokens form a directed prerequisite graph; blocking and unblocking of dependent cards is a separate mechanism from FSRS rating, invoked by callers after a failed review.
+tags:
+  - kernel
+  - scheduling
+  - prerequisites
+resource: "https://github.com/zam-os/zam/blob/main/docs/okf/prerequisite-blocking.md"
+timestamp: 2026-07-17T00:00:00Z
+---
+
+Tokens are connected by a **directed prerequisite graph** (table
+`prerequisites`): an edge means "learn this first". The graph powers two
+behaviors:
+
+**Blocking.** When a learner demonstrably lacks a foundation, cards that
+depend on it can be blocked out of the queue. `cascadeBlock()` in
+`src/kernel/scheduler/blocker.ts` walks the dependents of a failed token
+and marks their cards blocked; `unblockReady()` releases cards whose
+prerequisites have recovered.
+
+**Separation from rating.** Blocking is deliberately *not* part of
+`evaluateRating()` (see [fsrs-scheduling.md](fsrs-scheduling.md)). A rating
+of `1` (Again) only updates FSRS state and the review log; the caller —
+CLI command, bridge, or MCP handler — decides whether to invoke the
+blocker afterwards. This keeps the FSRS math pure and lets surfaces choose
+their own blocking policy.
+
+Blocked cards are excluded when `src/kernel/scheduler/queue.ts` builds the
+review queue; unblocking re-admits them.
+
+Prerequisite edges can be suggested semantically: the kernel ranks
+candidate foundations from stored embeddings (`suggestFoundations`), and
+agents link them explicitly (`zam_link_prereq` over MCP, or
+`zam bridge`'s prerequisite commands).
+
+# Citations
+
+- [ADR 2026-03-27 — Stabilization and Workflow Integrity](../adr/2026-03-27-stabilization-and-workflow-integrity.md)
+- [ADR 2026-07-03 — RAG Semantic Token Search](../adr/2026-07-03-rag-semantic-token-search.md)
+- Code: `src/kernel/scheduler/blocker.ts`, `src/kernel/scheduler/queue.ts`

--- a/docs/okf/token-card-model.md
+++ b/docs/okf/token-card-model.md
@@ -1,0 +1,52 @@
+---
+type: data-model
+title: Token and Card Model
+description: A token is a shared atomic knowledge concept; a card is one user's FSRS state for it — a concept only appears in a user's queue if a card exists.
+tags:
+  - kernel
+  - data-model
+  - tokens
+  - cards
+resource: "https://github.com/zam-os/zam/blob/main/docs/okf/token-card-model.md"
+timestamp: 2026-07-17T00:00:00Z
+---
+
+The central distinction in ZAM's domain model:
+
+A **token** is an atomic knowledge concept, shared across all users. It
+carries a slug, title, concept text, domain, a **Bloom level** (1–5,
+driving how recall prompts are phrased), an optional learning context, an
+optional `source_link` (the URL of the knowledge source the concept was
+derived from — for repo knowledge, an OKF article), provenance fields
+(`provider`, `topic_id` for curriculum imports), and a
+**`symbiosis_mode`** of `shadowing`, `copilot`, or `autonomy` describing
+how much of the skill the human should own versus delegate to AI. Token
+metadata is load-bearing: Bloom levels drive prompt generation
+(`src/kernel/recall/prompter.ts`, template-based, not LLM), and
+`symbiosis_mode` drives coaching behavior.
+
+A **card** is one user's FSRS scheduling state for a token: stability,
+difficulty, due date, state, and block status (see
+[fsrs-scheduling.md](fsrs-scheduling.md) and
+[prerequisite-blocking.md](prerequisite-blocking.md)).
+
+The practical consequence: **a concept only appears in a user's review
+queue if a card exists for that user.** `zam token register` creates only
+the shared token; `zam bridge add-token` creates the token *and* the
+calling user's card. Removing a card (`personal-card-remove`) clears that
+user's learning state and history but leaves the shared token untouched;
+deleting a token (`personal-card-delete`) removes the concept for
+everyone.
+
+Supporting tables: `prerequisites` (directed dependency edges between
+tokens), `review_logs` (immutable audit trail of review events),
+`session`/`session_step` (work+learning episodes with per-step ratings),
+and `token_embeddings` (semantic-search vectors, produced by the CLI
+layer, stored by the kernel).
+
+# Citations
+
+- [ADR 2026-03-26 — Personal Workflow Foundations](../adr/2026-03-26-personal-workflow-foundations.md)
+- [ADR 2026-07-04 — Knowledge Contexts](../adr/2026-07-04-knowledge-contexts.md)
+- [ADR 2026-07-03 — RAG Semantic Token Search](../adr/2026-07-03-rag-semantic-token-search.md)
+- Code: `src/kernel/models/token.ts`, `src/kernel/recall/prompter.ts`

--- a/docs/plans/2026-07-17-okf-knowledge-base.md
+++ b/docs/plans/2026-07-17-okf-knowledge-base.md
@@ -1,0 +1,84 @@
+# Plan — OKF Knowledge Base (ADR 2026-07-17)
+
+Harness-agnostic implementation plan. Any agent picking up a phase should
+read [the ADR](../adr/2026-07-17-okf-knowledge-base.md) first; the ADR is
+the contract, this plan is the sequencing. Delete this file once all phases
+ship (plans lifecycle rule).
+
+## Status
+
+- [x] **Phase 1 — ADR + plan**
+- [x] **Phase 2 — `src/cli/okf/` core module + unit tests**
+- [x] **Phase 3 — MCP tools (`zam_okf_catalog` / `zam_okf_read` / `zam_okf_upsert`)**
+- [x] **Phase 4 — seed bundle `docs/okf/` (6 articles) + conformance test**
+- [x] **Phase 5 — `okf` skill (three copies) + CLAUDE.md/AGENTS.md sync**
+- [x] **Phase 6 — verification (lint, tests, build) + PR**
+
+## Phase 2 — core module
+
+`src/cli/okf/bundle.ts` — pure, no fs, unit-testable:
+
+- `parseFrontmatter(md)` → `{ fields: Record<string, string | string[]>, body }`
+  or a typed error. Subset: `---` fences, scalar `key: value` (optional
+  single/double quotes), block string lists (`key:` + `- item` lines).
+- `validateArticle(fileName, md)` → `{ ok, problems[] }`: parseable
+  frontmatter, non-empty `type`, non-empty `description` (house rule,
+  stricter than OKF), kebab-case `*.md` file name, not a reserved name.
+- `buildCatalog(articles)` → sorted entries `{ file, type, title,
+  description, tags, resource, timestamp }` (title falls back to file stem).
+- `renderIndex(catalog, okfVersion)` → root `index.md` (frontmatter only
+  here: `okf_version`), grouped by `type`, one line per article sourced
+  from its `description`.
+- `appendLog(existing, date, line)` → `log.md` content, newest day first.
+
+`src/cli/okf/io.ts` — thin fs layer: `loadBundle(dir)`,
+`upsertArticle(dir, file, articleMd)` (validate → write → regenerate
+`index.md` → append `log.md`). Rejects paths that escape the bundle dir and
+writes to reserved names.
+
+Tests: `tests/cli/okf-bundle.test.ts` (parser edge cases, validator
+problems, index/log generation), tmpdir round-trip for `io.ts`.
+
+## Phase 3 — MCP tools
+
+In `createMcpServer` (`src/cli/commands/mcp.ts`), following the existing
+`wrapHandler` pattern; all three take optional `bundle_dir` (default
+`docs/okf` relative to the server cwd):
+
+- `zam_okf_catalog {}` → catalog + conformance problems (doubles as the
+  validation report).
+- `zam_okf_read { file }` → raw markdown + parsed frontmatter.
+- `zam_okf_upsert { file, markdown }` → validated write through
+  `upsertArticle`; returns the updated catalog entry. Never writes
+  `index.md`/`log.md` directly.
+
+Update `tests/cli/mcp.test.ts` tool count/name list (18 → 21).
+
+## Phase 4 — seed bundle
+
+`docs/okf/`: root `index.md` (`okf_version: "0.1"`), `log.md`, six
+articles, each grounded in the current code and citing ADRs instead of
+restating rationale (ADR rule 2): `kernel-architecture`, `fsrs-scheduling`,
+`token-card-model`, `prerequisite-blocking`, `bridge-protocol`,
+`mcp-surfaces`. Frontmatter per article: `type`, `title`, `description`,
+`tags`, `resource` (canonical `https://github.com/zam-os/zam/blob/main/docs/okf/<file>` URL),
+`timestamp`.
+
+`tests/cli/okf-conformance.test.ts`: loads the real `docs/okf` through the
+Phase-2 module; asserts zero problems, index lists every article, resource
+URLs match the canonical prefix + file name, internal links resolve.
+
+## Phase 5 — skill + rules
+
+- `okf` skill in `.claude/skills/okf/SKILL.md`, `.agent/skills/okf/SKILL.md`
+  (identical) and `.agents/skills/okf/SKILL.md` (`$okf` wording for Codex,
+  mirroring the `zam` skill copies): when to write an article, the
+  ADR-vs-OKF split, the frontmatter subset, "always write through
+  `zam_okf_upsert`", how to cite articles as `source_link`.
+- CLAUDE.md + AGENTS.md (kept in sync): short "OKF knowledge base" section
+  with the not-freely-editable rule and the same-PR staleness rule.
+
+## Phase 6 — verification
+
+`npm run lint`, `npm run test`, `npm run build` green; PR from
+`feat/okf-knowledge-base`, review by Thomas.

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1215,6 +1215,106 @@ export function createMcpServer(db: Database): McpServer {
     ),
   );
 
+  // 19.–21. zam_okf_* — the OKF knowledge-base surface (ADR 2026-07-17).
+  // Operates on any OKF bundle directory; docs/okf of the current workspace
+  // by default. Upsert is the ONLY sanctioned write path into a bundle.
+  const okfBundleDirSchema = z
+    .string()
+    .optional()
+    .describe("Bundle directory (default docs/okf under the server cwd)");
+
+  server.registerTool(
+    "zam_okf_catalog",
+    {
+      description:
+        "List the OKF knowledge-base articles (type, title, description, tags, resource URL) plus conformance problems, if any",
+      inputSchema: {
+        bundle_dir: okfBundleDirSchema,
+      },
+      annotations: {
+        ...commonAnnotations,
+        readOnlyHint: true,
+      },
+    },
+    wrapHandler(async (params: { bundle_dir?: string }) => {
+      const { DEFAULT_BUNDLE_DIR, loadBundle } = await import("../okf/io.js");
+      const bundle = loadBundle(params.bundle_dir ?? DEFAULT_BUNDLE_DIR);
+      return {
+        dir: bundle.dir,
+        articles: bundle.catalog,
+        problems: bundle.problems,
+      };
+    }),
+  );
+
+  server.registerTool(
+    "zam_okf_read",
+    {
+      description:
+        "Read one OKF knowledge-base article: raw markdown plus parsed frontmatter",
+      inputSchema: {
+        bundle_dir: okfBundleDirSchema,
+        file: z.string().describe("Article file name, e.g. fsrs-scheduling.md"),
+      },
+      annotations: {
+        ...commonAnnotations,
+        readOnlyHint: true,
+      },
+    },
+    wrapHandler(async (params: { bundle_dir?: string; file: string }) => {
+      const { readFileSync } = await import("node:fs");
+      const { DEFAULT_BUNDLE_DIR, resolveArticlePath } = await import(
+        "../okf/io.js"
+      );
+      const { parseFrontmatter } = await import("../okf/bundle.js");
+      const path = resolveArticlePath(
+        params.bundle_dir ?? DEFAULT_BUNDLE_DIR,
+        params.file,
+      );
+      const markdown = readFileSync(path, "utf8");
+      const { fields } = parseFrontmatter(markdown);
+      return { file: params.file, frontmatter: fields, markdown };
+    }),
+  );
+
+  server.registerTool(
+    "zam_okf_upsert",
+    {
+      description:
+        "Create or update an OKF knowledge-base article through the validated write path: checks the frontmatter contract, regenerates index.md, and appends the log.md entry. Never edit bundle files directly.",
+      inputSchema: {
+        bundle_dir: okfBundleDirSchema,
+        file: z
+          .string()
+          .describe("Kebab-case article file name ending in .md (permanent ID)"),
+        markdown: z
+          .string()
+          .describe(
+            "Full article: --- frontmatter (type, title, description, tags, resource, timestamp) then the body",
+          ),
+      },
+      annotations: {
+        ...commonAnnotations,
+      },
+    },
+    wrapHandler(
+      async (params: { bundle_dir?: string; file: string; markdown: string }) => {
+        const { DEFAULT_BUNDLE_DIR, upsertArticle } = await import(
+          "../okf/io.js"
+        );
+        const result = upsertArticle(
+          params.bundle_dir ?? DEFAULT_BUNDLE_DIR,
+          params.file,
+          params.markdown,
+        );
+        if (!result.validation.ok) {
+          return { ok: false, problems: result.validation.problems };
+        }
+        return { ok: true, created: result.created, entry: result.entry };
+      },
+    ),
+  );
+
   return server;
 }
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1286,7 +1286,9 @@ export function createMcpServer(db: Database): McpServer {
         bundle_dir: okfBundleDirSchema,
         file: z
           .string()
-          .describe("Kebab-case article file name ending in .md (permanent ID)"),
+          .describe(
+            "Kebab-case article file name ending in .md (permanent ID)",
+          ),
         markdown: z
           .string()
           .describe(
@@ -1298,7 +1300,11 @@ export function createMcpServer(db: Database): McpServer {
       },
     },
     wrapHandler(
-      async (params: { bundle_dir?: string; file: string; markdown: string }) => {
+      async (params: {
+        bundle_dir?: string;
+        file: string;
+        markdown: string;
+      }) => {
         const { DEFAULT_BUNDLE_DIR, upsertArticle } = await import(
           "../okf/io.js"
         );

--- a/src/cli/okf/bundle.ts
+++ b/src/cli/okf/bundle.ts
@@ -129,7 +129,9 @@ export function validateArticle(
   try {
     parsed = parseFrontmatter(markdown);
   } catch (err) {
-    problems.push(`${file}: ${err instanceof Error ? err.message : String(err)}`);
+    problems.push(
+      `${file}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
   if (parsed) {
     if (!scalar(parsed.fields, "type")) {

--- a/src/cli/okf/bundle.ts
+++ b/src/cli/okf/bundle.ts
@@ -198,7 +198,7 @@ export function renderIndex(
     "(ADR 2026-07-17). Do not edit by hand: write through the",
     "`zam_okf_upsert` MCP tool.",
     "",
-    ...sections,
+    sections.join("\n\n"),
     "",
   ].join("\n");
 }

--- a/src/cli/okf/bundle.ts
+++ b/src/cli/okf/bundle.ts
@@ -1,0 +1,230 @@
+/**
+ * Open Knowledge Format (OKF) v0.1 bundle primitives (ADR 2026-07-17).
+ *
+ * Pure module by design — no fs, no DB, no LLM — so the frontmatter
+ * contract is unit-testable in isolation; `io.ts` adds the thin fs layer.
+ *
+ * Frontmatter is a deliberate YAML *subset* (no new dependencies rule):
+ * scalar `key: value` pairs (optionally single/double quoted) and block
+ * string lists (`key:` followed by `- item` lines). Articles needing more
+ * must extend this parser and its tests first.
+ */
+
+export const OKF_VERSION = "0.1";
+export const RESERVED_FILES = ["index.md", "log.md"] as const;
+
+export type FrontmatterValue = string | string[];
+
+export interface ParsedArticle {
+  fields: Record<string, FrontmatterValue>;
+  body: string;
+}
+
+export interface CatalogEntry {
+  file: string;
+  type: string;
+  title: string;
+  description: string;
+  tags: string[];
+  resource?: string;
+  timestamp?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  problems: string[];
+}
+
+const FILE_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
+
+export function isReservedFile(file: string): boolean {
+  return (RESERVED_FILES as readonly string[]).includes(file);
+}
+
+function unquote(raw: string): string {
+  const v = raw.trim();
+  if (
+    v.length >= 2 &&
+    ((v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'")))
+  ) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+/**
+ * Parse the OKF frontmatter subset. Throws with a line-anchored message on
+ * anything outside the subset, so authors get actionable feedback instead
+ * of silently dropped fields.
+ */
+export function parseFrontmatter(markdown: string): ParsedArticle {
+  const lines = markdown.split("\n");
+  if (lines[0]?.trim() !== "---") {
+    throw new Error("frontmatter: file must start with a --- fence");
+  }
+  const fields: Record<string, FrontmatterValue> = {};
+  let listKey: string | null = null;
+  let i = 1;
+  for (; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "---") break;
+    if (line.trim() === "") continue;
+    const listItem = /^\s+-\s+(.+)$/.exec(line);
+    if (listItem) {
+      if (!listKey) {
+        throw new Error(`frontmatter line ${i + 1}: list item without a key`);
+      }
+      (fields[listKey] as string[]).push(unquote(listItem[1]));
+      continue;
+    }
+    const pair = /^([A-Za-z0-9_-]+):(.*)$/.exec(line);
+    if (!pair) {
+      throw new Error(
+        `frontmatter line ${i + 1}: expected "key: value" or "- item"`,
+      );
+    }
+    const key = pair[1];
+    const rest = pair[2].trim();
+    if (rest === "") {
+      fields[key] = [];
+      listKey = key;
+    } else {
+      fields[key] = unquote(rest);
+      listKey = null;
+    }
+  }
+  if (i >= lines.length) {
+    throw new Error("frontmatter: missing closing --- fence");
+  }
+  return { fields, body: lines.slice(i + 1).join("\n") };
+}
+
+function scalar(
+  fields: Record<string, FrontmatterValue>,
+  key: string,
+): string | undefined {
+  const v = fields[key];
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : undefined;
+}
+
+/**
+ * Validate one concept document. OKF conformance requires parseable
+ * frontmatter with a non-empty `type`; ZAM's house rules additionally
+ * require `description` (it seeds catalog and index lines) and kebab-case
+ * file names (they are permanent IDs for learners' source links).
+ */
+export function validateArticle(
+  file: string,
+  markdown: string,
+): ValidationResult {
+  const problems: string[] = [];
+  if (isReservedFile(file)) {
+    return { ok: false, problems: [`${file}: reserved OKF file name`] };
+  }
+  if (!FILE_NAME_RE.test(file)) {
+    problems.push(`${file}: file name must be kebab-case and end in .md`);
+  }
+  let parsed: ParsedArticle | null = null;
+  try {
+    parsed = parseFrontmatter(markdown);
+  } catch (err) {
+    problems.push(`${file}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (parsed) {
+    if (!scalar(parsed.fields, "type")) {
+      problems.push(`${file}: frontmatter field "type" is required`);
+    }
+    if (!scalar(parsed.fields, "description")) {
+      problems.push(`${file}: frontmatter field "description" is required`);
+    }
+    if (parsed.body.trim() === "") {
+      problems.push(`${file}: article body is empty`);
+    }
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+export function toCatalogEntry(file: string, markdown: string): CatalogEntry {
+  const { fields } = parseFrontmatter(markdown);
+  const tags = Array.isArray(fields.tags) ? fields.tags : [];
+  return {
+    file,
+    type: scalar(fields, "type") ?? "",
+    title: scalar(fields, "title") ?? file.replace(/\.md$/, ""),
+    description: scalar(fields, "description") ?? "",
+    tags,
+    resource: scalar(fields, "resource"),
+    timestamp: scalar(fields, "timestamp"),
+  };
+}
+
+/** Sorted catalog for index rendering and the MCP catalog tool. */
+export function buildCatalog(
+  articles: Array<{ file: string; markdown: string }>,
+): CatalogEntry[] {
+  return articles
+    .map(({ file, markdown }) => toCatalogEntry(file, markdown))
+    .sort((a, b) => a.file.localeCompare(b.file));
+}
+
+/**
+ * Render the root index.md. Per OKF v0.1 the root index is the only index
+ * file carrying frontmatter (`okf_version`); the body groups articles by
+ * `type` with each line sourced from the article's description.
+ */
+export function renderIndex(
+  catalog: CatalogEntry[],
+  okfVersion: string = OKF_VERSION,
+): string {
+  const types = [...new Set(catalog.map((e) => e.type))].sort();
+  const sections = types.map((type) => {
+    const rows = catalog
+      .filter((e) => e.type === type)
+      .map((e) => `- [${e.title}](${e.file}) — ${e.description}`)
+      .join("\n");
+    return `## ${type}\n\n${rows}`;
+  });
+  return [
+    "---",
+    `okf_version: "${okfVersion}"`,
+    "---",
+    "",
+    "# ZAM Knowledge Base",
+    "",
+    "Living reference knowledge for this repository in",
+    "[Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog).",
+    "Current truth only — the *why* behind it lives in [../adr/](../adr/)",
+    "(ADR 2026-07-17). Do not edit by hand: write through the",
+    "`zam_okf_upsert` MCP tool.",
+    "",
+    ...sections,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Append a log entry, newest day first, merging into an existing entry
+ * group when the date matches the current top group.
+ */
+export function appendLog(
+  existing: string,
+  date: string,
+  line: string,
+): string {
+  const header = `## ${date}`;
+  const entry = `- ${line}`;
+  const trimmed = existing.trim();
+  if (trimmed === "") {
+    return `# Log\n\n${header}\n\n${entry}\n`;
+  }
+  const lines = trimmed.split("\n");
+  const firstHeaderIdx = lines.findIndex((l) => l.startsWith("## "));
+  if (firstHeaderIdx !== -1 && lines[firstHeaderIdx].trim() === header) {
+    lines.splice(firstHeaderIdx + 2, 0, entry);
+    return `${lines.join("\n")}\n`;
+  }
+  const insertAt = firstHeaderIdx === -1 ? lines.length : firstHeaderIdx;
+  lines.splice(insertAt, 0, header, "", entry, "");
+  return `${lines.join("\n")}\n`;
+}

--- a/src/cli/okf/io.ts
+++ b/src/cli/okf/io.ts
@@ -1,0 +1,131 @@
+/**
+ * Filesystem layer for OKF bundles (ADR 2026-07-17). Everything that
+ * touches disk lives here; the contract itself is in bundle.ts.
+ */
+import { readFileSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  type CatalogEntry,
+  type ValidationResult,
+  buildCatalog,
+  isReservedFile,
+  renderIndex,
+  toCatalogEntry,
+  validateArticle,
+  appendLog,
+} from "./bundle.js";
+
+export interface LoadedBundle {
+  dir: string;
+  articles: Array<{ file: string; markdown: string }>;
+  catalog: CatalogEntry[];
+  problems: string[];
+}
+
+export const DEFAULT_BUNDLE_DIR = "docs/okf";
+
+/**
+ * Resolve an article file name inside the bundle. Names are plain kebab
+ * basenames (v1 bundles are flat) — anything with a path separator or a
+ * reserved name is rejected before it can escape the bundle directory.
+ */
+export function resolveArticlePath(dir: string, file: string): string {
+  if (file.includes("/") || file.includes("\\") || file.includes("..")) {
+    throw new Error(`invalid article file name: ${file}`);
+  }
+  if (isReservedFile(file)) {
+    throw new Error(`refusing to address reserved file: ${file}`);
+  }
+  return join(resolve(dir), file);
+}
+
+export function loadBundle(dir: string): LoadedBundle {
+  const root = resolve(dir);
+  let entries: string[];
+  try {
+    entries = readdirSync(root).filter(
+      (name) => name.endsWith(".md") && !isReservedFile(name),
+    );
+  } catch {
+    throw new Error(`OKF bundle directory not found: ${root}`);
+  }
+  const articles = entries.sort().map((file) => ({
+    file,
+    markdown: readFileSync(join(root, file), "utf8"),
+  }));
+  const problems = articles.flatMap(
+    ({ file, markdown }) => validateArticle(file, markdown).problems,
+  );
+  const catalog =
+    problems.length === 0 ? buildCatalog(articles) : safeCatalog(articles);
+  return { dir: root, articles, catalog, problems };
+}
+
+function safeCatalog(
+  articles: Array<{ file: string; markdown: string }>,
+): CatalogEntry[] {
+  const entries: CatalogEntry[] = [];
+  for (const { file, markdown } of articles) {
+    try {
+      entries.push(toCatalogEntry(file, markdown));
+    } catch {
+      // Unparseable article: already reported via problems; keep the
+      // catalog usable for the rest of the bundle.
+    }
+  }
+  return entries.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+export interface UpsertResult {
+  validation: ValidationResult;
+  entry?: CatalogEntry;
+  created?: boolean;
+}
+
+/**
+ * The sanctioned write path (ADR 2026-07-17 rule 3): validate, write the
+ * article, regenerate index.md, append a log.md entry. Returns problems
+ * instead of writing when validation fails.
+ */
+export function upsertArticle(
+  dir: string,
+  file: string,
+  markdown: string,
+  today: string = new Date().toISOString().slice(0, 10),
+): UpsertResult {
+  const target = resolveArticlePath(dir, file);
+  const validation = validateArticle(file, markdown);
+  if (!validation.ok) return { validation };
+
+  const root = resolve(dir);
+  mkdirSync(root, { recursive: true });
+  let created = true;
+  try {
+    readFileSync(target, "utf8");
+    created = false;
+  } catch {
+    // new article
+  }
+  writeFileSync(target, markdown, "utf8");
+
+  const bundle = loadBundle(root);
+  writeFileSync(join(root, "index.md"), renderIndex(bundle.catalog), "utf8");
+
+  let log = "";
+  try {
+    log = readFileSync(join(root, "log.md"), "utf8");
+  } catch {
+    // first entry creates the log
+  }
+  const entry = bundle.catalog.find((e) => e.file === file);
+  writeFileSync(
+    join(root, "log.md"),
+    appendLog(
+      log,
+      today,
+      `**${created ? "Creation" : "Update"}** — [${entry?.title ?? file}](${file})`,
+    ),
+    "utf8",
+  );
+  return { validation, entry, created };
+}

--- a/src/cli/okf/io.ts
+++ b/src/cli/okf/io.ts
@@ -2,17 +2,17 @@
  * Filesystem layer for OKF bundles (ADR 2026-07-17). Everything that
  * touches disk lives here; the contract itself is in bundle.ts.
  */
-import { readFileSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import {
-  type CatalogEntry,
-  type ValidationResult,
+  appendLog,
   buildCatalog,
+  type CatalogEntry,
   isReservedFile,
   renderIndex,
   toCatalogEntry,
+  type ValidationResult,
   validateArticle,
-  appendLog,
 } from "./bundle.js";
 
 export interface LoadedBundle {

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -88,9 +88,9 @@ describe("MCP stdio server tests", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("lists all 18 tools with correct annotations", async () => {
+  it("lists all 21 tools with correct annotations", async () => {
     const response = await client.listTools();
-    expect(response.tools).toHaveLength(18);
+    expect(response.tools).toHaveLength(21);
 
     const toolNames = response.tools.map((t) => t.name).sort();
     const expectedNames = [
@@ -112,6 +112,9 @@ describe("MCP stdio server tests", () => {
       "zam_studio_bridge",
       "zam_companion_context",
       "zam_companion_sample",
+      "zam_okf_catalog",
+      "zam_okf_read",
+      "zam_okf_upsert",
     ].sort();
     expect(toolNames).toEqual(expectedNames);
 

--- a/tests/cli/okf-bundle.test.ts
+++ b/tests/cli/okf-bundle.test.ts
@@ -1,0 +1,179 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendLog,
+  buildCatalog,
+  parseFrontmatter,
+  renderIndex,
+  validateArticle,
+} from "../../src/cli/okf/bundle.js";
+import {
+  loadBundle,
+  resolveArticlePath,
+  upsertArticle,
+} from "../../src/cli/okf/io.js";
+
+const article = (over: Partial<Record<string, string>> = {}) =>
+  [
+    "---",
+    `type: ${over.type ?? "concept"}`,
+    `title: ${over.title ?? "FSRS Scheduling"}`,
+    `description: ${over.description ?? "How ZAM schedules reviews."}`,
+    "tags:",
+    "  - kernel",
+    "  - fsrs",
+    'resource: "https://github.com/zam-os/zam/blob/main/docs/okf/fsrs-scheduling.md"',
+    "timestamp: 2026-07-17T00:00:00Z",
+    "---",
+    "",
+    over.body ?? "FSRS-5 drives the queue.",
+    "",
+  ].join("\n");
+
+describe("okf/bundle parseFrontmatter", () => {
+  it("parses scalars, quoted scalars, and block lists", () => {
+    const parsed = parseFrontmatter(article());
+    expect(parsed.fields.type).toBe("concept");
+    expect(parsed.fields.tags).toEqual(["kernel", "fsrs"]);
+    expect(parsed.fields.resource).toBe(
+      "https://github.com/zam-os/zam/blob/main/docs/okf/fsrs-scheduling.md",
+    );
+    expect(parsed.body).toContain("FSRS-5 drives the queue.");
+  });
+
+  it("rejects a missing opening fence", () => {
+    expect(() => parseFrontmatter("type: concept\n---\n")).toThrow(
+      /must start with a --- fence/,
+    );
+  });
+
+  it("rejects an unterminated fence", () => {
+    expect(() => parseFrontmatter("---\ntype: concept\n")).toThrow(
+      /missing closing/,
+    );
+  });
+
+  it("rejects list items without a key, with a line number", () => {
+    expect(() =>
+      parseFrontmatter("---\n  - stray\n---\nbody"),
+    ).toThrow(/line 2: list item without a key/);
+  });
+
+  it("rejects lines outside the subset", () => {
+    expect(() =>
+      parseFrontmatter("---\nnested:\n  child: 1\n---\nbody"),
+    ).toThrow(/line 3/);
+  });
+});
+
+describe("okf/bundle validateArticle", () => {
+  it("accepts a conforming article", () => {
+    expect(validateArticle("fsrs-scheduling.md", article())).toEqual({
+      ok: true,
+      problems: [],
+    });
+  });
+
+  it("requires type, description, and a body", () => {
+    const md = "---\ntitle: X\n---\n\n";
+    const { ok, problems } = validateArticle("x.md", md);
+    expect(ok).toBe(false);
+    expect(problems.join(" ")).toMatch(/"type" is required/);
+    expect(problems.join(" ")).toMatch(/"description" is required/);
+    expect(problems.join(" ")).toMatch(/body is empty/);
+  });
+
+  it("rejects reserved and non-kebab file names", () => {
+    expect(validateArticle("index.md", article()).ok).toBe(false);
+    expect(
+      validateArticle("Not_Kebab.md", article()).problems.join(" "),
+    ).toMatch(/kebab-case/);
+  });
+});
+
+describe("okf/bundle index and log rendering", () => {
+  it("groups the index by type and pins okf_version frontmatter", () => {
+    const catalog = buildCatalog([
+      { file: "b.md", markdown: article({ type: "protocol", title: "B" }) },
+      { file: "a.md", markdown: article({ title: "A" }) },
+    ]);
+    const index = renderIndex(catalog);
+    expect(index.startsWith('---\nokf_version: "0.1"\n---')).toBe(true);
+    expect(index).toContain("## concept");
+    expect(index).toContain("## protocol");
+    expect(index).toContain("- [A](a.md) — How ZAM schedules reviews.");
+    expect(index.indexOf("## concept")).toBeLessThan(
+      index.indexOf("## protocol"),
+    );
+  });
+
+  it("appends log entries newest-day-first and merges same-day entries", () => {
+    const first = appendLog("", "2026-07-17", "**Creation** — [A](a.md)");
+    const sameDay = appendLog(first, "2026-07-17", "**Update** — [A](a.md)");
+    const nextDay = appendLog(sameDay, "2026-07-18", "**Creation** — [B](b.md)");
+    expect(nextDay.indexOf("## 2026-07-18")).toBeLessThan(
+      nextDay.indexOf("## 2026-07-17"),
+    );
+    const seventeenth = nextDay.slice(nextDay.indexOf("## 2026-07-17"));
+    expect(seventeenth.indexOf("**Update**")).toBeLessThan(
+      seventeenth.indexOf("**Creation**"),
+    );
+  });
+});
+
+describe("okf/io", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "zam-okf-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("refuses path escapes and reserved targets", () => {
+    expect(() => resolveArticlePath(dir, "../evil.md")).toThrow(/invalid/);
+    expect(() => resolveArticlePath(dir, "sub/evil.md")).toThrow(/invalid/);
+    expect(() => resolveArticlePath(dir, "log.md")).toThrow(/reserved/);
+  });
+
+  it("upsert writes the article, regenerates index.md, appends log.md", () => {
+    const res = upsertArticle(dir, "fsrs-scheduling.md", article(), "2026-07-17");
+    expect(res.validation.ok).toBe(true);
+    expect(res.created).toBe(true);
+    expect(res.entry?.title).toBe("FSRS Scheduling");
+    expect(readFileSync(join(dir, "index.md"), "utf8")).toContain(
+      "[FSRS Scheduling](fsrs-scheduling.md)",
+    );
+    expect(readFileSync(join(dir, "log.md"), "utf8")).toContain(
+      "**Creation** — [FSRS Scheduling](fsrs-scheduling.md)",
+    );
+
+    const again = upsertArticle(
+      dir,
+      "fsrs-scheduling.md",
+      article({ description: "Updated." }),
+      "2026-07-18",
+    );
+    expect(again.created).toBe(false);
+    const log = readFileSync(join(dir, "log.md"), "utf8");
+    expect(log.indexOf("## 2026-07-18")).toBeLessThan(
+      log.indexOf("## 2026-07-17"),
+    );
+  });
+
+  it("upsert refuses invalid articles without touching the bundle", () => {
+    const res = upsertArticle(dir, "broken.md", "---\ntitle: X\n---\n\n");
+    expect(res.validation.ok).toBe(false);
+    expect(loadBundle(dir).articles).toEqual([]);
+  });
+
+  it("loadBundle reports problems but keeps parseable entries in the catalog", () => {
+    upsertArticle(dir, "good.md", article({ title: "Good" }), "2026-07-17");
+    writeFileSync(join(dir, "bad.md"), "no frontmatter at all\n");
+    const bundle = loadBundle(dir);
+    expect(bundle.problems.join(" ")).toMatch(/bad\.md/);
+    expect(bundle.catalog.map((e) => e.file)).toEqual(["good.md"]);
+  });
+});

--- a/tests/cli/okf-conformance.test.ts
+++ b/tests/cli/okf-conformance.test.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter, renderIndex } from "../../src/cli/okf/bundle.js";
+import { loadBundle } from "../../src/cli/okf/io.js";
+
+/**
+ * CI gate for the real docs/okf bundle (ADR 2026-07-17): learners' cards
+ * cite these articles as source_link, so a broken bundle ships broken
+ * learning sources.
+ */
+const BUNDLE_DIR = join(process.cwd(), "docs", "okf");
+const CANONICAL_PREFIX = "https://github.com/zam-os/zam/blob/main/docs/okf/";
+
+describe("docs/okf conformance", () => {
+  const bundle = loadBundle(BUNDLE_DIR);
+
+  it("has zero validation problems", () => {
+    expect(bundle.problems).toEqual([]);
+    expect(bundle.catalog.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("every article's resource is its canonical blob URL", () => {
+    for (const entry of bundle.catalog) {
+      expect(entry.resource, entry.file).toBe(
+        `${CANONICAL_PREFIX}${entry.file}`,
+      );
+      expect(entry.timestamp, entry.file).toBeTruthy();
+      expect(entry.tags.length, entry.file).toBeGreaterThan(0);
+    }
+  });
+
+  it("index.md is exactly the rendered catalog (regenerate via zam_okf_upsert)", () => {
+    const index = readFileSync(join(BUNDLE_DIR, "index.md"), "utf8");
+    expect(index).toBe(renderIndex(bundle.catalog));
+  });
+
+  it("log.md exists and mentions every article at least once", () => {
+    const log = readFileSync(join(BUNDLE_DIR, "log.md"), "utf8");
+    for (const entry of bundle.catalog) {
+      expect(log, entry.file).toContain(`](${entry.file})`);
+    }
+  });
+
+  it("relative markdown links inside articles resolve to real files", () => {
+    const linkRe = /\]\((?!https?:)([^)#]+)(?:#[^)]*)?\)/g;
+    for (const { file, markdown } of bundle.articles) {
+      const { body } = parseFrontmatter(markdown);
+      for (const match of body.matchAll(linkRe)) {
+        const target = join(BUNDLE_DIR, match[1]);
+        expect(existsSync(target), `${file} → ${match[1]}`).toBe(true);
+      }
+    }
+  });
+
+  it("articles cite ADRs instead of restating decisions", () => {
+    for (const { file, markdown } of bundle.articles) {
+      expect(markdown, file).toContain("# Citations");
+    }
+  });
+});


### PR DESCRIPTION
Implements ADR 2026-07-17: living repo reference knowledge as an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog) v0.1 bundle that ZAM cards cite as `source_link`.

## What's in here

- **`docs/okf/` seed bundle** — six English articles (kernel-architecture, fsrs-scheduling, token-card-model, prerequisite-blocking, bridge-protocol, mcp-surfaces), each grounded in current code, citing ADRs under `# Citations` instead of restating rationale (ADR/OKF complementarity rule). `index.md` + `log.md` are generated by the module itself.
- **`src/cli/okf/`** — dependency-free frontmatter-subset parser, validator, catalog and index/log generators (pure `bundle.ts`) plus the sanctioned write path `upsertArticle` (`io.ts`: validate → write → regenerate index → append log; path-escape and reserved-file guards).
- **Three MCP tools** — `zam_okf_catalog` (doubles as conformance report), `zam_okf_read`, `zam_okf_upsert`; generic over any bundle dir (default `docs/okf`). Kernel untouched.
- **CI conformance gate** — `tests/cli/okf-conformance.test.ts` pins canonical `resource` blob URLs, resolvable links, Citations discipline, and index/log integrity; `tests/cli/okf-bundle.test.ts` covers the module.
- **`okf` skill** (`.claude`/`.agent`/`.agents` copies, Codex `$okf` variant) + synced CLAUDE.md/AGENTS.md rule: `docs/okf/` is not hand-editable, staleness is fixed in the same PR that changes described behavior.

## Notes for review

- Frontmatter parser accepts a documented YAML subset (scalars + block string lists) — no new dependencies.
- Article file names are permanent IDs (learners' stored source links); renames are superseded, not moved.
- Bridge-command parity deferred (matches the `zam_companion_sample` precedent).
- The plan doc `docs/plans/2026-07-17-okf-knowledge-base.md` follows the plans lifecycle (delete before the release that ships this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
