### PR TITLE
fix: OKF visualizer reachable from VS Code Companion and Copilot canvases

### DIFF
--- a/desktop/src/panel/okf-panel.html
+++ b/desktop/src/panel/okf-panel.html
@@ -440,13 +440,36 @@
       .okf-graph-svg {
         width: 100%;
         height: auto;
+        /* Fit within the panel viewport instead of forcing a vertical
+           scroll; preserveAspectRatio centers the drawing when the cap
+           binds. */
+        max-height: 74vh;
         display: block;
       }
       .okf-graph-edge {
+        fill: none;
         stroke: var(--border);
         stroke-width: 1.4;
-        opacity: 0.8;
+        opacity: 0.55;
         pointer-events: none;
+        transition:
+          opacity 0.15s ease,
+          stroke 0.15s ease;
+      }
+      .okf-graph-edge.okf-edge-hot {
+        stroke: var(--accent);
+        stroke-width: 2;
+        opacity: 1;
+      }
+      .okf-graph-edge.okf-edge-dim {
+        opacity: 0.1;
+      }
+      .okf-graph-node-article,
+      .okf-graph-node-citation {
+        transition: opacity 0.15s ease;
+      }
+      .okf-node-dim {
+        opacity: 0.25;
       }
       .okf-graph-node-label {
         font-size: 11px;
@@ -472,6 +495,40 @@
       .okf-empty {
         text-align: center;
         padding: 32px 12px;
+      }
+      .okf-bundle-selector {
+        display: flex;
+        gap: 8px;
+        justify-content: center;
+        margin-top: 14px;
+      }
+      .okf-bundle-input {
+        width: min(420px, 70%);
+        padding: 6px 10px;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: var(--card);
+        color: var(--fg);
+        font-family: var(--mono, monospace);
+        font-size: 12px;
+      }
+      .okf-bundle-open {
+        padding: 6px 14px;
+        border: none;
+        border-radius: 6px;
+        background: var(--accent);
+        color: #fff;
+        cursor: pointer;
+      }
+      .okf-bundle-open:disabled {
+        opacity: 0.6;
+        cursor: default;
+      }
+      .okf-bundle-error {
+        margin-top: 10px;
+        color: var(--danger, #c4432b);
+        font-size: 12px;
+        min-height: 1em;
       }
       .okf-empty-emoji {
         font-size: 2rem;

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -30,6 +30,8 @@ export interface GraphNode {
   type?: string;
   /** Sort/identity key -- catalog file for articles, link target for citations. */
   file?: string;
+  /** Display label -- catalog title for articles, basename for citations. */
+  label?: string;
 }
 
 export interface GraphEdge {
@@ -101,6 +103,24 @@ function safeHref(target: string): string | null {
   return cleaned;
 }
 
+// -- Frontmatter ------------------------------------------------------------
+
+/**
+ * Drop a leading OKF frontmatter fence (`---` ... `---`) from an article
+ * source before markdown rendering. The reader shows that metadata as its
+ * meta strip (type badge, tags, timestamp, resource link) -- rendering the
+ * raw fence too produced one garbled paragraph above every article. An
+ * unterminated fence is not frontmatter; the source is returned unchanged.
+ */
+export function stripFrontmatter(source: string): string {
+  const lines = source.split("\n");
+  if (lines[0]?.trim() !== "---") return source;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") return lines.slice(i + 1).join("\n");
+  }
+  return source;
+}
+
 // -- Markdown rendering -----------------------------------------------------
 
 function renderLink(label: string, target: string): string {
@@ -122,6 +142,36 @@ function renderLink(label: string, target: string): string {
 }
 
 const LINK_RE = /^\[([^\]]*)\]\(([^)]+)\)/;
+
+/**
+ * Gather one list's items starting at `start`, where each item may continue
+ * over subsequent indented lines (standard markdown hanging indent). Without
+ * this, a wrapped list item's continuation line fell out of the list as a
+ * bare paragraph, splitting the sentence in the reader (0.13.0 live
+ * finding).
+ */
+function collectListItems(
+  lines: string[],
+  start: number,
+  markerRe: RegExp,
+): { texts: string[]; nextIndex: number } {
+  const texts: string[] = [];
+  let i = start;
+  while (i < lines.length && markerRe.test(lines[i])) {
+    let item = lines[i].replace(markerRe, "");
+    i++;
+    while (
+      i < lines.length &&
+      /^\s+\S/.test(lines[i]) &&
+      !markerRe.test(lines[i])
+    ) {
+      item += ` ${lines[i].trim()}`;
+      i++;
+    }
+    texts.push(item);
+  }
+  return { texts, nextIndex: i };
+}
 
 /**
  * Render inline constructs (code, links, bold, italic) within one line of
@@ -284,6 +334,14 @@ export function renderMarkdown(source: string): string {
       continue;
     }
 
+    // Thematic break -- must run before the list/paragraph fallbacks so a
+    // bare `---` never renders as literal dashes in a paragraph.
+    if (/^([-_*])\1{2,}$/.test(line.trim())) {
+      blocks.push("<hr>");
+      i++;
+      continue;
+    }
+
     if (
       line.includes("|") &&
       i + 1 < lines.length &&
@@ -305,25 +363,19 @@ export function renderMarkdown(source: string): string {
     }
 
     if (/^[-*]\s+/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^[-*]\s+/.test(lines[i])) {
-        items.push(lines[i].replace(/^[-*]\s+/, ""));
-        i++;
-      }
+      const items = collectListItems(lines, i, /^[-*]\s+/);
+      i = items.nextIndex;
       blocks.push(
-        `<ul>${items.map((item) => `<li>${renderInline(item)}</li>`).join("")}</ul>`,
+        `<ul>${items.texts.map((item) => `<li>${renderInline(item)}</li>`).join("")}</ul>`,
       );
       continue;
     }
 
     if (/^\d+\.\s+/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
-        items.push(lines[i].replace(/^\d+\.\s+/, ""));
-        i++;
-      }
+      const items = collectListItems(lines, i, /^\d+\.\s+/);
+      i = items.nextIndex;
       blocks.push(
-        `<ol>${items.map((item) => `<li>${renderInline(item)}</li>`).join("")}</ol>`,
+        `<ol>${items.texts.map((item) => `<li>${renderInline(item)}</li>`).join("")}</ol>`,
       );
       continue;
     }
@@ -431,8 +483,14 @@ export function extractLinks(body: string): {
 
 // -- Graph layout -------------------------------------------------------------
 
-const ARTICLE_RADIUS_FRACTION = 0.32;
-const CITATION_RADIUS_FRACTION = 0.46;
+/** Inner (article) ring size relative to the outer (citation) ring. */
+const ARTICLE_RING_FRACTION = 0.55;
+/** Horizontal margin kept free for node labels, as a fraction of width. */
+const MARGIN_X_FRACTION = 0.13;
+/** Vertical margin kept free for node labels, as a fraction of height. */
+const MARGIN_Y_FRACTION = 0.09;
+/** Minimum angular gap between citation nodes (radians) so labels stay apart. */
+const MIN_CITATION_SEPARATION = 0.34;
 
 function sortKey(node: GraphNode): string {
   return node.file ?? node.id;
@@ -445,64 +503,89 @@ function sortArticles(nodes: GraphNode[]): GraphNode[] {
   });
 }
 
-function sortCitations(nodes: GraphNode[]): GraphNode[] {
-  return [...nodes].sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
-}
-
-function placeOnCircle(
-  nodes: GraphNode[],
-  radius: number,
-  centerX: number,
-  centerY: number,
-): PositionedNode[] {
-  const n = nodes.length;
-  return nodes.map((node, index) => {
-    // n is never 0 here: an empty `nodes` makes `.map` skip this callback
-    // entirely, so the division below never sees a zero denominator.
-    const angle = (2 * Math.PI * index) / n - Math.PI / 2;
-    return {
-      ...node,
-      x: centerX + radius * Math.cos(angle),
-      y: centerY + radius * Math.sin(angle),
-    };
-  });
-}
-
 /**
- * Deterministic circle layout: article nodes on an inner ring ordered by
- * (type, file), citation nodes on an outer ring (arc) ordered by their link
- * target. Pure function of its inputs -- no randomness, no mutation of the
- * input arrays -- so identical input always yields identical coordinates.
+ * Deterministic two-ring ellipse layout. Articles sit on an inner ellipse
+ * ordered by (type, file) -- same-type articles are angular neighbors, so
+ * types read as clusters. Each citation sits on an outer ellipse at the
+ * circular mean of the angles of the articles that cite it (with a minimum
+ * angular separation between citations), so citation nodes appear next to
+ * their citers instead of at an alphabetical slot across the canvas --
+ * markedly fewer edge crossings. Ellipses (not circles) use a wide canvas
+ * fully, and the margins reserve space so labels never clip at the viewBox.
  *
- * `edges` isn't used for node placement (this is a radial layout, not
- * force-directed); it's accepted here so the panel can pass the same pair
- * of arrays it already has on hand for drawing the connecting lines.
+ * Pure function of its inputs -- no randomness, no input mutation -- so
+ * identical input always yields identical coordinates.
  */
 export function layoutGraph(
   nodes: GraphNode[],
-  _edges: GraphEdge[],
+  edges: GraphEdge[],
   width: number,
   height: number,
 ): PositionedNode[] {
   const centerX = width / 2;
   const centerY = height / 2;
-  const minDim = Math.min(width, height);
+  const rxOuter = width / 2 - width * MARGIN_X_FRACTION;
+  const ryOuter = height / 2 - height * MARGIN_Y_FRACTION;
+  const rxInner = rxOuter * ARTICLE_RING_FRACTION;
+  const ryInner = ryOuter * ARTICLE_RING_FRACTION;
 
   const articles = sortArticles(nodes.filter((n) => n.kind === "article"));
-  const citations = sortCitations(nodes.filter((n) => n.kind === "citation"));
+  const citations = [...nodes.filter((n) => n.kind === "citation")];
 
-  return [
-    ...placeOnCircle(
-      articles,
-      minDim * ARTICLE_RADIUS_FRACTION,
-      centerX,
-      centerY,
-    ),
-    ...placeOnCircle(
-      citations,
-      minDim * CITATION_RADIUS_FRACTION,
-      centerX,
-      centerY,
-    ),
-  ];
+  const articleAngle = new Map<string, number>();
+  const positionedArticles = articles.map((node, index) => {
+    const angle = (2 * Math.PI * index) / articles.length - Math.PI / 2;
+    articleAngle.set(node.id, angle);
+    return {
+      ...node,
+      x: centerX + rxInner * Math.cos(angle),
+      y: centerY + ryInner * Math.sin(angle),
+    };
+  });
+
+  const desired = citations.map((node, index) => {
+    const citerAngles = edges
+      .filter((edge) => edge.to === node.id)
+      .map((edge) => articleAngle.get(edge.from))
+      .filter((angle): angle is number => angle !== undefined);
+    if (citerAngles.length === 0) {
+      // Unreachable from buildFullGraph (citation nodes exist because an
+      // article links them), but a hand-built graph stays well-defined.
+      return {
+        node,
+        angle: (2 * Math.PI * index) / citations.length - Math.PI / 2,
+      };
+    }
+    const sumSin = citerAngles.reduce((sum, a) => sum + Math.sin(a), 0);
+    const sumCos = citerAngles.reduce((sum, a) => sum + Math.cos(a), 0);
+    return { node, angle: Math.atan2(sumSin, sumCos) };
+  });
+  desired.sort(
+    (a, b) =>
+      a.angle - b.angle || sortKey(a.node).localeCompare(sortKey(b.node)),
+  );
+  for (let i = 1; i < desired.length; i++) {
+    const minAngle = desired[i - 1].angle + MIN_CITATION_SEPARATION;
+    if (desired[i].angle < minAngle) desired[i].angle = minAngle;
+  }
+  // If the separation pass pushed the fan past a full turn, proximity is
+  // hopeless anyway -- fall back to an even spread instead of overlapping
+  // the first nodes.
+  if (
+    desired.length > 1 &&
+    desired[desired.length - 1].angle - desired[0].angle >
+      2 * Math.PI - MIN_CITATION_SEPARATION
+  ) {
+    for (let i = 0; i < desired.length; i++) {
+      desired[i].angle = (2 * Math.PI * i) / desired.length - Math.PI / 2;
+    }
+  }
+
+  const positionedCitations = desired.map(({ node, angle }) => ({
+    ...node,
+    x: centerX + rxOuter * Math.cos(angle),
+    y: centerY + ryOuter * Math.sin(angle),
+  }));
+
+  return [...positionedArticles, ...positionedCitations];
 }

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -49,11 +49,12 @@ import {
   groupCatalog,
   layoutGraph,
   renderMarkdown,
+  stripFrontmatter,
 } from "./okf-render.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
-const GRAPH_W = 680;
-const GRAPH_H = 680;
+const GRAPH_W = 960;
+const GRAPH_H = 620;
 const NODE_R = 22;
 
 const SURFACE: CompanionSurface = "okf";
@@ -339,6 +340,10 @@ function renderSidebar(): void {
 
 function renderContent(): void {
   if (!contentEl) return;
+  if (catalogLoaded && catalog.length === 0) {
+    renderBundleSelector(contentEl);
+    return;
+  }
   if (viewMode === "graph") {
     void renderGraphView();
     return;
@@ -348,6 +353,108 @@ function renderContent(): void {
     return;
   }
   renderReaderBody(contentEl);
+}
+
+// ── Bundle folder selector ────────────────────────────────────────────────
+
+/**
+ * Re-target the panel at a different bundle directory via
+ * `zam_okf_catalog` (the tool the 800ms fallback already uses), resetting
+ * all per-bundle state. Returns an error message, or null on success.
+ */
+async function retargetBundle(dir: string): Promise<string | null> {
+  try {
+    const result = (await callTool("zam_okf_catalog", {
+      bundle_dir: dir,
+      include_log: true,
+    })) as {
+      dir: string;
+      articles: CatalogEntry[];
+      problems: string[];
+      log?: string;
+    };
+    bundleDir = result.dir;
+    // The catalog tool does not report the bundle's okf_version -- hide the
+    // stale one rather than showing the previous bundle's.
+    bundleOkfVersion = null;
+    setCatalog(result.articles);
+    logText = result.log ?? "";
+    catalogLoaded = true;
+    bodyCache.clear();
+    readErrors.clear();
+    openCitations.clear();
+    currentFile = null;
+    citationView = null;
+    return null;
+  } catch (error) {
+    return errorMessage(error);
+  }
+}
+
+/**
+ * Shown when the resolved bundle has no articles -- typically because the
+ * server's cwd default (`docs/okf`) does not point at the workspace the
+ * user means. A sandboxed webview cannot open a native folder picker for a
+ * filesystem *path*, so this is a path input with inline validation via
+ * the same MCP tool that loads the catalog.
+ */
+function renderBundleSelector(container: HTMLElement): void {
+  container.replaceChildren();
+  const box = document.createElement("div");
+  box.className = "zam-card okf-empty";
+
+  const icon = document.createElement("div");
+  icon.className = "okf-empty-emoji";
+  icon.textContent = "📂";
+  const title = document.createElement("div");
+  title.className = "okf-empty-title";
+  title.textContent = "Wissensbasis nicht gefunden";
+  const sub = document.createElement("div");
+  sub.className = "okf-empty-sub";
+  sub.textContent = bundleDir
+    ? `Unter "${bundleDir}" liegen keine Artikel. Gib den Pfad zum docs/okf-Ordner eines Repos an:`
+    : "Gib den Pfad zum docs/okf-Ordner eines Repos an:";
+
+  const form = document.createElement("div");
+  form.className = "okf-bundle-selector";
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "okf-bundle-input";
+  input.placeholder = "C:\\pfad\\zum\\repo\\docs\\okf";
+  input.value = bundleDir ?? "";
+  const open = document.createElement("button");
+  open.type = "button";
+  open.className = "okf-bundle-open";
+  open.textContent = "Öffnen";
+  const errorEl = document.createElement("div");
+  errorEl.className = "okf-bundle-error";
+
+  const submit = async (): Promise<void> => {
+    const dir = input.value.trim();
+    if (!dir) return;
+    open.disabled = true;
+    errorEl.textContent = "";
+    const error = await retargetBundle(dir);
+    open.disabled = false;
+    if (error) {
+      errorEl.textContent = error;
+      return;
+    }
+    if (catalog.length === 0) {
+      errorEl.textContent =
+        "Der Ordner ist ein gültiges Bundle, enthält aber keine Artikel.";
+      return;
+    }
+    renderAll();
+  };
+  open.addEventListener("click", () => void submit());
+  input.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") void submit();
+  });
+
+  form.append(input, open);
+  box.append(icon, title, sub, form, errorEl);
+  container.appendChild(box);
 }
 
 // ── Reader ───────────────────────────────────────────────────────────────
@@ -391,7 +498,9 @@ function buildMetaStrip(entry: CatalogEntry | undefined): HTMLElement {
   }
   if (entry?.timestamp) {
     const ts = document.createElement("span");
-    ts.textContent = entry.timestamp;
+    // Frontmatter timestamps may carry a T00:00:00Z time part -- the strip
+    // shows the date only.
+    ts.textContent = entry.timestamp.slice(0, 10);
     strip.appendChild(ts);
   }
   if (entry?.resource) {
@@ -437,7 +546,9 @@ function renderReaderBody(container: HTMLElement): void {
   container.appendChild(buildMetaStrip(catalog.find((e) => e.file === currentFile)));
   const bodyEl = document.createElement("div");
   bodyEl.className = "okf-article-body zam-card";
-  bodyEl.innerHTML = renderMarkdown(body);
+  // The meta strip above renders the frontmatter; rendering the raw fence
+  // too showed it as one garbled paragraph at the top of every article.
+  bodyEl.innerHTML = renderMarkdown(stripFrontmatter(body));
   attachContentClickDelegation(bodyEl);
   decorateCitationLinks(bodyEl, new Set());
   container.appendChild(bodyEl);
@@ -469,7 +580,7 @@ function renderCitationFullView(container: HTMLElement, view: CitationView): voi
 
   const bodyEl = document.createElement("div");
   bodyEl.className = "okf-article-body zam-card";
-  bodyEl.innerHTML = renderMarkdown(view.content);
+  bodyEl.innerHTML = renderMarkdown(stripFrontmatter(view.content));
   attachContentClickDelegation(bodyEl);
   decorateCitationLinks(bodyEl, new Set());
   container.appendChild(bodyEl);
@@ -588,7 +699,7 @@ function buildCitationBox(
   });
   const contentBodyEl = document.createElement("div");
   contentBodyEl.className = "okf-article-body";
-  contentBodyEl.innerHTML = renderMarkdown(state.content ?? "");
+  contentBodyEl.innerHTML = renderMarkdown(stripFrontmatter(state.content ?? ""));
   attachContentClickDelegation(contentBodyEl);
   decorateCitationLinks(contentBodyEl, new Set([...ancestors, target]));
   box.append(badge, pathEl, openBtn, contentBodyEl);
@@ -627,7 +738,13 @@ function buildFullGraph(): { nodes: GraphNode[]; edges: GraphEdge[] } {
     nodes.push(node);
   };
   for (const entry of catalog) {
-    addNode({ id: entry.file, kind: "article", type: entry.type, file: entry.file });
+    addNode({
+      id: entry.file,
+      kind: "article",
+      type: entry.type,
+      file: entry.file,
+      label: entry.title,
+    });
   }
   for (const entry of catalog) {
     const body = bodyCache.get(entry.file);
@@ -639,38 +756,67 @@ function buildFullGraph(): { nodes: GraphNode[]; edges: GraphEdge[] } {
         kind: "article",
         type: byFile.get(target)?.type,
         file: target,
+        label: byFile.get(target)?.title,
       });
       edges.push({ from: entry.file, to: target });
     }
     for (const target of citations) {
-      addNode({ id: target, kind: "citation", file: target });
+      addNode({
+        id: target,
+        kind: "citation",
+        file: target,
+        label: citationLabel(target),
+      });
       edges.push({ from: entry.file, to: target });
     }
   }
   return { nodes, edges };
 }
 
