### PR TITLE
feat: knowledge-to-learning import — OKF articles become learning tokens (ADR 2026-07-18)

### DIFF
--- a/.agent/skills/okf/SKILL.md
+++ b/.agent/skills/okf/SKILL.md
@@ -59,3 +59,30 @@ prerequisite blocking, the bridge protocol, or MCP surfaces.
 When creating ZAM tokens about this repo (e.g. via `zam_add_token`), set
 the token's `source_link` to the article's `resource` URL. The article —
 not the chat — is the durable source a learner returns to.
+
+## Importing an article as learning content (ADR 2026-07-18)
+
+When the user wants to LEARN an article ("import this as learning
+content", the visualizer's import button, or any request that ends in
+`zam_okf_import`), **you do the decomposition** — it is a judgment task,
+never mechanical:
+
+1. Read the FULL article (`zam_okf_read`) before proposing anything.
+2. Extract the concepts a practitioner must produce **from memory** —
+   recall-speed knowledge. Facts one would reasonably look up stay in the
+   article; do not tokenize structure (headings are not concepts).
+3. One atomic concept per token; judge a Bloom level (1–5) and a domain
+   per token, reusing existing domains where they fit.
+4. Arrange a prerequisite DAG from foundational to dependent.
+5. Check existing tokens first (`zam_find_tokens`); link them as
+   prerequisites instead of duplicating them.
+6. Record once, atomically, with `zam_okf_import` — every token gets a
+   card for the importing user, and each token's `source_link` anchors
+   back into the article. Multiple tokens are the expected outcome for a
+   real article; a single token usually means under-decomposition.
+
+Re-import after the article changed: classify each token — `new` (add),
+`update` (content refreshed, learning state kept), `replace` (the concept
+changed, learning state resets to the beginning). Previously imported
+tokens you do not confirm move to maintenance (kept, unscheduled,
+awaiting repair) — never deleted.

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -62,3 +62,30 @@ prerequisite blocking, the bridge protocol, or MCP surfaces.
 When creating ZAM tokens about this repo (e.g. via `zam_add_token`), set
 the token's `source_link` to the article's `resource` URL. The article —
 not the chat — is the durable source a learner returns to.
+
+## Importing an article as learning content (ADR 2026-07-18)
+
+When the user wants to LEARN an article ("import this as learning
+content", the visualizer's import button, or any request that ends in
+`zam_okf_import`), **you do the decomposition** — it is a judgment task,
+never mechanical:
+
+1. Read the FULL article (`zam_okf_read`) before proposing anything.
+2. Extract the concepts a practitioner must produce **from memory** —
+   recall-speed knowledge. Facts one would reasonably look up stay in the
+   article; do not tokenize structure (headings are not concepts).
+3. One atomic concept per token; judge a Bloom level (1–5) and a domain
+   per token, reusing existing domains where they fit.
+4. Arrange a prerequisite DAG from foundational to dependent.
+5. Check existing tokens first (`zam_find_tokens`); link them as
+   prerequisites instead of duplicating them.
+6. Record once, atomically, with `zam_okf_import` — every token gets a
+   card for the importing user, and each token's `source_link` anchors
+   back into the article. Multiple tokens are the expected outcome for a
+   real article; a single token usually means under-decomposition.
+
+Re-import after the article changed: classify each token — `new` (add),
+`update` (content refreshed, learning state kept), `replace` (the concept
+changed, learning state resets to the beginning). Previously imported
+tokens you do not confirm move to maintenance (kept, unscheduled,
+awaiting repair) — never deleted.

--- a/.claude/skills/okf/SKILL.md
+++ b/.claude/skills/okf/SKILL.md
@@ -59,3 +59,30 @@ prerequisite blocking, the bridge protocol, or MCP surfaces.
 When creating ZAM tokens about this repo (e.g. via `zam_add_token`), set
 the token's `source_link` to the article's `resource` URL. The article —
 not the chat — is the durable source a learner returns to.
+
+## Importing an article as learning content (ADR 2026-07-18)
+
+When the user wants to LEARN an article ("import this as learning
+content", the visualizer's import button, or any request that ends in
+`zam_okf_import`), **you do the decomposition** — it is a judgment task,
+never mechanical:
+
+1. Read the FULL article (`zam_okf_read`) before proposing anything.
+2. Extract the concepts a practitioner must produce **from memory** —
+   recall-speed knowledge. Facts one would reasonably look up stay in the
+   article; do not tokenize structure (headings are not concepts).
+3. One atomic concept per token; judge a Bloom level (1–5) and a domain
+   per token, reusing existing domains where they fit.
+4. Arrange a prerequisite DAG from foundational to dependent.
+5. Check existing tokens first (`zam_find_tokens`); link them as
+   prerequisites instead of duplicating them.
+6. Record once, atomically, with `zam_okf_import` — every token gets a
+   card for the importing user, and each token's `source_link` anchors
+   back into the article. Multiple tokens are the expected outcome for a
+   real article; a single token usually means under-decomposition.
+
+Re-import after the article changed: classify each token — `new` (add),
+`update` (content refreshed, learning state kept), `replace` (the concept
+changed, learning state resets to the beginning). Previously imported
+tokens you do not confirm move to maintenance (kept, unscheduled,
+awaiting repair) — never deleted.

--- a/desktop/src/panel/okf-panel.html
+++ b/desktop/src/panel/okf-panel.html
@@ -530,6 +530,47 @@
         font-size: 12px;
         min-height: 1em;
       }
+
+      /* ── Knowledge → learning import action ─────────────────────────── */
+      .okf-import-action {
+        margin: 6px 0 10px;
+      }
+      .okf-import-btn {
+        padding: 5px 12px;
+        border: 1px solid var(--accent);
+        border-radius: 6px;
+        background: transparent;
+        color: var(--accent);
+        cursor: pointer;
+        font-size: 12px;
+      }
+      .okf-import-btn:hover {
+        background: var(--accent);
+        color: #fff;
+      }
+      .okf-import-btn:disabled {
+        opacity: 0.6;
+        cursor: default;
+      }
+      .okf-import-hint {
+        margin-top: 6px;
+        font-size: 12px;
+        color: var(--fg-muted, var(--fg));
+      }
+      .okf-import-fallback {
+        display: block;
+        width: 100%;
+        margin-top: 6px;
+        min-height: 84px;
+        padding: 6px 8px;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: var(--card);
+        color: var(--fg);
+        font-family: var(--mono, monospace);
+        font-size: 11px;
+        resize: vertical;
+      }
       .okf-empty-emoji {
         font-size: 2rem;
       }

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -518,6 +518,71 @@ function buildMetaStrip(entry: CatalogEntry | undefined): HTMLElement {
   return strip;
 }
 
