### PR TITLE
fix: okf tools default to the client workspace root, not the server cwd

### DIFF
--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1224,7 +1224,34 @@ export function createMcpServer(db: Database): McpServer {
   const okfBundleDirSchema = z
     .string()
     .optional()
-    .describe("Bundle directory (default docs/okf under the server cwd)");
+    .describe(
+      "Bundle directory (default: docs/okf under the client's workspace root, falling back to the server cwd)",
+    );
+
+  /**
+   * Default bundle dir for the okf tools: docs/okf under the MCP client's
+   * workspace root (roots/list) — NOT the server cwd, which for a
+   * host-spawned server is often the editor's installation directory
+   * (live 0.13.0 finding: "...\\Microsoft VS Code\\docs\\okf").
+   */
+  async function resolveOkfBundleDir(explicit?: string): Promise<string> {
+    const { DEFAULT_BUNDLE_DIR, resolveBundleDirFromRoots } = await import(
+      "../okf/io.js"
+    );
+    if (explicit) return explicit;
+    try {
+      if (server.server.getClientCapabilities()?.roots) {
+        const { roots } = await server.server.listRoots();
+        return resolveBundleDirFromRoots(
+          (roots ?? []).map((root) => root.uri),
+          DEFAULT_BUNDLE_DIR,
+        );
+      }
+    } catch {
+      // Client advertised roots but the request failed: cwd fallback.
+    }
+    return DEFAULT_BUNDLE_DIR;
+  }
 
   server.registerTool(
     "zam_okf_catalog",
@@ -1247,8 +1274,8 @@ export function createMcpServer(db: Database): McpServer {
     },
     wrapHandler(
       async (params: { bundle_dir?: string; include_log?: boolean }) => {
-        const { DEFAULT_BUNDLE_DIR, loadBundle } = await import("../okf/io.js");
-        const bundle = loadBundle(params.bundle_dir ?? DEFAULT_BUNDLE_DIR);
+        const { loadBundle } = await import("../okf/io.js");
+        const bundle = loadBundle(await resolveOkfBundleDir(params.bundle_dir));
         let log: string | undefined;
         if (params.include_log) {
           const { readFileSync } = await import("node:fs");
@@ -1284,12 +1311,10 @@ export function createMcpServer(db: Database): McpServer {
     },
     wrapHandler(async (params: { bundle_dir?: string; file: string }) => {
       const { readFileSync } = await import("node:fs");
-      const { DEFAULT_BUNDLE_DIR, resolveArticlePath } = await import(
-        "../okf/io.js"
-      );
+      const { resolveArticlePath } = await import("../okf/io.js");
       const { parseFrontmatter } = await import("../okf/bundle.js");
       const path = resolveArticlePath(
-        params.bundle_dir ?? DEFAULT_BUNDLE_DIR,
+        await resolveOkfBundleDir(params.bundle_dir),
         params.file,
       );
       const markdown = readFileSync(path, "utf8");
@@ -1326,11 +1351,9 @@ export function createMcpServer(db: Database): McpServer {
         file: string;
         markdown: string;
       }) => {
-        const { DEFAULT_BUNDLE_DIR, upsertArticle } = await import(
-          "../okf/io.js"
-        );
+        const { upsertArticle } = await import("../okf/io.js");
         const result = upsertArticle(
-          params.bundle_dir ?? DEFAULT_BUNDLE_DIR,
+          await resolveOkfBundleDir(params.bundle_dir),
           params.file,
           params.markdown,
         );
@@ -1427,7 +1450,7 @@ export function createMcpServer(db: Database): McpServer {
       }) => {
         return await handleImportOkfTokens(db, {
           user: await getUserId(params.user),
-          bundleDir: params.bundle_dir,
+          bundleDir: await resolveOkfBundleDir(params.bundle_dir),
           file: params.file,
           tokens: params.tokens,
         });
@@ -1456,9 +1479,10 @@ export function createMcpServer(db: Database): McpServer {
     wrapHandler(async (params: { bundle_dir?: string; target: string }) => {
       const { readFileSync } = await import("node:fs");
       const { relative, sep } = await import("node:path");
-      const { DEFAULT_BUNDLE_DIR, findRepoRoot, resolveCitationPath } =
-        await import("../okf/io.js");
-      const bundleDir = params.bundle_dir ?? DEFAULT_BUNDLE_DIR;
+      const { findRepoRoot, resolveCitationPath } = await import(
+        "../okf/io.js"
+      );
+      const bundleDir = await resolveOkfBundleDir(params.bundle_dir);
       const path = resolveCitationPath(bundleDir, params.target);
       const content = readFileSync(path, "utf8");
       const root = findRepoRoot(bundleDir);
@@ -1509,9 +1533,9 @@ export function createMcpServer(db: Database): McpServer {
         getNativeClientInfo(),
         { clientSamplingCapable: getClientSamplingCapable() },
       );
-      const { DEFAULT_BUNDLE_DIR, loadBundle } = await import("../okf/io.js");
+      const { loadBundle } = await import("../okf/io.js");
       const { resolve } = await import("node:path");
-      const requestedDir = bundle_dir ?? DEFAULT_BUNDLE_DIR;
+      const requestedDir = await resolveOkfBundleDir(bundle_dir);
       let resolvedBundleDir = resolve(requestedDir);
       // Publish the RESOLVED absolute dir, not the raw argument: the VS Code
       // Companion's own zam server runs with a different cwd, so a relative

--- a/src/cli/okf/io.ts
+++ b/src/cli/okf/io.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   appendLog,
   buildCatalog,
@@ -30,6 +31,32 @@ export interface LoadedBundle {
 }
 
 export const DEFAULT_BUNDLE_DIR = "docs/okf";
+
+/**
+ * Resolve the default bundle directory from MCP client roots (the host's
+ * workspace folders). An MCP server is often spawned with an unrelated
+ * cwd — e.g. the editor's installation directory — so "docs/okf under the
+ * cwd" points nowhere; the workspace the user actually has open is what
+ * "the repo's bundle" means. Picks the first root that contains a
+ * `docs/okf` directory; if none does, the first root still wins over the
+ * cwd (so error messages name the workspace, not the application path);
+ * with no usable roots, falls back to `fallback` (cwd-relative).
+ */
+export function resolveBundleDirFromRoots(
+  rootUris: string[],
+  fallback: string,
+): string {
+  const dirs: string[] = [];
+  for (const uri of rootUris) {
+    if (!uri?.startsWith("file:")) continue;
+    try {
+      dirs.push(join(fileURLToPath(uri), DEFAULT_BUNDLE_DIR));
+    } catch {
+      // malformed root URI: skip
+    }
+  }
+  return dirs.find((dir) => existsSync(dir)) ?? dirs[0] ?? fallback;
+}
 
 /**
  * Resolve an article file name inside the bundle. Names are plain kebab

--- a/src/vscode-extension/extension.ts
+++ b/src/vscode-extension/extension.ts
@@ -172,11 +172,16 @@ class ZamMcpHost {
     if (!this.connectionPromise) {
       this.connectionPromise = (async () => {
         const launch = await readLaunchConfig(this.launchConfigPath);
+        // Spawn with the workspace as cwd: the extension host's own cwd is
+        // the editor's installation directory, so cwd-relative defaults in
+        // the server (e.g. the okf tools' docs/okf) would point nowhere.
+        const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         const transport = new StdioClientTransport({
           command: launch.command,
           args: launch.args,
           env: childEnvironment(),
           stderr: "pipe",
+          ...(workspace ? { cwd: workspace } : {}),
         });
         transport.stderr?.on("data", (chunk: Buffer | string) => {
           this.output.appendLine(

--- a/tests/cli/okf-bundle.test.ts
+++ b/tests/cli/okf-bundle.test.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   appendLog,
@@ -19,6 +20,7 @@ import {
 import {
   loadBundle,
   resolveArticlePath,
+  resolveBundleDirFromRoots,
   resolveCitationPath,
   upsertArticle,
 } from "../../src/cli/okf/io.js";
@@ -293,5 +295,50 @@ describe("resolveCitationPath", () => {
     expect(() =>
       resolveCitationPath(join(root, "docs", "okf"), target),
     ).toThrow(/invalid citation target/);
+  });
+});
+
+describe("okf/io resolveBundleDirFromRoots", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-okf-roots-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("picks the first root that contains a docs/okf bundle", () => {
+    const withBundle = join(tempDir, "repo-b");
+    mkdirSync(join(withBundle, "docs", "okf"), { recursive: true });
+    const withoutBundle = join(tempDir, "repo-a");
+    mkdirSync(withoutBundle, { recursive: true });
+
+    const dir = resolveBundleDirFromRoots(
+      [pathToFileURL(withoutBundle).href, pathToFileURL(withBundle).href],
+      "docs/okf",
+    );
+    expect(dir).toBe(join(withBundle, "docs", "okf"));
+  });
+
+  it("prefers the first workspace root over the cwd fallback even without a bundle", () => {
+    const workspace = join(tempDir, "workspace");
+    mkdirSync(workspace, { recursive: true });
+    const dir = resolveBundleDirFromRoots(
+      [pathToFileURL(workspace).href],
+      "docs/okf",
+    );
+    // A missing-bundle error should name the workspace, never the server
+    // process's application-path cwd (live 0.13.0 finding:
+    // "...\Microsoft VS Code\docs\okf").
+    expect(dir).toBe(join(workspace, "docs", "okf"));
+  });
+
+  it("falls back to the cwd default with no usable roots", () => {
+    expect(resolveBundleDirFromRoots([], "docs/okf")).toBe("docs/okf");
+    expect(
+      resolveBundleDirFromRoots(["https://not-a-file.example"], "docs/okf"),
+    ).toBe("docs/okf");
   });
 });


### PR DESCRIPTION
Live 0.14.0-rc finding: a host-spawned zam MCP server inherits an unrelated cwd — the report showed `C:\...\Programs\Microsoft VS Code\docs\okf` — so every okf tool's `docs/okf` default pointed into the editor's installation directory.

## Fix

- **MCP roots resolution**: all six okf tools (`catalog`/`read`/`upsert`/`read_citation`/`visualize`/`import`) resolve their default bundle dir via the client's `roots/list` (the open workspace — e.g. `C:\src\github\zam` → `C:\src\github\zam\docs\okf`). First root with a `docs/okf` wins; a root without one still beats the cwd (error messages then name the workspace, not the application path); cwd remains the fallback for clients without roots (pure helper `resolveBundleDirFromRoots` + 3 unit tests).
- **Companion cwd**: the VS Code Companion now spawns its zam server with the workspace folder as cwd (the extension host's own cwd is the editor install dir).

An explicit `bundle_dir` argument still overrides everything, unchanged.

## Verification

okf-bundle 24/24 (3 new roots tests), okf-import 10/10, panel + companion protocol suites green; root + desktop typechecks and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)