-function truncateLabel(text: string, max = 16): string {
+/**
+ * A citation target like "../adr/2026-07-17b-okf-visualizer-panel.md" used
+ * to label as a clipped "../adr/2026-07-…" -- six of those are
+ * indistinguishable. The basename's tail is the distinctive part (dated ADR
+ * file names share their prefix), so keep the tail.
+ */
+function citationLabel(target: string): string {
+  return target.split("/").pop()?.replace(/\.md$/, "") ?? target;
+}
+
+function truncateLabel(text: string, keep: "head" | "tail", max = 26): string {
   const base = text.replace(/\.md$/, "");
-  return base.length > max ? `${base.slice(0, max - 1)}…` : base;
+  if (base.length <= max) return base;
+  return keep === "head"
+    ? `${base.slice(0, max - 1)}…`
+    : `…${base.slice(-(max - 1))}`;
 }
 
 function buildGraphNodeEl(node: PositionedNode): SVGGElement {
   const g = document.createElementNS(SVG_NS, "g") as SVGGElement;
   g.setAttribute("transform", `translate(${node.x}, ${node.y})`);
   g.setAttribute("class", `okf-graph-node-${node.kind}`);
+  g.setAttribute("data-node-id", node.id);
 
   const title = document.createElementNS(SVG_NS, "title");
   title.textContent = node.file ?? node.id;
   g.appendChild(title);
 
+  const labelText =
+    node.kind === "article"
+      ? truncateLabel(node.label ?? node.file ?? node.id, "head")
+      : truncateLabel(node.label ?? node.file ?? node.id, "tail");
+
   if (node.kind === "article") {
+    // Pill sized to its label (11px font ≈ 6.2px/char) so titles sit inside
+    // the shape instead of overflowing a fixed-width box.
+    const pillW = Math.min(Math.max(labelText.length * 6.2 + 20, 64), 200);
+    const pillH = 26;
     const rect = document.createElementNS(SVG_NS, "rect");
-    rect.setAttribute("x", String(-NODE_R));
-    rect.setAttribute("y", String(-NODE_R * 0.6));
-    rect.setAttribute("width", String(NODE_R * 2));
-    rect.setAttribute("height", String(NODE_R * 1.2));
-    rect.setAttribute("rx", "8");
+    rect.setAttribute("x", String(-pillW / 2));
+    rect.setAttribute("y", String(-pillH / 2));
+    rect.setAttribute("width", String(pillW));
+    rect.setAttribute("height", String(pillH));
+    rect.setAttribute("rx", String(pillH / 2));
     rect.style.fill = typeColorVar(node.type ?? "", "-bg");
     rect.style.stroke = typeColorVar(node.type ?? "");
     g.appendChild(rect);
@@ -681,16 +827,25 @@ function buildGraphNodeEl(node: PositionedNode): SVGGElement {
     });
   } else {
     const circle = document.createElementNS(SVG_NS, "circle");
-    circle.setAttribute("r", String(NODE_R * 0.55));
+    circle.setAttribute("r", String(NODE_R * 0.45));
     g.appendChild(circle);
   }
 
   const label = document.createElementNS(SVG_NS, "text");
   label.setAttribute("class", "okf-graph-node-label");
-  label.setAttribute("text-anchor", "middle");
   label.setAttribute("dominant-baseline", "central");
-  label.setAttribute("y", node.kind === "article" ? "0" : String(NODE_R * 0.55 + 11));
-  label.textContent = truncateLabel(node.file ?? node.id);
+  if (node.kind === "article") {
+    label.setAttribute("text-anchor", "middle");
+    label.setAttribute("y", "0");
+  } else {
+    // Citations sit on the outer ring: grow their labels inward (toward the
+    // center) so text never runs past the viewBox edge.
+    const onRightHalf = node.x > GRAPH_W / 2;
+    label.setAttribute("text-anchor", onRightHalf ? "end" : "start");
+    label.setAttribute("x", onRightHalf ? "-14" : "14");
+    label.setAttribute("y", "0");
+  }
+  label.textContent = labelText;
   g.appendChild(label);
 
   return g;
@@ -749,20 +904,56 @@ async function renderGraphView(): Promise<void> {
     const from = byId.get(edge.from);
     const to = byId.get(edge.to);
     if (!from || !to) continue;
-    const line = document.createElementNS(SVG_NS, "line");
-    line.setAttribute("x1", String(from.x));
-    line.setAttribute("y1", String(from.y));
-    line.setAttribute("x2", String(to.x));
-    line.setAttribute("y2", String(to.y));
-    line.setAttribute("class", "okf-graph-edge");
-    line.setAttribute("aria-hidden", "true");
-    edgesGroup.appendChild(line);
+    // Quadratic curve with the control point pulled toward the canvas
+    // center: edges bow gently inward instead of slicing straight across.
+    const midX = (from.x + to.x) / 2;
+    const midY = (from.y + to.y) / 2;
+    const ctrlX = midX + (GRAPH_W / 2 - midX) * 0.22;
+    const ctrlY = midY + (GRAPH_H / 2 - midY) * 0.22;
+    const path = document.createElementNS(SVG_NS, "path");
+    path.setAttribute(
+      "d",
+      `M ${from.x} ${from.y} Q ${ctrlX} ${ctrlY} ${to.x} ${to.y}`,
+    );
+    path.setAttribute("class", "okf-graph-edge");
+    path.setAttribute("data-from", edge.from);
+    path.setAttribute("data-to", edge.to);
+    path.setAttribute("aria-hidden", "true");
+    edgesGroup.appendChild(path);
   }
 
   const nodesGroup = document.createElementNS(SVG_NS, "g") as SVGGElement;
   svg.appendChild(nodesGroup);
+
+  // Hovering a node lights up its edges and neighbors and dims the rest;
+  // hover-out restores the neutral state.
+  const emphasize = (id: string | null): void => {
+    const neighbors = new Set<string>();
+    for (const el of Array.from(edgesGroup.children)) {
+      const from = el.getAttribute("data-from");
+      const to = el.getAttribute("data-to");
+      const hot = id !== null && (from === id || to === id);
+      el.setAttribute(
+        "class",
+        `okf-graph-edge${hot ? " okf-edge-hot" : id !== null ? " okf-edge-dim" : ""}`,
+      );
+      if (hot) {
+        if (from) neighbors.add(from);
+        if (to) neighbors.add(to);
+      }
+    }
+    for (const el of Array.from(nodesGroup.children)) {
+      const nodeId = el.getAttribute("data-node-id");
+      const dim =
+        id !== null && nodeId !== id && !neighbors.has(nodeId ?? "");
+      el.classList.toggle("okf-node-dim", dim);
+    }
+  };
   for (const node of positioned) {
-    nodesGroup.appendChild(buildGraphNodeEl(node));
+    const el = buildGraphNodeEl(node);
+    el.addEventListener("mouseenter", () => emphasize(node.id));
+    el.addEventListener("mouseleave", () => emphasize(null));
+    nodesGroup.appendChild(el);
   }
 
   contentEl.appendChild(wrap);

--- a/scripts/prepare-vscode-extension.mjs
+++ b/scripts/prepare-vscode-extension.mjs
@@ -48,7 +48,7 @@ const extensionPackage = {
   name: "zam-companion",
   displayName: "ZAM Companion",
   description:
-    "Persistent Recall, Graph, and Settings surfaces for ZAM agent workflows.",
+    "Persistent Recall, Knowledge Base, Graph, and Settings surfaces for ZAM agent workflows.",
   version,
   publisher: "zam-os",
   license: "Apache-2.0",
@@ -66,6 +66,7 @@ const extensionPackage = {
     "onView:zam.companion",
     "onCommand:zam.openRecall",
     "onCommand:zam.showGraph",
+    "onCommand:zam.showOkf",
     "onCommand:zam.openSettings",
     "onCommand:zam.chooseRecallModel",
   ],
@@ -99,9 +100,15 @@ const extensionPackage = {
       },
       {
         command: "zam.showGraph",
-        title: "Open Knowledge Graph",
+        title: "Open Learning Graph",
         category: "ZAM",
         icon: "$(type-hierarchy)",
+      },
+      {
+        command: "zam.showOkf",
+        title: "Open Knowledge Base",
+        category: "ZAM",
+        icon: "$(library)",
       },
       {
         command: "zam.openSettings",
@@ -117,6 +124,11 @@ const extensionPackage = {
       },
     ],
     menus: {
+      // Slot @2 toggles between the two knowledge surfaces: the Knowledge
+      // Base (OKF) is the default; while it is open, the slot flips to the
+      // Learning Graph. `zam.companionApp` is set by CompanionViewProvider
+      // .open in src/vscode-extension/extension.ts. Both commands remain
+      // always available via the command palette.
       "view/title": [
         {
           command: "zam.openRecall",
@@ -124,8 +136,13 @@ const extensionPackage = {
           group: "navigation@1",
         },
         {
+          command: "zam.showOkf",
+          when: "view == zam.companion && zam.companionApp != 'okf'",
+          group: "navigation@2",
+        },
+        {
           command: "zam.showGraph",
-          when: "view == zam.companion",
+          when: "view == zam.companion && zam.companionApp == 'okf'",
           group: "navigation@2",
         },
         {
@@ -145,7 +162,7 @@ writeFileSync(
 );
 writeFileSync(
   join(extensionDir, "README.md"),
-  `# ZAM Companion\n\nThis extension keeps ZAM Recall, Graph, and Settings in a movable VS Code view that does not scroll away with agent chat.\n\nInstall and configure it with:\n\n\`\`\`sh\nzam agent connect vscode\n\`\`\`\n\nThe extension hosts the existing MCP App resources from your local \`zam mcp\` server. It contains no second learning engine or database.\n`,
+  `# ZAM Companion\n\nThis extension keeps ZAM Recall, Knowledge Base (OKF), Learning Graph, and Settings in a movable VS Code view that does not scroll away with agent chat.\n\nInstall and configure it with:\n\n\`\`\`sh\nzam agent connect vscode\n\`\`\`\n\nThe extension hosts the existing MCP App resources from your local \`zam mcp\` server. It contains no second learning engine or database.\n`,
   "utf8",
 );
 writeFileSync(

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1415,12 +1415,15 @@ export function createMcpServer(db: Database): McpServer {
         getNativeClientInfo(),
         { clientSamplingCapable: getClientSamplingCapable() },
       );
-      await publishUiIntent("okf", { bundle_dir });
-
       const { DEFAULT_BUNDLE_DIR, loadBundle } = await import("../okf/io.js");
       const { resolve } = await import("node:path");
       const requestedDir = bundle_dir ?? DEFAULT_BUNDLE_DIR;
       let resolvedBundleDir = resolve(requestedDir);
+      // Publish the RESOLVED absolute dir, not the raw argument: the VS Code
+      // Companion's own zam server runs with a different cwd, so a relative
+      // (or defaulted) dir would resolve to a different bundle over there
+      // (0.13.0 live finding: the Companion opened an empty bundle).
+      await publishUiIntent("okf", { bundle_dir: resolvedBundleDir });
       let catalog: CatalogEntry[] = [];
       let problems: string[] = [];
       let log = "";

--- a/src/copilot-extension/extension.mjs
+++ b/src/copilot-extension/extension.mjs
@@ -31,6 +31,15 @@ const APP_CONFIG = {
     toolName: "zam_show_graph",
     allowedTools: new Set(["zam_studio_bridge"]),
   },
+  okf: {
+    title: "ZAM Knowledge Base",
+    toolName: "zam_okf_visualize",
+    allowedTools: new Set([
+      "zam_okf_catalog",
+      "zam_okf_read",
+      "zam_okf_read_citation",
+    ]),
+  },
   settings: {
     title: "ZAM Settings",
     toolName: "zam_open_settings",
@@ -79,6 +88,11 @@ function compactObject(value) {
 }
 
 function buildToolArguments(kind, input) {
+  // `okf` takes no `user`: `zam_okf_visualize` is repo-scoped and its input
+  // schema only knows `bundle_dir`.
+  if (kind === "okf") {
+    return compactObject({ bundle_dir: input?.bundle_dir });
+  }
   const common = { user: input?.user };
   if (kind === "recall") {
     return compactObject({ ...common, domain: input?.domain });
@@ -489,6 +503,26 @@ await joinSession({
       },
       actions: [connectionStatusAction()],
       open: (context) => openApp("graph", context),
+      onClose: closeApp,
+    }),
+    createCanvas({
+      id: "zam-knowledge",
+      displayName: "ZAM Knowledge Base",
+      description:
+        "Open the ZAM OKF knowledge-base visualizer MCP App in a hosted Copilot canvas.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          bundle_dir: {
+            type: "string",
+            description:
+              "Bundle directory (default docs/okf under the zam server cwd).",
+          },
+        },
+        additionalProperties: false,
+      },
+      actions: [connectionStatusAction()],
+      open: (context) => openApp("okf", context),
       onClose: closeApp,
     }),
     createCanvas({

--- a/src/vscode-extension/extension.ts
+++ b/src/vscode-extension/extension.ts
@@ -309,6 +309,13 @@ class CompanionViewProvider implements vscode.WebviewViewProvider {
         vscodeLmAdapter,
       );
       this.sendBootstrap();
+      // Drives the title-bar Knowledge-Base/Learning-Graph toggle: the menu
+      // `when` clauses in scripts/prepare-vscode-extension.mjs read this key.
+      void vscode.commands.executeCommand(
+        "setContext",
+        "zam.companionApp",
+        kind,
+      );
       this.output.appendLine(
         `[${new Date().toISOString()}] opened ${kind} via ${this.prepared.resourceUri}`,
       );
@@ -631,6 +638,17 @@ export async function activate(
     vscode.commands.registerCommand("zam.showGraph", () =>
       provider.open("graph"),
     ),
+    vscode.commands.registerCommand("zam.showOkf", () => {
+      // The Companion's zam server does not run with the workspace as cwd,
+      // so the tool's "docs/okf under the server cwd" default is meaningless
+      // here — point it at the workspace's bundle explicitly. A workspace
+      // without docs/okf gets the panel's problem state, which says so.
+      const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      return provider.open(
+        "okf",
+        workspace ? { bundle_dir: join(workspace, "docs", "okf") } : {},
+      );
+    }),
     vscode.commands.registerCommand("zam.openSettings", () =>
       provider.open("settings"),
     ),

--- a/src/vscode-extension/protocol.ts
+++ b/src/vscode-extension/protocol.ts
@@ -3,7 +3,7 @@ import type {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 
-export type CompanionApp = "recall" | "graph" | "settings";
+export type CompanionApp = "recall" | "graph" | "settings" | "okf";
 
 export interface CompanionIntent {
   version: 1;
@@ -51,6 +51,16 @@ export const COMPANION_APPS: Record<CompanionApp, CompanionAppConfig> = {
     title: "ZAM Graph",
     toolName: "zam_show_graph",
     allowedTools: new Set(["zam_studio_bridge", "zam_companion_context"]),
+  },
+  okf: {
+    title: "ZAM Knowledge Base",
+    toolName: "zam_okf_visualize",
+    allowedTools: new Set([
+      "zam_okf_catalog",
+      "zam_okf_read",
+      "zam_okf_read_citation",
+      "zam_companion_context",
+    ]),
   },
   settings: {
     title: "ZAM Settings",
@@ -165,12 +175,16 @@ export function buildOpeningArguments(
   app: CompanionApp,
   input: Record<string, string>,
 ): Record<string, string> {
+  // `okf` deliberately omits `user`: `zam_okf_visualize` is repo-scoped and
+  // its input schema has no user parameter (unlike the learner-scoped apps).
   const allowed =
     app === "recall"
       ? ["user", "domain"]
       : app === "graph"
         ? ["user", "focus"]
-        : ["user"];
+        : app === "okf"
+          ? ["bundle_dir"]
+          : ["user"];
   return Object.fromEntries(
     allowed.flatMap((key) =>
       typeof input[key] === "string" ? [[key, input[key]]] : [],

--- a/src/vscode-extension/vscode.d.ts
+++ b/src/vscode-extension/vscode.d.ts
@@ -104,6 +104,12 @@ declare module "vscode" {
     appName: string;
   };
 
+  export const workspace: {
+    readonly workspaceFolders:
+      | readonly { readonly uri: { readonly fsPath: string } }[]
+      | undefined;
+  };
+
   export const lm: {
     selectChatModels(
       selector?: Record<string, string>,

--- a/tests/cli/vscode-companion-protocol.test.ts
+++ b/tests/cli/vscode-companion-protocol.test.ts
@@ -1,4 +1,11 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  type UiIntentApp,
+  writeUiIntent,
+} from "../../src/cli/ui-intent.js";
 import {
   buildOpeningArguments,
   COMPANION_APPS,
@@ -76,6 +83,40 @@ describe("VS Code companion protocol", () => {
       expect(app.allowedTools.has("zam_companion_context")).toBe(true);
     }
     expect(COMPANION_APPS).not.toHaveProperty("studio");
+  });
+
+  it("proxies the OKF knowledge-base panel with repo-scoped arguments", () => {
+    // `zam_okf_visualize` has no `user` parameter — forwarding one would
+    // violate the tool's input schema (0.13.0 live finding).
+    expect(
+      buildOpeningArguments("okf", {
+        user: "thomas",
+        bundle_dir: "C:/src/dw/Cops.AI/docs/okf",
+        focus: "ignore-me",
+      }),
+    ).toEqual({ bundle_dir: "C:/src/dw/Cops.AI/docs/okf" });
+    expect(COMPANION_APPS.okf.toolName).toBe("zam_okf_visualize");
+  });
+
+  // Regression guard for the 0.13.0 gap: `zam_okf_visualize` published a UI
+  // intent the extension's parser rejected, because `CompanionApp` lagged
+  // behind `UiIntentApp`. Every intent the server can publish must be one
+  // the Companion can consume — tested through the real producer.
+  it("consumes every intent the ui-intent producer can publish", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "zam-ui-intent-"));
+    try {
+      const apps: UiIntentApp[] = ["recall", "graph", "settings", "okf"];
+      for (const app of apps) {
+        const path = join(dir, `${app}.json`);
+        await writeUiIntent(app, { bundle_dir: "docs/okf" }, { path });
+        const parsed = parseCompanionIntent(
+          JSON.parse(await readFile(path, "utf8")),
+        );
+        expect(parsed?.app).toBe(app);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("accepts current and legacy MCP Apps resource metadata", () => {

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -8,6 +8,7 @@ import {
   groupCatalog,
   layoutGraph,
   renderMarkdown,
+  stripFrontmatter,
 } from "../../desktop/src/panel/okf-render.js";
 
 // Collects every href="..." attribute value from rendered HTML, with ASCII
@@ -129,6 +130,24 @@ describe("renderMarkdown", () => {
     expect(html).toBe(
       "<table><thead><tr><th>A</th><th>B</th></tr></thead>" +
         "<tbody><tr><td>x|y</td><td>2</td></tr></tbody></table>",
+    );
+  });
+
+  it("keeps a wrapped list item's continuation lines inside its <li>", () => {
+    const source = [
+      "- **JSON only.** Every bridge response is JSON — all",
+      "  output goes through the helpers.",
+      "- Second item.",
+    ].join("\n");
+    expect(renderMarkdown(source)).toBe(
+      "<ul><li><strong>JSON only.</strong> Every bridge response is JSON — all output goes through the helpers.</li>" +
+        "<li>Second item.</li></ul>",
+    );
+  });
+
+  it("renders a thematic break instead of a literal dash paragraph", () => {
+    expect(renderMarkdown("above\n\n---\n\nbelow")).toBe(
+      "<p>above</p>\n<hr>\n<p>below</p>",
     );
   });
 
@@ -340,6 +359,35 @@ describe("extractLinks", () => {
   });
 });
 
+describe("stripFrontmatter", () => {
+  it("drops a leading frontmatter fence so the reader never renders it", () => {
+    const source = [
+      "---",
+      "type: reference",
+      "title: cops Output Contract",
+      "tags:",
+      "  - cli",
+      "---",
+      "",
+      "# cops Output Contract",
+      "Body text.",
+    ].join("\n");
+    expect(stripFrontmatter(source)).toBe(
+      "\n# cops Output Contract\nBody text.",
+    );
+  });
+
+  it("returns a source without frontmatter unchanged", () => {
+    const source = "# Title\n\nBody.";
+    expect(stripFrontmatter(source)).toBe(source);
+  });
+
+  it("treats an unterminated fence as content, not frontmatter", () => {
+    const source = "---\ntype: reference\nno closing fence";
+    expect(stripFrontmatter(source)).toBe(source);
+  });
+});
+
 describe("layoutGraph", () => {
   const nodes: GraphNode[] = [
     { id: "b.md", kind: "article", type: "guide", file: "b.md" },
@@ -353,25 +401,51 @@ describe("layoutGraph", () => {
   ];
   const edges: GraphEdge[] = [{ from: "a.md", to: "../adr/x.md" }];
 
-  it("orders articles by (type, file) and places citations further out", () => {
-    const positioned = layoutGraph(nodes, edges, 200, 200);
+  it("orders articles by (type, file) and places citations on the outer ring", () => {
+    const width = 960;
+    const height = 620;
+    const positioned = layoutGraph(nodes, edges, width, height);
     const articles = positioned.filter((n) => n.kind === "article");
     const citations = positioned.filter((n) => n.kind === "citation");
 
     expect(articles.map((n) => n.id)).toEqual(["a.md", "c.md", "b.md"]);
     expect(citations.map((n) => n.id)).toEqual(["../adr/x.md"]);
 
-    const centerX = 100;
-    const centerY = 100;
-    const distance = (n: { x: number; y: number }) =>
-      Math.hypot(n.x - centerX, n.y - centerY);
-
-    const articleRadius = distance(articles[0]);
-    for (const node of articles) {
-      expect(distance(node)).toBeCloseTo(articleRadius, 5);
+    // Aspect-normalized radial distance: citations sit on a strictly
+    // larger ellipse than every article, whatever the canvas aspect.
+    const radial = (n: { x: number; y: number }) =>
+      Math.hypot((n.x - width / 2) / width, (n.y - height / 2) / height);
+    for (const article of articles) {
+      expect(radial(citations[0])).toBeGreaterThan(radial(article));
     }
-    const citationRadius = distance(citations[0]);
-    expect(citationRadius).toBeGreaterThan(articleRadius);
+  });
+
+  it("keeps every node inside the label margins", () => {
+    const width = 960;
+    const height = 620;
+    for (const node of layoutGraph(nodes, edges, width, height)) {
+      expect(node.x).toBeGreaterThanOrEqual(width * 0.1);
+      expect(node.x).toBeLessThanOrEqual(width * 0.9);
+      expect(node.y).toBeGreaterThanOrEqual(height * 0.05);
+      expect(node.y).toBeLessThanOrEqual(height * 0.95);
+    }
+  });
+
+  it("places a citation next to its citing article, not at an alphabetical slot", () => {
+    const width = 960;
+    const height = 620;
+    const positioned = layoutGraph(nodes, edges, width, height);
+    const citer = positioned.find((n) => n.id === "a.md");
+    const citation = positioned.find((n) => n.id === "../adr/x.md");
+    if (!citer || !citation) throw new Error("nodes missing from layout");
+
+    // Same direction from the center: the angle between the citing
+    // article's and the citation's position vectors is small.
+    const angleOf = (n: { x: number; y: number }) =>
+      Math.atan2((n.y - height / 2) / height, (n.x - width / 2) / width);
+    const diff = Math.abs(angleOf(citer) - angleOf(citation));
+    const wrapped = Math.min(diff, 2 * Math.PI - diff);
+    expect(wrapped).toBeLessThan(0.4);
   });
 
   it("is deterministic across repeated calls with fresh input arrays", () => {


### PR DESCRIPTION
## Problem

0.13.0 shipped the OKF visualizer as an MCP-Apps-only surface. `zam_okf_visualize` dutifully published an `okf` UI intent, but the VS Code Companion's `CompanionApp` union predated it — `parseCompanionIntent` silently dropped the intent, `COMPANION_APPS` had no entry, and the sidebar showed only Recall/Graph/Settings. The Copilot extension's `APP_CONFIG` had the same gap. A dead producer→consumer seam that unit tests on either side couldn't see.

## Fix

- `okf` added to `CompanionApp` + `COMPANION_APPS` (tools: catalog/read/read_citation + companion context) and to the Copilot `APP_CONFIG` + a `zam-knowledge` canvas
- New `zam.showOkf` command; defaults `bundle_dir` to the workspace's `docs/okf` (the Companion's server cwd is not the workspace)
- View title bar: slot 2 is now a toggle — **Knowledge Base** by default, flips to **Learning Graph** while the OKF panel is open (`zam.companionApp` context key); Graph stays in the command palette
- `zam_okf_visualize` now publishes the **resolved absolute** bundle dir in the intent, so the Companion opens the same bundle the chat host displayed (live finding: raw relative default resolved against the wrong cwd → empty bundle)
- Contract test: every app `writeUiIntent` can publish must parse via `parseCompanionIntent` — pins `UiIntentApp`/`CompanionApp` in sync so this class of gap fails CI

## Verification

- Protocol tests 8/8; typecheck + lint clean; full suite: only the 4 known environmental failures (identical on main, isolated-HOME confirmed)
- **Live end-to-end** in a real VS Code instance (isolated profile, dev VSIX): published the intent via the production `publishUiIntent` path → extension log `opened okf via ui://zam/okf` within ~1s → screenshot shows the panel rendering the zam bundle (6 articles, link graph incl. ADR citation nodes); `bundle_dir` pass-through verified with a second intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)