+/**
+ * The agent-facing decomposition request (ADR 2026-07-18 Decision 5). The
+ * jump from knowledge to learning goes THROUGH the conversation: the agent
+ * must understand the article before anything is recorded — the panel
+ * never calls zam_okf_import itself.
+ */
+function importInstruction(file: string): string {
+  const dir = bundleDir ? ` (bundle: ${bundleDir})` : "";
+  return (
+    `Import the OKF article "${file}"${dir} as learning content: read the ` +
+    "full article with zam_okf_read, extract the concepts I must be able " +
+    "to produce from memory (look-up facts stay in the article), judge a " +
+    "Bloom level and a domain per concept, arrange them in prerequisite " +
+    "order, check for existing tokens with zam_find_tokens, then record " +
+    "your decomposition with zam_okf_import."
+  );
+}
+
+function buildImportAction(file: string): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.className = "okf-import-action";
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "okf-import-btn";
+  btn.textContent = "Als Lerninhalt importieren";
+  const hint = document.createElement("div");
+  hint.className = "okf-import-hint";
+
+  btn.addEventListener("click", () => {
+    void (async () => {
+      btn.disabled = true;
+      hint.replaceChildren();
+      try {
+        const result = await app.sendMessage({
+          role: "user",
+          content: [{ type: "text", text: importInstruction(file) }],
+        });
+        if (result.isError) {
+          throw new Error("host rejected the message");
+        }
+        hint.textContent =
+          "An den Agenten übergeben — die Zerlegung läuft im Chat.";
+      } catch {
+        // Hosts without a conversation surface (e.g. the Companion
+        // sidebar) reject sendMessage: show the instruction to hand to
+        // the agent manually instead.
+        const note = document.createElement("div");
+        note.textContent =
+          "Dieser Host hat keinen Chat — gib deinem Agenten diese Anweisung:";
+        const copyable = document.createElement("textarea");
+        copyable.readOnly = true;
+        copyable.className = "okf-import-fallback";
+        copyable.value = importInstruction(file);
+        copyable.addEventListener("focus", () => copyable.select());
+        hint.append(note, copyable);
+      } finally {
+        btn.disabled = false;
+      }
+    })();
+  });
+
+  wrap.append(btn, hint);
+  return wrap;
+}
+
 function renderReaderBody(container: HTMLElement): void {
   if (citationView) {
     renderCitationFullView(container, citationView);
@@ -544,6 +609,7 @@ function renderReaderBody(container: HTMLElement): void {
   }
   container.replaceChildren();
   container.appendChild(buildMetaStrip(catalog.find((e) => e.file === currentFile)));
+  container.appendChild(buildImportAction(currentFile));
   const bodyEl = document.createElement("div");
   bodyEl.className = "okf-article-body zam-card";
   // The meta strip above renders the frontmatter; rendering the raw fence

--- a/docs/adr/2026-07-18-okf-learning-import.md
+++ b/docs/adr/2026-07-18-okf-learning-import.md
@@ -1,6 +1,6 @@
 # Knowledge-to-Learning Import (OKF Articles → Learning Tokens)
 
-**Status:** Proposed
+**Status:** Implemented
 **Date:** 2026-07-18
 **Deciders:** Thomas (project owner), designed with Fable 5
 **Related:**

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,4 +49,4 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-16b](2026-07-16b-in-recall-card-management.md) | In-Recall Card Management: Stop, Fix, and Remove | Implemented |
 | [2026-07-17](2026-07-17-okf-knowledge-base.md) | OKF Knowledge Base — Living Repo Knowledge as Learning Sources | Implemented |
 | [2026-07-17b](2026-07-17b-okf-visualizer-panel.md) | OKF Visualizer Panel (MCP App) | Implemented |
-| [2026-07-18](2026-07-18-okf-learning-import.md) | Knowledge-to-Learning Import (OKF Articles → Learning Tokens) | Proposed |
+| [2026-07-18](2026-07-18-okf-learning-import.md) | Knowledge-to-Learning Import (OKF Articles → Learning Tokens) | Implemented |

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-07-18
+
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+
 ## 2026-07-17
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-07-17T15:00:00Z
+timestamp: 2026-07-18
 ---
 
 `zam mcp` starts a stdio **Model Context Protocol** server
@@ -24,8 +24,8 @@ The server exposes ZAM's tool surface (session start/end, queue and
 review actions, token search and registration, prerequisite linking,
 companion context and sampling, and the OKF knowledge-base tools
 `zam_okf_catalog` / `zam_okf_read` / `zam_okf_upsert` /
-`zam_okf_read_citation`). The authoritative tool list with annotations
-is pinned by `tests/cli/mcp.test.ts`.
+`zam_okf_read_citation` / `zam_okf_import`). The authoritative tool list
+with annotations is pinned by `tests/cli/mcp.test.ts`.
 
 `zam_okf_catalog` accepts an optional `include_log` flag that adds the
 raw `log.md` text to the result (empty string if the bundle has none
@@ -34,6 +34,17 @@ to — an ADR, for example — read-only and restricted to `.md` files that
 resolve inside the repository root; the target may be outside the
 bundle (that's its purpose) but never outside the repo
 (`resolveCitationPath` / `findRepoRoot` in `src/cli/okf/io.ts`).
+
+`zam_okf_import` records an agent's finished decomposition of one
+article as learning tokens plus cards for the importing user, in one
+transaction. The agent judges (concepts worth remembering, Bloom level
+and domain per token, prerequisite order); the tool only validates and
+writes. Re-imports are classified per token: `new` adds, `update`
+refreshes content and keeps learning state, `replace` refreshes content
+and resets learning state to the beginning; previously imported tokens
+absent from a re-import move to token maintenance (kept, excluded from
+scheduling) instead of being deleted. Also available as
+`zam bridge okf-import`.
 
 # MCP Apps panels
 
@@ -52,7 +63,12 @@ reader that expands cited ADRs and other citation targets inline via
 `zam_okf_read_citation`, a link graph (articles as nodes, inter-article
 links as edges, citations as visually distinct nodes), and the
 `log.md` history. The panel always opens — a missing or invalid bundle
-surfaces as `problems` in the panel instead of a tool error.
+surfaces as `problems` in the panel instead of a tool error. The
+article reader's "import as learning content" action posts the
+decomposition request into the host conversation (MCP Apps
+`sendMessage`) — the agent does the thinking, then records via
+`zam_okf_import`; hosts without a conversation surface get the
+instruction as copyable text instead.
 
 # Citations
 
@@ -60,4 +76,5 @@ surfaces as `problems` in the panel instead of a tool error.
 - [ADR 2026-07-16 — Companion Context Bar and Harness Affinity](../adr/2026-07-16-companion-context-and-harness-affinity.md)
 - [ADR 2026-07-17 — OKF Knowledge Base](../adr/2026-07-17-okf-knowledge-base.md)
 - [ADR 2026-07-17b — OKF Visualizer Panel](../adr/2026-07-17b-okf-visualizer-panel.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`
+- [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/bridge-handlers.ts` (importOkfTokens)

--- a/docs/plans/2026-07-18-okf-learning-import-plan.md
+++ b/docs/plans/2026-07-18-okf-learning-import-plan.md
@@ -1,0 +1,73 @@
+# OKF Learning Import — Scope Checklist
+
+Working plan for [ADR 2026-07-18](../adr/2026-07-18-okf-learning-import.md)
+(deleted once shipped, per plans lifecycle). Lean checklist: every box is
+verified against the shipped branch in the final check.
+
+## Kernel (AI-agnostic)
+
+- [ ] `tokens.maintenance_at` / `tokens.maintenance_reason` columns
+      (schema.ts + idempotent migration M014)
+- [ ] `Token` interface + row mapping carry the new fields
+- [ ] `setTokenMaintenance(db, tokenId, reason)` /
+      `clearTokenMaintenance(db, tokenId)`
+- [ ] Review queue excludes tokens in maintenance (both legs of
+      `buildReviewQueue`, plus `getDueCards`)
+- [ ] `resetCardsForToken(db, tokenId)` — learning state back to the
+      beginning for all users' cards of a token (stability, difficulty,
+      elapsed/scheduled, reps, lapses, state='new', due now, last review
+      cleared); `blocked` untouched (prereq-derived)
+- [ ] Kernel exports via `src/kernel/index.ts`
+- [ ] Kernel tests: maintenance set/clear + queue exclusion + reset
+      semantics
+
+## CLI import operation
+
+- [ ] `importOkfTokens(db, params)` in bridge-handlers: transactional;
+      resolves the article (bundle dir + file → frontmatter `resource`
+      as source_link base, `#anchor` per token); per-token mode
+      `new | update | replace`; `new` collision → instructive error;
+      `update` keeps learning state; `replace` updates + resets cards;
+      previously-imported tokens of the article absent from the call →
+      maintenance (reason names the re-import); prerequisites resolve
+      in-import names first, then existing token slugs (cycle detection
+      via kernel); cards created for the importing user; ≥1 token
+      accepted (no minimum-two gate)
+- [ ] Best-effort embeddings refresh after import (mirrors add-token)
+- [ ] `zam bridge okf-import` command (JSON payload)
+- [ ] `zam_okf_import` MCP tool with the quality contract in its
+      description; registered alongside the other okf tools
+- [ ] Handler tests: create (tokens+cards+prereqs+source_links),
+      update-keeps-state, replace-resets-state, absent→maintenance,
+      new-collision error, prereq-to-existing-token, cycle rejection,
+      single-token accepted
+
+## Panel
+
+- [ ] Article reader action "Import as learning content" →
+      `app.sendMessage` with the decomposition request (mirrors
+      recall.ts's existing sendMessage usage)
+- [ ] Rejected/failed sendMessage → copyable instruction fallback shown
+      in the panel
+
+## Skill & docs (same-PR rule)
+
+- [ ] okf skill (`.claude/.agent/.agents` triplet): quality-contract
+      section (read full article; recall-speed concepts only; judged
+      Bloom per token; judged domain reusing existing; prerequisite DAG;
+      dedup via zam_find_tokens; re-import classification
+      new/update/replace/maintenance)
+- [ ] `docs/okf/mcp-surfaces.md` documents `zam_okf_import` (guarded
+      upsert path)
+- [ ] ADR 2026-07-18 status → Implemented (+ README index)
+
+## Final check (prove nothing slipped)
+
+- [ ] Every box above verified against the branch diff
+- [ ] Full test suite: no new failures vs. the known environmental
+      baseline
+- [ ] Root + desktop typechecks, lint, build
+- [ ] E2E with isolated DB (USERPROFILE/HOME temp): real
+      `zam bridge okf-import` against a fixture bundle — tokens, cards,
+      prereqs, re-import lifecycle observed via bridge reads
+- [ ] Panel action verified in the real host (dev server + Companion)

--- a/docs/plans/2026-07-18-okf-learning-import-plan.md
+++ b/docs/plans/2026-07-18-okf-learning-import-plan.md
@@ -6,24 +6,24 @@ verified against the shipped branch in the final check.
 
 ## Kernel (AI-agnostic)
 
-- [ ] `tokens.maintenance_at` / `tokens.maintenance_reason` columns
+- [x] `tokens.maintenance_at` / `tokens.maintenance_reason` columns
       (schema.ts + idempotent migration M014)
-- [ ] `Token` interface + row mapping carry the new fields
-- [ ] `setTokenMaintenance(db, tokenId, reason)` /
+- [x] `Token` interface + row mapping carry the new fields
+- [x] `setTokenMaintenance(db, tokenId, reason)` /
       `clearTokenMaintenance(db, tokenId)`
-- [ ] Review queue excludes tokens in maintenance (both legs of
+- [x] Review queue excludes tokens in maintenance (both legs of
       `buildReviewQueue`, plus `getDueCards`)
-- [ ] `resetCardsForToken(db, tokenId)` — learning state back to the
+- [x] `resetCardsForToken(db, tokenId)` — learning state back to the
       beginning for all users' cards of a token (stability, difficulty,
       elapsed/scheduled, reps, lapses, state='new', due now, last review
       cleared); `blocked` untouched (prereq-derived)
-- [ ] Kernel exports via `src/kernel/index.ts`
-- [ ] Kernel tests: maintenance set/clear + queue exclusion + reset
+- [x] Kernel exports via `src/kernel/index.ts`
+- [x] Kernel tests: maintenance set/clear + queue exclusion + reset
       semantics
 
 ## CLI import operation
 
-- [ ] `importOkfTokens(db, params)` in bridge-handlers: transactional;
+- [x] `importOkfTokens(db, params)` in bridge-handlers: transactional;
       resolves the article (bundle dir + file → frontmatter `resource`
       as source_link base, `#anchor` per token); per-token mode
       `new | update | replace`; `new` collision → instructive error;
@@ -33,41 +33,56 @@ verified against the shipped branch in the final check.
       in-import names first, then existing token slugs (cycle detection
       via kernel); cards created for the importing user; ≥1 token
       accepted (no minimum-two gate)
-- [ ] Best-effort embeddings refresh after import (mirrors add-token)
-- [ ] `zam bridge okf-import` command (JSON payload)
-- [ ] `zam_okf_import` MCP tool with the quality contract in its
+- [x] Best-effort embeddings refresh after import (mirrors add-token)
+- [x] `zam bridge okf-import` command (JSON payload)
+- [x] `zam_okf_import` MCP tool with the quality contract in its
       description; registered alongside the other okf tools
-- [ ] Handler tests: create (tokens+cards+prereqs+source_links),
+- [x] Handler tests: create (tokens+cards+prereqs+source_links),
       update-keeps-state, replace-resets-state, absent→maintenance,
       new-collision error, prereq-to-existing-token, cycle rejection,
       single-token accepted
 
 ## Panel
 
-- [ ] Article reader action "Import as learning content" →
+- [x] Article reader action "Import as learning content" →
       `app.sendMessage` with the decomposition request (mirrors
       recall.ts's existing sendMessage usage)
-- [ ] Rejected/failed sendMessage → copyable instruction fallback shown
+- [x] Rejected/failed sendMessage → copyable instruction fallback shown
       in the panel
 
 ## Skill & docs (same-PR rule)
 
-- [ ] okf skill (`.claude/.agent/.agents` triplet): quality-contract
+- [x] okf skill (`.claude/.agent/.agents` triplet): quality-contract
       section (read full article; recall-speed concepts only; judged
       Bloom per token; judged domain reusing existing; prerequisite DAG;
       dedup via zam_find_tokens; re-import classification
       new/update/replace/maintenance)
-- [ ] `docs/okf/mcp-surfaces.md` documents `zam_okf_import` (guarded
+- [x] `docs/okf/mcp-surfaces.md` documents `zam_okf_import` (guarded
       upsert path)
-- [ ] ADR 2026-07-18 status → Implemented (+ README index)
+- [x] ADR 2026-07-18 status → Implemented (+ README index)
 
 ## Final check (prove nothing slipped)
 
-- [ ] Every box above verified against the branch diff
-- [ ] Full test suite: no new failures vs. the known environmental
+- [x] Every box above verified against the branch diff
+- [x] Full test suite: no new failures vs. the known environmental
       baseline
-- [ ] Root + desktop typechecks, lint, build
-- [ ] E2E with isolated DB (USERPROFILE/HOME temp): real
+- [x] Root + desktop typechecks, lint, build
+- [x] E2E with isolated DB (USERPROFILE/HOME temp): real
       `zam bridge okf-import` against a fixture bundle — tokens, cards,
       prereqs, re-import lifecycle observed via bridge reads
-- [ ] Panel action verified in the real host (dev server + Companion)
+- [x] Panel action verified in the real host (dev server + Companion)
+
+## Final check record (2026-07-18)
+
+Verified against branch `feat/okf-learning-import` (5 commits, 22 files):
+kernel tests 6/6, import handler tests 10/10, MCP tool-count test updated
+to 24; full suite 1094 passed with only the 4 known environmental
+failures (identical set on main); root + desktop typechecks, lint, and
+build green. Isolated-DB e2e via the real CLI observed the full
+lifecycle: import → 2 due cards; re-import (replace + one unconfirmed) →
+learning state reset to `new`, unconfirmed token in maintenance and
+excluded from the due queue (dueCount 2 → 1). Panel: the new build's
+Companion consumed the okf intent and mounted the panel with the import
+action (extension log); the button click-through (fallback textarea in
+the chat-less Companion) remains for a human pass — the machine locked
+mid-verification.

--- a/src/cli/bridge-handlers.ts
+++ b/src/cli/bridge-handlers.ts
@@ -19,6 +19,7 @@ import {
   analyzeObservation,
   assignTokenToContext,
   buildReviewQueue,
+  clearTokenMaintenance,
   createToken,
   decideUpdate,
   ensureCard,
@@ -38,6 +39,7 @@ import {
   getTokenById,
   getTokenBySlug,
   getTokenDeleteImpact,
+  getTokensBySourceLinkBase,
   getUserStats,
   isObserverPolicyConfigured,
   endSession as kernelEndSession,
@@ -49,9 +51,12 @@ import {
   pairCommands,
   prepareSessionSynthesis,
   readMonitorLog,
+  resetCardsForToken,
   resolveReviewContext,
   searchTokensHybrid,
+  setTokenMaintenance,
   updateCard,
+  updateToken,
   verifySnapshot,
 } from "../kernel/index.js";
 import { resolveOperationKnowledgeContexts } from "./knowledge-contexts.js";
@@ -697,6 +702,232 @@ export async function addToken(db: Database, params: AddTokenParams) {
       blocked: card.blocked,
     },
     possible_duplicates: possibleDuplicates,
+  };
+}
+
+// 6b. importOkfTokens (ADR 2026-07-18)
+
+export interface ImportOkfTokenInput {
+  slug: string;
+  title?: string;
+  concept: string;
+  bloomLevel?: number;
+  domain?: string;
+  /** Heading anchor within the article; appended to the source link. */
+  anchor?: string;
+  /** In-import slugs and/or existing token slugs. */
+  prerequisites?: string[];
+  knowledgeContexts?: string[];
+  question?: string | null;
+  /** Re-import classification (ADR 2026-07-18 Decision 4). Default "new". */
+  mode?: "new" | "update" | "replace";
+}
+
+export interface ImportOkfParams {
+  user?: string;
+  bundleDir?: string;
+  file: string;
+  tokens: ImportOkfTokenInput[];
+}
+
+/**
+ * Record an agent's finished decomposition of one OKF article as learning
+ * tokens (ADR 2026-07-18). The agent judges; this handler only validates
+ * and writes — atomically. Per token `mode`:
+ * - "new" (default): create; an existing slug is an instructive error.
+ * - "update": refresh content, keep every user's learning state.
+ * - "replace": concept changed — refresh content and reset all cards to
+ *   the beginning.
+ * Tokens previously imported from this article but absent from the call
+ * are moved to maintenance (kept, unscheduled, awaiting repair).
+ */
+export async function importOkfTokens(db: Database, params: ImportOkfParams) {
+  const userId = await resolveHandlerUser(db, params.user);
+  if (!params.file?.trim()) throw new Error("file must be non-empty");
+  if (!Array.isArray(params.tokens) || params.tokens.length === 0) {
+    throw new Error("tokens must be a non-empty array");
+  }
+  const seen = new Set<string>();
+  for (const input of params.tokens) {
+    const slug = input.slug?.trim();
+    if (!slug || !input.concept?.trim()) {
+      throw new Error("every token needs a non-empty slug and concept");
+    }
+    if (seen.has(slug)) throw new Error(`duplicate token slug: ${slug}`);
+    seen.add(slug);
+    if (
+      input.bloomLevel !== undefined &&
+      (!Number.isInteger(input.bloomLevel) ||
+        input.bloomLevel < 1 ||
+        input.bloomLevel > 5)
+    ) {
+      throw new Error(`bloomLevel must be 1-5 (token: ${slug})`);
+    }
+  }
+
+  // Resolve the article and its canonical source link. The frontmatter
+  // `resource` URL is the durable anchor tokens carry as source_link; a
+  // bundle without one falls back to the resolved article path.
+  const { DEFAULT_BUNDLE_DIR, resolveArticlePath } = await import(
+    "./okf/io.js"
+  );
+  const { parseFrontmatter } = await import("./okf/bundle.js");
+  const { readFileSync } = await import("node:fs");
+  const bundleDir = params.bundleDir ?? DEFAULT_BUNDLE_DIR;
+  const articlePath = resolveArticlePath(bundleDir, params.file);
+  let markdown: string;
+  try {
+    markdown = readFileSync(articlePath, "utf8");
+  } catch {
+    throw new Error(`Article not found: ${articlePath}`);
+  }
+  let resource: string | undefined;
+  try {
+    const { fields } = parseFrontmatter(markdown);
+    resource =
+      typeof fields.resource === "string" ? fields.resource : undefined;
+  } catch {
+    resource = undefined;
+  }
+  const sourceBase = resource ?? articlePath;
+  const sourceLinkFor = (anchor?: string): string =>
+    anchor?.trim() ? `${sourceBase}#${anchor.trim()}` : sourceBase;
+
+  const created: string[] = [];
+  const updated: string[] = [];
+  const replaced: string[] = [];
+  const maintenance: string[] = [];
+  let cardsEnsured = 0;
+
+  await db.transaction(async (tx) => {
+    const inImport = new Map<string, Token>();
+
+    for (const input of params.tokens) {
+      const mode = input.mode ?? "new";
+      const existing = await getTokenBySlug(tx, input.slug);
+
+      if (mode === "new") {
+        if (existing) {
+          throw new Error(
+            `Token '${input.slug}' already exists. Use mode "update" to refresh it ` +
+              `(keeps learning state), "replace" if the concept changed ` +
+              `(resets learning state), or choose a different slug.`,
+          );
+        }
+        const token = await createToken(tx, {
+          slug: input.slug,
+          title: input.title,
+          concept: input.concept,
+          domain: input.domain,
+          bloom_level: (input.bloomLevel ?? 1) as BloomLevel,
+          source_link: sourceLinkFor(input.anchor),
+          question: input.question ?? null,
+          question_source: input.question ? "llm" : undefined,
+        });
+        inImport.set(input.slug, token);
+        created.push(input.slug);
+      } else {
+        if (!existing) {
+          throw new Error(
+            `Token '${input.slug}' does not exist — mode "${mode}" requires an existing token.`,
+          );
+        }
+        const updates: UpdateTokenInput = {
+          concept: input.concept,
+          source_link: sourceLinkFor(input.anchor),
+        };
+        if (input.title !== undefined) updates.title = input.title;
+        if (input.domain !== undefined) updates.domain = input.domain;
+        if (input.bloomLevel !== undefined) {
+          updates.bloom_level = input.bloomLevel as BloomLevel;
+        }
+        if (input.question !== undefined) {
+          updates.question = input.question;
+          updates.question_source = input.question ? "llm" : undefined;
+        }
+        const token = await updateToken(tx, input.slug, updates);
+        // An explicit update/replace re-confirms the source binding.
+        if (existing.maintenance_at) {
+          await clearTokenMaintenance(tx, input.slug);
+        }
+        if (mode === "replace") {
+          await resetCardsForToken(tx, token.id);
+          replaced.push(input.slug);
+        } else {
+          updated.push(input.slug);
+        }
+        inImport.set(input.slug, token);
+      }
+
+      const ctxNames = parseKnowledgeContextNames(input.knowledgeContexts);
+      const assigned = await resolveKnowledgeContexts(tx, ctxNames);
+      const token = inImport.get(input.slug);
+      if (token) {
+        for (const context of assigned) {
+          await assignTokenToContext(tx, token.id, context.id);
+        }
+      }
+    }
+
+    // Prerequisites in a second pass, so forward references within the
+    // import resolve. In-import slugs win; otherwise existing tokens.
+    for (const input of params.tokens) {
+      const token = inImport.get(input.slug);
+      if (!token) continue;
+      const prereqSlugs = [
+        ...new Set(
+          (input.prerequisites ?? []).map((s) => s.trim()).filter(Boolean),
+        ),
+      ];
+      for (const prereqSlug of prereqSlugs) {
+        const target =
+          inImport.get(prereqSlug) ?? (await getTokenBySlug(tx, prereqSlug));
+        if (!target) {
+          throw new Error(
+            `Prerequisite token not found: ${prereqSlug} (for '${input.slug}')`,
+          );
+        }
+        await addPrerequisite(tx, token.id, target.id);
+      }
+    }
+
+    // Import means "I want to learn this": a card per token for the user.
+    for (const token of inImport.values()) {
+      await ensureCard(tx, token.id, userId);
+      cardsEnsured++;
+    }
+
+    // Tokens previously bound to this article that the new decomposition
+    // did not confirm: maintenance, never deletion (learning history is
+    // preserved for manual repair or doctor auto-heal).
+    const prior = await getTokensBySourceLinkBase(tx, sourceBase);
+    for (const token of prior) {
+      if (!inImport.has(token.slug)) {
+        await setTokenMaintenance(
+          tx,
+          token.slug,
+          `absent from re-import of ${params.file}`,
+        );
+        maintenance.push(token.slug);
+      }
+    }
+  });
+
+  try {
+    await ensureTokenEmbeddings(db, { limit: 16 });
+  } catch {
+    // best-effort, mirrors addToken
+  }
+
+  return {
+    success: true,
+    user: userId,
+    article: { file: params.file, source_link: sourceBase },
+    created,
+    updated,
+    replaced,
+    maintenance,
+    cards: cardsEnsured,
   };
 }
 

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -124,13 +124,13 @@ import {
   getReview as handleGetReview,
   getReviewsBatch as handleGetReviewsBatch,
   importOkfTokens as handleImportOkfTokens,
-  type ImportOkfTokenInput,
   reviewAction as handleReviewAction,
   sessionOpen as handleSessionOpen,
   startSession as handleStartSession,
   submitReview as handleSubmitReview,
   suggestFoundations as handleSuggestFoundations,
   updateCheck as handleUpdateCheck,
+  type ImportOkfTokenInput,
 } from "../bridge-handlers.js";
 import { installCliShim } from "../cli-install.js";
 import {

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -123,6 +123,8 @@ import {
   getMonitor as handleGetMonitor,
   getReview as handleGetReview,
   getReviewsBatch as handleGetReviewsBatch,
+  importOkfTokens as handleImportOkfTokens,
+  type ImportOkfTokenInput,
   reviewAction as handleReviewAction,
   sessionOpen as handleSessionOpen,
   startSession as handleStartSession,
@@ -1165,6 +1167,66 @@ bridgeCommand
             knowledgeContexts: data.knowledgeContexts,
             knowledge_contexts: data.knowledge_contexts,
             prerequisites: data.prerequisites,
+          });
+          jsonOut(result);
+        } catch (err) {
+          jsonError((err as Error).message);
+        }
+      });
+    } catch (err) {
+      jsonError((err as Error).message);
+    }
+  });
+
+// ── zam bridge okf-import ─────────────────────────────────────────────────
+
+bridgeCommand
+  .command("okf-import")
+  .description(
+    "Record an agent's decomposition of an OKF article as learning tokens (JSON stdin, ADR 2026-07-18)",
+  )
+  .option("--user <id>", "User ID (default: whoami)")
+  .action(async (opts) => {
+    try {
+      let raw: string;
+      if (isServeMode) {
+        raw = serveStdinPayload ?? "";
+      } else {
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) {
+          chunks.push(chunk as Buffer);
+        }
+        raw = Buffer.concat(chunks).toString("utf-8").trim();
+      }
+
+      if (!raw) {
+        jsonError(
+          "No input received on stdin. Pipe JSON: { file, bundle_dir?, tokens: [...] }",
+        );
+      }
+
+      let data: {
+        file: string;
+        bundle_dir?: string;
+        tokens: ImportOkfTokenInput[];
+      };
+      try {
+        data = JSON.parse(raw);
+      } catch {
+        jsonError("Invalid JSON input");
+      }
+      if (!data?.file || !Array.isArray(data?.tokens)) {
+        jsonError("JSON must include 'file' and a 'tokens' array");
+      }
+
+      await withDb(async (db) => {
+        try {
+          const userId = await resolveUser(opts, db, { json: true });
+          const result = await handleImportOkfTokens(db, {
+            user: userId,
+            bundleDir: data.bundle_dir,
+            file: data.file,
+            tokens: data.tokens,
           });
           jsonOut(result);
         } catch (err) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -28,6 +28,7 @@ import {
   findTokens as handleFindTokens,
   getMonitor as handleGetMonitor,
   getReviewsBatch as handleGetReviewsBatch,
+  importOkfTokens as handleImportOkfTokens,
   linkPrereq as handleLinkPrereq,
   reviewAction as handleReviewAction,
   startSession as handleStartSession,
@@ -1337,6 +1338,99 @@ export function createMcpServer(db: Database): McpServer {
           return { ok: false, problems: result.validation.problems };
         }
         return { ok: true, created: result.created, entry: result.entry };
+      },
+    ),
+  );
+
+  server.registerTool(
+    "zam_okf_import",
+    {
+      description:
+        "Record YOUR finished decomposition of one OKF article as learning tokens + cards (ADR 2026-07-18). " +
+        "Decomposition is your job, not this tool's — before calling: (1) read the FULL article (zam_okf_read); " +
+        "(2) extract the concepts a practitioner must produce FROM MEMORY — recall-speed knowledge only; facts one " +
+        "would look up stay in the article; (3) one atomic concept per token, with a JUDGED bloom level and a JUDGED " +
+        "domain per token (reuse existing domains where they fit); (4) arrange a prerequisite DAG from foundational " +
+        "to dependent (in-import slugs and existing tokens both allowed); (5) check for existing tokens first " +
+        "(zam_find_tokens) and link them as prerequisites instead of duplicating. Multiple tokens are the expected " +
+        "outcome for real articles. On RE-import classify each token via mode: 'new' adds, 'update' refreshes " +
+        "content and KEEPS learning state, 'replace' means the concept changed — content refreshed and learning " +
+        "state RESET to the beginning. Previously imported tokens you do not confirm are moved to maintenance " +
+        "(kept, unscheduled) — never deleted. The write is atomic; every token gets a card for the importing user.",
+      inputSchema: {
+        user: z.string().optional().describe("User ID to create cards for"),
+        bundle_dir: okfBundleDirSchema,
+        file: z
+          .string()
+          .describe("Article file name inside the bundle (kebab-case .md)"),
+        tokens: z
+          .array(
+            z.object({
+              slug: z.string().describe("Unique kebab-case token slug"),
+              title: z.string().optional().describe("Display title"),
+              concept: z
+                .string()
+                .describe("The memorable concept, stated precisely"),
+              bloomLevel: z
+                .number()
+                .int()
+                .min(1)
+                .max(5)
+                .optional()
+                .describe("Judged Bloom level (1-5)"),
+              domain: z
+                .string()
+                .optional()
+                .describe("Judged domain (reuse existing domains)"),
+              anchor: z
+                .string()
+                .optional()
+                .describe(
+                  "Heading anchor in the article; appended to the source link",
+                ),
+              prerequisites: z
+                .array(z.string())
+                .optional()
+                .describe(
+                  "Slugs this token requires — in-import or existing tokens",
+                ),
+              knowledgeContexts: z
+                .array(z.string())
+                .optional()
+                .describe("Knowledge contexts to assign"),
+              question: z
+                .string()
+                .nullable()
+                .optional()
+                .describe("Optional pre-defined review question"),
+              mode: z
+                .enum(["new", "update", "replace"])
+                .optional()
+                .describe(
+                  "Re-import classification: new (default) | update (keep learning state) | replace (concept changed, reset learning state)",
+                ),
+            }),
+          )
+          .min(1)
+          .describe("Your finished decomposition"),
+      },
+      annotations: {
+        ...commonAnnotations,
+      },
+    },
+    wrapHandler(
+      async (params: {
+        user?: string;
+        bundle_dir?: string;
+        file: string;
+        tokens: Parameters<typeof handleImportOkfTokens>[1]["tokens"];
+      }) => {
+        return await handleImportOkfTokens(db, {
+          user: await getUserId(params.user),
+          bundleDir: params.bundle_dir,
+          file: params.file,
+          tokens: params.tokens,
+        });
       },
     ),
   );

--- a/src/kernel/db/connection.ts
+++ b/src/kernel/db/connection.ts
@@ -581,4 +581,15 @@ async function runMigrations(db: Database): Promise<void> {
       `ALTER TABLE tokens ADD COLUMN question_source TEXT NOT NULL DEFAULT 'llm'`,
     );
   }
+
+  // M014: token maintenance state (ADR 2026-07-18). NULL = healthy; a
+  // timestamp marks the token as needing repair (stale source binding,
+  // ambiguous re-import) — its cards leave the review queue until cleared.
+  if (
+    tokenCols.length > 0 &&
+    !tokenCols.some((c) => c.name === "maintenance_at")
+  ) {
+    await db.exec(`ALTER TABLE tokens ADD COLUMN maintenance_at TEXT`);
+    await db.exec(`ALTER TABLE tokens ADD COLUMN maintenance_reason TEXT`);
+  }
 }

