### PR TITLE
feat: OKF visualizer panel (MCP App) — zam_okf_visualize + scoped citation read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ desktop/src-tauri/target/
 desktop/src-tauri/resources/zam-cli/
 desktop/src-tauri/resources/zam-observer/
 observer/target/
+
+# agent orchestration scratch
+.superpowers/

--- a/desktop/src/panel/context-bar.ts
+++ b/desktop/src/panel/context-bar.ts
@@ -39,7 +39,12 @@ import { t, tf } from "../i18n.js";
 
 // ── Wire shapes (mirror src/vscode-extension/companion-context.ts) ────────
 
-export type CompanionSurface = "recall" | "graph" | "settings" | "studio";
+export type CompanionSurface =
+  | "recall"
+  | "graph"
+  | "settings"
+  | "studio"
+  | "okf";
 
 export type CompanionUserSource =
   | "invocation"

--- a/desktop/src/panel/okf-panel.html
+++ b/desktop/src/panel/okf-panel.html
@@ -1,0 +1,536 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ZAM OKF</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --accent: #827dbd;
+        --bg: #f5f7fb;
+        --fg: #1c2030;
+        --muted: #6b7280;
+        --card: #ffffff;
+        --border: rgba(15, 23, 42, 0.14);
+        --field-bg: #ffffff;
+        --danger: #ef4444;
+        --danger-bg: rgba(239, 68, 68, 0.1);
+        --hover: rgba(130, 125, 189, 0.1);
+        --ok: #2fbf71;
+        --ok-bg: rgba(47, 191, 113, 0.12);
+
+        /* OKF article-type palette — dataviz skill's validated 8-hue
+           categorical order, first 4 slots only (the "all-pairs" safe
+           subset for a scatter-like graph view; a 5th+ distinct `type`
+           string folds into --okf-type-other rather than cycling back
+           through the ramp — see okf.ts's typeSlot()). Each slot pairs a
+           foreground with a translucent "-bg" companion, same idiom as
+           --danger/--danger-bg above. */
+        --okf-type-1: #2a78d6;
+        --okf-type-1-bg: rgba(42, 120, 214, 0.16);
+        --okf-type-2: #008300;
+        --okf-type-2-bg: rgba(0, 131, 0, 0.16);
+        --okf-type-3: #e87ba4;
+        --okf-type-3-bg: rgba(232, 123, 164, 0.16);
+        --okf-type-4: #eda100;
+        --okf-type-4-bg: rgba(237, 161, 0, 0.16);
+        --okf-type-other: #6b7280;
+        --okf-type-other-bg: rgba(107, 114, 128, 0.16);
+
+        /* Aliases so any shared markup built against the richer --clr-*
+           palette (desktop/src/styles.css) still resolves here. Defined once;
+           the dark block below only redefines the base tokens and custom
+           properties resolve dynamically, so these follow along. */
+        --clr-text-muted: var(--muted);
+        --clr-text-secondary: var(--muted);
+        --clr-bg-surface: var(--card);
+        --clr-border: var(--border);
+        --clr-accent-purple: var(--accent);
+        --clr-accent-teal: var(--accent);
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #14161f;
+          --fg: #e8eaf2;
+          --muted: #9aa0b0;
+          --card: #1e2230;
+          --border: rgba(255, 255, 255, 0.14);
+          --field-bg: #262b3d;
+          --danger: #f87171;
+          --danger-bg: rgba(248, 113, 113, 0.14);
+          --hover: rgba(130, 125, 189, 0.18);
+          --ok: #34d399;
+          --ok-bg: rgba(52, 211, 153, 0.16);
+
+          --okf-type-1: #3987e5;
+          --okf-type-1-bg: rgba(57, 135, 229, 0.18);
+          --okf-type-2: #008300;
+          --okf-type-2-bg: rgba(0, 131, 0, 0.18);
+          --okf-type-3: #d55181;
+          --okf-type-3-bg: rgba(213, 81, 129, 0.18);
+          --okf-type-4: #c98500;
+          --okf-type-4-bg: rgba(201, 133, 0, 0.18);
+          --okf-type-other: #9aa0b0;
+          --okf-type-other-bg: rgba(154, 160, 176, 0.18);
+        }
+      }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        background: var(--bg);
+        color: var(--fg);
+      }
+      #zam-okf-panel {
+        padding: 16px;
+        max-width: 1080px;
+        margin: 0 auto;
+      }
+      /* Shared context-bar CSS is injected once at runtime by
+         desktop/src/panel/context-bar.ts's mountContextBar (item 9, 0.11.0
+         review) instead of being duplicated in every panel's HTML. */
+      .zam-card {
+        background: var(--card);
+        border-radius: 10px;
+        padding: 14px 16px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+      }
+
+      /* ── Header: article count, okf_version, view toggle ────────────── */
+      .okf-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-bottom: 12px;
+      }
+      .okf-header-info {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 0.82rem;
+        color: var(--muted);
+      }
+      .okf-article-count {
+        font-weight: 600;
+        color: var(--fg);
+      }
+      .okf-version {
+        font-variant-numeric: tabular-nums;
+      }
+      .okf-view-toggle {
+        display: inline-flex;
+        gap: 2px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        padding: 3px;
+      }
+      .okf-view-btn {
+        font: inherit;
+        font-size: 0.78rem;
+        font-weight: 600;
+        padding: 5px 13px;
+        border-radius: 999px;
+        border: none;
+        background: transparent;
+        color: var(--muted);
+        cursor: pointer;
+      }
+      .okf-view-btn.active {
+        background: var(--accent);
+        color: #ffffff;
+      }
+      .okf-view-btn:hover:not(.active) {
+        background: var(--hover);
+        color: var(--accent);
+      }
+
+      /* ── Sidebar: search + type-grouped catalog list ────────────────── */
+      .okf-layout {
+        display: flex;
+        gap: 16px;
+        align-items: flex-start;
+      }
+      .okf-sidebar {
+        width: 260px;
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .okf-search-input {
+        width: 100%;
+        box-sizing: border-box;
+        font: inherit;
+        font-size: 0.85rem;
+        padding: 7px 10px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: var(--field-bg);
+        color: var(--fg);
+      }
+      .okf-search-input:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 1px;
+      }
+      .okf-catalog-groups {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        max-height: 72vh;
+        overflow-y: auto;
+      }
+      .okf-catalog-group-title {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin: 0 0 4px 2px;
+        font-size: 0.68rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--muted);
+      }
+      .okf-type-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        display: inline-block;
+        flex-shrink: 0;
+      }
+      .okf-catalog-item {
+        display: block;
+        width: 100%;
+        text-align: left;
+        font: inherit;
+        font-size: 0.82rem;
+        padding: 6px 8px;
+        border-radius: 7px;
+        border: none;
+        background: transparent;
+        color: var(--fg);
+        cursor: pointer;
+      }
+      .okf-catalog-item:hover {
+        background: var(--hover);
+      }
+      .okf-catalog-item.active {
+        background: var(--hover);
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .okf-catalog-empty {
+        color: var(--muted);
+        font-size: 0.82rem;
+        padding: 8px 2px;
+      }
+
+      /* ── Content pane (reader / graph / log) ────────────────────────── */
+      .okf-content {
+        flex: 1;
+        min-width: 0;
+      }
+      .okf-meta-strip {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 12px;
+        font-size: 0.78rem;
+        color: var(--muted);
+      }
+      .okf-type-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        font-size: 0.68rem;
+        padding: 3px 9px;
+        border-radius: 999px;
+      }
+      .okf-tag {
+        background: var(--hover);
+        border-radius: 999px;
+        padding: 2px 9px;
+        font-size: 0.72rem;
+      }
+      .okf-resource-link {
+        color: var(--accent);
+        text-decoration: underline;
+      }
+
+      /* Typography for renderMarkdown's plain semantic HTML — shared by the
+         reader body, the log view, and inline citation content. */
+      .okf-article-body,
+      .okf-log-body {
+        font-size: 0.92rem;
+        line-height: 1.55;
+      }
+      .okf-article-body :is(h1, h2, h3, h4, h5, h6),
+      .okf-log-body :is(h1, h2, h3, h4, h5, h6) {
+        line-height: 1.3;
+        margin: 1.1em 0 0.4em;
+      }
+      .okf-article-body :is(h1, h2, h3, h4, h5, h6):first-child,
+      .okf-log-body :is(h1, h2, h3, h4, h5, h6):first-child {
+        margin-top: 0;
+      }
+      .okf-article-body h1,
+      .okf-log-body h1 {
+        font-size: 1.35rem;
+      }
+      .okf-article-body h2,
+      .okf-log-body h2 {
+        font-size: 1.15rem;
+      }
+      .okf-article-body :is(h3, h4, h5, h6),
+      .okf-log-body :is(h3, h4, h5, h6) {
+        font-size: 1rem;
+      }
+      .okf-article-body p,
+      .okf-log-body p {
+        margin: 0.6em 0;
+      }
+      .okf-article-body code,
+      .okf-log-body code {
+        font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+        font-size: 0.86em;
+        background: var(--hover);
+        border-radius: 4px;
+        padding: 0.12em 0.35em;
+      }
+      .okf-article-body pre,
+      .okf-log-body pre {
+        background: var(--hover);
+        border-radius: 8px;
+        padding: 10px 12px;
+        overflow-x: auto;
+      }
+      .okf-article-body pre code,
+      .okf-log-body pre code {
+        background: none;
+        padding: 0;
+      }
+      .okf-article-body :is(ul, ol),
+      .okf-log-body :is(ul, ol) {
+        margin: 0.5em 0;
+        padding-left: 1.4em;
+      }
+      .okf-article-body li,
+      .okf-log-body li {
+        margin: 0.2em 0;
+      }
+      .okf-article-body blockquote,
+      .okf-log-body blockquote {
+        margin: 0.7em 0;
+        padding: 4px 12px;
+        border-left: 3px solid var(--border);
+        color: var(--muted);
+      }
+      .okf-article-body table,
+      .okf-log-body table {
+        border-collapse: collapse;
+        margin: 0.7em 0;
+        font-size: 0.86rem;
+        max-width: 100%;
+        display: block;
+        overflow-x: auto;
+      }
+      .okf-article-body :is(th, td),
+      .okf-log-body :is(th, td) {
+        border: 1px solid var(--border);
+        padding: 5px 9px;
+        text-align: left;
+      }
+      .okf-article-body th,
+      .okf-log-body th {
+        background: var(--hover);
+      }
+      .okf-article-body a,
+      .okf-log-body a {
+        color: var(--accent);
+      }
+
+      /* ── Inline citation preview (data-okf-citation click target) ───── */
+      .okf-citation-inline {
+        margin: 4px 0 14px;
+        padding: 10px 12px;
+        border-left: 3px solid var(--accent);
+        background: var(--hover);
+        border-radius: 0 8px 8px 0;
+        font-size: 0.86rem;
+      }
+      .okf-citation-badge {
+        display: inline-block;
+        font-weight: 700;
+        font-size: 0.63rem;
+        letter-spacing: 0.04em;
+        padding: 2px 7px;
+        border-radius: 5px;
+        background: var(--accent);
+        color: #ffffff;
+        margin-right: 8px;
+        vertical-align: middle;
+      }
+      .okf-citation-open {
+        margin-left: 4px;
+        font: inherit;
+        font-size: 0.76rem;
+        color: var(--accent);
+        text-decoration: underline;
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+      }
+      .okf-citation-error {
+        color: var(--danger);
+        background: var(--danger-bg);
+        border: 1px solid var(--danger);
+        border-radius: 6px;
+        padding: 6px 10px;
+        font-size: 0.8rem;
+        margin: 4px 0 14px;
+      }
+      .okf-citation-view-back {
+        font: inherit;
+        font-size: 0.78rem;
+        color: var(--accent);
+        text-decoration: underline;
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        margin-bottom: 10px;
+        display: inline-block;
+      }
+
+      /* ── Graph view ──────────────────────────────────────────────────── */
+      .okf-graph-legend {
+        display: flex;
+        gap: 14px;
+        flex-wrap: wrap;
+        font-size: 0.76rem;
+        color: var(--muted);
+        margin-bottom: 8px;
+      }
+      .okf-graph-legend-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+      }
+      .okf-graph-legend-mark {
+        width: 10px;
+        height: 10px;
+        display: inline-block;
+      }
+      .okf-graph-legend-mark.article {
+        border-radius: 3px;
+        background: var(--accent);
+      }
+      .okf-graph-legend-mark.citation {
+        border-radius: 50%;
+        background: var(--card);
+        border: 1.6px dashed var(--accent);
+      }
+      .okf-graph-svg {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+      .okf-graph-edge {
+        stroke: var(--border);
+        stroke-width: 1.4;
+        opacity: 0.8;
+        pointer-events: none;
+      }
+      .okf-graph-node-label {
+        font-size: 11px;
+        fill: var(--fg);
+        font-family: inherit;
+        pointer-events: none;
+      }
+      .okf-graph-node-article rect {
+        stroke-width: 1.6;
+        transition: filter 0.15s ease;
+      }
+      .okf-graph-node-article:hover rect {
+        filter: brightness(1.12);
+      }
+      .okf-graph-node-citation circle {
+        fill: var(--card);
+        stroke: var(--accent);
+        stroke-width: 1.6;
+        stroke-dasharray: 3 2.5;
+      }
+
+      /* ── Empty / error states ────────────────────────────────────────── */
+      .okf-empty {
+        text-align: center;
+        padding: 32px 12px;
+      }
+      .okf-empty-emoji {
+        font-size: 2rem;
+      }
+      .okf-empty-title {
+        font-size: 1.05rem;
+        font-weight: 600;
+        margin: 8px 0 4px;
+      }
+      .okf-empty-sub {
+        color: var(--muted);
+        font-size: 0.88rem;
+      }
+
+      @media (max-width: 720px) {
+        .okf-layout {
+          flex-direction: column;
+        }
+        .okf-sidebar {
+          width: 100%;
+        }
+        .okf-catalog-groups {
+          max-height: 40vh;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="zam-okf-panel">
+      <div id="zam-contextbar-root"></div>
+      <div class="zam-connection-notice" id="zam-connection-notice" hidden></div>
+      <div class="okf-header">
+        <div class="okf-header-info">
+          <span class="okf-article-count" id="okf-article-count"></span>
+          <span class="okf-version" id="okf-version"></span>
+        </div>
+        <div class="okf-view-toggle" id="okf-view-toggle">
+          <button type="button" class="okf-view-btn" data-view="reader">
+            Artikel
+          </button>
+          <button type="button" class="okf-view-btn" data-view="graph">
+            Graph
+          </button>
+          <button type="button" class="okf-view-btn" data-view="log">Log</button>
+        </div>
+      </div>
+      <div class="okf-layout">
+        <aside class="okf-sidebar">
+          <input
+            type="search"
+            id="okf-search"
+            class="okf-search-input"
+            placeholder="Artikel durchsuchen..."
+          />
+          <div class="okf-catalog-groups" id="okf-catalog-groups"></div>
+        </aside>
+        <main class="okf-content" id="okf-content"></main>
+      </div>
+    </div>
+    <script type="module" src="./okf.ts"></script>
+  </body>
+</html>

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -77,19 +77,27 @@ function classifyLink(target: string): LinkKind {
 const CONTROL_CHARS_RE = /[\x00-\x1F]/g;
 const SCHEME_RE = /^([a-z][a-z0-9+.-]*):/i;
 const SAFE_HREF_SCHEMES = new Set(["http", "https", "mailto"]);
+// Two or more leading slash/backslash characters, in any combination, form
+// an authority-relative target ("//host/x", "\\host\x", "/\host"): browsers
+// resolve these to a *different* origin (and normalize backslashes to
+// forward slashes for http/https, so mixed forms are just as live), even
+// though there is no scheme token for the check above to catch.
+const AUTHORITY_RELATIVE_RE = /^[/\\]{2,}/;
 
 /**
  * Decide whether `target` may be used as a navigating anchor `href`.
  * Returns the sanitized href to use, or `null` if the target must render
  * inert instead (visible label, no executing/navigating href) -- any
  * scheme outside the allowlist, e.g. `javascript:`, `data:`, `vbscript:`,
- * `file:`. A scheme-less target (relative path, `#fragment`) is always
- * safe, since it has no scheme to be hostile.
+ * `file:`; or an authority-relative target (see `AUTHORITY_RELATIVE_RE`).
+ * A scheme-less, non-authority-relative target (relative path, `#fragment`)
+ * is always safe, since it stays on the current origin.
  */
 function safeHref(target: string): string | null {
   const cleaned = target.replace(CONTROL_CHARS_RE, "").trim();
   const scheme = SCHEME_RE.exec(cleaned)?.[1].toLowerCase();
   if (scheme && !SAFE_HREF_SCHEMES.has(scheme)) return null;
+  if (AUTHORITY_RELATIVE_RE.test(cleaned)) return null;
   return cleaned;
 }
 

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -67,6 +67,32 @@ function classifyLink(target: string): LinkKind {
   return "other";
 }
 
+// -- Link href safety ---------------------------------------------------------
+
+// Browsers strip ASCII control characters from a URL before parsing its
+// scheme (e.g. "java\tscript:" parses as "javascript:"), so scheme
+// detection below must run on a control-char-stripped, trimmed copy, or a
+// hostile scheme can hide behind an embedded control character.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matches raw control chars 0x00-0x1F -- stripping a scheme's disguise is the point
+const CONTROL_CHARS_RE = /[\x00-\x1F]/g;
+const SCHEME_RE = /^([a-z][a-z0-9+.-]*):/i;
+const SAFE_HREF_SCHEMES = new Set(["http", "https", "mailto"]);
+
+/**
+ * Decide whether `target` may be used as a navigating anchor `href`.
+ * Returns the sanitized href to use, or `null` if the target must render
+ * inert instead (visible label, no executing/navigating href) -- any
+ * scheme outside the allowlist, e.g. `javascript:`, `data:`, `vbscript:`,
+ * `file:`. A scheme-less target (relative path, `#fragment`) is always
+ * safe, since it has no scheme to be hostile.
+ */
+function safeHref(target: string): string | null {
+  const cleaned = target.replace(CONTROL_CHARS_RE, "").trim();
+  const scheme = SCHEME_RE.exec(cleaned)?.[1].toLowerCase();
+  if (scheme && !SAFE_HREF_SCHEMES.has(scheme)) return null;
+  return cleaned;
+}
+
 // -- Markdown rendering -----------------------------------------------------
 
 function renderLink(label: string, target: string): string {
@@ -80,7 +106,11 @@ function renderLink(label: string, target: string): string {
   if (kind === "citation") {
     return `<a href="#" data-okf-citation="${target}">${label}</a>`;
   }
-  return `<a href="${target}">${label}</a>`;
+  const href = safeHref(target);
+  if (href === null) {
+    return `<span>${label}</span>`;
+  }
+  return `<a href="${href}">${label}</a>`;
 }
 
 const LINK_RE = /^\[([^\]]*)\]\(([^)]+)\)/;
@@ -147,7 +177,11 @@ function renderInline(text: string): string {
 
 function splitTableRow(line: string): string[] {
   const trimmed = line.trim().replace(/^\|/, "").replace(/\|$/, "");
-  return trimmed.split("|").map((cell) => cell.trim());
+  // Split on unescaped pipes only (a `\|` inside a cell is a literal pipe,
+  // not a column separator), then unescape it back to `|` in each cell.
+  return trimmed
+    .split(/(?<!\\)\|/)
+    .map((cell) => cell.trim().replace(/\\\|/g, "|"));
 }
 
 function isTableSeparator(line: string): boolean {
@@ -368,6 +402,12 @@ export function extractLinks(body: string): {
 
   const linkRe = /\[[^\]]*\]\(([^)]+)\)/g;
   for (const match of scanned.matchAll(linkRe)) {
+    // This scans raw (unescaped) source, while renderMarkdown's link
+    // rendering scans escaped source -- classification is identical either
+    // way because escaped characters (&<>"') never appear in a
+    // classifyLink pattern, and the panel (Task 4) reads the rendered
+    // attribute back via the DOM, which entity-decodes on parse, so a
+    // value written from either copy round-trips to the same string.
     const target = match[1].trim();
     const kind = classifyLink(target);
     if (kind === "article" && !seenArticles.has(target)) {
@@ -409,7 +449,9 @@ function placeOnCircle(
 ): PositionedNode[] {
   const n = nodes.length;
   return nodes.map((node, index) => {
-    const angle = n === 0 ? 0 : (2 * Math.PI * index) / n - Math.PI / 2;
+    // n is never 0 here: an empty `nodes` makes `.map` skip this callback
+    // entirely, so the division below never sees a zero denominator.
+    const angle = (2 * Math.PI * index) / n - Math.PI / 2;
     return {
       ...node,
       x: centerX + radius * Math.cos(angle),

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -1,0 +1,458 @@
+/**
+ * Pure, DOM-free rendering core for the OKF visualizer panel (Task 3,
+ * docs/plans/2026-07-17-okf-visualizer-panel-plan.md). No `document`/
+ * `window` at module scope, so it is importable under Vitest without a DOM
+ * -- mirrors the split in graph-layout.ts (pure geometry/formatting driven
+ * by the untestable, DOM-touching panel entry, here `okf.ts` in Task 4).
+ *
+ * `CatalogEntry` below mirrors `CatalogEntry` in src/cli/okf/bundle.ts
+ * structurally (that module is this component's source of truth) rather
+ * than importing it, so this panel keeps bundling independently of
+ * src/cli -- same pattern context-bar.ts uses for the companion-context
+ * wire shapes. Keep the two definitions in sync by hand if bundle.ts
+ * changes.
+ */
+
+export interface CatalogEntry {
+  file: string;
+  type: string;
+  title: string;
+  description: string;
+  tags: string[];
+  resource?: string;
+  timestamp?: string;
+}
+
+export interface GraphNode {
+  id: string;
+  kind: "article" | "citation";
+  /** Catalog `type`, for articles; unused for citation nodes. */
+  type?: string;
+  /** Sort/identity key -- catalog file for articles, link target for citations. */
+  file?: string;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+}
+
+export interface PositionedNode extends GraphNode {
+  x: number;
+  y: number;
+}
+
+// -- HTML escaping ---------------------------------------------------------
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// -- Link classification (shared by renderMarkdown and extractLinks) ------
+
+type LinkKind = "article" | "citation" | "external" | "other";
+
+const BARE_KEBAB_MD_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
+
+function classifyLink(target: string): LinkKind {
+  const trimmed = target.trim();
+  if (/^https?:\/\//i.test(trimmed)) return "external";
+  if (BARE_KEBAB_MD_RE.test(trimmed)) return "article";
+  if (trimmed.endsWith(".md")) return "citation";
+  return "other";
+}
+
+// -- Markdown rendering -----------------------------------------------------
+
+function renderLink(label: string, target: string): string {
+  const kind = classifyLink(target);
+  if (kind === "external") {
+    return `<a href="${target}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+  }
+  if (kind === "article") {
+    return `<a href="#" data-okf-article="${target}">${label}</a>`;
+  }
+  if (kind === "citation") {
+    return `<a href="#" data-okf-citation="${target}">${label}</a>`;
+  }
+  return `<a href="${target}">${label}</a>`;
+}
+
+const LINK_RE = /^\[([^\]]*)\]\(([^)]+)\)/;
+
+/**
+ * Render inline constructs (code, links, bold, italic) within one line of
+ * already-HTML-escaped text via a single left-to-right scan. A scan (rather
+ * than sequential global regex replacements) means a matched code span or
+ * link is copied straight to the output and never revisited by the bold/
+ * italic handling that follows it, with no placeholder/sentinel text needed
+ * to protect it in the meantime.
+ */
+function renderInline(text: string): string {
+  let out = "";
+  let i = 0;
+  const n = text.length;
+
+  while (i < n) {
+    const ch = text[i];
+
+    if (ch === "`") {
+      const end = text.indexOf("`", i + 1);
+      if (end !== -1) {
+        out += `<code>${text.slice(i + 1, end)}</code>`;
+        i = end + 1;
+        continue;
+      }
+    }
+
+    if (ch === "[") {
+      const linkMatch = LINK_RE.exec(text.slice(i));
+      if (linkMatch) {
+        out += renderLink(linkMatch[1], linkMatch[2].trim());
+        i += linkMatch[0].length;
+        continue;
+      }
+    }
+
+    if (text.startsWith("**", i) || text.startsWith("__", i)) {
+      const marker = text.slice(i, i + 2);
+      const end = text.indexOf(marker, i + 2);
+      if (end !== -1) {
+        out += `<strong>${text.slice(i + 2, end)}</strong>`;
+        i = end + 2;
+        continue;
+      }
+    }
+
+    if (ch === "*" || ch === "_") {
+      const end = text.indexOf(ch, i + 1);
+      if (end !== -1 && end > i + 1) {
+        out += `<em>${text.slice(i + 1, end)}</em>`;
+        i = end + 1;
+        continue;
+      }
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+function splitTableRow(line: string): string[] {
+  const trimmed = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  return trimmed.split("|").map((cell) => cell.trim());
+}
+
+function isTableSeparator(line: string): boolean {
+  return /^[\s|:-]+$/.test(line) && line.includes("-");
+}
+
+function renderTable(header: string[], rows: string[][]): string {
+  const head = `<thead><tr>${header.map((c) => `<th>${renderInline(c)}</th>`).join("")}</tr></thead>`;
+  const body = `<tbody>${rows
+    .map(
+      (row) =>
+        `<tr>${row.map((c) => `<td>${renderInline(c)}</td>`).join("")}</tr>`,
+    )
+    .join("")}</tbody>`;
+  return `<table>${head}${body}</table>`;
+}
+
+// The source is escaped before block detection runs, so a leading literal
+// ">" (the blockquote marker) has already become the 4-char entity "&gt;"
+// -- match that escaped form, not a literal ">".
+const BLOCKQUOTE_RE = /^&gt;\s?/;
+
+function isBlockStart(line: string): boolean {
+  return (
+    /^#{1,6}\s+/.test(line) ||
+    BLOCKQUOTE_RE.test(line) ||
+    /^[-*]\s+/.test(line) ||
+    /^\d+\.\s+/.test(line) ||
+    /^```/.test(line.trim()) ||
+    line.includes("|")
+  );
+}
+
+/**
+ * Render OKF article markdown to HTML. Escapes the *entire* raw source
+ * first, then builds markup on top of the escaped text -- so any literal
+ * HTML (a `<script>` tag, an `onerror` attribute inside inline code, etc.)
+ * in the source is inert entities by the time any tag is emitted and can
+ * never survive as live markup.
+ *
+ * Supports: headings (1-6), paragraphs, bold/italic, inline code, fenced
+ * code blocks, ordered/unordered lists, tables, blockquotes, and links
+ * classified per the panel's link contract (see classifyLink above).
+ */
+export function renderMarkdown(source: string): string {
+  const lines = escapeHtml(source).split("\n");
+  const blocks: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    const fenceMatch = /^```(\w*)\s*$/.exec(line.trim());
+    if (fenceMatch) {
+      const lang = fenceMatch[1];
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && lines[i].trim() !== "```") {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      i++; // skip the closing fence (or end of input)
+      const classAttr = lang ? ` class="language-${lang}"` : "";
+      blocks.push(
+        `<pre><code${classAttr}>${codeLines.join("\n")}</code></pre>`,
+      );
+      continue;
+    }
+
+    const headingMatch = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      blocks.push(`<h${level}>${renderInline(headingMatch[2])}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    if (BLOCKQUOTE_RE.test(line)) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && BLOCKQUOTE_RE.test(lines[i])) {
+        quoteLines.push(lines[i].replace(BLOCKQUOTE_RE, ""));
+        i++;
+      }
+      blocks.push(
+        `<blockquote>${renderInline(quoteLines.join(" "))}</blockquote>`,
+      );
+      continue;
+    }
+
+    if (
+      line.includes("|") &&
+      i + 1 < lines.length &&
+      isTableSeparator(lines[i + 1])
+    ) {
+      const header = splitTableRow(line);
+      i += 2;
+      const rows: string[][] = [];
+      while (
+        i < lines.length &&
+        lines[i].trim() !== "" &&
+        lines[i].includes("|")
+      ) {
+        rows.push(splitTableRow(lines[i]));
+        i++;
+      }
+      blocks.push(renderTable(header, rows));
+      continue;
+    }
+
+    if (/^[-*]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[-*]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^[-*]\s+/, ""));
+        i++;
+      }
+      blocks.push(
+        `<ul>${items.map((item) => `<li>${renderInline(item)}</li>`).join("")}</ul>`,
+      );
+      continue;
+    }
+
+    if (/^\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\d+\.\s+/, ""));
+        i++;
+      }
+      blocks.push(
+        `<ol>${items.map((item) => `<li>${renderInline(item)}</li>`).join("")}</ol>`,
+      );
+      continue;
+    }
+
+    // Paragraph fallback. Always consume at least this line -- a line can
+    // trip `isBlockStart` (e.g. a stray "|") without any dedicated branch
+    // above having claimed it, and gathering zero lines would spin forever.
+    const paraLines = [line];
+    i++;
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !isBlockStart(lines[i])
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    blocks.push(`<p>${renderInline(paraLines.join(" "))}</p>`);
+  }
+
+  return blocks.join("\n");
+}
+
+// -- Catalog grouping/filtering ---------------------------------------------
+
+/** Group by frontmatter `type`, preserving first-seen type order and each group's catalog order. */
+export function groupCatalog(
+  catalog: CatalogEntry[],
+): Map<string, CatalogEntry[]> {
+  const groups = new Map<string, CatalogEntry[]>();
+  for (const entry of catalog) {
+    const existing = groups.get(entry.type);
+    if (existing) existing.push(entry);
+    else groups.set(entry.type, [entry]);
+  }
+  return groups;
+}
+
+/** Case-insensitive match against title, description, tags, or file name. */
+export function filterCatalog(
+  catalog: CatalogEntry[],
+  query: string,
+): CatalogEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return catalog;
+  return catalog.filter(
+    (entry) =>
+      entry.title.toLowerCase().includes(q) ||
+      entry.description.toLowerCase().includes(q) ||
+      entry.file.toLowerCase().includes(q) ||
+      entry.tags.some((tag) => tag.toLowerCase().includes(q)),
+  );
+}
+
+// -- Link extraction (for the graph view) ------------------------------------
+
+function stripFencedCodeBlocks(text: string): string {
+  const out: string[] = [];
+  let inFence = false;
+  for (const line of text.split("\n")) {
+    if (/^```/.test(line.trim())) {
+      inFence = !inFence;
+      continue;
+    }
+    if (!inFence) out.push(line);
+  }
+  return out.join("\n");
+}
+
+/**
+ * Extract markdown link targets from an article body for the graph view.
+ * Links inside fenced code blocks are ignored (a code example that happens
+ * to contain `[text](target.md)` must not create a graph edge).
+ */
+export function extractLinks(body: string): {
+  articles: string[];
+  citations: string[];
+} {
+  const scanned = stripFencedCodeBlocks(body);
+  const articles: string[] = [];
+  const citations: string[] = [];
+  const seenArticles = new Set<string>();
+  const seenCitations = new Set<string>();
+
+  const linkRe = /\[[^\]]*\]\(([^)]+)\)/g;
+  for (const match of scanned.matchAll(linkRe)) {
+    const target = match[1].trim();
+    const kind = classifyLink(target);
+    if (kind === "article" && !seenArticles.has(target)) {
+      seenArticles.add(target);
+      articles.push(target);
+    } else if (kind === "citation" && !seenCitations.has(target)) {
+      seenCitations.add(target);
+      citations.push(target);
+    }
+  }
+  return { articles, citations };
+}
+
+// -- Graph layout -------------------------------------------------------------
+
+const ARTICLE_RADIUS_FRACTION = 0.32;
+const CITATION_RADIUS_FRACTION = 0.46;
+
+function sortKey(node: GraphNode): string {
+  return node.file ?? node.id;
+}
+
+function sortArticles(nodes: GraphNode[]): GraphNode[] {
+  return [...nodes].sort((a, b) => {
+    const byType = (a.type ?? "").localeCompare(b.type ?? "");
+    return byType !== 0 ? byType : sortKey(a).localeCompare(sortKey(b));
+  });
+}
+
+function sortCitations(nodes: GraphNode[]): GraphNode[] {
+  return [...nodes].sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+}
+
+function placeOnCircle(
+  nodes: GraphNode[],
+  radius: number,
+  centerX: number,
+  centerY: number,
+): PositionedNode[] {
+  const n = nodes.length;
+  return nodes.map((node, index) => {
+    const angle = n === 0 ? 0 : (2 * Math.PI * index) / n - Math.PI / 2;
+    return {
+      ...node,
+      x: centerX + radius * Math.cos(angle),
+      y: centerY + radius * Math.sin(angle),
+    };
+  });
+}
+
+/**
+ * Deterministic circle layout: article nodes on an inner ring ordered by
+ * (type, file), citation nodes on an outer ring (arc) ordered by their link
+ * target. Pure function of its inputs -- no randomness, no mutation of the
+ * input arrays -- so identical input always yields identical coordinates.
+ *
+ * `edges` isn't used for node placement (this is a radial layout, not
+ * force-directed); it's accepted here so the panel can pass the same pair
+ * of arrays it already has on hand for drawing the connecting lines.
+ */
+export function layoutGraph(
+  nodes: GraphNode[],
+  _edges: GraphEdge[],
+  width: number,
+  height: number,
+): PositionedNode[] {
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const minDim = Math.min(width, height);
+
+  const articles = sortArticles(nodes.filter((n) => n.kind === "article"));
+  const citations = sortCitations(nodes.filter((n) => n.kind === "citation"));
+
+  return [
+    ...placeOnCircle(
+      articles,
+      minDim * ARTICLE_RADIUS_FRACTION,
+      centerX,
+      centerY,
+    ),
+    ...placeOnCircle(
+      citations,
+      minDim * CITATION_RADIUS_FRACTION,
+      centerX,
+      centerY,
+    ),
+  ];
+}

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -81,6 +81,11 @@ type ViewMode = "reader" | "graph" | "log";
 
 interface OpenOkfResult {
   bundleDir?: string | null;
+  /** The OKF bundle-format version (index.md's `okf_version` frontmatter),
+   * not the zam app/package version — see `zam_okf_visualize`'s `okfVersion`
+   * field (src/cli/commands/mcp.ts). `null` when the bundle failed to load
+   * or index.md has no `okf_version`. */
+  okfVersion?: string | null;
   catalog?: CatalogEntry[];
   log?: string;
   version?: string;
@@ -108,6 +113,12 @@ let connected = false;
 let started = false;
 let catalogLoaded = false;
 let bundleDir: string | null = null;
+/** Bundle-format version shown in the `#okf-version` header element —
+ * distinct from `panelVersion` (the zam app/package version, still shown in
+ * the context-bar title). Null/unset until a tool result with `okfVersion`
+ * arrives; the 800ms zam_okf_catalog fallback never sets it, since that tool
+ * doesn't return it. */
+let bundleOkfVersion: string | null = null;
 let catalog: CatalogEntry[] = [];
 /** First-seen `type` order across the full (unfiltered) catalog, fixed once
  * per catalog load — the categorical-color assignment must never reshuffle
@@ -221,12 +232,22 @@ function renderAll(): void {
 
 function renderHeader(): void {
   if (headerCountEl) headerCountEl.textContent = `${catalog.length} Artikel`;
-  // zam_okf_visualize now returns a distinct OKF-format `okfVersion` (Task
-  // 5), but this panel doesn't thread it through OpenOkfResult yet — still
-  // showing the panel/app version here, same convention as every other
-  // zam_open_*/zam_show_* card. Wiring the real okf_version through is
-  // follow-up work, not required for the panel to render correctly today.
-  if (headerVersionEl) headerVersionEl.textContent = panelVersion ? `v${panelVersion}` : "";
+  // #okf-version shows the OKF BUNDLE's format version (index.md's
+  // `okf_version`), not the zam app/package version — that's still shown
+  // separately in the context-bar title (see ensureContextBar/panelVersion).
+  // Unknown (bundle failed to load, no `okf_version` field, or the 800ms
+  // zam_okf_catalog fallback ran because no host ever fired ontoolresult)
+  // degrades to hiding the element rather than falling back to the app
+  // version, which would mislabel it.
+  if (headerVersionEl) {
+    if (bundleOkfVersion) {
+      headerVersionEl.hidden = false;
+      headerVersionEl.textContent = `OKF v${bundleOkfVersion}`;
+    } else {
+      headerVersionEl.hidden = true;
+      headerVersionEl.textContent = "";
+    }
+  }
 }
 
 function updateViewToggleActiveState(): void {
@@ -802,6 +823,7 @@ app.ontoolresult = (params) => {
   const previousBundleDir = bundleDir;
   currentUser = structured.user ?? null;
   if (structured.bundleDir !== undefined) bundleDir = structured.bundleDir;
+  if (structured.okfVersion !== undefined) bundleOkfVersion = structured.okfVersion;
   if (structured.catalog) {
     setCatalog(structured.catalog);
     catalogLoaded = true;

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -1,0 +1,892 @@
+/**
+ * ZAM OKF Visualizer — MCP Apps panel entry (Task 4,
+ * docs/plans/2026-07-17-okf-visualizer-panel-plan.md).
+ *
+ * Browses an Open Knowledge Format bundle (docs/okf by default): a sidebar
+ * of articles grouped by frontmatter `type` with a search box, a markdown
+ * reader with inline-expandable cited ADRs, a link graph, and a raw log
+ * view. All data comes from the `zam_okf_*` MCP tools — no fs/DB access of
+ * its own, no external static-visualizer code (ADR 2026-07-17b Decision 4).
+ *
+ * Standalone by design (tests/desktop/module-boundaries.test.ts): no Tauri,
+ * no Three.js, no import from ./main, ./panel, or ./recall. The rendering
+ * core (escaping, markdown, catalog grouping/filtering, link extraction,
+ * graph layout) is the pure, DOM-free module ./okf-render.js (Task 3); the
+ * callTool/context-bar plumbing is shared via ./context-bar.js (item 9,
+ * 0.11.0 review), same as every other panel entry.
+ *
+ * Two known forward references to later plan tasks, both harmless today:
+ *  - `SURFACE` below is cast to `CompanionSurface` even though "okf" isn't
+ *    a member yet — Task 5 adds it to both `CompanionSurface`
+ *    (context-bar.ts) and `COMPANION_SURFACES`
+ *    (src/vscode-extension/companion-context.ts) in the same task that
+ *    registers `zam_okf_visualize` and starts supplying a real
+ *    `companionContext` shaped with `surface: "okf"`. Until then, a manual
+ *    Agent/User pill change on this panel round-trips to a surface the
+ *    server doesn't recognize yet and degrades through the context bar's
+ *    own `onError` path (an inline notice) instead of crashing — first
+ *    paint and `ontoolresult`-driven rendering are unaffected either way.
+ *  - `app.ontoolresult` is written against `zam_okf_visualize`'s result
+ *    shape (Task 5), which doesn't exist yet, so in practice today only the
+ *    800ms fallback (`zam_okf_catalog`, which does exist) ever actually
+ *    populates the panel — exactly the "testable-by-build now" framing in
+ *    the plan.
+ */
+
+import { App } from "@modelcontextprotocol/ext-apps";
+import { setCurrentLocale } from "../i18n.js";
+import {
+  type CompanionContextBarState,
+  type CompanionSurface,
+  type ContextBarHandle,
+  clearConnectionNotice as clearConnectionNoticeShared,
+  createCallTool,
+  createContextReader,
+  createContextWriter,
+  ensureContextBar,
+  fallbackContextBarState,
+  showConnectionNotice as showConnectionNoticeShared,
+} from "./context-bar.js";
+import {
+  type CatalogEntry,
+  type GraphEdge,
+  type GraphNode,
+  type PositionedNode,
+  extractLinks,
+  filterCatalog,
+  groupCatalog,
+  layoutGraph,
+  renderMarkdown,
+} from "./okf-render.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const GRAPH_W = 680;
+const GRAPH_H = 680;
+const NODE_R = 22;
+
+// See the module doc comment above: Task 5 adds "okf" to CompanionSurface.
+const SURFACE = "okf" as CompanionSurface;
+
+const contextBarRoot = document.getElementById("zam-contextbar-root");
+const noticeEl = document.getElementById("zam-connection-notice");
+const headerCountEl = document.getElementById("okf-article-count");
+const headerVersionEl = document.getElementById("okf-version");
+const viewToggleEl = document.getElementById("okf-view-toggle");
+const searchInputEl = document.getElementById(
+  "okf-search",
+) as HTMLInputElement | null;
+const catalogGroupsEl = document.getElementById("okf-catalog-groups");
+const contentEl = document.getElementById("okf-content");
+
+const showConnectionNotice = (message: string): void =>
+  showConnectionNoticeShared(noticeEl, message);
+const clearConnectionNotice = (): void => clearConnectionNoticeShared(noticeEl);
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+type ViewMode = "reader" | "graph" | "log";
+
+interface OpenOkfResult {
+  bundleDir?: string | null;
+  catalog?: CatalogEntry[];
+  log?: string;
+  version?: string;
+  user?: string | null;
+  companionContext?: CompanionContextBarState;
+}
+
+interface CitationState {
+  status: "loading" | "ok" | "error";
+  path?: string;
+  content?: string;
+  error?: string;
+}
+
+interface CitationView {
+  target: string;
+  path: string;
+  content: string;
+}
+
+let contextBar: ContextBarHandle | undefined;
+let panelVersion: string | undefined;
+let currentUser: string | null = null;
+let connected = false;
+let started = false;
+let catalogLoaded = false;
+let bundleDir: string | null = null;
+let catalog: CatalogEntry[] = [];
+/** First-seen `type` order across the full (unfiltered) catalog, fixed once
+ * per catalog load — the categorical-color assignment must never reshuffle
+ * while the user types in the search box (dataviz skill: fixed order, never
+ * cycled). */
+let typeOrder: string[] = [];
+let logText = "";
+let viewMode: ViewMode = "reader";
+let currentFile: string | null = null;
+let citationView: CitationView | null = null;
+let searchQuery = "";
+/** file -> markdown body, populated by the reader and by the graph view's
+ * prefetch; shared by both so navigating never re-fetches. */
+const bodyCache = new Map<string, string>();
+const readErrors = new Map<string, string>();
+const openCitations = new Map<string, CitationState>();
+
+const app = new App({ name: "ZAM OKF", version: "0.1.0" });
+const callTool = createCallTool(app);
+const writeCompanionContext = createContextWriter(callTool, SURFACE);
+const readCompanionContext = createContextReader(callTool, SURFACE);
+
+/**
+ * OKF content is bundle-scoped, not per-learner (articles have no user
+ * dimension — contrast graph.ts's token/card neighborhoods, which do), so a
+ * learner/agent switch only needs to update the displayed user; nothing
+ * else on this panel depends on `currentUser`.
+ */
+function reloadForContext(newState: CompanionContextBarState): void {
+  currentUser = newState.user.currentId ?? null;
+}
+
+function setCatalog(next: CatalogEntry[]): void {
+  catalog = next;
+  typeOrder = [...groupCatalog(catalog).keys()];
+}
+
+/**
+ * Deterministic index into the 4 fixed categorical slots defined in
+ * okf-panel.html (--okf-type-1..4, the dataviz skill's validated 8-hue
+ * order's first 4 — the "all-pairs" safe subset for this scatter-like
+ * graph/badge use). Assigned by first-seen order across the full catalog; a
+ * 5th+ distinct `type` folds into the shared "other" slot rather than
+ * cycling back through the ramp. Returns 0 for "other".
+ */
+function typeSlot(type: string): number {
+  const idx = typeOrder.indexOf(type);
+  return idx >= 0 && idx < 4 ? idx + 1 : 0;
+}
+
+function typeColorVar(type: string, suffix: "" | "-bg" = ""): string {
+  const slot = typeSlot(type);
+  return slot === 0
+    ? `var(--okf-type-other${suffix})`
+    : `var(--okf-type-${slot}${suffix})`;
+}
+
+/**
+ * `resource` is contractually an http(s) URL per the OKF article frontmatter
+ * schema (see src/cli/okf/bundle.ts's toCatalogEntry) — not markdown, so it
+ * doesn't go through okf-render.ts's renderMarkdown/link-classification
+ * pipeline. This is a narrower, allow-list-only counterpart to that
+ * module's private `safeHref` (not exported, so not reusable here): refuse
+ * anything that isn't literally `http://`/`https://` rather than trying to
+ * block specific unsafe schemes.
+ */
+function safeExternalHref(url: string): string | null {
+  const trimmed = url.trim();
+  return /^https?:\/\//i.test(trimmed) ? trimmed : null;
+}
+
+async function loadCatalogFallback(): Promise<void> {
+  try {
+    const result = (await callTool("zam_okf_catalog", {
+      bundle_dir: bundleDir ?? undefined,
+      include_log: true,
+    })) as {
+      dir: string;
+      articles: CatalogEntry[];
+      problems: string[];
+      log?: string;
+    };
+    bundleDir = result.dir;
+    setCatalog(result.articles);
+    logText = result.log ?? "";
+    catalogLoaded = true;
+    renderAll();
+  } catch (error) {
+    renderTopLevelError(errorMessage(error));
+  }
+}
+
+function start(): void {
+  if (started || !connected) return;
+  started = true;
+  if (catalogLoaded) {
+    renderAll();
+  } else {
+    void loadCatalogFallback();
+  }
+}
+
+// ── Render orchestration ────────────────────────────────────────────────
+
+function renderAll(): void {
+  renderHeader();
+  updateViewToggleActiveState();
+  renderSidebar();
+  renderContent();
+}
+
+function renderHeader(): void {
+  if (headerCountEl) headerCountEl.textContent = `${catalog.length} Artikel`;
+  // See the module doc comment: no `zam_okf_*` tool currently returns a
+  // distinct OKF-format `okf_version` (index.md's frontmatter field) —
+  // every seeding path names this field `version` (the panel/app version,
+  // same convention as every other zam_open_*/zam_show_* tool). Displaying
+  // it here is the closest faithful match to the plan's "okf_version in the
+  // header" until/unless a tool exposes the format version distinctly.
+  if (headerVersionEl) headerVersionEl.textContent = panelVersion ? `v${panelVersion}` : "";
+}
+
+function updateViewToggleActiveState(): void {
+  for (const btn of viewButtons()) {
+    btn.classList.toggle("active", btn.dataset.view === viewMode);
+  }
+}
+
+function viewButtons(): HTMLButtonElement[] {
+  return viewToggleEl
+    ? Array.from(viewToggleEl.querySelectorAll<HTMLButtonElement>(".okf-view-btn"))
+    : [];
+}
+
+function renderEmptyInto(
+  container: HTMLElement,
+  emoji: string,
+  title: string,
+  sub: string,
+): void {
+  container.replaceChildren();
+  const box = document.createElement("div");
+  box.className = "zam-card okf-empty";
+  const emojiEl = document.createElement("div");
+  emojiEl.className = "okf-empty-emoji";
+  emojiEl.textContent = emoji;
+  const titleEl = document.createElement("div");
+  titleEl.className = "okf-empty-title";
+  titleEl.textContent = title;
+  const subEl = document.createElement("div");
+  subEl.className = "okf-empty-sub";
+  subEl.textContent = sub;
+  box.append(emojiEl, titleEl, subEl);
+  container.appendChild(box);
+}
+
+function renderTopLevelError(message: string): void {
+  catalogGroupsEl?.replaceChildren();
+  if (contentEl) {
+    renderEmptyInto(
+      contentEl,
+      "⚠️",
+      "Wissensbasis konnte nicht geladen werden",
+      message,
+    );
+  }
+}
+
+function renderSidebar(): void {
+  if (!catalogGroupsEl) return;
+  catalogGroupsEl.replaceChildren();
+  const filtered = filterCatalog(catalog, searchQuery);
+  if (filtered.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "okf-catalog-empty";
+    empty.textContent = searchQuery ? "Keine Treffer." : "Keine Artikel.";
+    catalogGroupsEl.appendChild(empty);
+    return;
+  }
+  for (const [type, entries] of groupCatalog(filtered)) {
+    const groupEl = document.createElement("div");
+    const titleEl = document.createElement("div");
+    titleEl.className = "okf-catalog-group-title";
+    const dot = document.createElement("span");
+    dot.className = "okf-type-dot";
+    dot.style.background = typeColorVar(type);
+    const label = document.createElement("span");
+    label.textContent = type || "(ohne Typ)";
+    titleEl.append(dot, label);
+    groupEl.appendChild(titleEl);
+    for (const entry of entries) {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = "okf-catalog-item";
+      if (viewMode === "reader" && !citationView && currentFile === entry.file) {
+        item.classList.add("active");
+      }
+      item.textContent = entry.title;
+      item.title = entry.description;
+      item.addEventListener("click", () => {
+        viewMode = "reader";
+        void openArticle(entry.file);
+      });
+      groupEl.appendChild(item);
+    }
+    catalogGroupsEl.appendChild(groupEl);
+  }
+}
+
+function renderContent(): void {
+  if (!contentEl) return;
+  if (viewMode === "graph") {
+    void renderGraphView();
+    return;
+  }
+  if (viewMode === "log") {
+    renderLogView(contentEl);
+    return;
+  }
+  renderReaderBody(contentEl);
+}
+
+// ── Reader ───────────────────────────────────────────────────────────────
+
+async function openArticle(file: string): Promise<void> {
+  currentFile = file;
+  citationView = null;
+  readErrors.delete(file);
+  renderAll();
+  if (!bodyCache.has(file)) {
+    try {
+      const result = (await callTool("zam_okf_read", {
+        bundle_dir: bundleDir ?? undefined,
+        file,
+      })) as { markdown: string };
+      bodyCache.set(file, result.markdown);
+    } catch (error) {
+      readErrors.set(file, errorMessage(error));
+    }
+  }
+  renderAll();
+}
+
+function buildMetaStrip(entry: CatalogEntry | undefined): HTMLElement {
+  const strip = document.createElement("div");
+  strip.className = "okf-meta-strip";
+  const type = entry?.type ?? "";
+  if (type) {
+    const badge = document.createElement("span");
+    badge.className = "okf-type-badge";
+    badge.style.background = typeColorVar(type, "-bg");
+    badge.style.color = typeColorVar(type);
+    badge.textContent = type;
+    strip.appendChild(badge);
+  }
+  for (const tag of entry?.tags ?? []) {
+    const tagEl = document.createElement("span");
+    tagEl.className = "okf-tag";
+    tagEl.textContent = tag;
+    strip.appendChild(tagEl);
+  }
+  if (entry?.timestamp) {
+    const ts = document.createElement("span");
+    ts.textContent = entry.timestamp;
+    strip.appendChild(ts);
+  }
+  if (entry?.resource) {
+    const href = safeExternalHref(entry.resource);
+    if (href) {
+      const link = document.createElement("a");
+      link.className = "okf-resource-link";
+      link.href = href;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = "Quelle ↗";
+      strip.appendChild(link);
+    }
+  }
+  return strip;
+}
+
+function renderReaderBody(container: HTMLElement): void {
+  if (citationView) {
+    renderCitationFullView(container, citationView);
+    return;
+  }
+  if (!currentFile) {
+    renderEmptyInto(
+      container,
+      "📚",
+      "Kein Artikel ausgewählt",
+      "Wähle links einen Artikel aus der Wissensbasis.",
+    );
+    return;
+  }
+  const error = readErrors.get(currentFile);
+  if (error) {
+    renderEmptyInto(container, "⚠️", "Artikel konnte nicht geladen werden", error);
+    return;
+  }
+  const body = bodyCache.get(currentFile);
+  if (body === undefined) {
+    renderEmptyInto(container, "⏳", "Lädt...", currentFile);
+    return;
+  }
+  container.replaceChildren();
+  container.appendChild(buildMetaStrip(catalog.find((e) => e.file === currentFile)));
+  const bodyEl = document.createElement("div");
+  bodyEl.className = "okf-article-body zam-card";
+  bodyEl.innerHTML = renderMarkdown(body);
+  attachContentClickDelegation(bodyEl);
+  decorateCitationLinks(bodyEl, new Set());
+  container.appendChild(bodyEl);
+}
+
+function renderCitationFullView(container: HTMLElement, view: CitationView): void {
+  container.replaceChildren();
+  const back = document.createElement("button");
+  back.type = "button";
+  back.className = "okf-citation-view-back";
+  back.textContent = "← Zurück zum Artikel";
+  back.addEventListener("click", () => {
+    citationView = null;
+    renderAll();
+  });
+  container.appendChild(back);
+
+  const strip = document.createElement("div");
+  strip.className = "okf-meta-strip";
+  const badge = document.createElement("span");
+  badge.className = "okf-type-badge";
+  badge.style.background = "var(--accent)";
+  badge.style.color = "#ffffff";
+  badge.textContent = "ADR";
+  const pathEl = document.createElement("span");
+  pathEl.textContent = view.path;
+  strip.append(badge, pathEl);
+  container.appendChild(strip);
+
+  const bodyEl = document.createElement("div");
+  bodyEl.className = "okf-article-body zam-card";
+  bodyEl.innerHTML = renderMarkdown(view.content);
+  attachContentClickDelegation(bodyEl);
+  decorateCitationLinks(bodyEl, new Set());
+  container.appendChild(bodyEl);
+}
+
+/** Click delegation for the two link kinds okf-render.ts's renderMarkdown
+ * classifies as in-panel (article/citation) rather than a plain href — see
+ * classifyLink in okf-render.ts. External links carry a real href and need
+ * no handler here. */
+function attachContentClickDelegation(container: HTMLElement): void {
+  container.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const articleLink = target.closest("[data-okf-article]");
+    if (articleLink) {
+      event.preventDefault();
+      const file = articleLink.getAttribute("data-okf-article");
+      if (file) {
+        viewMode = "reader";
+        void openArticle(file);
+      }
+      return;
+    }
+    const citationLink = target.closest("[data-okf-citation]");
+    if (citationLink) {
+      event.preventDefault();
+      const citationTarget = citationLink.getAttribute("data-okf-citation");
+      if (citationTarget) void toggleInlineCitation(citationTarget);
+    }
+  });
+}
+
+async function toggleInlineCitation(target: string): Promise<void> {
+  if (openCitations.has(target)) {
+    openCitations.delete(target);
+    renderAll();
+    return;
+  }
+  openCitations.set(target, { status: "loading" });
+  renderAll();
+  try {
+    const result = (await callTool("zam_okf_read_citation", {
+      bundle_dir: bundleDir ?? undefined,
+      target,
+    })) as { target: string; path: string; content: string };
+    openCitations.set(target, {
+      status: "ok",
+      path: result.path,
+      content: result.content,
+    });
+  } catch (error) {
+    openCitations.set(target, { status: "error", error: errorMessage(error) });
+  }
+  renderAll();
+}
+
+/**
+ * Insert an inline preview box after every currently-open citation link
+ * inside `container` (state-driven, rebuilt on every render rather than
+ * mutated in place, so it survives the innerHTML replace that draws the
+ * surrounding article/log body). `ancestors` guards a pathological
+ * self-/mutually-referential citation chain from recursing forever — each
+ * level only expands a target it hasn't already expanded on the way down.
+ */
+function decorateCitationLinks(
+  container: HTMLElement,
+  ancestors: ReadonlySet<string>,
+): void {
+  for (const link of container.querySelectorAll("[data-okf-citation]")) {
+    const target = link.getAttribute("data-okf-citation");
+    if (!target || ancestors.has(target)) continue;
+    const state = openCitations.get(target);
+    if (!state) continue;
+    link.insertAdjacentElement(
+      "afterend",
+      buildCitationBox(target, state, ancestors),
+    );
+  }
+}
+
+function buildCitationBox(
+  target: string,
+  state: CitationState,
+  ancestors: ReadonlySet<string>,
+): HTMLElement {
+  const box = document.createElement("div");
+  if (state.status === "loading") {
+    box.className = "okf-citation-inline";
+    box.textContent = "Lädt Zitat...";
+    return box;
+  }
+  if (state.status === "error") {
+    box.className = "okf-citation-error";
+    box.textContent = `Zitat nicht erreichbar: ${state.error ?? target}`;
+    return box;
+  }
+
+  box.className = "okf-citation-inline";
+  const badge = document.createElement("span");
+  badge.className = "okf-citation-badge";
+  badge.textContent = "ADR";
+  const pathEl = document.createElement("span");
+  pathEl.textContent = state.path ?? target;
+  const openBtn = document.createElement("button");
+  openBtn.type = "button";
+  openBtn.className = "okf-citation-open";
+  openBtn.textContent = "Vollständig öffnen ↗";
+  openBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+    citationView = {
+      target,
+      path: state.path ?? target,
+      content: state.content ?? "",
+    };
+    renderAll();
+  });
+  const contentBodyEl = document.createElement("div");
+  contentBodyEl.className = "okf-article-body";
+  contentBodyEl.innerHTML = renderMarkdown(state.content ?? "");
+  attachContentClickDelegation(contentBodyEl);
+  decorateCitationLinks(contentBodyEl, new Set([...ancestors, target]));
+  box.append(badge, pathEl, openBtn, contentBodyEl);
+  return box;
+}
+
+// ── Graph view ───────────────────────────────────────────────────────────
+
+async function ensureAllBodiesLoaded(): Promise<void> {
+  const missing = catalog.filter(
+    (entry) => !bodyCache.has(entry.file) && !readErrors.has(entry.file),
+  );
+  await Promise.all(
+    missing.map(async (entry) => {
+      try {
+        const result = (await callTool("zam_okf_read", {
+          bundle_dir: bundleDir ?? undefined,
+          file: entry.file,
+        })) as { markdown: string };
+        bodyCache.set(entry.file, result.markdown);
+      } catch (error) {
+        readErrors.set(entry.file, errorMessage(error));
+      }
+    }),
+  );
+}
+
+function buildFullGraph(): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const byFile = new Map(catalog.map((e): [string, CatalogEntry] => [e.file, e]));
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  const seen = new Set<string>();
+  const addNode = (node: GraphNode): void => {
+    if (seen.has(node.id)) return;
+    seen.add(node.id);
+    nodes.push(node);
+  };
+  for (const entry of catalog) {
+    addNode({ id: entry.file, kind: "article", type: entry.type, file: entry.file });
+  }
+  for (const entry of catalog) {
+    const body = bodyCache.get(entry.file);
+    if (body === undefined) continue;
+    const { articles, citations } = extractLinks(body);
+    for (const target of articles) {
+      addNode({
+        id: target,
+        kind: "article",
+        type: byFile.get(target)?.type,
+        file: target,
+      });
+      edges.push({ from: entry.file, to: target });
+    }
+    for (const target of citations) {
+      addNode({ id: target, kind: "citation", file: target });
+      edges.push({ from: entry.file, to: target });
+    }
+  }
+  return { nodes, edges };
+}
+
+function truncateLabel(text: string, max = 16): string {
+  const base = text.replace(/\.md$/, "");
+  return base.length > max ? `${base.slice(0, max - 1)}…` : base;
+}
+
+function buildGraphNodeEl(node: PositionedNode): SVGGElement {
+  const g = document.createElementNS(SVG_NS, "g") as SVGGElement;
+  g.setAttribute("transform", `translate(${node.x}, ${node.y})`);
+  g.setAttribute("class", `okf-graph-node-${node.kind}`);
+
+  const title = document.createElementNS(SVG_NS, "title");
+  title.textContent = node.file ?? node.id;
+  g.appendChild(title);
+
+  if (node.kind === "article") {
+    const rect = document.createElementNS(SVG_NS, "rect");
+    rect.setAttribute("x", String(-NODE_R));
+    rect.setAttribute("y", String(-NODE_R * 0.6));
+    rect.setAttribute("width", String(NODE_R * 2));
+    rect.setAttribute("height", String(NODE_R * 1.2));
+    rect.setAttribute("rx", "8");
+    rect.style.fill = typeColorVar(node.type ?? "", "-bg");
+    rect.style.stroke = typeColorVar(node.type ?? "");
+    g.appendChild(rect);
+    g.style.cursor = "pointer";
+    g.addEventListener("click", () => {
+      viewMode = "reader";
+      void openArticle(node.file ?? node.id);
+    });
+  } else {
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("r", String(NODE_R * 0.55));
+    g.appendChild(circle);
+  }
+
+  const label = document.createElementNS(SVG_NS, "text");
+  label.setAttribute("class", "okf-graph-node-label");
+  label.setAttribute("text-anchor", "middle");
+  label.setAttribute("dominant-baseline", "central");
+  label.setAttribute("y", node.kind === "article" ? "0" : String(NODE_R * 0.55 + 11));
+  label.textContent = truncateLabel(node.file ?? node.id);
+  g.appendChild(label);
+
+  return g;
+}
+
+async function renderGraphView(): Promise<void> {
+  if (!contentEl) return;
+  contentEl.replaceChildren();
+  const loading = document.createElement("div");
+  loading.className = "okf-empty";
+  loading.textContent = "Lädt Graph...";
+  contentEl.appendChild(loading);
+
+  await ensureAllBodiesLoaded();
+  if (viewMode !== "graph" || !contentEl) return; // user switched away while loading
+
+  const { nodes, edges } = buildFullGraph();
+  contentEl.replaceChildren();
+  if (nodes.length === 0) {
+    renderEmptyInto(
+      contentEl,
+      "🕸️",
+      "Kein Graph verfügbar",
+      "Diese Wissensbasis enthält noch keine Artikel.",
+    );
+    return;
+  }
+
+  const legend = document.createElement("div");
+  legend.className = "okf-graph-legend";
+  const articleLegend = document.createElement("span");
+  articleLegend.className = "okf-graph-legend-item";
+  articleLegend.innerHTML = '<span class="okf-graph-legend-mark article"></span>Artikel';
+  const citationLegend = document.createElement("span");
+  citationLegend.className = "okf-graph-legend-item";
+  citationLegend.innerHTML =
+    '<span class="okf-graph-legend-mark citation"></span>Zitat (ADR)';
+  legend.append(articleLegend, citationLegend);
+  contentEl.appendChild(legend);
+
+  const positioned = layoutGraph(nodes, edges, GRAPH_W, GRAPH_H);
+  const byId = new Map(positioned.map((n): [string, PositionedNode] => [n.id, n]));
+
+  const wrap = document.createElement("div");
+  wrap.className = "graph-canvas-wrap";
+  const svg = document.createElementNS(SVG_NS, "svg") as SVGSVGElement;
+  svg.setAttribute("viewBox", `0 0 ${GRAPH_W} ${GRAPH_H}`);
+  svg.setAttribute("class", "okf-graph-svg");
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", "OKF Wissensgraph");
+  wrap.appendChild(svg);
+
+  const edgesGroup = document.createElementNS(SVG_NS, "g") as SVGGElement;
+  svg.appendChild(edgesGroup);
+  for (const edge of edges) {
+    const from = byId.get(edge.from);
+    const to = byId.get(edge.to);
+    if (!from || !to) continue;
+    const line = document.createElementNS(SVG_NS, "line");
+    line.setAttribute("x1", String(from.x));
+    line.setAttribute("y1", String(from.y));
+    line.setAttribute("x2", String(to.x));
+    line.setAttribute("y2", String(to.y));
+    line.setAttribute("class", "okf-graph-edge");
+    line.setAttribute("aria-hidden", "true");
+    edgesGroup.appendChild(line);
+  }
+
+  const nodesGroup = document.createElementNS(SVG_NS, "g") as SVGGElement;
+  svg.appendChild(nodesGroup);
+  for (const node of positioned) {
+    nodesGroup.appendChild(buildGraphNodeEl(node));
+  }
+
+  contentEl.appendChild(wrap);
+}
+
+// ── Log view ─────────────────────────────────────────────────────────────
+
+function renderLogView(container: HTMLElement): void {
+  container.replaceChildren();
+  if (!logText.trim()) {
+    renderEmptyInto(
+      container,
+      "📜",
+      "Kein Log vorhanden",
+      "Für diese Wissensbasis wurde noch kein log.md geschrieben.",
+    );
+    return;
+  }
+  // log.md entries are appended newest-day-first, newest-entry-first within
+  // a day (src/cli/okf/bundle.ts's appendLog) -- already the order the spec
+  // wants, no re-sorting needed.
+  const bodyEl = document.createElement("div");
+  bodyEl.className = "okf-log-body zam-card";
+  bodyEl.innerHTML = renderMarkdown(logText);
+  attachContentClickDelegation(bodyEl);
+  decorateCitationLinks(bodyEl, new Set());
+  container.appendChild(bodyEl);
+}
+
+// ── Static event wiring ──────────────────────────────────────────────────
+
+for (const btn of viewButtons()) {
+  btn.addEventListener("click", () => {
+    const mode = btn.dataset.view as ViewMode | undefined;
+    if (!mode || mode === viewMode) return;
+    viewMode = mode;
+    renderAll();
+  });
+}
+updateViewToggleActiveState();
+
+searchInputEl?.addEventListener("input", () => {
+  searchQuery = searchInputEl.value;
+  renderSidebar();
+});
+
+// ── Host lifecycle (mirrors graph.ts) ───────────────────────────────────
+
+app.ontoolresult = (params) => {
+  const structured = (params.structuredContent ?? {}) as OpenOkfResult;
+  panelVersion = structured.version;
+  // Same late-tool-result race as graph.ts/recall.ts: the 800ms fallback
+  // below may have already started against a previous bundle/user. The
+  // tool result's context is authoritative -- restart when it names a
+  // different bundle, since cached bodies/reader/citation state are scoped
+  // to the previous one.
+  const previousUser = currentUser;
+  const previousBundleDir = bundleDir;
+  currentUser = structured.user ?? null;
+  if (structured.bundleDir !== undefined) bundleDir = structured.bundleDir;
+  if (structured.catalog) {
+    setCatalog(structured.catalog);
+    catalogLoaded = true;
+  }
+  if (structured.log !== undefined) logText = structured.log;
+  if (started && (previousUser !== currentUser || previousBundleDir !== bundleDir)) {
+    started = false;
+    bodyCache.clear();
+    readErrors.clear();
+    openCitations.clear();
+    currentFile = null;
+    citationView = null;
+  }
+  clearConnectionNotice();
+
+  const contextState =
+    structured.companionContext ?? fallbackContextBarState(SURFACE, currentUser);
+  contextBar = ensureContextBar(
+    contextBar,
+    contextBarRoot,
+    "ZAM OKF",
+    panelVersion,
+    contextState,
+    {
+      write: writeCompanionContext,
+      read: readCompanionContext,
+      onReload: reloadForContext,
+      onError: showConnectionNotice,
+    },
+  );
+  start();
+};
+
+// Mount the bar immediately — before any tool result — so the title and an
+// honest "no learner/agent resolved yet" state (fallbackContextBarState) are
+// visible from first paint, not only once a host's ontoolresult (or the
+// 800ms grace-period fallback below) actually fires.
+contextBar = ensureContextBar(
+  contextBar,
+  contextBarRoot,
+  "ZAM OKF",
+  panelVersion,
+  fallbackContextBarState(SURFACE, currentUser),
+  {
+    write: writeCompanionContext,
+    read: readCompanionContext,
+    onReload: reloadForContext,
+    onError: showConnectionNotice,
+  },
+);
+
+// A plain file viewer (e.g. an editor preview) renders this HTML without
+// ever answering ui/initialize — connect() then stays pending forever.
+// Degrade honestly instead of showing "Connecting to host…" for good.
+const NO_HOST_NOTICE =
+  "Kein MCP-Apps-Host — diese Karte braucht einen Host mit ui/initialize " +
+  "(z. B. basic-host oder Copilot-Panel).";
+const noHostTimer = setTimeout(() => showConnectionNotice(NO_HOST_NOTICE), 4000);
+
+app
+  .connect()
+  .then(() => {
+    clearTimeout(noHostTimer);
+    connected = true;
+    if (navigator.language.startsWith("de")) {
+      setCurrentLocale("de");
+    }
+    // ontoolresult (which carries the initial bundle/catalog/log and the
+    // signed-in user) normally fires right after the handshake and triggers
+    // the load. If a host never delivers it (today: always, until Task 5's
+    // zam_okf_visualize exists), still load via zam_okf_catalog after a
+    // short grace period instead of leaving the card stuck waiting.
+    window.setTimeout(start, 800);
+  })
+  .catch((error: unknown) => {
+    clearTimeout(noHostTimer);
+    showConnectionNotice(`ZAM OKF failed to start: ${errorMessage(error)}`);
+  });

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -15,22 +15,14 @@
  * callTool/context-bar plumbing is shared via ./context-bar.js (item 9,
  * 0.11.0 review), same as every other panel entry.
  *
- * Two known forward references to later plan tasks, both harmless today:
- *  - `SURFACE` below is cast to `CompanionSurface` even though "okf" isn't
- *    a member yet — Task 5 adds it to both `CompanionSurface`
- *    (context-bar.ts) and `COMPANION_SURFACES`
- *    (src/vscode-extension/companion-context.ts) in the same task that
- *    registers `zam_okf_visualize` and starts supplying a real
- *    `companionContext` shaped with `surface: "okf"`. Until then, a manual
- *    Agent/User pill change on this panel round-trips to a surface the
- *    server doesn't recognize yet and degrades through the context bar's
- *    own `onError` path (an inline notice) instead of crashing — first
- *    paint and `ontoolresult`-driven rendering are unaffected either way.
- *  - `app.ontoolresult` is written against `zam_okf_visualize`'s result
- *    shape (Task 5), which doesn't exist yet, so in practice today only the
- *    800ms fallback (`zam_okf_catalog`, which does exist) ever actually
- *    populates the panel — exactly the "testable-by-build now" framing in
- *    the plan.
+ * `SURFACE` is `"okf"`, a real `CompanionSurface` member (context-bar.ts)
+ * and `COMPANION_SURFACES` entry (src/vscode-extension/companion-context.ts)
+ * since Task 5, which also registers `zam_okf_visualize` — the tool
+ * `app.ontoolresult` below is written against, seeding the panel with the
+ * bundle catalog/log and a real `companionContext` shaped with
+ * `surface: "okf"` on first paint. The 800ms fallback to `zam_okf_catalog`
+ * still runs for hosts that never deliver a tool result to the app (e.g. a
+ * plain resource viewer).
  */
 
 import { App } from "@modelcontextprotocol/ext-apps";
@@ -64,8 +56,7 @@ const GRAPH_W = 680;
 const GRAPH_H = 680;
 const NODE_R = 22;
 
-// See the module doc comment above: Task 5 adds "okf" to CompanionSurface.
-const SURFACE = "okf" as CompanionSurface;
+const SURFACE: CompanionSurface = "okf";
 
 const contextBarRoot = document.getElementById("zam-contextbar-root");
 const noticeEl = document.getElementById("zam-connection-notice");
@@ -230,12 +221,11 @@ function renderAll(): void {
 
 function renderHeader(): void {
   if (headerCountEl) headerCountEl.textContent = `${catalog.length} Artikel`;
-  // See the module doc comment: no `zam_okf_*` tool currently returns a
-  // distinct OKF-format `okf_version` (index.md's frontmatter field) —
-  // every seeding path names this field `version` (the panel/app version,
-  // same convention as every other zam_open_*/zam_show_* tool). Displaying
-  // it here is the closest faithful match to the plan's "okf_version in the
-  // header" until/unless a tool exposes the format version distinctly.
+  // zam_okf_visualize now returns a distinct OKF-format `okfVersion` (Task
+  // 5), but this panel doesn't thread it through OpenOkfResult yet — still
+  // showing the panel/app version here, same convention as every other
+  // zam_open_*/zam_show_* card. Wiring the real okf_version through is
+  // follow-up work, not required for the panel to render correctly today.
   if (headerVersionEl) headerVersionEl.textContent = panelVersion ? `v${panelVersion}` : "";
 }
 

--- a/docs/adr/2026-07-17b-okf-visualizer-panel.md
+++ b/docs/adr/2026-07-17b-okf-visualizer-panel.md
@@ -1,0 +1,89 @@
+# OKF Visualizer Panel (MCP App)
+
+**Status:** Accepted
+**Date:** 2026-07-17
+**Deciders:** Thomas (project owner), designed with Fable 5
+**Related:**
+[2026-07-17-okf-knowledge-base.md](2026-07-17-okf-knowledge-base.md) (OKF bundles and MCP tools) ·
+[2026-07-06a-mcp-agent-transport-and-surfaces.md](2026-07-06a-mcp-agent-transport-and-surfaces.md) (MCP Apps as a surface) ·
+[2026-07-16-companion-context-and-harness-affinity.md](2026-07-16-companion-context-and-harness-affinity.md) (harness affinity)
+
+---
+
+## Context
+
+OKF bundles are no longer confined to ZAM's own repo: the OKF tools
+(`zam_okf_catalog`, `zam_okf_read`, `zam_okf_upsert`) operate on any
+bundle directory, and downstream users maintain bundles in their own
+repos whose articles serve as ZAM learning sources via `source_link`.
+
+A companion pattern has emerged in bundle-owning repos: a static,
+self-contained HTML visualizer committed next to the bundle (article list
+by type, search, markdown reader, link graph including citation nodes,
+log view). Its structural weakness is data access — a browser page has no
+filesystem access, so it needs a local HTTP server or a folder picker.
+
+That weakness disappears inside an MCP Apps host: the server reads the
+bundle from disk and the panel renders where the user already works.
+MCP Apps-capable harnesses (Claude Code, GitHub Copilot Chat in VS Code,
+and others) are already wired through `zam agent connect <harness>`, and
+ZAM already ships MCP Apps panels (studio, recall, graph). ZAM is
+therefore the natural home: every repo with an OKF bundle gets the panel
+for free, regardless of which team owns it.
+
+## Decision
+
+1. **ZAM gains an OKF visualizer MCP Apps panel** (`okf-panel`, built via
+   Vite alongside the existing panels) showing an OKF bundle: articles
+   grouped by `type` with search, a markdown reader with frontmatter
+   meta, a link graph (articles as nodes, inter-article links as edges,
+   ADR citations as visually distinct nodes), and the `log.md` history.
+2. **Data flows exclusively through the existing MCP tools** —
+   `zam_okf_catalog` and `zam_okf_read` over the MCP Apps bridge. No
+   HTTP fetch, no new kernel code; the bundle directory resolves exactly
+   as it does for the other OKF tools (parameter, default `docs/okf`
+   under the server's working directory).
+3. **A new CLI-layer tool `zam_okf_visualize` opens the panel**, naming
+   and mechanics consistent with `zam_open_studio` / `zam_show_graph`.
+4. **The panel is independent ZAM code against the OKF v0.1 contract.**
+   Static visualizers maintained by bundle owners remain useful as
+   zero-dependency browser fallbacks; no coupling in either direction.
+5. **Cited decision records render inline via a strictly-scoped
+   citation read.** Articles commonly cite ADRs via relative links
+   (`../adr/<file>.md`) outside the bundle directory. The OKF read
+   surface gains a repo-relative citation read (parameter or sibling
+   tool of `zam_okf_read`) with hard validation: no absolute paths, the
+   resolved path must stay inside the repository root, `.md` files only,
+   read-only. The panel uses it to show cited records inline.
+6. **CLI layer only.** Nothing enters the kernel — consistent with the
+   OKF knowledge-base ADR: documentation plumbing, not learning logic.
+
+## Future work (out of v1 scope)
+
+- **Learning-state overlay** (mark articles whose `resource` URL backs
+  due cards via `source_link`) is a natural follow-up. The panel's
+  article model stays keyed by `resource` URL so the overlay can attach
+  later without rework.
+
+## Options considered
+
+- **Each consuming team hosts a panel in its own MCP server** — rejected:
+  duplicates panel infrastructure per consumer; ZAM serves every OKF
+  bundle from one implementation.
+- **Static HTML only (status quo)** — rejected as the primary surface:
+  loading friction, no harness integration, no path to the learning
+  overlay. Kept as the browser fallback.
+- **A tab inside the studio panel** — considered; rejected to keep the
+  studio focused on authoring/learning content and because the
+  visualizer's audience includes agents opening it mid-task on arbitrary
+  repos.
+
+## Consequences
+
+- The panel ships with ZAM releases; bundle repos need nothing beyond
+  being valid OKF v0.1.
+- Any team adopting ZAM gets the panel in every MCP Apps-capable harness
+  its members connect via `zam agent connect <harness>`.
+- Panel and static fallbacks share a conceptual model but independent
+  code; divergence is accepted — the static files are deliberately
+  dependency-free.

--- a/docs/adr/2026-07-17b-okf-visualizer-panel.md
+++ b/docs/adr/2026-07-17b-okf-visualizer-panel.md
@@ -1,6 +1,6 @@
 # OKF Visualizer Panel (MCP App)
 
-**Status:** Accepted
+**Status:** Implemented
 **Date:** 2026-07-17
 **Deciders:** Thomas (project owner), designed with Fable 5
 **Related:**

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,4 +48,4 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-16](2026-07-16-companion-context-and-harness-affinity.md) | Companion Context Bar and Harness Affinity | Implemented |
 | [2026-07-16b](2026-07-16b-in-recall-card-management.md) | In-Recall Card Management: Stop, Fix, and Remove | Implemented |
 | [2026-07-17](2026-07-17-okf-knowledge-base.md) | OKF Knowledge Base — Living Repo Knowledge as Learning Sources | Implemented |
-| [2026-07-17b](2026-07-17b-okf-visualizer-panel.md) | OKF Visualizer Panel (MCP App) | Accepted |
+| [2026-07-17b](2026-07-17b-okf-visualizer-panel.md) | OKF Visualizer Panel (MCP App) | Implemented |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,4 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-16](2026-07-16-companion-context-and-harness-affinity.md) | Companion Context Bar and Harness Affinity | Implemented |
 | [2026-07-16b](2026-07-16b-in-recall-card-management.md) | In-Recall Card Management: Stop, Fix, and Remove | Implemented |
 | [2026-07-17](2026-07-17-okf-knowledge-base.md) | OKF Knowledge Base — Living Repo Knowledge as Learning Sources | Implemented |
+| [2026-07-17b](2026-07-17b-okf-visualizer-panel.md) | OKF Visualizer Panel (MCP App) | Accepted |

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-17
 
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Creation** — [Token and Card Model](token-card-model.md)
 - **Creation** — [Prerequisite Graph and Blocking](prerequisite-blocking.md)
 - **Creation** — [MCP Transport and Surfaces](mcp-surfaces.md)

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,7 @@
 ## 2026-07-17
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Creation** — [Token and Card Model](token-card-model.md)
 - **Creation** — [Prerequisite Graph and Blocking](prerequisite-blocking.md)
 - **Creation** — [MCP Transport and Surfaces](mcp-surfaces.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-07-17T00:00:00Z
+timestamp: 2026-07-17T15:00:00Z
 ---
 
 `zam mcp` starts a stdio **Model Context Protocol** server
@@ -37,12 +37,22 @@ bundle (that's its purpose) but never outside the repo
 
 # MCP Apps panels
 
-Four self-contained HTML panels ship as MCP Apps resources and open
+Five self-contained HTML panels ship as MCP Apps resources and open
 in hosts that support them: `ui://zam/studio`, `ui://zam/recall`,
-`ui://zam/graph`, `ui://zam/settings` (built by `npm run build:panel`,
-served from `dist/ui/`). The VS Code / Antigravity Companion extension
-(`src/vscode-extension/`) hosts the same panels in a webview and routes
-recall evaluation through per-IDE evaluator selections.
+`ui://zam/graph`, `ui://zam/settings`, `ui://zam/okf` (built by
+`npm run build:panel`, served from `dist/ui/`). The VS Code /
+Antigravity Companion extension (`src/vscode-extension/`) hosts the
+same panels in a webview and routes recall evaluation through
+per-IDE evaluator selections.
+
+`zam_okf_visualize` opens the OKF panel on any OKF bundle (default
+`docs/okf` under the server's working directory, like the other
+`zam_okf_*` tools): articles grouped by type with search, a markdown
+reader that expands cited ADRs and other citation targets inline via
+`zam_okf_read_citation`, a link graph (articles as nodes, inter-article
+links as edges, citations as visually distinct nodes), and the
+`log.md` history. The panel always opens — a missing or invalid bundle
+surfaces as `problems` in the panel instead of a tool error.
 
 # Citations
 

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -23,8 +23,17 @@ installed harnesses.
 The server exposes ZAM's tool surface (session start/end, queue and
 review actions, token search and registration, prerequisite linking,
 companion context and sampling, and the OKF knowledge-base tools
-`zam_okf_catalog` / `zam_okf_read` / `zam_okf_upsert`). The authoritative
-tool list with annotations is pinned by `tests/cli/mcp.test.ts`.
+`zam_okf_catalog` / `zam_okf_read` / `zam_okf_upsert` /
+`zam_okf_read_citation`). The authoritative tool list with annotations
+is pinned by `tests/cli/mcp.test.ts`.
+
+`zam_okf_catalog` accepts an optional `include_log` flag that adds the
+raw `log.md` text to the result (empty string if the bundle has none
+yet). `zam_okf_read_citation` reads a citation target an article points
+to — an ADR, for example — read-only and restricted to `.md` files that
+resolve inside the repository root; the target may be outside the
+bundle (that's its purpose) but never outside the repo
+(`resolveCitationPath` / `findRepoRoot` in `src/cli/okf/io.ts`).
 
 # MCP Apps panels
 
@@ -40,4 +49,5 @@ recall evaluation through per-IDE evaluator selections.
 - [ADR 2026-07-06a — MCP as the Canonical Agent Transport](../adr/2026-07-06a-mcp-agent-transport-and-surfaces.md)
 - [ADR 2026-07-16 — Companion Context Bar and Harness Affinity](../adr/2026-07-16-companion-context-and-harness-affinity.md)
 - [ADR 2026-07-17 — OKF Knowledge Base](../adr/2026-07-17-okf-knowledge-base.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`
+- [ADR 2026-07-17b — OKF Visualizer Panel](../adr/2026-07-17b-okf-visualizer-panel.md)
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`

--- a/docs/plans/2026-07-17-okf-visualizer-panel-plan.md
+++ b/docs/plans/2026-07-17-okf-visualizer-panel-plan.md
@@ -1,0 +1,199 @@
+# OKF Visualizer Panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement ADR [2026-07-17b](../adr/2026-07-17b-okf-visualizer-panel.md): an `okf-panel` MCP Apps panel (articles by type + search, markdown reader with inline cited ADRs, link graph, log view), opened by a new `zam_okf_visualize` tool, fed exclusively by OKF MCP tools including a new strictly-scoped citation read.
+
+**Architecture:** CLI layer only (no kernel changes). Panel = self-contained Vite single-file build (`dist/ui/okf-panel.html`) like the four existing panels; data via `createCallTool` over the MCP Apps bridge. New fs logic goes in `src/cli/okf/io.ts` (citation path resolution); tool registrations in `src/cli/commands/mcp.ts` with lazy `await import("../okf/…")` in handlers.
+
+**Tech Stack:** existing only — TypeScript, Vite + vite-plugin-singlefile, `@modelcontextprotocol/ext-apps`, Vitest, Biome. **No new dependencies** (hard rule).
+
+## Global Constraints
+
+- Repo `c:\src\github\zam`, branch `feat/okf-visualizer-panel` (carries the accepted ADR). Commit format `<type>: <short summary>`. Push/PR is the CONTROLLER's step, not a subagent's.
+- Gate before every commit: `npm run format && npm run lint && npm run typecheck && npm run test` (and `npm run build` where a task touches build wiring). Vitest hard-asserts the MCP tool count — every tool addition updates `tests/cli/mcp.test.ts` in the same task.
+- Tool count trajectory: 21 today → **22** after Task 2 (`zam_okf_read_citation`) → **23** after Task 5 (`zam_okf_visualize`).
+- Panel entry must stay Tauri-free/Three.js-free/`./main`-free (`tests/desktop/module-boundaries.test.ts` — add the new file to its cases). Panel root ids: `zam-okf-panel`, plus `zam-contextbar-root` and `zam-connection-notice` divs, matching the other panels.
+- Citation-read validation (ADR Decision 5, binding): reject absolute paths; reject `..` escaping the repository root (nearest ancestor of the bundle dir containing `.git`, else the resolved bundle parent); `.md` files only; read-only; the target may be OUTSIDE the bundle (that is its purpose) but never outside the repo root.
+- The panel's article model is keyed by `resource` URL (future learning overlay — ADR Future work).
+- Same-PR rule: `docs/okf/mcp-surfaces.md` describes the MCP tools/panels surface and must be updated in this branch via the sanctioned write path (`upsertArticle` code path; index/log regenerate).
+- Panel code is independent of any external static visualizer implementations (ADR Decision 4) — spec-driven fresh code, generic wording only (public repo: no team/company references anywhere).
+
+---
+
+### Task 1: Citation path resolution in the OKF io layer (TDD)
+
+**Files:**
+- Modify: `src/cli/okf/io.ts`
+- Test: `tests/cli/okf-bundle.test.ts` (extend)
+
+**Interfaces:**
+- Produces: `resolveCitationPath(bundleDir: string, target: string): string` exported from `src/cli/okf/io.ts` — returns the absolute path of a valid citation target or throws `Error` with a message starting `invalid citation target:` naming the reason. Also export `findRepoRoot(startDir: string): string` (walks up to the nearest directory containing `.git`; falls back to `resolve(startDir, "..")`).
+
+- [ ] **Step 1: Write failing tests** — extend `tests/cli/okf-bundle.test.ts` with a new `describe("resolveCitationPath")` using `mkdtempSync` temp dirs shaped like a repo (`<tmp>/.git/` dir, `<tmp>/docs/okf/`, `<tmp>/docs/adr/x.md`):
+
+```ts
+describe("resolveCitationPath", () => {
+  const makeRepo = () => {
+    const root = mkdtempSync(join(tmpdir(), "zam-okf-cite-"));
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, "docs", "okf"), { recursive: true });
+    mkdirSync(join(root, "docs", "adr"), { recursive: true });
+    writeFileSync(join(root, "docs", "adr", "2026-01-01-x.md"), "# X\n");
+    return root;
+  };
+
+  it("resolves a relative ADR citation inside the repo", () => {
+    const root = makeRepo();
+    const p = resolveCitationPath(join(root, "docs", "okf"), "../adr/2026-01-01-x.md");
+    expect(p).toBe(resolve(root, "docs", "adr", "2026-01-01-x.md"));
+  });
+
+  it("rejects absolute paths", () => {
+    const root = makeRepo();
+    expect(() => resolveCitationPath(join(root, "docs", "okf"), resolve(root, "docs/adr/2026-01-01-x.md")))
+      .toThrow(/invalid citation target/);
+  });
+
+  it("rejects escape from the repo root", () => {
+    const root = makeRepo();
+    expect(() => resolveCitationPath(join(root, "docs", "okf"), "../../../etc/passwd.md"))
+      .toThrow(/invalid citation target/);
+  });
+
+  it("rejects non-markdown targets", () => {
+    const root = makeRepo();
+    expect(() => resolveCitationPath(join(root, "docs", "okf"), "../adr/x.png"))
+      .toThrow(/invalid citation target/);
+  });
+
+  it("falls back to the bundle parent as root when no .git exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "zam-okf-nogit-"));
+    mkdirSync(join(root, "okf"), { recursive: true });
+    writeFileSync(join(root, "sibling.md"), "# S\n");
+    expect(resolveCitationPath(join(root, "okf"), "../sibling.md")).toBe(resolve(root, "sibling.md"));
+    expect(() => resolveCitationPath(join(root, "okf"), "../../outside.md")).toThrow(/invalid citation target/);
+  });
+});
+```
+
+- [ ] **Step 2: Run, observe failure** (`npm run test -- tests/cli/okf-bundle.test.ts`) — missing exports.
+
+- [ ] **Step 3: Implement** in `src/cli/okf/io.ts` (style-match the existing functions):
+
+```ts
+export function findRepoRoot(startDir: string): string {
+  let dir = resolve(startDir);
+  for (;;) {
+    if (existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return resolve(startDir, "..");
+    dir = parent;
+  }
+}
+
+export function resolveCitationPath(bundleDir: string, target: string): string {
+  if (isAbsolute(target)) throw new Error(`invalid citation target: absolute paths are not allowed (${target})`);
+  if (!target.endsWith(".md")) throw new Error(`invalid citation target: only .md files are readable (${target})`);
+  const root = findRepoRoot(bundleDir);
+  const resolved = resolve(bundleDir, target);
+  const rel = relative(root, resolved);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(`invalid citation target: resolves outside the repository root (${target})`);
+  }
+  return resolved;
+}
+```
+
+(Note the no-`.git` fallback: `findRepoRoot` returns the bundle's parent, so `../sibling.md` passes and `../../outside.md` fails — exactly what the test pins.)
+
+- [ ] **Step 4: Run tests, verify pass; run the full gate** (`npm run format && npm run lint && npm run typecheck && npm run test`).
+- [ ] **Step 5: Commit** — `feat: scoped citation path resolution for OKF bundles`
+
+---
+
+### Task 2: `zam_okf_read_citation` tool + `include_log` on catalog (TDD)
+
+**Files:**
+- Modify: `src/cli/commands/mcp.ts`, `tests/cli/mcp.test.ts`
+
+**Interfaces:**
+- Produces tool `zam_okf_read_citation`: input `{ bundle_dir?: string, target: string }` (zod: `okfBundleDirSchema` reuse + `z.string()`), plain tool, `commonAnnotations`, lazy handler: `const { resolveCitationPath } = await import("../okf/io.js")`; reads the file (`readFile` utf-8), returns `{ target, path: <repo-relative path>, content }`; validation/read errors surface through the existing `wrapHandler` error shape.
+- Produces: `zam_okf_catalog` accepts optional `include_log?: boolean`; when true the result gains `log: string` (raw `log.md` content, empty string if the file is missing).
+- `tests/cli/mcp.test.ts`: tool count 21→22, name list updated; new cases — citation read round-trip against a temp repo bundle, traversal rejection surfaces `isError` with `invalid citation target`, catalog `include_log` returns log text.
+
+- [ ] **Step 1: Write failing tests** in `tests/cli/mcp.test.ts` (follow the existing in-memory client pattern; temp bundle fixture with `.git` dir, one article via `upsertArticle`, one `docs/adr/*.md` file).
+- [ ] **Step 2: Observe failure** (count assertion + missing tool).
+- [ ] **Step 3: Implement** in `createMcpServer` beside the existing OKF tools (lines ~1218-1322), mirroring their registration style and lazy imports exactly.
+- [ ] **Step 4: Full gate.**
+- [ ] **Step 5: Commit** — `feat: okf citation read tool and catalog log option`
+
+---
+
+### Task 3: Panel rendering core as pure module (TDD)
+
+**Files:**
+- Create: `desktop/src/panel/okf-render.ts`
+- Test: `tests/desktop/okf-render.test.ts`
+
+**Interfaces:**
+- Produces (pure, DOM-free, importable under Vitest without a DOM):
+  - `renderMarkdown(source: string): string` — escapes ALL HTML first, then renders headings, paragraphs, bold/italic/inline code, fenced code, ordered/unordered lists, tables, blockquotes, links. Link classification hook: `[x](<kebab>.md)` → `<a data-okf-article="<file>">`, `[x](../adr/<file>.md)` (or any relative `.md` outside the bundle) → `<a data-okf-citation="<target>">`, external URLs → `target="_blank" rel="noopener noreferrer"`.
+  - `groupCatalog(catalog: CatalogEntry[]): Map<string, CatalogEntry[]>` — by frontmatter `type`, stable order.
+  - `filterCatalog(catalog: CatalogEntry[], query: string): CatalogEntry[]` — title/description/tags/file matching, case-insensitive.
+  - `extractLinks(body: string): { articles: string[]; citations: string[] }` — for the graph.
+  - `layoutGraph(nodes: GraphNode[], edges: GraphEdge[], width: number, height: number): PositionedNode[]` — deterministic circle layout, articles on the ring by type order, citation nodes on an outer arc.
+- Tests pin: escaping (a `<script>` in source never survives), each markdown construct, link classification (all three kinds), grouping/filter behavior, layout determinism (same input → same coordinates), citation extraction from a real-shaped article body with a `# Citations` section.
+
+- [ ] Steps: failing tests → implement → gate → commit `feat: okf panel rendering core`.
+
+---
+
+### Task 4: The panel itself + build wiring
+
+**Files:**
+- Create: `desktop/src/panel/okf-panel.html`, `desktop/src/panel/okf.ts`
+- Modify: `vite.config.panel.mts` (`MODE_TO_INPUT` gains `okf`), `package.json` (`build:panel` gains `vite build --config vite.config.panel.mts --mode okf` — appending, never emptying), `tests/desktop/module-boundaries.test.ts` (add `okf.ts` case)
+
+**Interfaces:**
+- Consumes: `okf-render.ts` (Task 3), `context-bar.ts` (`App`, `createCallTool`, `ensureContextBar`, `fallbackContextBarState`, `showConnectionNotice`/`clearConnectionNotice`), `i18n.ts`.
+- Behavior spec (pinned by Task 3's pure functions plus the mcp.test.ts resource assertion in Task 5):
+  - `app.ontoolresult` seeds `{ bundleDir, catalog, log, version, user, companionContext }` from `zam_okf_visualize` (Task 5 shape); 800ms fallback after `app.connect()` calls `zam_okf_catalog { bundle_dir: bundleDir ?? undefined, include_log: true }`; 4s no-host notice — all mirroring `graph.ts`.
+  - Sidebar: type groups + search box (`filterCatalog`); article count + `okf_version` in the header.
+  - Reader: `zam_okf_read { bundle_dir, file }` → `renderMarkdown`; meta strip from frontmatter (type badge, tags, timestamp, `resource` link out). Clicks on `data-okf-article` navigate in-panel; clicks on `data-okf-citation` call `zam_okf_read_citation { bundle_dir, target }` and render inline with an "ADR" badge and a link out; citation read errors show a non-blocking "not reachable" note.
+  - Graph view (toggle): SVG from `extractLinks` + `layoutGraph`; article nodes colored per type via CSS variables (`--okf-type-*` with light/dark values), citation nodes visually distinct; click article node → reader.
+  - Log view (toggle): raw log lines, newest first (they already are).
+  - Theming: CSS custom properties + `@media (prefers-color-scheme: dark)`, `color-scheme: light dark` — copy the token approach from `graph-panel.html`, panel-specific styles inline in the HTML.
+- [ ] Steps: write HTML + TS per spec → extend module-boundaries test (failing first) → wire vite mode + build script → `npm run build` and verify `dist/ui/okf-panel.html` exists, is self-contained, contains `zam-okf-panel` → full gate → commit `feat: okf visualizer panel`.
+
+---
+
+### Task 5: `zam_okf_visualize` app tool + resource + surface union
+
+**Files:**
+- Modify: `src/cli/commands/mcp.ts` (URI `ui://zam/okf`, `registerAppTool` + `registerAppResource` via `loadPanelHtml("okf-panel.html", …)`), `desktop/src/panel/context-bar.ts` + `src/vscode-extension/companion-context.ts` (surface union gains `"okf"` — keep both sides in sync by hand, as documented), `tests/cli/mcp.test.ts` (count 22→23; resource html contains `zam-okf-panel`; `_meta.ui.resourceUri` link; companion-context degradation case with `makeThrowingDb`)
+
+**Interfaces:**
+- Tool `zam_okf_visualize`: input `{ bundle_dir?: string }`; handler mirrors `zam_show_graph`'s open-tool pattern (resolve companion context safely, `publishUiIntent`, return `{ okf: "zam", version, user, bundleDir: <resolved>, catalog, log, companionContext }`) — catalog + log loaded lazily via `await import("../okf/io.js")` so the panel renders without a first round-trip; on a missing/invalid bundle return `{ …, catalog: [], problems }` rather than an error (panel shows the empty/problem state).
+- [ ] Steps: failing mcp.test.ts additions → implement → full gate incl. `npm run build` (resource assertion needs the real dist HTML) → commit `feat: zam_okf_visualize opens the okf panel`.
+
+---
+
+### Task 6: Same-PR knowledge + ADR status
+
+**Files:**
+- Modify (via sanctioned write path only): `docs/okf/mcp-surfaces.md` (+ regenerated `docs/okf/index.md`, `docs/okf/log.md`)
+- Modify: `docs/adr/README.md` (2026-07-17b row → Implemented), `docs/adr/2026-07-17b-okf-visualizer-panel.md` (Status → Implemented)
+
+- [ ] **Step 1:** Update the `mcp-surfaces` article through the code path the tool uses (small one-off node script in the scratchpad invoking `upsertArticle` from `src/cli/okf/io.ts` via tsx, passing the full updated body) — mention the okf panel among the MCP Apps panels and the two new tools, current-truth wording only. Never hand-edit `index.md`/`log.md`.
+- [ ] **Step 2:** Run `npm run test -- tests/cli/okf-conformance.test.ts` — must pass (this gates the bundle including your update).
+- [ ] **Step 3:** ADR + index status flips; full gate; commit `docs: okf surface article and ADR status for the visualizer panel`.
+
+---
+
+## Self-review notes
+
+- ADR coverage: Decisions 1 (panel) → Task 4; 2 (data via tools) → Tasks 2/4/5; 3 (`zam_okf_visualize`) → Task 5; 4 (independent code) → Tasks 3/4 spec-driven; 5 (scoped citation read) → Tasks 1/2; 6 (CLI-only) → no kernel file is touched anywhere. Future-work overlay: article model keyed by `resource` (Task 3 CatalogEntry carries it).
+- Tool-count assertions are updated in the same task as each registration (Tasks 2, 5) — the known hard-assert trap.
+- The panel cannot be imported under Vitest (module-scope `document`) — hence the pure-module split (Task 3) mirroring `graph-layout.ts`, and build-level verification (Task 4/5), matching existing repo practice.
+- No new dependencies anywhere; heavy imports stay lazy inside handlers; single-bundle constraint untouched.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "tsup && npm run build:panel && npm run build:copilot-extension && npm run build:vscode-extension",
     "build:copilot-extension": "tsup --config tsup.config.copilot-extension.ts && vite build --config vite.config.copilot-extension.mts && node scripts/prepare-copilot-extension.mjs",
     "build:vscode-extension": "tsup --config tsup.config.vscode-extension.ts && vite build --config vite.config.vscode-extension.mts && node scripts/prepare-vscode-extension.mjs",
-    "build:panel": "vite build --config vite.config.panel.mts && vite build --config vite.config.panel.mts --mode recall && vite build --config vite.config.panel.mts --mode graph && vite build --config vite.config.panel.mts --mode settings",
+    "build:panel": "vite build --config vite.config.panel.mts && vite build --config vite.config.panel.mts --mode recall && vite build --config vite.config.panel.mts --mode graph && vite build --config vite.config.panel.mts --mode settings && vite build --config vite.config.panel.mts --mode okf",
     "prepare": "npm run build",
     "dev": "tsx src/cli/index.ts",
     "test": "vitest run",

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -39,6 +39,7 @@ import {
   resolveOpeningCompanionContext,
   writeCompanionContext,
 } from "../companion-context-server.js";
+import type { CatalogEntry } from "../okf/bundle.js";
 import { publishUiIntent } from "../ui-intent.js";
 import { executeBridgeCommandJson } from "./bridge.js";
 
@@ -53,6 +54,7 @@ const STUDIO_RESOURCE_URI = "ui://zam/studio";
 const RECALL_RESOURCE_URI = "ui://zam/recall";
 const GRAPH_RESOURCE_URI = "ui://zam/graph";
 const SETTINGS_RESOURCE_URI = "ui://zam/settings";
+const OKF_RESOURCE_URI = "ui://zam/okf";
 
 /**
  * Commands the ZAM Studio panel may run through `zam_studio_bridge`. A
@@ -1368,6 +1370,116 @@ export function createMcpServer(db: Database): McpServer {
       const root = findRepoRoot(bundleDir);
       const repoRelativePath = relative(root, path).split(sep).join("/");
       return { target: params.target, path: repoRelativePath, content };
+    }),
+  );
+
+  // 23. zam_okf_visualize — the OKF visualizer panel (MCP Apps; ADR
+  // 2026-07-17b). Mirrors zam_show_graph's open-tool pattern, but the
+  // catalog and log.md are loaded eagerly (unlike graph's data, which the
+  // panel always pulls itself via zam_studio_bridge) so the panel paints its
+  // sidebar and log view without a first round-trip; article bodies, the
+  // link graph, and citation reads stay on-demand through the existing
+  // zam_okf_* tools. A missing or invalid bundle is not an error: the result
+  // carries an empty catalog plus `problems` and still opens the panel.
+  registerAppTool(
+    server,
+    "zam_okf_visualize",
+    {
+      title: "Open ZAM OKF visualizer",
+      description:
+        "Open the ZAM OKF knowledge-base visualizer: articles by type with " +
+        "search, a markdown reader with inline-expandable cited ADRs, a " +
+        "link graph, and the log. Pass `bundle_dir` to browse a bundle " +
+        "other than the default (docs/okf under the server cwd).",
+      inputSchema: {
+        bundle_dir: okfBundleDirSchema,
+      },
+      annotations: {
+        ...commonAnnotations,
+        readOnlyHint: true,
+      },
+      _meta: {
+        ui: { resourceUri: OKF_RESOURCE_URI },
+      },
+    },
+    wrapHandler(async ({ bundle_dir }: { bundle_dir?: string }) => {
+      // Mirror zam_open_recall/zam_show_graph/zam_open_settings: never fails
+      // to open the panel — any companion-context resolution failure
+      // degrades to a minimal fallback context instead of rejecting the
+      // call. This tool takes no `user` argument (the bundle is
+      // repo-scoped, not per-learner), so there is no invocation override.
+      const opening = await resolveOpeningCompanionContextSafely(
+        db,
+        "okf",
+        undefined,
+        getNativeClientInfo(),
+        { clientSamplingCapable: getClientSamplingCapable() },
+      );
+      await publishUiIntent("okf", { bundle_dir });
+
+      const { DEFAULT_BUNDLE_DIR, loadBundle } = await import("../okf/io.js");
+      const { resolve } = await import("node:path");
+      const requestedDir = bundle_dir ?? DEFAULT_BUNDLE_DIR;
+      let resolvedBundleDir = resolve(requestedDir);
+      let catalog: CatalogEntry[] = [];
+      let problems: string[] = [];
+      let log = "";
+      let okfVersion: string | null = null;
+      try {
+        const bundle = loadBundle(requestedDir);
+        resolvedBundleDir = bundle.dir;
+        catalog = bundle.catalog;
+        problems = bundle.problems;
+        const { readFileSync } = await import("node:fs");
+        try {
+          log = readFileSync(join(bundle.dir, "log.md"), "utf8");
+        } catch {
+          log = "";
+        }
+        try {
+          const { parseFrontmatter } = await import("../okf/bundle.js");
+          const indexRaw = readFileSync(join(bundle.dir, "index.md"), "utf8");
+          const { fields } = parseFrontmatter(indexRaw);
+          okfVersion =
+            typeof fields.okf_version === "string" ? fields.okf_version : null;
+        } catch {
+          okfVersion = null;
+        }
+      } catch (error) {
+        // Missing/invalid bundle directory (loadBundle throws only when the
+        // directory itself cannot be read) — report it as `problems`, not a
+        // tool error, so the panel still opens and shows the empty state.
+        problems = [error instanceof Error ? error.message : String(error)];
+      }
+
+      return {
+        okf: "zam",
+        version: pkg.version,
+        user: opening.context.user.currentId ?? null,
+        bundleDir: resolvedBundleDir,
+        okfVersion,
+        catalog,
+        problems,
+        log,
+        companionContext: opening.context,
+        ...(opening.degraded ? { companionContextDegraded: true } : {}),
+      };
+    }),
+  );
+
+  registerAppResource(
+    server,
+    "zam-okf",
+    OKF_RESOURCE_URI,
+    { mimeType: RESOURCE_MIME_TYPE },
+    async () => ({
+      contents: [
+        {
+          uri: OKF_RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: loadPanelHtml("okf-panel.html", "ZAM OKF"),
+        },
+      ],
     }),
   );
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1215,7 +1215,7 @@ export function createMcpServer(db: Database): McpServer {
     ),
   );
 
-  // 19.–21. zam_okf_* — the OKF knowledge-base surface (ADR 2026-07-17).
+  // 19.–22. zam_okf_* — the OKF knowledge-base surface (ADR 2026-07-17).
   // Operates on any OKF bundle directory; docs/okf of the current workspace
   // by default. Upsert is the ONLY sanctioned write path into a bundle.
   const okfBundleDirSchema = z
@@ -1230,21 +1230,39 @@ export function createMcpServer(db: Database): McpServer {
         "List the OKF knowledge-base articles (type, title, description, tags, resource URL) plus conformance problems, if any",
       inputSchema: {
         bundle_dir: okfBundleDirSchema,
+        include_log: z
+          .boolean()
+          .optional()
+          .describe(
+            "Also return the raw log.md text (empty string if missing)",
+          ),
       },
       annotations: {
         ...commonAnnotations,
         readOnlyHint: true,
       },
     },
-    wrapHandler(async (params: { bundle_dir?: string }) => {
-      const { DEFAULT_BUNDLE_DIR, loadBundle } = await import("../okf/io.js");
-      const bundle = loadBundle(params.bundle_dir ?? DEFAULT_BUNDLE_DIR);
-      return {
-        dir: bundle.dir,
-        articles: bundle.catalog,
-        problems: bundle.problems,
-      };
-    }),
+    wrapHandler(
+      async (params: { bundle_dir?: string; include_log?: boolean }) => {
+        const { DEFAULT_BUNDLE_DIR, loadBundle } = await import("../okf/io.js");
+        const bundle = loadBundle(params.bundle_dir ?? DEFAULT_BUNDLE_DIR);
+        let log: string | undefined;
+        if (params.include_log) {
+          const { readFileSync } = await import("node:fs");
+          try {
+            log = readFileSync(join(bundle.dir, "log.md"), "utf8");
+          } catch {
+            log = "";
+          }
+        }
+        return {
+          dir: bundle.dir,
+          articles: bundle.catalog,
+          problems: bundle.problems,
+          ...(params.include_log ? { log } : {}),
+        };
+      },
+    ),
   );
 
   server.registerTool(
@@ -1319,6 +1337,38 @@ export function createMcpServer(db: Database): McpServer {
         return { ok: true, created: result.created, entry: result.entry };
       },
     ),
+  );
+
+  server.registerTool(
+    "zam_okf_read_citation",
+    {
+      description:
+        "Read a citation target referenced by an OKF article (e.g. an ADR): read-only, restricted to .md files that resolve inside the repository root — the target may be outside the bundle but never outside the repo",
+      inputSchema: {
+        bundle_dir: okfBundleDirSchema,
+        target: z
+          .string()
+          .describe(
+            "Path to the citation target relative to bundle_dir, e.g. ../adr/2026-07-17-x.md",
+          ),
+      },
+      annotations: {
+        ...commonAnnotations,
+        readOnlyHint: true,
+      },
+    },
+    wrapHandler(async (params: { bundle_dir?: string; target: string }) => {
+      const { readFileSync } = await import("node:fs");
+      const { relative, sep } = await import("node:path");
+      const { DEFAULT_BUNDLE_DIR, findRepoRoot, resolveCitationPath } =
+        await import("../okf/io.js");
+      const bundleDir = params.bundle_dir ?? DEFAULT_BUNDLE_DIR;
+      const path = resolveCitationPath(bundleDir, params.target);
+      const content = readFileSync(path, "utf8");
+      const root = findRepoRoot(bundleDir);
+      const repoRelativePath = relative(root, path).split(sep).join("/");
+      return { target: params.target, path: repoRelativePath, content };
+    }),
   );
 
   return server;

--- a/src/cli/okf/io.ts
+++ b/src/cli/okf/io.ts
@@ -2,8 +2,14 @@
  * Filesystem layer for OKF bundles (ADR 2026-07-17). Everything that
  * touches disk lives here; the contract itself is in bundle.ts.
  */
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   appendLog,
   buildCatalog,
@@ -37,6 +43,50 @@ export function resolveArticlePath(dir: string, file: string): string {
     throw new Error(`refusing to address reserved file: ${file}`);
   }
   return join(resolve(dir), file);
+}
+
+/**
+ * Walk up from `startDir` to the nearest ancestor containing a `.git`
+ * directory (the repository root). Falls back to the parent of
+ * `startDir` when no `.git` is found (e.g. installed/vendored bundles
+ * outside a git checkout).
+ */
+export function findRepoRoot(startDir: string): string {
+  let dir = resolve(startDir);
+  for (;;) {
+    if (existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return resolve(startDir, "..");
+    dir = parent;
+  }
+}
+
+/**
+ * Resolve a citation target relative to a bundle directory. Citations may
+ * point outside the bundle (e.g. an ADR) but never outside the repository
+ * root, must be relative `.md` paths, and are read-only (ADR 2026-07-17
+ * Decision 5).
+ */
+export function resolveCitationPath(bundleDir: string, target: string): string {
+  if (isAbsolute(target)) {
+    throw new Error(
+      `invalid citation target: absolute paths are not allowed (${target})`,
+    );
+  }
+  if (!target.endsWith(".md")) {
+    throw new Error(
+      `invalid citation target: only .md files are readable (${target})`,
+    );
+  }
+  const root = findRepoRoot(bundleDir);
+  const resolved = resolve(bundleDir, target);
+  const rel = relative(root, resolved);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(
+      `invalid citation target: resolves outside the repository root (${target})`,
+    );
+  }
+  return resolved;
 }
 
 export function loadBundle(dir: string): LoadedBundle {

--- a/src/cli/okf/io.ts
+++ b/src/cli/okf/io.ts
@@ -7,9 +7,10 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
   appendLog,
   buildCatalog,
@@ -80,13 +81,36 @@ export function resolveCitationPath(bundleDir: string, target: string): string {
   }
   const root = findRepoRoot(bundleDir);
   const resolved = resolve(bundleDir, target);
-  const rel = relative(root, resolved);
-  if (rel.startsWith("..") || isAbsolute(rel)) {
+  assertContained(root, resolved, target);
+
+  // Lexical containment can pass while the path actually redirects
+  // outside the repo root through a symlink or (on Windows) a directory
+  // junction. Once the target exists on disk, re-check containment
+  // against the realpath so a reparse point cannot smuggle a read outside
+  // the repository.
+  if (existsSync(resolved)) {
+    assertContained(realpathSync(root), realpathSync(resolved), target);
+  }
+  return resolved;
+}
+
+/**
+ * Segment-aware containment check: `rel` must be `root` itself or a path
+ * strictly beneath it. A bare `rel.startsWith("..")` false-positives on any
+ * real path segment that merely starts with the two characters ".." (e.g. a
+ * directory named `..staging`) without ever escaping `root`.
+ */
+function assertContained(
+  root: string,
+  candidate: string,
+  target: string,
+): void {
+  const rel = relative(root, candidate);
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
     throw new Error(
       `invalid citation target: resolves outside the repository root (${target})`,
     );
   }
-  return resolved;
 }
 
 export function loadBundle(dir: string): LoadedBundle {

--- a/src/cli/ui-intent.ts
+++ b/src/cli/ui-intent.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { ulid } from "ulid";
 
-export type UiIntentApp = "recall" | "graph" | "settings";
+export type UiIntentApp = "recall" | "graph" | "settings" | "okf";
 
 export interface UiIntent {
   version: 1;

--- a/src/vscode-extension/companion-context.ts
+++ b/src/vscode-extension/companion-context.ts
@@ -42,6 +42,7 @@ export const COMPANION_SURFACES = [
   "graph",
   "settings",
   "studio",
+  "okf",
 ] as const;
 
 export type CompanionSurface = (typeof COMPANION_SURFACES)[number];

--- a/tests/cli/companion-context.test.ts
+++ b/tests/cli/companion-context.test.ts
@@ -12,11 +12,12 @@ import {
 import { EvaluatorUnavailableError } from "../../src/vscode-extension/companion-evaluator.js";
 
 describe("companion context surfaces", () => {
-  it("recognizes exactly the four shared-header surfaces", () => {
+  it("recognizes exactly the five shared-header surfaces", () => {
     expect(isCompanionSurface("recall")).toBe(true);
     expect(isCompanionSurface("graph")).toBe(true);
     expect(isCompanionSurface("settings")).toBe(true);
     expect(isCompanionSurface("studio")).toBe(true);
+    expect(isCompanionSurface("okf")).toBe(true);
     expect(isCompanionSurface("unknown")).toBe(false);
     expect(isCompanionSurface(undefined)).toBe(false);
   });

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -7,6 +7,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createMcpServer } from "../../src/cli/commands/mcp.js";
+import { upsertArticle } from "../../src/cli/okf/io.js";
 import type { Database } from "../../src/kernel/index.js";
 import {
   createToken,
@@ -88,9 +89,9 @@ describe("MCP stdio server tests", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("lists all 21 tools with correct annotations", async () => {
+  it("lists all 22 tools with correct annotations", async () => {
     const response = await client.listTools();
-    expect(response.tools).toHaveLength(21);
+    expect(response.tools).toHaveLength(22);
 
     const toolNames = response.tools.map((t) => t.name).sort();
     const expectedNames = [
@@ -115,6 +116,7 @@ describe("MCP stdio server tests", () => {
       "zam_okf_catalog",
       "zam_okf_read",
       "zam_okf_upsert",
+      "zam_okf_read_citation",
     ].sort();
     expect(toolNames).toEqual(expectedNames);
 
@@ -1008,6 +1010,109 @@ describe("MCP stdio server tests", () => {
       });
       const otherData = JSON.parse(otherSurface.content[0].text);
       expect(otherData.collapsed).toBe(false);
+    });
+  });
+
+  describe("zam_okf_read_citation and zam_okf_catalog include_log", () => {
+    let repoRoot: string;
+    let bundleDir: string;
+
+    beforeEach(() => {
+      // Shaped like a repo checkout: .git at the root, docs/okf as the
+      // bundle, docs/adr holding a citation target outside the bundle.
+      repoRoot = mkdtempSync(join(tmpdir(), "zam-okf-mcp-"));
+      mkdirSync(join(repoRoot, ".git"));
+      bundleDir = join(repoRoot, "docs", "okf");
+      mkdirSync(bundleDir, { recursive: true });
+      mkdirSync(join(repoRoot, "docs", "adr"), { recursive: true });
+      writeFileSync(
+        join(repoRoot, "docs", "adr", "2026-07-17-x.md"),
+        "# Decision X\n",
+      );
+      upsertArticle(
+        bundleDir,
+        "fsrs-scheduling.md",
+        [
+          "---",
+          "type: concept",
+          "title: FSRS Scheduling",
+          "description: How ZAM schedules reviews.",
+          "tags:",
+          "  - kernel",
+          'resource: "https://github.com/zam-os/zam/blob/main/docs/okf/fsrs-scheduling.md"',
+          "timestamp: 2026-07-17T00:00:00Z",
+          "---",
+          "",
+          "FSRS-5 drives the queue.",
+          "",
+        ].join("\n"),
+        "2026-07-17",
+      );
+    });
+
+    afterEach(() => {
+      rmSync(repoRoot, { recursive: true, force: true });
+    });
+
+    it("reads a citation target outside the bundle as a repo-relative, forward-slash path", async () => {
+      const res = await client.callTool({
+        name: "zam_okf_read_citation",
+        arguments: {
+          bundle_dir: bundleDir,
+          target: "../adr/2026-07-17-x.md",
+        },
+      });
+      expect(res.isError).toBeUndefined();
+      const data = JSON.parse(res.content[0].text);
+      expect(data.target).toBe("../adr/2026-07-17-x.md");
+      expect(data.path).toBe("docs/adr/2026-07-17-x.md");
+      expect(data.content).toBe("# Decision X\n");
+    });
+
+    it("rejects a traversal target with isError and an invalid citation target message", async () => {
+      const res = await client.callTool({
+        name: "zam_okf_read_citation",
+        arguments: {
+          bundle_dir: bundleDir,
+          target: "../../../outside.md",
+        },
+      });
+      expect(res.isError).toBe(true);
+      const data = JSON.parse(res.content[0].text);
+      expect(data.error).toContain("invalid citation target");
+    });
+
+    it("returns the raw log.md text from zam_okf_catalog when include_log is set", async () => {
+      const res = await client.callTool({
+        name: "zam_okf_catalog",
+        arguments: { bundle_dir: bundleDir, include_log: true },
+      });
+      expect(res.isError).toBeUndefined();
+      const data = JSON.parse(res.content[0].text);
+      expect(data.log).toContain("FSRS Scheduling");
+      expect(data.log).toContain("Creation");
+    });
+
+    it("omits log from zam_okf_catalog when include_log is absent", async () => {
+      const res = await client.callTool({
+        name: "zam_okf_catalog",
+        arguments: { bundle_dir: bundleDir },
+      });
+      expect(res.isError).toBeUndefined();
+      const data = JSON.parse(res.content[0].text);
+      expect(data.log).toBeUndefined();
+    });
+
+    it("returns an empty log string when log.md does not exist yet", async () => {
+      const emptyBundleDir = join(repoRoot, "docs", "empty-okf");
+      mkdirSync(emptyBundleDir, { recursive: true });
+      const res = await client.callTool({
+        name: "zam_okf_catalog",
+        arguments: { bundle_dir: emptyBundleDir, include_log: true },
+      });
+      expect(res.isError).toBeUndefined();
+      const data = JSON.parse(res.content[0].text);
+      expect(data.log).toBe("");
     });
   });
 });

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -89,9 +89,9 @@ describe("MCP stdio server tests", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("lists all 22 tools with correct annotations", async () => {
+  it("lists all 23 tools with correct annotations", async () => {
     const response = await client.listTools();
-    expect(response.tools).toHaveLength(22);
+    expect(response.tools).toHaveLength(23);
 
     const toolNames = response.tools.map((t) => t.name).sort();
     const expectedNames = [
@@ -117,6 +117,7 @@ describe("MCP stdio server tests", () => {
       "zam_okf_read",
       "zam_okf_upsert",
       "zam_okf_read_citation",
+      "zam_okf_visualize",
     ].sort();
     expect(toolNames).toEqual(expectedNames);
 
@@ -639,6 +640,7 @@ describe("MCP stdio server tests", () => {
           "zam_open_studio",
           "zam_show_graph",
           "zam_open_settings",
+          "zam_okf_visualize",
         ]) {
           const res = await brokenClient.callTool({ name, arguments: {} });
           expect(res.isError).toBeUndefined();
@@ -1113,6 +1115,129 @@ describe("MCP stdio server tests", () => {
       expect(res.isError).toBeUndefined();
       const data = JSON.parse(res.content[0].text);
       expect(data.log).toBe("");
+    });
+  });
+
+  describe("zam_okf_visualize", () => {
+    let repoRoot: string;
+    let bundleDir: string;
+
+    beforeEach(() => {
+      // Shaped like a repo checkout: .git at the root, docs/okf as the
+      // bundle — same fixture shape as the citation-read tests above.
+      repoRoot = mkdtempSync(join(tmpdir(), "zam-okf-visualize-"));
+      mkdirSync(join(repoRoot, ".git"));
+      bundleDir = join(repoRoot, "docs", "okf");
+      mkdirSync(bundleDir, { recursive: true });
+      upsertArticle(
+        bundleDir,
+        "fsrs-scheduling.md",
+        [
+          "---",
+          "type: concept",
+          "title: FSRS Scheduling",
+          "description: How ZAM schedules reviews.",
+          "tags:",
+          "  - kernel",
+          "---",
+          "",
+          "FSRS-5 drives the queue.",
+          "",
+        ].join("\n"),
+        "2026-07-17",
+      );
+    });
+
+    afterEach(() => {
+      rmSync(repoRoot, { recursive: true, force: true });
+    });
+
+    it("exposes the okf panel as an MCP Apps resource", async () => {
+      const resources = await client.listResources();
+      const okf = resources.resources.find((r) => r.uri === "ui://zam/okf");
+      expect(okf).toBeDefined();
+
+      const read = await client.readResource({ uri: "ui://zam/okf" });
+      const content = read.contents[0] as { text: string; mimeType: string };
+      expect(content.mimeType).toContain("text/html");
+      // The bundled okf panel roots at <div id="zam-okf-panel">. The
+      // no-build placeholder in loadPanelHtml uses a data-panel attribute
+      // instead of this id, so this assertion only passes against a real
+      // dist/ui/okf-panel.html build (CI builds before running tests).
+      expect(content.text).toContain("zam-okf-panel");
+    });
+
+    it("links zam_okf_visualize to the okf panel resource and eagerly returns the bundle catalog/log", async () => {
+      const response = await client.listTools();
+      const tool = response.tools.find((t) => t.name === "zam_okf_visualize");
+      expect(tool).toBeDefined();
+      const meta = tool?._meta as
+        | { ui?: { resourceUri?: string } }
+        | undefined;
+      expect(meta?.ui?.resourceUri).toBe("ui://zam/okf");
+      expect((tool as any).annotations).toEqual({
+        openWorldHint: false,
+        readOnlyHint: true,
+      });
+
+      // inputSchema accepts only an optional bundle_dir.
+      const schema = tool?.inputSchema as
+        | { properties?: Record<string, unknown>; required?: string[] }
+        | undefined;
+      expect(schema?.properties).toHaveProperty("bundle_dir");
+      expect(schema?.required ?? []).not.toContain("bundle_dir");
+
+      const res = await client.callTool({
+        name: "zam_okf_visualize",
+        arguments: { bundle_dir: bundleDir },
+      });
+      expect(res.isError).toBeUndefined();
+      const structured = (res as any).structuredContent as {
+        okf?: string;
+        version?: string;
+        user?: string | null;
+        bundleDir?: string;
+        okfVersion?: string | null;
+        catalog?: Array<{ file: string }>;
+        log?: string;
+        problems?: string[];
+        companionContext?: { surface?: string };
+      };
+      expect(structured.okf).toBe("zam");
+      expect(typeof structured.version).toBe("string");
+      // Default user seeded in beforeEach via user_config.
+      expect(structured.user).toBe("thomas");
+      expect(structured.bundleDir).toBe(bundleDir);
+      // okf_version comes from the bundle's own index.md frontmatter
+      // (renderIndex's default), not the zam package version.
+      expect(structured.okfVersion).toBe("0.1");
+      expect(structured.catalog?.map((e) => e.file)).toEqual([
+        "fsrs-scheduling.md",
+      ]);
+      expect(structured.problems).toEqual([]);
+      // log.md was written by upsertArticle in beforeEach — returned eagerly,
+      // with no separate zam_okf_catalog round-trip required.
+      expect(structured.log).toContain("FSRS Scheduling");
+      expect(structured.companionContext?.surface).toBe("okf");
+    });
+
+    it("returns an empty catalog and problems instead of erroring on a missing bundle directory", async () => {
+      const missingDir = join(repoRoot, "docs", "does-not-exist");
+      const res = await client.callTool({
+        name: "zam_okf_visualize",
+        arguments: { bundle_dir: missingDir },
+      });
+      expect(res.isError).toBeUndefined();
+      const structured = (res as any).structuredContent as {
+        catalog?: unknown[];
+        problems?: string[];
+        okfVersion?: string | null;
+        bundleDir?: string;
+      };
+      expect(structured.catalog).toEqual([]);
+      expect(structured.problems?.length).toBeGreaterThan(0);
+      expect(structured.okfVersion).toBeNull();
+      expect(structured.bundleDir).toBe(missingDir);
     });
   });
 });

--- a/tests/cli/okf-bundle.test.ts
+++ b/tests/cli/okf-bundle.test.ts
@@ -1,6 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   appendLog,
@@ -12,6 +18,7 @@ import {
 import {
   loadBundle,
   resolveArticlePath,
+  resolveCitationPath,
   upsertArticle,
 } from "../../src/cli/okf/io.js";
 
@@ -175,5 +182,48 @@ describe("okf/io", () => {
     const bundle = loadBundle(dir);
     expect(bundle.problems.join(" ")).toMatch(/bad\.md/);
     expect(bundle.catalog.map((e) => e.file)).toEqual(["good.md"]);
+  });
+});
+
+describe("resolveCitationPath", () => {
+  const makeRepo = () => {
+    const root = mkdtempSync(join(tmpdir(), "zam-okf-cite-"));
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, "docs", "okf"), { recursive: true });
+    mkdirSync(join(root, "docs", "adr"), { recursive: true });
+    writeFileSync(join(root, "docs", "adr", "2026-01-01-x.md"), "# X\n");
+    return root;
+  };
+
+  it("resolves a relative ADR citation inside the repo", () => {
+    const root = makeRepo();
+    const p = resolveCitationPath(join(root, "docs", "okf"), "../adr/2026-01-01-x.md");
+    expect(p).toBe(resolve(root, "docs", "adr", "2026-01-01-x.md"));
+  });
+
+  it("rejects absolute paths", () => {
+    const root = makeRepo();
+    expect(() => resolveCitationPath(join(root, "docs", "okf"), resolve(root, "docs/adr/2026-01-01-x.md")))
+      .toThrow(/invalid citation target/);
+  });
+
+  it("rejects escape from the repo root", () => {
+    const root = makeRepo();
+    expect(() => resolveCitationPath(join(root, "docs", "okf"), "../../../etc/passwd.md"))
+      .toThrow(/invalid citation target/);
+  });
+
+  it("rejects non-markdown targets", () => {
+    const root = makeRepo();
+    expect(() => resolveCitationPath(join(root, "docs", "okf"), "../adr/x.png"))
+      .toThrow(/invalid citation target/);
+  });
+
+  it("falls back to the bundle parent as root when no .git exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "zam-okf-nogit-"));
+    mkdirSync(join(root, "okf"), { recursive: true });
+    writeFileSync(join(root, "sibling.md"), "# S\n");
+    expect(resolveCitationPath(join(root, "okf"), "../sibling.md")).toBe(resolve(root, "sibling.md"));
+    expect(() => resolveCitationPath(join(root, "okf"), "../../outside.md")).toThrow(/invalid citation target/);
   });
 });

--- a/tests/cli/okf-bundle.test.ts
+++ b/tests/cli/okf-bundle.test.ts
@@ -3,6 +3,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -225,5 +226,72 @@ describe("resolveCitationPath", () => {
     writeFileSync(join(root, "sibling.md"), "# S\n");
     expect(resolveCitationPath(join(root, "okf"), "../sibling.md")).toBe(resolve(root, "sibling.md"));
     expect(() => resolveCitationPath(join(root, "okf"), "../../outside.md")).toThrow(/invalid citation target/);
+  });
+
+  // Hardening (Task 1 review): the containment check must be segment-aware.
+  // A bare `rel.startsWith("..")` false-positives on any real path segment
+  // that merely starts with the two characters "..", even though it never
+  // escapes the repository root.
+  it("accepts a directory literally named ..staging inside the repo root", () => {
+    const root = makeRepo();
+    mkdirSync(join(root, "..staging"), { recursive: true });
+    writeFileSync(join(root, "..staging", "note.md"), "# staging\n");
+    const p = resolveCitationPath(
+      join(root, "docs", "okf"),
+      "../../..staging/note.md",
+    );
+    expect(p).toBe(resolve(root, "..staging", "note.md"));
+  });
+
+  // Hardening (Task 1 review): symlink/junction defense. Lexical
+  // containment can pass while the path actually redirects outside the
+  // repo root via a reparse point; resolveCitationPath must re-check
+  // containment against the realpath once the target exists on disk.
+  it("rejects a symlink (or, where symlinks are denied, a directory junction) that redirects outside the repo", () => {
+    const root = makeRepo();
+    const outside = mkdtempSync(join(tmpdir(), "zam-okf-outside-"));
+    writeFileSync(join(outside, "secret.md"), "# secret\n");
+
+    let mode: "file-symlink" | "dir-junction" | "skipped" = "skipped";
+    try {
+      symlinkSync(
+        join(outside, "secret.md"),
+        join(root, "docs", "adr", "escape-link.md"),
+        "file",
+      );
+      mode = "file-symlink";
+    } catch {
+      // Windows non-admin denies file symlinks (EPERM) without Developer
+      // Mode. Directory junctions are a reparse point too and do not
+      // require elevated privilege on Windows, so try that next.
+      try {
+        symlinkSync(
+          outside,
+          join(root, "docs", "adr", "escape-junction"),
+          "junction",
+        );
+        mode = "dir-junction";
+      } catch {
+        mode = "skipped";
+      }
+    }
+
+    if (mode === "skipped") {
+      // eslint-disable-next-line no-console
+      console.info(
+        "[resolveCitationPath symlink test] OS denied both file symlinks and directory junctions; skipping the live containment assertion.",
+      );
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.info(`[resolveCitationPath symlink test] exercised via ${mode}`);
+
+    const target =
+      mode === "file-symlink"
+        ? "../adr/escape-link.md"
+        : "../adr/escape-junction/secret.md";
+    expect(() =>
+      resolveCitationPath(join(root, "docs", "okf"), target),
+    ).toThrow(/invalid citation target/);
   });
 });

--- a/tests/desktop/module-boundaries.test.ts
+++ b/tests/desktop/module-boundaries.test.ts
@@ -128,4 +128,25 @@ describe("desktop module boundaries", () => {
       ).toBe(false);
     }
   });
+
+  // OKF visualizer panel (Task 4, docs/plans/2026-07-17-okf-visualizer-panel-plan.md).
+  it("okf.ts stays Tauri-free, Three-free, and does not import ./main, ./panel, or ./recall", () => {
+    const specifiers = importSpecifiers(read("panel/okf.ts"));
+    for (const specifier of specifiers) {
+      expect(
+        specifier.startsWith("@tauri-apps"),
+        `okf.ts must not import Tauri APIs (found "${specifier}")`,
+      ).toBe(false);
+      expect(
+        specifier === "three" || specifier.startsWith("three/"),
+        `okf.ts must not import Three.js (found "${specifier}")`,
+      ).toBe(false);
+      for (const forbidden of ["./main", "../main", "./panel", "./recall"]) {
+        expect(
+          specifier.startsWith(forbidden),
+          `okf.ts must not import ${forbidden}.js (found "${specifier}")`,
+        ).toBe(false);
+      }
+    }
+  });
 });

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -10,6 +10,18 @@ import {
   renderMarkdown,
 } from "../../desktop/src/panel/okf-render.js";
 
+// Collects every href="..." attribute value from rendered HTML, with ASCII
+// control characters stripped -- mirrors how a browser's URL parser reads
+// an href (control chars are discarded before scheme detection), so a test
+// can assert on what the browser would actually navigate to rather than on
+// the raw markup text.
+function hrefValues(html: string): string[] {
+  return [...html.matchAll(/href="([^"]*)"/g)].map((m) =>
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: mirrors safeHref's own control-char strip so the assertion sees what a browser would parse
+    m[1].replace(/[\x00-\x1F]/g, ""),
+  );
+}
+
 // Real-shaped article body (docs/okf/fsrs-scheduling.md, sans frontmatter) —
 // used to pin extractLinks against genuine OKF prose rather than a synthetic
 // stand-in, per the Task 3 brief.
@@ -112,6 +124,14 @@ describe("renderMarkdown", () => {
     );
   });
 
+  it("keeps an escaped pipe as a literal character in a table cell instead of splitting the column", () => {
+    const html = renderMarkdown("| A | B |\n| --- | --- |\n| x\\|y | 2 |");
+    expect(html).toBe(
+      "<table><thead><tr><th>A</th><th>B</th></tr></thead>" +
+        "<tbody><tr><td>x|y</td><td>2</td></tr></tbody></table>",
+    );
+  });
+
   it("renders a blockquote", () => {
     const html = renderMarkdown("> Quoted line one.\n> Quoted line two.");
     expect(html).toBe(
@@ -142,6 +162,48 @@ describe("renderMarkdown", () => {
     expect(html).toBe(
       '<p>Read the <a href="https://example.com/spec" target="_blank" rel="noopener noreferrer">spec</a>.</p>',
     );
+  });
+
+  describe("link safety (unsafe URI schemes render inert)", () => {
+    it("renders a javascript: link inert -- no executing href, keeps the label", () => {
+      const html = renderMarkdown("[click me](javascript:alert(1))");
+      expect(hrefValues(html).some((h) => /^javascript:/i.test(h))).toBe(false);
+      expect(html).toContain("click me");
+    });
+
+    it("renders a data: URI link inert -- no navigating href, keeps the label", () => {
+      const html = renderMarkdown("[open](data:text/html;base64,PHNjcmlwdD4=)");
+      expect(hrefValues(html).some((h) => /^data:/i.test(h))).toBe(false);
+      expect(html).toContain("open");
+    });
+
+    it("treats the scheme check case-insensitively -- JavaScript: also renders inert", () => {
+      const html = renderMarkdown("[click](JavaScript:alert(1))");
+      expect(hrefValues(html).some((h) => /^javascript:/i.test(h))).toBe(false);
+      expect(html).toContain("click");
+    });
+
+    it("strips an embedded control character before scheme detection, so java<TAB>script: also renders inert", () => {
+      const html = renderMarkdown("[click](java\tscript:alert(1))");
+      expect(hrefValues(html).some((h) => /^javascript:/i.test(h))).toBe(false);
+      expect(html).toContain("click");
+    });
+
+    it("keeps a mailto: link navigable (allowlisted scheme)", () => {
+      const html = renderMarkdown("[email me](mailto:a@b.com)");
+      expect(html).toBe('<p><a href="mailto:a@b.com">email me</a></p>');
+    });
+
+    it("still classifies and renders external, article, and citation links exactly as before", () => {
+      const html = renderMarkdown(
+        "See [spec](https://example.com/spec) and [prereqs](prerequisite-blocking.md) and [adr](../adr/2026-01-01-x.md).",
+      );
+      expect(html).toBe(
+        '<p>See <a href="https://example.com/spec" target="_blank" rel="noopener noreferrer">spec</a>' +
+          ' and <a href="#" data-okf-article="prerequisite-blocking.md">prereqs</a>' +
+          ' and <a href="#" data-okf-citation="../adr/2026-01-01-x.md">adr</a>.</p>',
+      );
+    });
   });
 });
 

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -205,6 +205,47 @@ describe("renderMarkdown", () => {
       );
     });
   });
+
+  describe("link safety (authority-relative // and \\ targets render inert)", () => {
+    // "//evil.com/x", "\\evil.com\x", and mixed "/\evil.com" have no scheme
+    // token, but a browser still resolves them to an off-origin authority
+    // (backslashes are normalized to forward slashes for http/https), so
+    // they must be rejected the same as an unsafe scheme -- not treated as
+    // a safe scheme-less relative path.
+    it("renders a //host authority-relative target inert -- no off-origin href, keeps the label", () => {
+      const html = renderMarkdown("[x](//evil.com/steal)");
+      expect(hrefValues(html).some((h) => h.startsWith("//"))).toBe(false);
+      expect(html).not.toContain("evil.com");
+      expect(html).toBe("<p><span>x</span></p>");
+    });
+
+    it("renders a \\\\host UNC-style target inert -- no off-origin href, keeps the label", () => {
+      const html = renderMarkdown("[x](\\\\evil.com\\steal)");
+      expect(html).not.toContain("evil.com");
+      expect(html).toBe("<p><span>x</span></p>");
+    });
+
+    it("renders a mixed /\\host target inert (browsers normalize \\ to / for http(s), so this is also off-origin)", () => {
+      const html = renderMarkdown("[x](/\\evil.com)");
+      expect(html).not.toContain("evil.com");
+      expect(html).toBe("<p><span>x</span></p>");
+    });
+
+    it("regression: a non-authority-relative fallback target (single leading dot, no scheme) still renders as a normal link", () => {
+      const html = renderMarkdown("[x](../adr/)");
+      expect(html).toBe('<p><a href="../adr/">x</a></p>');
+    });
+
+    it("regression: mailto and external https links stay navigable with attributes intact", () => {
+      const html = renderMarkdown(
+        "[email me](mailto:a@b.com) and visit [site](https://x.example).",
+      );
+      expect(html).toBe(
+        '<p><a href="mailto:a@b.com">email me</a> and visit ' +
+          '<a href="https://x.example" target="_blank" rel="noopener noreferrer">site</a>.</p>',
+      );
+    });
+  });
 });
 
 describe("groupCatalog", () => {

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CatalogEntry,
+  extractLinks,
+  filterCatalog,
+  type GraphEdge,
+  type GraphNode,
+  groupCatalog,
+  layoutGraph,
+  renderMarkdown,
+} from "../../desktop/src/panel/okf-render.js";
+
+// Real-shaped article body (docs/okf/fsrs-scheduling.md, sans frontmatter) —
+// used to pin extractLinks against genuine OKF prose rather than a synthetic
+// stand-in, per the Task 3 brief.
+const FSRS_BODY = [
+  "ZAM's spaced repetition uses **FSRS-5** (Free Spaced Repetition Scheduler,",
+  "v5), implemented as pure functions in `src/kernel/scheduler/fsrs.ts`.",
+  "",
+  "A review takes a **rating** on a four-point scale: `1` Again (forgot),",
+  "`2` Hard, `3` Good, `4` Easy. Each card carries FSRS state per user:",
+  "**stability** (expected recall half-life in days), **difficulty** (1-10),",
+  "elapsed/scheduled days, repetition and lapse counts, a **state** of",
+  "`new`, `learning`, `review`, or `relearning`, and the next due date.",
+  "",
+  "`evaluateRating()` in `src/kernel/recall/evaluator.ts` applies a rating: it",
+  "runs FSRS scheduling, updates the card, and appends an immutable entry to",
+  "`review_logs`. Rating is deliberately separate from prerequisite blocking -",
+  "`evaluateRating()` never blocks or unblocks anything; callers decide",
+  "whether to invoke the blocker after a rating of `1` (see",
+  "[prerequisite-blocking.md](prerequisite-blocking.md)).",
+  "",
+  "# Review queue",
+  "",
+  "`src/kernel/scheduler/queue.ts` builds each session's queue from due cards",
+  "plus new cards: it interleaves cards by domain (so one topic doesn't",
+  "monopolize a session) and inserts new cards at every 5th position.",
+  "",
+  "# Examples",
+  "",
+  "```ts",
+  'import { evaluateRating } from "zam-core";',
+  "// rating: 1 | 2 | 3 | 4 - updates FSRS state and appends to review_logs",
+  "await evaluateRating(db, { cardId, tokenId, userId, rating: 3 });",
+  "```",
+  "",
+  "# Citations",
+  "",
+  "- [ADR 2026-05-30a - Standalone Learning Session](../adr/2026-05-30a-standalone-learning-session.md)",
+  "- Tests as source of truth for scheduling semantics: `tests/kernel/fsrs.test.ts`",
+  "- Code: `src/kernel/scheduler/fsrs.ts`, `src/kernel/scheduler/queue.ts`, `src/kernel/recall/evaluator.ts`",
+  "- Algorithm reference: <https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm>",
+].join("\n");
+
+describe("renderMarkdown", () => {
+  it("escapes HTML first so an embedded script can never survive", () => {
+    const html = renderMarkdown("<script>alert(1)</script>\n\nSafe text.");
+    expect(html.toLowerCase()).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("<p>Safe text.</p>");
+  });
+
+  it("escapes HTML inside inline code and links too", () => {
+    const html = renderMarkdown("Use `<img onerror=alert(1)>` carefully.");
+    expect(html.toLowerCase()).not.toContain("<img");
+    expect(html).toContain("&lt;img onerror=alert(1)&gt;");
+  });
+
+  it("renders headings 1-6 and leaves 7+ hashes as a paragraph", () => {
+    const html = renderMarkdown("# Title\n\n## Sub\n\nBody text.");
+    expect(html).toContain("<h1>Title</h1>");
+    expect(html).toContain("<h2>Sub</h2>");
+    expect(html).toContain("<p>Body text.</p>");
+  });
+
+  it("renders bold, italic, and inline code together", () => {
+    const html = renderMarkdown("This is **bold**, *italic*, and `code`.");
+    expect(html).toBe(
+      "<p>This is <strong>bold</strong>, <em>italic</em>, and <code>code</code>.</p>",
+    );
+  });
+
+  it("renders a fenced code block verbatim (escaped) with a language class", () => {
+    const html = renderMarkdown("```ts\nconst x = 1;\n```");
+    expect(html).toBe(
+      '<pre><code class="language-ts">const x = 1;</code></pre>',
+    );
+  });
+
+  it("renders a fenced code block with no language marker", () => {
+    const html = renderMarkdown("```\nplain\n```");
+    expect(html).toBe("<pre><code>plain</code></pre>");
+  });
+
+  it("renders an unordered list", () => {
+    const html = renderMarkdown("- One\n- Two\n- Three");
+    expect(html).toBe("<ul><li>One</li><li>Two</li><li>Three</li></ul>");
+  });
+
+  it("renders an ordered list", () => {
+    const html = renderMarkdown("1. First\n2. Second");
+    expect(html).toBe("<ol><li>First</li><li>Second</li></ol>");
+  });
+
+  it("renders a table", () => {
+    const html = renderMarkdown(
+      "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |",
+    );
+    expect(html).toBe(
+      "<table><thead><tr><th>A</th><th>B</th></tr></thead>" +
+        "<tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>",
+    );
+  });
+
+  it("renders a blockquote", () => {
+    const html = renderMarkdown("> Quoted line one.\n> Quoted line two.");
+    expect(html).toBe(
+      "<blockquote>Quoted line one. Quoted line two.</blockquote>",
+    );
+  });
+
+  it("classifies a bare kebab .md link as an in-bundle article link", () => {
+    const html = renderMarkdown(
+      "See [prereqs](prerequisite-blocking.md) for details.",
+    );
+    expect(html).toBe(
+      '<p>See <a href="#" data-okf-article="prerequisite-blocking.md">prereqs</a> for details.</p>',
+    );
+  });
+
+  it("classifies a relative .md path outside the bundle as a citation link", () => {
+    const html = renderMarkdown(
+      "See [ADR](../adr/2026-01-01-x.md) for rationale.",
+    );
+    expect(html).toBe(
+      '<p>See <a href="#" data-okf-citation="../adr/2026-01-01-x.md">ADR</a> for rationale.</p>',
+    );
+  });
+
+  it("opens external http(s) links safely in a new tab", () => {
+    const html = renderMarkdown("Read the [spec](https://example.com/spec).");
+    expect(html).toBe(
+      '<p>Read the <a href="https://example.com/spec" target="_blank" rel="noopener noreferrer">spec</a>.</p>',
+    );
+  });
+});
+
+describe("groupCatalog", () => {
+  const entry = (file: string, type: string): CatalogEntry => ({
+    file,
+    type,
+    title: file,
+    description: "",
+    tags: [],
+  });
+
+  it("groups by frontmatter type in stable, first-seen order", () => {
+    const catalog = [
+      entry("a.md", "guide"),
+      entry("b.md", "architecture"),
+      entry("c.md", "guide"),
+    ];
+    const groups = groupCatalog(catalog);
+    expect([...groups.keys()]).toEqual(["guide", "architecture"]);
+    expect(groups.get("guide")).toEqual([catalog[0], catalog[2]]);
+    expect(groups.get("architecture")).toEqual([catalog[1]]);
+  });
+});
+
+describe("filterCatalog", () => {
+  const catalog: CatalogEntry[] = [
+    {
+      file: "fsrs-scheduling.md",
+      type: "algorithm",
+      title: "FSRS-5 Scheduling",
+      description: "Pure-function scheduler",
+      tags: ["kernel", "fsrs"],
+    },
+    {
+      file: "mcp-surfaces.md",
+      type: "architecture",
+      title: "MCP Transport and Surfaces",
+      description: "Agent transport",
+      tags: ["mcp", "agents"],
+    },
+  ];
+
+  it("matches case-insensitively on title", () => {
+    expect(filterCatalog(catalog, "fsrs-5")).toEqual([catalog[0]]);
+  });
+
+  it("matches case-insensitively on description", () => {
+    expect(filterCatalog(catalog, "AGENT TRANSPORT")).toEqual([catalog[1]]);
+  });
+
+  it("matches on tags", () => {
+    expect(filterCatalog(catalog, "kernel")).toEqual([catalog[0]]);
+  });
+
+  it("matches on file name", () => {
+    expect(filterCatalog(catalog, "mcp-surfaces")).toEqual([catalog[1]]);
+  });
+
+  it("returns the full catalog for an empty query", () => {
+    expect(filterCatalog(catalog, "")).toEqual(catalog);
+    expect(filterCatalog(catalog, "   ")).toEqual(catalog);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(filterCatalog(catalog, "nonexistent")).toEqual([]);
+  });
+});
+
+describe("extractLinks", () => {
+  it("ignores markdown-looking links inside fenced code blocks", () => {
+    const body = [
+      "See [prerequisite-blocking.md](prerequisite-blocking.md) and:",
+      "",
+      "```md",
+      "[nope.md](nope.md)",
+      "[nope-adr](../adr/nope.md)",
+      "```",
+      "",
+      "Done.",
+    ].join("\n");
+    const links = extractLinks(body);
+    expect(links.articles).toEqual(["prerequisite-blocking.md"]);
+    expect(links.citations).toEqual([]);
+  });
+
+  it("extracts article and citation links from a real-shaped article body", () => {
+    const links = extractLinks(FSRS_BODY);
+    expect(links.articles).toEqual(["prerequisite-blocking.md"]);
+    expect(links.citations).toEqual([
+      "../adr/2026-05-30a-standalone-learning-session.md",
+    ]);
+  });
+});
+
+describe("layoutGraph", () => {
+  const nodes: GraphNode[] = [
+    { id: "b.md", kind: "article", type: "guide", file: "b.md" },
+    { id: "a.md", kind: "article", type: "algorithm", file: "a.md" },
+    { id: "c.md", kind: "article", type: "algorithm", file: "c.md" },
+    {
+      id: "../adr/x.md",
+      kind: "citation",
+      file: "../adr/x.md",
+    },
+  ];
+  const edges: GraphEdge[] = [{ from: "a.md", to: "../adr/x.md" }];
+
+  it("orders articles by (type, file) and places citations further out", () => {
+    const positioned = layoutGraph(nodes, edges, 200, 200);
+    const articles = positioned.filter((n) => n.kind === "article");
+    const citations = positioned.filter((n) => n.kind === "citation");
+
+    expect(articles.map((n) => n.id)).toEqual(["a.md", "c.md", "b.md"]);
+    expect(citations.map((n) => n.id)).toEqual(["../adr/x.md"]);
+
+    const centerX = 100;
+    const centerY = 100;
+    const distance = (n: { x: number; y: number }) =>
+      Math.hypot(n.x - centerX, n.y - centerY);
+
+    const articleRadius = distance(articles[0]);
+    for (const node of articles) {
+      expect(distance(node)).toBeCloseTo(articleRadius, 5);
+    }
+    const citationRadius = distance(citations[0]);
+    expect(citationRadius).toBeGreaterThan(articleRadius);
+  });
+
+  it("is deterministic across repeated calls with fresh input arrays", () => {
+    const first = layoutGraph(
+      nodes.map((n) => ({ ...n })),
+      edges.map((e) => ({ ...e })),
+      200,
+      200,
+    );
+    const second = layoutGraph(
+      nodes.map((n) => ({ ...n })),
+      edges.map((e) => ({ ...e })),
+      200,
+      200,
+    );
+    expect(second).toEqual(first);
+  });
+
+  it("handles an empty graph without dividing by zero", () => {
+    expect(layoutGraph([], [], 200, 200)).toEqual([]);
+  });
+});

--- a/vite.config.panel.mts
+++ b/vite.config.panel.mts
@@ -18,6 +18,7 @@ const MODE_TO_INPUT: Record<string, string> = {
   recall: "recall-panel.html",
   graph: "graph-panel.html",
   settings: "settings-panel.html",
+  okf: "okf-panel.html",
 };
 
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
Implements ADR [2026-07-17b](docs/adr/2026-07-17b-okf-visualizer-panel.md): an `okf-panel` MCP Apps panel that renders any OKF bundle (articles grouped by type + search, markdown reader with inline-expandable cited ADRs, link graph, log view), opened by a new `zam_okf_visualize` tool and fed exclusively by the OKF MCP tools.

## What's here
- **`zam_okf_read_citation`** — a new tool with a strictly-scoped, repo-relative citation read (rejects absolute paths, `..` escaping the repo root, non-`.md`, and authority-relative `//`/`\` targets; realpath symlink defense). `zam_okf_catalog` gains `include_log`.
- **`okf-render.ts`** — a pure, DOM-free rendering core (markdown with escape-first sanitization + a `safeHref` scheme allowlist, catalog grouping/filtering, link extraction, deterministic graph layout), independently unit-tested.
- **`okf-panel.html` / `okf.ts`** — the self-contained Vite single-file panel, mirroring the existing graph/studio panels; every DOM sink routes through the escaping renderer or `textContent`.
- **`zam_okf_visualize`** — opens the panel (ui://zam/okf), surfaces the bundle's `okf_version`, and never fails to open (missing/invalid bundle → `problems`, not an error). `CompanionSurface` gains `okf`. 23 MCP tools total.

## Verification
- New tests: okf-render (37), citation-path + tool cases, mcp resource/link/degradation, module-boundaries. okf-conformance green.
- Two security issues (URI-scheme XSS; authority-relative link bypass) were found and fixed under adversarial review before this PR.
- CLI-layer only — nothing touches `src/kernel/`. No new dependencies. Full gate green (modulo the known Windows/live-process env-baseline test failures).

Docs: `docs/okf/mcp-surfaces.md` updated via the sanctioned `zam_okf_upsert` path; ADR + index flipped to Implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)