--- a/src/kernel/db/schema.ts
+++ b/src/kernel/db/schema.ts
@@ -34,7 +34,13 @@ CREATE TABLE IF NOT EXISTS tokens (
   -- validated in code, not via CHECK. Column default is 'llm' so unlabeled
   -- writes (pre-M013 rows, old snapshot restores) count as LLM-era content;
   -- createToken() defaults to 'manual' for API callers instead.
-  question_source TEXT NOT NULL DEFAULT 'llm'
+  question_source TEXT NOT NULL DEFAULT 'llm',
+  -- Maintenance state (ADR 2026-07-18): when set, the token's binding to
+  -- its source is unclear (e.g. stale source_link after an article split,
+  -- or an ambiguous re-import). Cards of a token in maintenance are
+  -- excluded from scheduling until repaired; learning state is preserved.
+  maintenance_at     TEXT,
+  maintenance_reason TEXT
 );
 
 -- Prerequisite dependency graph: "to learn A, first know B"

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -103,6 +103,7 @@ export {
   getCardById,
   getCardDeletionImpact,
   getDueCards,
+  resetCardsForToken,
   updateCard,
 } from "./models/card.js";
 export type {
@@ -185,6 +186,7 @@ export type {
 // Models
 export {
   applySourceProposals,
+  clearTokenMaintenance,
   confirmCardSplit,
   confirmFoundations,
   confirmSourceImport,
@@ -204,6 +206,7 @@ export {
   listPersonalCards,
   listTokens,
   listUserCardsForCurriculumTopic,
+  setTokenMaintenance,
   slugify,
   tokenMatchesCurriculumTopicScope,
   updateToken,

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -202,6 +202,7 @@ export {
   getTokenById,
   getTokenBySlug,
   getTokenDeleteImpact,
+  getTokensBySourceLinkBase,
   importCurriculumCards,
   listPersonalCards,
   listTokens,

--- a/src/kernel/models/card.ts
+++ b/src/kernel/models/card.ts
@@ -202,6 +202,39 @@ export async function updateCard(
 /**
  * Preview the review-log rows that will be removed when deleting a user's card.
  */
+/**
+ * Reset the learning state of every user's card for a token back to the
+ * beginning (ADR 2026-07-18): when a concept changed on re-import, the old
+ * knowledge is irrelevant and must be learned fresh. Values mirror a
+ * brand-new card's schema defaults. `blocked` is left untouched — it is
+ * derived from prerequisites, not from learning progress.
+ *
+ * Returns the number of cards reset.
+ */
+export async function resetCardsForToken(
+  db: Database,
+  tokenId: string,
+  now?: string,
+): Promise<number> {
+  const ts = now ?? new Date().toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE cards SET
+         stability = 0.0,
+         difficulty = 0.5,
+         elapsed_days = 0.0,
+         scheduled_days = 0.0,
+         reps = 0,
+         lapses = 0,
+         state = 'new',
+         due_at = ?,
+         last_review_at = NULL
+       WHERE token_id = ?`,
+    )
+    .run(ts, tokenId);
+  return result.changes;
+}
+
 export async function getCardDeletionImpact(
   db: Database,
   tokenId: string,
@@ -262,7 +295,8 @@ export async function getDueCards(
   let sql = `SELECT c.*, t.slug, t.concept, t.domain, t.bloom_level
     FROM cards c
     JOIN tokens t ON t.id = c.token_id
-    WHERE c.user_id = ? AND c.blocked = 0 AND c.due_at <= ?`;
+    WHERE c.user_id = ? AND c.blocked = 0 AND c.due_at <= ?
+      AND t.maintenance_at IS NULL`;
   const params: unknown[] = [userId, cutoff];
 
   if (domain) {

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -39,6 +39,12 @@ export interface Token {
   deprecated_at: string | null;
   provider: string | null;
   topic_id: string | null;
+  /** Maintenance state (ADR 2026-07-18): set when the token's source
+   * binding is unclear (stale source_link, ambiguous re-import). Cards of
+   * a token in maintenance leave the review queue; learning state is
+   * preserved. NULL = healthy. */
+  maintenance_at: string | null;
+  maintenance_reason: string | null;
 }
 
 export interface CreateTokenInput {
@@ -349,6 +355,48 @@ export async function deprecateToken(
     )
     .run(now, now, slug);
 
+  return (await getTokenBySlug(db, slug)) as Token;
+}
+
+/**
+ * Put a token into maintenance (ADR 2026-07-18): its source binding needs
+ * repair — manually or via doctor auto-heal — and its cards leave the
+ * review queue until cleared. Learning state is preserved. Idempotent:
+ * re-entering maintenance refreshes the timestamp and reason.
+ */
+export async function setTokenMaintenance(
+  db: Database,
+  slug: string,
+  reason: string,
+): Promise<Token> {
+  const token = await getTokenBySlug(db, slug);
+  if (!token) {
+    throw new Error(`Token not found: ${slug}`);
+  }
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      "UPDATE tokens SET maintenance_at = ?, maintenance_reason = ?, updated_at = ? WHERE slug = ?",
+    )
+    .run(now, reason, now, slug);
+  return (await getTokenBySlug(db, slug)) as Token;
+}
+
+/** Clear a token's maintenance state — its cards re-enter scheduling. */
+export async function clearTokenMaintenance(
+  db: Database,
+  slug: string,
+): Promise<Token> {
+  const token = await getTokenBySlug(db, slug);
+  if (!token) {
+    throw new Error(`Token not found: ${slug}`);
+  }
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      "UPDATE tokens SET maintenance_at = NULL, maintenance_reason = NULL, updated_at = ? WHERE slug = ?",
+    )
+    .run(now, slug);
   return (await getTokenBySlug(db, slug)) as Token;
 }
 

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -359,6 +359,29 @@ export async function deprecateToken(
 }
 
 /**
+ * All non-deprecated tokens whose source_link is `base` or `base#<anchor>`
+ * — i.e. the tokens previously imported from one OKF article (ADR
+ * 2026-07-18). `base` is matched literally, not as a pattern.
+ */
+export async function getTokensBySourceLinkBase(
+  db: Database,
+  base: string,
+): Promise<Token[]> {
+  return (await db
+    .prepare(
+      `SELECT * FROM tokens
+       WHERE (source_link = ? OR source_link LIKE ? || '#%' ESCAPE '\\')
+         AND deprecated_at IS NULL`,
+    )
+    .all(base, escapeLike(base))) as Token[];
+}
+
+/** Escape LIKE wildcards so a literal base cannot over-match. */
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+/**
  * Put a token into maintenance (ADR 2026-07-18): its source binding needs
  * repair — manually or via doctor auto-heal — and its cards leave the
  * review queue until cleared. Learning state is preserved. Idempotent:

--- a/src/kernel/scheduler/queue.ts
+++ b/src/kernel/scheduler/queue.ts
@@ -105,7 +105,8 @@ export async function buildReviewQueue(
          AND c.blocked = 0
          AND c.due_at <= ?
          AND c.state IN ('review', 'relearning', 'learning')
-         AND t.deprecated_at IS NULL`;
+         AND t.deprecated_at IS NULL
+         AND t.maintenance_at IS NULL`;
 
   const dueParams: unknown[] = [options.userId, nowISO];
 
@@ -141,7 +142,8 @@ export async function buildReviewQueue(
        WHERE c.user_id = ?
          AND c.blocked = 0
          AND c.state = 'new'
-         AND t.deprecated_at IS NULL`;
+         AND t.deprecated_at IS NULL
+         AND t.maintenance_at IS NULL`;
 
   const newParams: unknown[] = [options.userId];
 

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -89,9 +89,9 @@ describe("MCP stdio server tests", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("lists all 23 tools with correct annotations", async () => {
+  it("lists all 24 tools with correct annotations", async () => {
     const response = await client.listTools();
-    expect(response.tools).toHaveLength(23);
+    expect(response.tools).toHaveLength(24);
 
     const toolNames = response.tools.map((t) => t.name).sort();
     const expectedNames = [
@@ -118,6 +118,7 @@ describe("MCP stdio server tests", () => {
       "zam_okf_upsert",
       "zam_okf_read_citation",
       "zam_okf_visualize",
+      "zam_okf_import",
     ].sort();
     expect(toolNames).toEqual(expectedNames);
 

--- a/tests/cli/okf-import.test.ts
+++ b/tests/cli/okf-import.test.ts
@@ -1,0 +1,263 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { importOkfTokens } from "../../src/cli/bridge-handlers.js";
+import {
+  type Database,
+  evaluateRating,
+  getCard,
+  getTokenBySlug,
+  openDatabase,
+} from "../../src/kernel/index.js";
+
+const USER = "importer";
+const RESOURCE = "https://example.com/kb/sample-article.md";
+
+const ARTICLE = `---
+type: reference
+title: Sample Article
+description: Fixture article for import tests.
+resource: ${RESOURCE}
+timestamp: 2026-07-18
+---
+
+# Sample Article
+
+## First concept
+
+Body one.
+
+## Second concept
+
+Body two.
+`;
+
+describe("importOkfTokens (ADR 2026-07-18)", () => {
+  let db: Database;
+  let tempDir: string;
+  let bundleDir: string;
+  let previousConfigPath: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-okf-import-"));
+    // Isolate the machine-local config: the developer's real active
+    // knowledge context must not leak into the fresh test database.
+    previousConfigPath = process.env.ZAM_CONFIG_PATH;
+    process.env.ZAM_CONFIG_PATH = join(tempDir, "machine-config.json");
+    db = await openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    bundleDir = join(tempDir, "docs", "okf");
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(join(bundleDir, "sample-article.md"), ARTICLE, "utf8");
+  });
+
+  afterEach(async () => {
+    await db.close();
+    if (previousConfigPath === undefined) {
+      delete process.env.ZAM_CONFIG_PATH;
+    } else {
+      process.env.ZAM_CONFIG_PATH = previousConfigPath;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function importSample(
+    tokens: Parameters<typeof importOkfTokens>[1]["tokens"],
+  ) {
+    return importOkfTokens(db, {
+      user: USER,
+      bundleDir,
+      file: "sample-article.md",
+      tokens,
+    });
+  }
+
+  it("creates tokens, cards, prerequisites, and anchored source links", async () => {
+    const result = await importSample([
+      {
+        slug: "first-concept",
+        title: "First Concept",
+        concept: "The first memorable concept.",
+        bloomLevel: 2,
+        domain: "fixtures/basics",
+        anchor: "first-concept",
+      },
+      {
+        slug: "second-concept",
+        concept: "The dependent concept.",
+        bloomLevel: 3,
+        domain: "fixtures/basics",
+        anchor: "second-concept",
+        prerequisites: ["first-concept"],
+      },
+    ]);
+
+    expect(result.created.sort()).toEqual(["first-concept", "second-concept"]);
+    expect(result.cards).toBe(2);
+    expect(result.article.source_link).toBe(RESOURCE);
+
+    const first = await getTokenBySlug(db, "first-concept");
+    expect(first?.source_link).toBe(`${RESOURCE}#first-concept`);
+    expect(first?.bloom_level).toBe(2);
+
+    const second = await getTokenBySlug(db, "second-concept");
+    if (!first || !second) throw new Error("tokens missing");
+    const prereqs = (await db
+      .prepare("SELECT requires_id FROM prerequisites WHERE token_id = ?")
+      .all(second.id)) as Array<{ requires_id: string }>;
+    expect(prereqs.map((p) => p.requires_id)).toEqual([first.id]);
+
+    expect(await getCard(db, first.id, USER)).toBeTruthy();
+    expect(await getCard(db, second.id, USER)).toBeTruthy();
+  });
+
+  it("accepts a deliberate single-token import", async () => {
+    const result = await importSample([
+      { slug: "only-concept", concept: "One genuine concept." },
+    ]);
+    expect(result.created).toEqual(["only-concept"]);
+  });
+
+  it("rejects mode 'new' on an existing slug with an instructive error", async () => {
+    await importSample([{ slug: "first-concept", concept: "V1." }]);
+    await expect(
+      importSample([{ slug: "first-concept", concept: "V2." }]),
+    ).rejects.toThrow(/update.*replace|already exists/);
+  });
+
+  it("update refreshes content and keeps learning state", async () => {
+    await importSample([{ slug: "first-concept", concept: "V1." }]);
+    const token = await getTokenBySlug(db, "first-concept");
+    if (!token) throw new Error("token missing");
+    const card = await getCard(db, token.id, USER);
+    if (!card) throw new Error("card missing");
+    await evaluateRating(db, {
+      cardId: card.id,
+      tokenId: token.id,
+      userId: USER,
+      rating: 3,
+    });
+
+    await importSample([
+      { slug: "first-concept", concept: "V1, refreshed.", mode: "update" },
+    ]);
+    const after = await getTokenBySlug(db, "first-concept");
+    expect(after?.concept).toBe("V1, refreshed.");
+    const cardAfter = await getCard(db, token.id, USER);
+    expect(cardAfter?.reps).toBeGreaterThan(0);
+    expect(cardAfter?.state).not.toBe("new");
+  });
+
+  it("replace refreshes content and resets learning state to the beginning", async () => {
+    await importSample([{ slug: "first-concept", concept: "Old meaning." }]);
+    const token = await getTokenBySlug(db, "first-concept");
+    if (!token) throw new Error("token missing");
+    const card = await getCard(db, token.id, USER);
+    if (!card) throw new Error("card missing");
+    await evaluateRating(db, {
+      cardId: card.id,
+      tokenId: token.id,
+      userId: USER,
+      rating: 3,
+    });
+
+    await importSample([
+      { slug: "first-concept", concept: "New meaning.", mode: "replace" },
+    ]);
+    const cardAfter = await getCard(db, token.id, USER);
+    expect(cardAfter?.state).toBe("new");
+    expect(cardAfter?.reps).toBe(0);
+    expect(cardAfter?.last_review_at).toBeNull();
+  });
+
+  it("moves previously imported tokens absent from a re-import into maintenance", async () => {
+    await importSample([
+      { slug: "first-concept", concept: "A." },
+      { slug: "second-concept", concept: "B." },
+    ]);
+    const result = await importSample([
+      { slug: "first-concept", concept: "A2.", mode: "update" },
+    ]);
+    expect(result.maintenance).toEqual(["second-concept"]);
+    const absent = await getTokenBySlug(db, "second-concept");
+    expect(absent?.maintenance_at).toBeTruthy();
+    expect(absent?.maintenance_reason).toContain("sample-article.md");
+  });
+
+  it("an explicit update clears a token's maintenance state", async () => {
+    await importSample([
+      { slug: "first-concept", concept: "A." },
+      { slug: "second-concept", concept: "B." },
+    ]);
+    await importSample([
+      { slug: "first-concept", concept: "A2.", mode: "update" },
+    ]);
+    await importSample([
+      { slug: "first-concept", concept: "A3.", mode: "update" },
+      { slug: "second-concept", concept: "B2.", mode: "update" },
+    ]);
+    const repaired = await getTokenBySlug(db, "second-concept");
+    expect(repaired?.maintenance_at).toBeNull();
+  });
+
+  it("links prerequisites to pre-existing tokens outside the import", async () => {
+    await importSample([{ slug: "first-concept", concept: "Foundation." }]);
+    await importSample([
+      {
+        slug: "advanced-concept",
+        concept: "Builds on the foundation.",
+        prerequisites: ["first-concept"],
+      },
+    ]);
+    const advanced = await getTokenBySlug(db, "advanced-concept");
+    const foundation = await getTokenBySlug(db, "first-concept");
+    if (!advanced || !foundation) throw new Error("tokens missing");
+    const prereqs = (await db
+      .prepare("SELECT requires_id FROM prerequisites WHERE token_id = ?")
+      .all(advanced.id)) as Array<{ requires_id: string }>;
+    expect(prereqs.map((p) => p.requires_id)).toEqual([foundation.id]);
+  });
+
+  it("rejects a prerequisite cycle and rolls the import back", async () => {
+    await importSample([
+      { slug: "alpha", concept: "A." },
+      { slug: "beta", concept: "B.", prerequisites: ["alpha"] },
+    ]);
+    await expect(
+      importSample([
+        {
+          slug: "alpha",
+          concept: "A2.",
+          mode: "update",
+          prerequisites: ["beta"],
+        },
+      ]),
+    ).rejects.toThrow(/cycle/i);
+    // Rolled back: alpha's concept unchanged.
+    const alpha = await getTokenBySlug(db, "alpha");
+    expect(alpha?.concept).toBe("A.");
+  });
+
+  it("rejects an unknown article and an empty token list", async () => {
+    await expect(
+      importOkfTokens(db, {
+        user: USER,
+        bundleDir,
+        file: "missing.md",
+        tokens: [{ slug: "x", concept: "y" }],
+      }),
+    ).rejects.toThrow(/not found/i);
+    await expect(
+      importOkfTokens(db, {
+        user: USER,
+        bundleDir,
+        file: "sample-article.md",
+        tokens: [],
+      }),
+    ).rejects.toThrow(/non-empty/);
+  });
+});

--- a/tests/kernel/maintenance-reset.test.ts
+++ b/tests/kernel/maintenance-reset.test.ts
@@ -1,0 +1,202 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearTokenMaintenance,
+  createToken,
+  type Database,
+  ensureCard,
+  evaluateRating,
+  getCard,
+  getDueCards,
+  getTokenBySlug,
+  openDatabase,
+  resetCardsForToken,
+  setTokenMaintenance,
+} from "../../src/kernel/index.js";
+import { buildReviewQueue } from "../../src/kernel/scheduler/queue.js";
+
+const USER = "maintenance-tester";
+
+describe("token maintenance state (ADR 2026-07-18)", () => {
+  let db: Database;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-maintenance-"));
+    db = await openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("set/clear round-trips and stamps a reason", async () => {
+    const token = await createToken(db, {
+      slug: "maint-a",
+      concept: "Concept A",
+    });
+    expect(token.maintenance_at).toBeNull();
+
+    const flagged = await setTokenMaintenance(
+      db,
+      "maint-a",
+      "absent from re-import of output-contract.md",
+    );
+    expect(flagged.maintenance_at).toBeTruthy();
+    expect(flagged.maintenance_reason).toBe(
+      "absent from re-import of output-contract.md",
+    );
+
+    const cleared = await clearTokenMaintenance(db, "maint-a");
+    expect(cleared.maintenance_at).toBeNull();
+    expect(cleared.maintenance_reason).toBeNull();
+  });
+
+  it("excludes a maintenance token's cards from the queue and due list, and restores them on clear", async () => {
+    const token = await createToken(db, {
+      slug: "maint-queued",
+      concept: "Queued concept",
+    });
+    await ensureCard(db, token.id, USER);
+
+    // New card appears in the queue while healthy.
+    let queue = await buildReviewQueue(db, { userId: USER });
+    expect(queue.items.some((item) => item.slug === "maint-queued")).toBe(true);
+
+    await setTokenMaintenance(db, "maint-queued", "stale source link");
+    queue = await buildReviewQueue(db, { userId: USER });
+    expect(queue.items.some((item) => item.slug === "maint-queued")).toBe(
+      false,
+    );
+
+    // Due leg too: rate the card into review state first, then flag.
+    await clearTokenMaintenance(db, "maint-queued");
+    const card = await getCard(db, token.id, USER);
+    if (!card) throw new Error("card missing");
+    await evaluateRating(db, {
+      cardId: card.id,
+      tokenId: token.id,
+      userId: USER,
+      rating: 3,
+    });
+    const future = "2027-01-01T00:00:00.000Z";
+    expect(
+      (await getDueCards(db, USER, future)).some(
+        (due) => due.slug === "maint-queued",
+      ),
+    ).toBe(true);
+    await setTokenMaintenance(db, "maint-queued", "stale source link");
+    expect(
+      (await getDueCards(db, USER, future)).some(
+        (due) => due.slug === "maint-queued",
+      ),
+    ).toBe(false);
+  });
+
+  it("migrates an existing database (M014 idempotent)", async () => {
+    // openDatabase in beforeEach already ran migrations; reopening must not
+    // fail and the columns must exist.
+    await db.close();
+    db = await openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    const cols = (await db.pragma("table_info(tokens)")) as Array<{
+      name: string;
+    }>;
+    expect(cols.some((c) => c.name === "maintenance_at")).toBe(true);
+    expect(cols.some((c) => c.name === "maintenance_reason")).toBe(true);
+  });
+});
+
+describe("resetCardsForToken (ADR 2026-07-18)", () => {
+  let db: Database;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-reset-"));
+    db = await openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns every user's card to a brand-new learning state", async () => {
+    const token = await createToken(db, {
+      slug: "reset-me",
+      concept: "Concept whose meaning changed",
+    });
+    await ensureCard(db, token.id, "user-one");
+    await ensureCard(db, token.id, "user-two");
+
+    // Progress user-one's card so the reset has something to undo.
+    const card = await getCard(db, token.id, "user-one");
+    if (!card) throw new Error("card missing");
+    await evaluateRating(db, {
+      cardId: card.id,
+      tokenId: token.id,
+      userId: "user-one",
+      rating: 3,
+    });
+    const progressed = await getCard(db, token.id, "user-one");
+    expect(progressed?.reps).toBeGreaterThan(0);
+    expect(progressed?.state).not.toBe("new");
+
+    const resetCount = await resetCardsForToken(db, token.id);
+    expect(resetCount).toBe(2);
+
+    for (const user of ["user-one", "user-two"]) {
+      const fresh = await getCard(db, token.id, user);
+      if (!fresh) throw new Error("card missing after reset");
+      expect(fresh.state).toBe("new");
+      expect(fresh.reps).toBe(0);
+      expect(fresh.lapses).toBe(0);
+      expect(fresh.stability).toBe(0);
+      expect(fresh.difficulty).toBe(0.5);
+      expect(fresh.last_review_at).toBeNull();
+    }
+  });
+
+  it("leaves the prerequisite-derived blocked flag untouched", async () => {
+    const token = await createToken(db, {
+      slug: "reset-blocked",
+      concept: "Blocked concept",
+    });
+    await ensureCard(db, token.id, USER);
+    const card = await getCard(db, token.id, USER);
+    if (!card) throw new Error("card missing");
+    await db
+      .prepare("UPDATE cards SET blocked = 1 WHERE id = ?")
+      .run(card.id);
+
+    await resetCardsForToken(db, token.id);
+    const after = await getCard(db, token.id, USER);
+    expect(after?.blocked).toBe(1);
+  });
+
+  it("does not touch maintenance token metadata", async () => {
+    const token = await createToken(db, {
+      slug: "reset-meta",
+      concept: "Meta concept",
+    });
+    await ensureCard(db, token.id, USER);
+    await setTokenMaintenance(db, "reset-meta", "why not");
+    await resetCardsForToken(db, token.id);
+    const t = await getTokenBySlug(db, "reset-meta");
+    expect(t?.maintenance_at).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Implements [ADR 2026-07-18](docs/adr/2026-07-18-okf-learning-import.md): the agent decomposes, ZAM records.

## What's in

**Kernel (AI-agnostic):** `tokens.maintenance_at/_reason` (+ idempotent migration M014) — a token whose source binding is unclear is kept but excluded from scheduling (both queue legs + `getDueCards`) until repaired; `setTokenMaintenance`/`clearTokenMaintenance`; `resetCardsForToken` returns every user's card to a brand-new learning state (concept changed → learn fresh); `getTokensBySourceLinkBase` for article-bound token lookup.

**CLI:** `importOkfTokens` — atomic transactional recording of an agent's finished decomposition: per-token `mode` (`new` | `update` keeps learning state | `replace` resets it), instructive collision errors, prerequisites across in-import and pre-existing tokens (kernel cycle detection), a card per token for the importing user, anchored `source_link`s from the article's frontmatter `resource`, absent-from-re-import tokens → maintenance (never deleted). Exposed as the `zam_okf_import` MCP tool (24 tools now) with the quality contract in its description, and as `zam bridge okf-import`.

**Panel:** "Als Lerninhalt importieren" in the article reader posts the decomposition request into the host conversation via MCP Apps `sendMessage` — the jump goes through the agent, never around it; chat-less hosts (Companion sidebar) get the instruction as copyable text.

**Skill & docs (same-PR rule):** okf skill triplet carries the decomposition contract; `mcp-surfaces.md` updated through the guarded upsert path; ADR → Implemented.

## Verification (final-check record in docs/plans/2026-07-18-okf-learning-import-plan.md)

- Kernel tests 6/6, import handler tests 10/10 (create/update/replace/maintenance/cycle-rollback/single-token/errors); full suite 1094 passed, only the 4 known environmental failures (identical on main)
- Root + desktop typechecks, lint, build green
- **Isolated-DB e2e via the real CLI**: import → 2 due cards; re-import (one `replace`, one unconfirmed) → card reset to `new`, unconfirmed token in maintenance and out of the due queue (dueCount 2 → 1)
- Companion (real host, dev server): okf intent consumed, panel with the import action mounted (extension log); button click-through pending a human pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)