### PR TITLE
feat: learning graph scope selectors — repo/OKF-scoped default

### DIFF
--- a/desktop/src/panel/graph-panel.html
+++ b/desktop/src/panel/graph-panel.html
@@ -93,6 +93,78 @@
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
       }
 
+      /* ── Scope selectors (repo/all, domains, token list) ─────────────── */
+      .graph-scope {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        margin-bottom: 10px;
+      }
+      .graph-scope:empty {
+        display: none;
+      }
+      .graph-scope-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
+      }
+      .scope-pill,
+      .domain-pill,
+      .token-pill {
+        border: 1px solid var(--border);
+        background: var(--card);
+        color: var(--fg);
+        border-radius: 999px;
+        padding: 3px 10px;
+        font: inherit;
+        font-size: 0.76rem;
+        cursor: pointer;
+        transition: background 0.12s ease;
+      }
+      .scope-pill:hover,
+      .domain-pill:hover,
+      .token-pill:hover {
+        background: var(--hover);
+      }
+      .scope-pill.active,
+      .domain-pill.active {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #ffffff;
+      }
+      .domain-pill,
+      .token-pill {
+        font-size: 0.72rem;
+        padding: 2px 9px;
+      }
+      .token-pill.active {
+        border-color: var(--accent);
+        background: var(--hover);
+        font-weight: 600;
+      }
+      .token-pill-nocard {
+        border-style: dashed;
+        opacity: 0.75;
+      }
+      .graph-token-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px;
+        max-height: 96px;
+        overflow-y: auto;
+        padding: 2px;
+      }
+      .graph-scope-count {
+        color: var(--muted);
+        font-size: 0.72rem;
+        margin-left: auto;
+      }
+      .graph-scope-empty {
+        color: var(--muted);
+        font-size: 0.76rem;
+      }
+
       /* ── Legend + breadcrumb ─────────────────────────────────────────── */
       .graph-legend {
         display: flex;
@@ -237,6 +309,7 @@
           <span class="graph-legend-dot dependent"></span>Aufbauwissen
         </span>
       </div>
+      <div class="graph-scope" id="graph-scope"></div>
       <div class="graph-breadcrumb" id="graph-breadcrumb"></div>
       <div id="graph-content"></div>
     </div>

--- a/desktop/src/panel/graph-panel.html
+++ b/desktop/src/panel/graph-panel.html
@@ -165,32 +165,7 @@
         font-size: 0.76rem;
       }
 
-      /* ── Legend + breadcrumb ─────────────────────────────────────────── */
-      .graph-legend {
-        display: flex;
-        gap: 14px;
-        flex-wrap: wrap;
-        font-size: 0.76rem;
-        color: var(--muted);
-        margin-bottom: 8px;
-      }
-      .graph-legend-item {
-        display: inline-flex;
-        align-items: center;
-        gap: 5px;
-      }
-      .graph-legend-dot {
-        width: 9px;
-        height: 9px;
-        border-radius: 50%;
-        display: inline-block;
-      }
-      .graph-legend-dot.prereq {
-        background: var(--prereq);
-      }
-      .graph-legend-dot.dependent {
-        background: var(--dependent);
-      }
+      /* ── Breadcrumb ──────────────────────────────────────────────────── */
       .graph-breadcrumb {
         display: flex;
         flex-wrap: wrap;
@@ -301,14 +276,6 @@
     <div id="zam-graph-panel">
       <div id="zam-contextbar-root"></div>
       <div class="zam-connection-notice" id="zam-connection-notice" hidden></div>
-      <div class="graph-legend">
-        <span class="graph-legend-item">
-          <span class="graph-legend-dot prereq"></span>Voraussetzungen
-        </span>
-        <span class="graph-legend-item">
-          <span class="graph-legend-dot dependent"></span>Aufbauwissen
-        </span>
-      </div>
       <div class="graph-scope" id="graph-scope"></div>
       <div class="graph-breadcrumb" id="graph-breadcrumb"></div>
       <div id="graph-content"></div>

--- a/desktop/src/panel/graph-scope.ts
+++ b/desktop/src/panel/graph-scope.ts
@@ -1,0 +1,70 @@
+/**
+ * Scope-selector logic for the 2D graph card — pure functions, no DOM, so
+ * the selector behavior is unit-testable. Mirrors the desktop app's graph
+ * selectors (main.ts `loadAndRenderDomains` / `bootstrapGraphWithDomain`):
+ * domain options with `/`-prefix groups, prefix-aware domain filtering, and
+ * the default-focus pick for a scoped token list.
+ */
+
+export interface DomainOption {
+  value: string;
+  /**
+   * True when the option is a `/`-prefix group covering child domains
+   * (e.g. "company-team" over "company-team/xyz") rather than a domain any
+   * token carries verbatim.
+   */
+  isGroup: boolean;
+}
+
+/** Distinct domains of `tokens`, plus their `/`-prefix groups, sorted. */
+export function buildDomainOptions(
+  tokens: ReadonlyArray<{ domain: string }>,
+): DomainOption[] {
+  const real = new Set<string>();
+  for (const token of tokens) {
+    if (token.domain) real.add(token.domain);
+  }
+  const all = new Set<string>(real);
+  for (const domain of real) {
+    if (!domain.includes("/")) continue;
+    const parts = domain.split("/");
+    for (let i = 1; i < parts.length; i++) {
+      all.add(parts.slice(0, i).join("/"));
+    }
+  }
+  return [...all]
+    .sort()
+    .map((value) => ({ value, isGroup: !real.has(value) }));
+}
+
+/** `null` selects everything; otherwise exact match or `<selected>/…`. */
+export function domainMatches(
+  domain: string,
+  selected: string | null,
+): boolean {
+  if (selected === null) return true;
+  return domain === selected || domain.startsWith(`${selected}/`);
+}
+
+export function filterByDomain<T extends { domain: string }>(
+  tokens: readonly T[],
+  selected: string | null,
+): T[] {
+  return tokens.filter((token) => domainMatches(token.domain, selected));
+}
+
+/**
+ * The token a scoped, focus-less graph should open on: lowest Bloom level
+ * first (foundations before applications), preferring tokens the learner
+ * actually has a card for. Ties keep the input order (stable sort), which
+ * for bridge `list-tokens` results means domain/slug order.
+ */
+export function pickDefaultFocus<
+  T extends { slug: string; bloomLevel: number; card: unknown },
+>(tokens: readonly T[]): T | null {
+  if (tokens.length === 0) return null;
+  const sorted = [...tokens].sort(
+    (a, b) => (a.bloomLevel || 99) - (b.bloomLevel || 99),
+  );
+  return sorted.find((token) => token.card != null) ?? sorted[0];
+}

--- a/desktop/src/panel/graph.ts
+++ b/desktop/src/panel/graph.ts
@@ -142,6 +142,14 @@ let scopeKind: ScopeKind = "all";
 let scopeDomain: string | null = null;
 /** Tokens of the current scope (before the domain filter); null = not loaded. */
 let scopeTokens: GraphNode[] | null = null;
+/**
+ * Bumped whenever the session restarts (late tool result with a different
+ * user/focus/repoScope, or a context-bar change). In-flight navigations and
+ * scope loads from an older generation discard their results instead of
+ * landing in the restarted session — without this, the 800ms fallback
+ * bootstrap races the real tool result and leaves a stale breadcrumb entry.
+ */
+let navGeneration = 0;
 
 const SURFACE = "graph";
 
@@ -158,6 +166,7 @@ const readCompanionContext = createContextReader(callTool, SURFACE);
 function reloadForContext(newState: CompanionContextBarState): void {
   currentUser = newState.user.currentId ?? null;
   scopeTokens = null;
+  navGeneration++;
   const focus = history[history.length - 1]?.slug ?? initialFocus;
   if (focus) {
     void navigateTo(focus);
@@ -352,12 +361,15 @@ function renderScopeBar(): void {
 
 /** Load the current scope's tokens and render the bar. False on failure. */
 async function loadScope(): Promise<boolean> {
+  const generation = navGeneration;
   try {
-    scopeTokens = await listScopeTokens(scopeKind);
+    const tokens = await listScopeTokens(scopeKind);
+    if (generation !== navGeneration) return false; // superseded meanwhile
+    scopeTokens = tokens;
     renderScopeBar();
     return true;
   } catch {
-    scopeTokens = null;
+    if (generation === navGeneration) scopeTokens = null;
     return false;
   }
 }
@@ -647,6 +659,7 @@ function pushHistory(slug: string, title: string): void {
 }
 
 async function navigateTo(slug: string): Promise<void> {
+  const generation = navGeneration;
   try {
     const args = ["--focus", slug];
     if (currentUser) args.push("--user", currentUser);
@@ -654,6 +667,7 @@ async function navigateTo(slug: string): Promise<void> {
       cmd: "get-neighborhood",
       args,
     })) as Neighborhood;
+    if (generation !== navGeneration) return; // session restarted meanwhile
     pushHistory(data.focus, graphNodeTitle(data.center));
     renderBreadcrumb((s) => void navigateTo(s));
     renderGraph(data, (s) => void navigateTo(s));
@@ -699,6 +713,7 @@ app.ontoolresult = (params) => {
     started = false;
     history = [];
     scopeTokens = null;
+    navGeneration++;
   }
   clearConnectionNotice();
 

--- a/desktop/src/panel/graph.ts
+++ b/desktop/src/panel/graph.ts
@@ -33,6 +33,11 @@ import {
   graphNodeTitle,
   wrapGraphLabel,
 } from "./graph-layout.js";
+import {
+  buildDomainOptions,
+  filterByDomain,
+  pickDefaultFocus,
+} from "./graph-scope.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -53,6 +58,7 @@ const HISTORY_LIMIT = 5;
 
 const contextBarRoot = document.getElementById("zam-contextbar-root");
 const noticeEl = document.getElementById("zam-connection-notice");
+const scopeEl = document.getElementById("graph-scope");
 const breadcrumbEl = document.getElementById("graph-breadcrumb");
 const contentEl = document.getElementById("graph-content");
 
@@ -73,6 +79,16 @@ interface OpenGraphResult {
   version?: string;
   user?: string | null;
   companionContext?: CompanionContextBarState;
+  repoScope?: RepoScope;
+}
+
+/**
+ * Tokens anchored in the current workspace's OKF bundle (source-link bases,
+ * one per article) — computed server-side by zam_show_graph from MCP roots.
+ */
+interface RepoScope {
+  label: string;
+  bases: string[];
 }
 
 interface KnowledgeContextRef {
@@ -119,6 +135,14 @@ let initialFocus: string | null = null;
 /** Last up to HISTORY_LIMIT focuses, most-recent last (current focus). */
 let history: Array<{ slug: string; title: string }> = [];
 
+// ── Scope selectors (desktop-app style; ADR: default = current repo) ──────
+let repoScope: RepoScope | null = null;
+type ScopeKind = "repo" | "all";
+let scopeKind: ScopeKind = "all";
+let scopeDomain: string | null = null;
+/** Tokens of the current scope (before the domain filter); null = not loaded. */
+let scopeTokens: GraphNode[] | null = null;
+
 const SURFACE = "graph";
 
 const callTool = createCallTool(app);
@@ -128,15 +152,18 @@ const readCompanionContext = createContextReader(callTool, SURFACE);
 /**
  * A user/evaluator context change is a context boundary (ADR §Decision 4):
  * re-navigate to the current focus under the new context rather than
- * continue showing a neighborhood scoped to the previous learner.
+ * continue showing a neighborhood scoped to the previous learner. Scope
+ * tokens carry the learner's card state, so they reload too.
  */
 function reloadForContext(newState: CompanionContextBarState): void {
   currentUser = newState.user.currentId ?? null;
+  scopeTokens = null;
   const focus = history[history.length - 1]?.slug ?? initialFocus;
   if (focus) {
     void navigateTo(focus);
+    void loadScope();
   } else {
-    renderNoFocus();
+    void bootstrapWithoutFocus();
   }
 }
 
@@ -194,6 +221,189 @@ function renderNoFocus(): void {
 
 function renderError(message: string): void {
   renderMessage("⚠️", "Graph konnte nicht geladen werden", message);
+}
+
+function renderEmptyScope(): void {
+  renderMessage(
+    "🌱",
+    "Keine Tokens in diesem Umfang",
+    "Importiere einen Artikel aus der Wissensbasis (zam_okf_import) oder lege Tokens an (zam_add_token).",
+  );
+}
+
+// ── Scope selectors ────────────────────────────────────────────────────────
+
+async function listScopeTokens(kind: ScopeKind): Promise<GraphNode[]> {
+  const args: string[] = [];
+  if (currentUser) args.push("--user", currentUser);
+  if (kind === "repo" && repoScope) {
+    for (const base of repoScope.bases) {
+      args.push("--source-link-base", base);
+    }
+  }
+  const data = (await callTool("zam_studio_bridge", {
+    cmd: "list-tokens",
+    args,
+  })) as { tokens?: GraphNode[] };
+  return data.tokens ?? [];
+}
+
+function scopedTokens(): GraphNode[] {
+  return filterByDomain(scopeTokens ?? [], scopeDomain);
+}
+
+function scopePill(
+  text: string,
+  className: string,
+  active: boolean,
+  title: string,
+  onClick: () => void,
+): HTMLButtonElement {
+  const pill = document.createElement("button");
+  pill.type = "button";
+  pill.className = className + (active ? " active" : "");
+  pill.textContent = text;
+  pill.title = title;
+  pill.addEventListener("click", onClick);
+  return pill;
+}
+
+function renderScopeBar(): void {
+  if (!scopeEl) return;
+  scopeEl.replaceChildren();
+  if (scopeTokens === null) return; // scope not loaded (yet)
+
+  const scopeRow = document.createElement("div");
+  scopeRow.className = "graph-scope-row";
+  if (repoScope) {
+    scopeRow.appendChild(
+      scopePill(
+        `📚 ${repoScope.label}`,
+        "scope-pill",
+        scopeKind === "repo",
+        "Tokens aus der Wissensbasis (docs/okf) dieses Repos",
+        () => void switchScope("repo"),
+      ),
+    );
+  }
+  scopeRow.appendChild(
+    scopePill("Alle", "scope-pill", scopeKind === "all", "Alle Tokens", () =>
+      void switchScope("all"),
+    ),
+  );
+  const count = document.createElement("span");
+  count.className = "graph-scope-count";
+  const visible = scopedTokens();
+  count.textContent = `${visible.length} Token${visible.length === 1 ? "" : "s"}`;
+  scopeRow.appendChild(count);
+  scopeEl.appendChild(scopeRow);
+
+  const options = buildDomainOptions(scopeTokens);
+  if (options.length > 1) {
+    const domainRow = document.createElement("div");
+    domainRow.className = "graph-scope-row graph-domain-row";
+    domainRow.appendChild(
+      scopePill(
+        "Alle Bereiche",
+        "domain-pill",
+        scopeDomain === null,
+        "Alle Wissensbereiche",
+        () => switchDomain(null),
+      ),
+    );
+    for (const option of options) {
+      domainRow.appendChild(
+        scopePill(
+          option.isGroup ? `${option.value} ⋯` : option.value,
+          "domain-pill",
+          scopeDomain === option.value,
+          option.isGroup
+            ? `Gruppe: alles unter "${option.value}"`
+            : `Bereich ${option.value}`,
+          () => switchDomain(option.value),
+        ),
+      );
+    }
+    scopeEl.appendChild(domainRow);
+  }
+
+  const currentSlug = history[history.length - 1]?.slug;
+  const list = document.createElement("div");
+  list.className = "graph-token-list";
+  for (const token of visible) {
+    list.appendChild(
+      scopePill(
+        graphNodeTitle(token),
+        `token-pill${token.card ? "" : " token-pill-nocard"}`,
+        token.slug === currentSlug,
+        token.concept,
+        () => void navigateTo(token.slug),
+      ),
+    );
+  }
+  if (visible.length === 0) {
+    const empty = document.createElement("span");
+    empty.className = "graph-scope-empty";
+    empty.textContent = "Keine Tokens in diesem Umfang.";
+    list.appendChild(empty);
+  }
+  scopeEl.appendChild(list);
+}
+
+/** Load the current scope's tokens and render the bar. False on failure. */
+async function loadScope(): Promise<boolean> {
+  try {
+    scopeTokens = await listScopeTokens(scopeKind);
+    renderScopeBar();
+    return true;
+  } catch {
+    scopeTokens = null;
+    return false;
+  }
+}
+
+function focusScopeDefault(): void {
+  const pick = pickDefaultFocus(scopedTokens());
+  if (pick) {
+    void navigateTo(pick.slug);
+  } else {
+    renderEmptyScope();
+  }
+}
+
+async function switchScope(kind: ScopeKind): Promise<void> {
+  scopeKind = kind;
+  scopeDomain = null;
+  if (await loadScope()) focusScopeDefault();
+}
+
+function switchDomain(domain: string | null): void {
+  scopeDomain = domain;
+  renderScopeBar();
+  focusScopeDefault();
+}
+
+/**
+ * No focus supplied: instead of a dead "Kein Fokus" hint, load the default
+ * scope — the current repo's OKF-anchored tokens when the workspace has a
+ * bundle with imported tokens, else all tokens — and open on its foundation
+ * (lowest Bloom level, preferring tokens the learner has a card for).
+ */
+async function bootstrapWithoutFocus(): Promise<void> {
+  scopeKind = repoScope ? "repo" : "all";
+  scopeDomain = null;
+  if (!(await loadScope())) {
+    renderNoFocus(); // data channel unavailable: keep the old hint
+    return;
+  }
+  if (scopeKind === "repo" && (scopeTokens?.length ?? 0) === 0) {
+    scopeKind = "all";
+    if (!(await loadScope())) {
+      renderNoFocus();
+      return;
+    }
+  }
+  focusScopeDefault();
 }
 
 function bloomStep(level: number): number {
@@ -447,6 +657,7 @@ async function navigateTo(slug: string): Promise<void> {
     pushHistory(data.focus, graphNodeTitle(data.center));
     renderBreadcrumb((s) => void navigateTo(s));
     renderGraph(data, (s) => void navigateTo(s));
+    renderScopeBar(); // refresh the token list's current-focus highlight
     pushContext(data);
   } catch (error) {
     renderError(error instanceof Error ? error.message : String(error));
@@ -458,8 +669,12 @@ function start(): void {
   started = true;
   if (initialFocus) {
     void navigateTo(initialFocus);
+    // The selector bar is a browsing enhancement here — load it in the
+    // background and ignore failures; the focused graph already renders.
+    scopeKind = repoScope ? "repo" : "all";
+    void loadScope();
   } else {
-    renderNoFocus();
+    void bootstrapWithoutFocus();
   }
 }
 
@@ -471,14 +686,19 @@ app.ontoolresult = (params) => {
   // is authoritative — restart the session when it names a different one.
   const previousUser = currentUser;
   const previousFocus = initialFocus;
+  const previousRepoLabel = repoScope?.label ?? null;
   currentUser = structured.user ?? null;
   initialFocus = structured.focus ?? null;
+  repoScope = structured.repoScope ?? null;
   if (
     started &&
-    (previousUser !== currentUser || previousFocus !== initialFocus)
+    (previousUser !== currentUser ||
+      previousFocus !== initialFocus ||
+      (repoScope?.label ?? null) !== previousRepoLabel)
   ) {
     started = false;
     history = [];
+    scopeTokens = null;
   }
   clearConnectionNotice();
 

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,7 @@
 ## 2026-07-18
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 
 ## 2026-07-17
 

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -27,6 +27,13 @@ companion context and sampling, and the OKF knowledge-base tools
 `zam_okf_read_citation` / `zam_okf_import`). The authoritative tool list
 with annotations is pinned by `tests/cli/mcp.test.ts`.
 
+The `zam_okf_*` tools resolve their default bundle directory as
+`docs/okf` under the MCP client's workspace root (MCP `roots/list`),
+falling back to the server's working directory — a host-spawned server
+often runs from the editor's installation directory, so the workspace
+the user has open is what "the repo's bundle" means. An explicit
+`bundle_dir` always wins.
+
 `zam_okf_catalog` accepts an optional `include_log` flag that adds the
 raw `log.md` text to the result (empty string if the bundle has none
 yet). `zam_okf_read_citation` reads a citation target an article points
@@ -57,18 +64,28 @@ same panels in a webview and routes recall evaluation through
 per-IDE evaluator selections.
 
 `zam_okf_visualize` opens the OKF panel on any OKF bundle (default
-`docs/okf` under the server's working directory, like the other
-`zam_okf_*` tools): articles grouped by type with search, a markdown
-reader that expands cited ADRs and other citation targets inline via
-`zam_okf_read_citation`, a link graph (articles as nodes, inter-article
-links as edges, citations as visually distinct nodes), and the
-`log.md` history. The panel always opens — a missing or invalid bundle
-surfaces as `problems` in the panel instead of a tool error. The
-article reader's "import as learning content" action posts the
-decomposition request into the host conversation (MCP Apps
-`sendMessage`) — the agent does the thinking, then records via
-`zam_okf_import`; hosts without a conversation surface get the
-instruction as copyable text instead.
+resolved like the other `zam_okf_*` tools — see above): articles
+grouped by type with search, a markdown reader that expands cited ADRs
+and other citation targets inline via `zam_okf_read_citation`, a link
+graph (articles as nodes, inter-article links as edges, citations as
+visually distinct nodes), and the `log.md` history. The panel always
+opens — a missing or invalid bundle surfaces as `problems` in the panel
+instead of a tool error. The article reader's "import as learning
+content" action posts the decomposition request into the host
+conversation (MCP Apps `sendMessage`) — the agent does the thinking,
+then records via `zam_okf_import`; hosts without a conversation surface
+get the instruction as copyable text instead.
+
+The knowledge-graph card (`zam_show_graph`, `ui://zam/graph`) centers
+on a focus token's direct prerequisites and dependents. Opened without
+a focus it does not dead-end: it shows scope selectors (desktop-app
+style — scope pills, domains with `/`-prefix groups, and a clickable
+token list) and defaults to the tokens anchored in the workspace's OKF
+bundle — the articles' source-link bases, resolved like the okf tools —
+falling back to all tokens when the workspace has no imported
+knowledge. The scoped listing runs through
+`zam bridge list-tokens --source-link-base` (repeatable), which is also
+available directly.
 
 # Citations
 

--- a/docs/plans/2026-07-18-graph-scope-selectors-plan.md
+++ b/docs/plans/2026-07-18-graph-scope-selectors-plan.md
@@ -36,17 +36,33 @@ Goal: the MCP-Apps graph panel, opened without a focus, must never dead-end in
 
 ## Checklist
 
-- [ ] 1. Kernel: `sourceLinkBases` filter in `listTokens` (src/kernel/models/token.ts) + kernel test
-- [ ] 2. Bridge: repeatable `--source-link-base` on `list-tokens` (src/cli/commands/bridge.ts) + CLI test
-- [ ] 3. `collectSourceLinkBases(dir)` in src/cli/okf/io.ts (resource ?? resolved path) + test in okf-bundle.test.ts
-- [ ] 4. `zam_show_graph`: add `repoScope` to result (src/cli/commands/mcp.ts), update tool description; mcp.test.ts coverage
-- [ ] 5. Pure helpers `desktop/src/panel/graph-scope.ts` (domain options w/ prefixes, domain filter, default-focus pick) + tests/desktop/graph-scope.test.ts
-- [ ] 6. Panel wiring in graph.ts (scope state, bridge list-tokens call, selector bar render, bootstrap-without-focus) + CSS/containers in graph-panel.html
-- [ ] 7. Docs: update docs/okf/mcp-surfaces.md if it describes the graph tool's no-focus behavior (via zam_okf_upsert only)
-- [ ] 8. Build + lint + full test run, compare against 4-failure environmental baseline
-- [ ] 9. E2E in real host: point Companion at dev dist (backup launch config), isolated VS Code, "Open Learning Graph" without focus → screenshot shows selectors + auto-focused graph; restore launch config
-- [ ] 10. Final check: re-read this plan, verify nothing slipped; PR
+- [x] 1. Kernel: `sourceLinkBases` filter in `listTokens` (src/kernel/models/token.ts) + kernel test
+- [x] 2. Bridge: repeatable `--source-link-base` on `list-tokens` (src/cli/commands/bridge.ts) + CLI test
+- [x] 3. `collectSourceLinkBases(dir)` in src/cli/okf/io.ts (resource ?? resolved path) + test in okf-bundle.test.ts
+- [x] 4. `zam_show_graph`: add `repoScope` to result (src/cli/commands/mcp.ts), update tool description; mcp.test.ts coverage
+- [x] 5. Pure helpers `desktop/src/panel/graph-scope.ts` (domain options w/ prefixes, domain filter, default-focus pick) + tests/desktop/graph-scope.test.ts
+- [x] 6. Panel wiring in graph.ts (scope state, bridge list-tokens call, selector bar render, bootstrap-without-focus) + CSS/containers in graph-panel.html
+- [x] 7. Docs: update docs/okf/mcp-surfaces.md if it describes the graph tool's no-focus behavior (via zam_okf_upsert only)
+- [x] 8. Build + lint + full test run, compare against 4-failure environmental baseline
+- [x] 9. E2E in real host: point Companion at dev dist (backup launch config), isolated VS Code, "Open Learning Graph" without focus → screenshot shows selectors + auto-focused graph; restore launch config
+- [x] 10. Final check: re-read this plan, verify nothing slipped; PR
 
 ## Final check record
 
-(fill in before PR)
+- Kernel filter: exact/anchored match, LIKE-escape, empty-list-matches-nothing,
+  composes with domainPrefix — tests/kernel/token-source-link-filter.test.ts (4).
+- Bridge flag repeatable via collector; spawned-CLI test (2) against dist.
+- collectSourceLinkBases: resource-else-path rule + missing-dir throw (okf-bundle, 26 total).
+- zam_show_graph repoScope asserted in tests/cli/mcp.test.ts (label + non-empty bases,
+  this checkout's own bundle via cwd fallback); tool description updated.
+- Panel: scope pills (repo/all) + domain pills (prefix groups) + token list +
+  no-focus bootstrap; navGeneration guard added after E2E surfaced a
+  fallback-vs-tool-result race (stale breadcrumb). Legend removed on request.
+- mcp-surfaces.md: workspace-roots default paragraph (was stale) + graph-card
+  scope paragraph, written via zam_okf_upsert.
+- Full suite: 4 failures = exactly the known environmental baseline
+  (agent-harness, cli-install, mcp stdio smoke, ui-intent live-bleed).
+- E2E evidence: e2e-graph-scope-1/2.png — repo pill "zam" active, 4 imported
+  tokens listed, auto-focus on lowest-bloom-with-card, prerequisite DAG
+  rendered; real DB (mcp-surfaces import: 3 new + 1 update, 4 cards).
+- Launch config restored to global zam 0.14.0 after E2E.

--- a/docs/plans/2026-07-18-graph-scope-selectors-plan.md
+++ b/docs/plans/2026-07-18-graph-scope-selectors-plan.md
@@ -1,0 +1,52 @@
+# Learning Graph scope selectors — plan (2026-07-18)
+
+Request (Thomas): "The learning graph needs selectors - similar to the zam app.
+Otherwise it stays usually empty. Maybe it could default to the tokens -
+related to the current repo and okf bundles."
+
+Goal: the MCP-Apps graph panel, opened without a focus, must never dead-end in
+"Kein Fokus" when tokens exist. It gets scope selectors like the desktop app
+(scope + domain pills + browsable token list) and defaults to tokens whose
+`source_link` points into the current repo's OKF bundle (possible since the
+0.14.0 import feature anchors tokens as `<article resource>#<anchor>`).
+
+## Design
+
+- **Repo scope, server-side**: `zam_show_graph` resolves the bundle dir via
+  MCP roots (existing `resolveOkfBundleDir`), collects each article's
+  source-link base (`resource` frontmatter, else resolved article path — same
+  rule as `importOkfTokens`), and puts `repoScope: { label, bases }` into the
+  tool result. Never fails the open: any error → no repoScope.
+- **Token filter, kernel**: `ListTokensOptions.sourceLinkBases?: string[]` —
+  matches `source_link = base OR source_link LIKE base||'#%' ESCAPE '\'`
+  (same semantics as `getTokensBySourceLinkBase`, N bases OR-ed).
+- **Bridge**: `zam bridge list-tokens --source-link-base <base>` repeatable
+  (collector option). Already on the studio-bridge allowlist via list-tokens.
+- **Panel** (`desktop/src/panel/graph.ts` + new pure `graph-scope.ts`):
+  - Scope bar under the breadcrumb: pills `[<repo label>] [Alle]` (repo pill
+    only when repoScope present) + domain pills (with `/`-prefix groups,
+    ported from desktop `loadAndRenderDomains`) + scrollable token-pill list
+    (click = focus, current focus highlighted).
+  - No focus passed: load scoped tokens (repo scope first; empty → fall back
+    to Alle), auto-focus first token with a card, else first token. Only a
+    truly empty DB shows the empty message.
+  - Focus passed: unchanged behavior, scope bar still shown for browsing.
+  - Scope/domain switch: re-list, re-render pills + token list, focus the
+    scope's default token. Context-bar user change keeps working (reload).
+
+## Checklist
+
+- [ ] 1. Kernel: `sourceLinkBases` filter in `listTokens` (src/kernel/models/token.ts) + kernel test
+- [ ] 2. Bridge: repeatable `--source-link-base` on `list-tokens` (src/cli/commands/bridge.ts) + CLI test
+- [ ] 3. `collectSourceLinkBases(dir)` in src/cli/okf/io.ts (resource ?? resolved path) + test in okf-bundle.test.ts
+- [ ] 4. `zam_show_graph`: add `repoScope` to result (src/cli/commands/mcp.ts), update tool description; mcp.test.ts coverage
+- [ ] 5. Pure helpers `desktop/src/panel/graph-scope.ts` (domain options w/ prefixes, domain filter, default-focus pick) + tests/desktop/graph-scope.test.ts
+- [ ] 6. Panel wiring in graph.ts (scope state, bridge list-tokens call, selector bar render, bootstrap-without-focus) + CSS/containers in graph-panel.html
+- [ ] 7. Docs: update docs/okf/mcp-surfaces.md if it describes the graph tool's no-focus behavior (via zam_okf_upsert only)
+- [ ] 8. Build + lint + full test run, compare against 4-failure environmental baseline
+- [ ] 9. E2E in real host: point Companion at dev dist (backup launch config), isolated VS Code, "Open Learning Graph" without focus → screenshot shows selectors + auto-focused graph; restore launch config
+- [ ] 10. Final check: re-read this plan, verify nothing slipped; PR
+
+## Final check record
+
+(fill in before PR)

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -3424,6 +3424,12 @@ bridgeCommand
     "Filter by domain prefix (e.g. company-team) — uses / separator for hierarchy",
   )
   .option("--knowledge-context <context>", "Filter by knowledge context")
+  .option(
+    "--source-link-base <base>",
+    "Filter by source-link base (exact or '<base>#<anchor>', as written by OKF imports); repeatable",
+    (value: string, previous: string[]) => [...previous, value],
+    [] as string[],
+  )
   .action(async (opts) => {
     await withDb(async (db) => {
       const userId = opts.user
@@ -3434,6 +3440,8 @@ bridgeCommand
       if (opts.domainPrefix) listOpts.domainPrefix = opts.domainPrefix;
       if (opts.knowledgeContext)
         listOpts.knowledgeContext = opts.knowledgeContext;
+      if (opts.sourceLinkBase.length)
+        listOpts.sourceLinkBases = opts.sourceLinkBase;
 
       const tokens = await listTokens(
         db,

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   RESOURCE_MIME_TYPE,
@@ -936,8 +936,9 @@ export function createMcpServer(db: Database): McpServer {
       description:
         "Open the ZAM 2D knowledge-graph card, centered on a token's direct " +
         "prerequisites and dependents. Pass `focus` (a token slug) when the " +
-        "conversation already names one; otherwise the card shows a hint to " +
-        "supply one.",
+        "conversation already names one; without it the card offers scope " +
+        "selectors and defaults to tokens anchored in the current repo's " +
+        "OKF knowledge base.",
       inputSchema: {
         focus: z
           .string()
@@ -966,6 +967,25 @@ export function createMcpServer(db: Database): McpServer {
         { clientSamplingCapable: getClientSamplingCapable() },
       );
       const userId = opening.context.user.currentId ?? null;
+
+      // Repo scope for the card's selectors (no-focus bootstrap): the
+      // source-link bases of the workspace's OKF bundle, resolved the same
+      // way as the okf tools (MCP roots, else cwd). Best-effort — a missing
+      // bundle or a roots failure must never block opening the panel.
+      let repoScope: { label: string; bases: string[] } | undefined;
+      try {
+        const { collectSourceLinkBases, findRepoRoot } = await import(
+          "../okf/io.js"
+        );
+        const bundleDir = await resolveOkfBundleDir();
+        const bases = collectSourceLinkBases(bundleDir);
+        if (bases.length > 0) {
+          repoScope = { label: basename(findRepoRoot(bundleDir)), bases };
+        }
+      } catch {
+        // No bundle in this workspace — the card just offers "Alle".
+      }
+
       await publishUiIntent("graph", { user, focus });
       return {
         graph: "zam",
@@ -973,6 +993,7 @@ export function createMcpServer(db: Database): McpServer {
         version: pkg.version,
         user: userId,
         companionContext: opening.context,
+        ...(repoScope ? { repoScope } : {}),
         ...(opening.degraded ? { companionContextDegraded: true } : {}),
       };
     }),

--- a/src/cli/okf/io.ts
+++ b/src/cli/okf/io.ts
@@ -59,6 +59,21 @@ export function resolveBundleDirFromRoots(
 }
 
 /**
+ * Collect the source-link bases of every article in a bundle: the
+ * frontmatter `resource` URL when present, else the resolved article path —
+ * the exact base rule `importOkfTokens` uses when writing tokens'
+ * `source_link` (`<base>` or `<base>#<anchor>`). This is what "tokens
+ * related to this repo's knowledge base" means to the learning graph.
+ * Throws when the bundle directory does not exist (same as `loadBundle`).
+ */
+export function collectSourceLinkBases(dir: string): string[] {
+  const bundle = loadBundle(dir);
+  return bundle.catalog.map(
+    (entry) => entry.resource ?? resolveArticlePath(dir, entry.file),
+  );
+}
+
+/**
  * Resolve an article file name inside the bundle. Names are plain kebab
  * basenames (v1 bundles are flat) — anything with a path separator or a
  * reserved name is rejected before it can escape the bundle directory.

--- a/src/kernel/models/token.ts
+++ b/src/kernel/models/token.ts
@@ -87,6 +87,13 @@ export interface ListTokensOptions {
    * Filter by knowledge context name (e.g. "work-company").
    */
   knowledgeContext?: string;
+  /**
+   * Filter by source-link base(s): tokens whose `source_link` is one of the
+   * bases exactly or `<base>#<anchor>` (the anchored form OKF imports
+   * write). Same matching rule as `getTokensBySourceLinkBase`, OR-ed over
+   * all bases. An empty array matches nothing.
+   */
+  sourceLinkBases?: string[];
 }
 
 export interface TokenDeleteImpact {
@@ -637,6 +644,17 @@ export async function listTokens(
       WHERE tc.token_id = tokens.id AND c.name = ?
     )`);
     params.push(options.knowledgeContext);
+  }
+
+  if (options?.sourceLinkBases) {
+    const clauses = options.sourceLinkBases.map(
+      () => `(source_link = ? OR source_link LIKE ? || '#%' ESCAPE '\\')`,
+    );
+    // An explicit empty list means "nothing matches", not "no filter".
+    whereClauses.push(clauses.length ? `(${clauses.join(" OR ")})` : "0 = 1");
+    for (const base of options.sourceLinkBases) {
+      params.push(base, escapeLike(base));
+    }
   }
 
   const orderBy =

--- a/tests/cli/bridge-list-tokens-source-link.test.ts
+++ b/tests/cli/bridge-list-tokens-source-link.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createToken, openDatabase, setSetting } from "../../src/kernel/index.js";
+
+const BASE_A = "https://example.com/okf/output-contract";
+const BASE_B = "https://example.com/okf/queue-design";
+
+describe("zam bridge list-tokens --source-link-base", () => {
+  let tempHome: string;
+  let tempCwd: string;
+  let cliPath: string;
+
+  beforeEach(async () => {
+    tempHome = mkdtempSync(join(tmpdir(), "zam-bridge-slb-home-"));
+    tempCwd = mkdtempSync(join(tmpdir(), "zam-bridge-slb-cwd-"));
+    cliPath = join(process.cwd(), "dist", "cli", "index.js");
+
+    const dataDir = join(tempHome, ".zam");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      join(dataDir, "config.json"),
+      JSON.stringify({
+        activeWorkspaceId: "test-workspace",
+        workspaces: [
+          {
+            id: "test-workspace",
+            kind: "personal",
+            path: tempCwd,
+            label: "Test Workspace",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const db = await openDatabase({
+      dbPath: join(dataDir, "zam.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    await setSetting(db, "user.id", "thomas");
+    await createToken(db, {
+      slug: "from-article-a",
+      concept: "From article A",
+      source_link: `${BASE_A}#json-only`,
+    });
+    await createToken(db, {
+      slug: "from-article-b",
+      concept: "From article B",
+      source_link: BASE_B,
+    });
+    await createToken(db, { slug: "unrelated", concept: "Unrelated" });
+    await db.close();
+  });
+
+  afterEach(() => {
+    for (const dir of [tempHome, tempCwd]) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function runCliJson(args: string[]): any {
+    return JSON.parse(
+      execFileSync("node", [cliPath, ...args], {
+        cwd: tempCwd,
+        env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+        input: "",
+        encoding: "utf8",
+      }),
+    );
+  }
+
+  it("filters by one base and OR-s repeated flags", () => {
+    const one = runCliJson([
+      "bridge",
+      "list-tokens",
+      "--source-link-base",
+      BASE_A,
+    ]);
+    expect(one.tokens.map((t: any) => t.slug)).toEqual(["from-article-a"]);
+
+    const both = runCliJson([
+      "bridge",
+      "list-tokens",
+      "--source-link-base",
+      BASE_A,
+      "--source-link-base",
+      BASE_B,
+    ]);
+    expect(both.tokens.map((t: any) => t.slug).sort()).toEqual([
+      "from-article-a",
+      "from-article-b",
+    ]);
+  });
+
+  it("omitting the flag keeps the unfiltered listing", () => {
+    const all = runCliJson(["bridge", "list-tokens"]);
+    expect(all.tokens.length).toBe(3);
+  });
+});

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -494,6 +494,22 @@ describe("MCP stdio server tests", () => {
     // Default user seeded in beforeEach via user_config.
     expect(structured.user).toBe("thomas");
 
+    // Repo scope for the card's no-focus bootstrap: without client roots the
+    // server falls back to docs/okf under its cwd — this checkout's own OKF
+    // bundle, so the scope must name the repo and carry one source-link base
+    // per article (resource URL, else resolved article path).
+    const repoScope = (structured as any).repoScope as {
+      label: string;
+      bases: string[];
+    };
+    expect(typeof repoScope?.label).toBe("string");
+    expect(repoScope.label.length).toBeGreaterThan(0);
+    expect(Array.isArray(repoScope.bases)).toBe(true);
+    expect(repoScope.bases.length).toBeGreaterThan(0);
+    for (const base of repoScope.bases) {
+      expect(typeof base).toBe("string");
+    }
+
     const focusedRes = await client.callTool({
       name: "zam_show_graph",
       arguments: { focus: "some-slug" },

--- a/tests/cli/okf-bundle.test.ts
+++ b/tests/cli/okf-bundle.test.ts
@@ -18,6 +18,7 @@ import {
   validateArticle,
 } from "../../src/cli/okf/bundle.js";
 import {
+  collectSourceLinkBases,
   loadBundle,
   resolveArticlePath,
   resolveBundleDirFromRoots,
@@ -177,6 +178,37 @@ describe("okf/io", () => {
     const res = upsertArticle(dir, "broken.md", "---\ntitle: X\n---\n\n");
     expect(res.validation.ok).toBe(false);
     expect(loadBundle(dir).articles).toEqual([]);
+  });
+
+  it("collectSourceLinkBases prefers the resource URL, falls back to the article path", () => {
+    upsertArticle(dir, "with-resource.md", article(), "2026-07-17");
+    const noResource = [
+      "---",
+      "type: concept",
+      "title: No Resource",
+      "description: Article without a resource URL.",
+      "tags:",
+      "  - kernel",
+      "timestamp: 2026-07-17T00:00:00Z",
+      "---",
+      "",
+      "Body.",
+      "",
+    ].join("\n");
+    upsertArticle(dir, "no-resource.md", noResource, "2026-07-17");
+
+    const bases = collectSourceLinkBases(dir);
+    expect(bases).toContain(
+      "https://github.com/zam-os/zam/blob/main/docs/okf/fsrs-scheduling.md",
+    );
+    expect(bases).toContain(resolveArticlePath(dir, "no-resource.md"));
+    expect(bases).toHaveLength(2);
+  });
+
+  it("collectSourceLinkBases throws on a missing bundle directory", () => {
+    expect(() => collectSourceLinkBases(join(dir, "nope"))).toThrow(
+      /not found/,
+    );
   });
 
   it("loadBundle reports problems but keeps parseable entries in the catalog", () => {

--- a/tests/desktop/graph-scope.test.ts
+++ b/tests/desktop/graph-scope.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDomainOptions,
+  domainMatches,
+  filterByDomain,
+  pickDefaultFocus,
+} from "../../desktop/src/panel/graph-scope.js";
+
+const token = (
+  slug: string,
+  domain: string,
+  bloomLevel: number,
+  card: object | null = null,
+) => ({ slug, domain, bloomLevel, card });
+
+describe("graph-scope buildDomainOptions", () => {
+  it("returns distinct domains sorted, skipping empty ones", () => {
+    const options = buildDomainOptions([
+      { domain: "zam" },
+      { domain: "fsrs" },
+      { domain: "zam" },
+      { domain: "" },
+    ]);
+    expect(options).toEqual([
+      { value: "fsrs", isGroup: false },
+      { value: "zam", isGroup: false },
+    ]);
+  });
+
+  it("adds /-prefix groups and marks them", () => {
+    const options = buildDomainOptions([
+      { domain: "company-team/ad" },
+      { domain: "company-team/boards" },
+      { domain: "zam" },
+    ]);
+    expect(options).toEqual([
+      { value: "company-team", isGroup: true },
+      { value: "company-team/ad", isGroup: false },
+      { value: "company-team/boards", isGroup: false },
+      { value: "zam", isGroup: false },
+    ]);
+  });
+
+  it("does not mark a prefix as group when a token carries it verbatim", () => {
+    const options = buildDomainOptions([
+      { domain: "company-team" },
+      { domain: "company-team/ad" },
+    ]);
+    expect(options.find((o) => o.value === "company-team")?.isGroup).toBe(
+      false,
+    );
+  });
+});
+
+describe("graph-scope domain filtering", () => {
+  const tokens = [
+    token("a", "company-team/ad", 1),
+    token("b", "company-team", 2),
+    token("c", "company-teamster", 2),
+    token("d", "zam", 1),
+  ];
+
+  it("null selects everything", () => {
+    expect(filterByDomain(tokens, null)).toHaveLength(4);
+  });
+
+  it("matches exact and /-children but not sibling prefixes", () => {
+    const filtered = filterByDomain(tokens, "company-team");
+    expect(filtered.map((t) => t.slug)).toEqual(["a", "b"]);
+    expect(domainMatches("company-teamster", "company-team")).toBe(false);
+  });
+});
+
+describe("graph-scope pickDefaultFocus", () => {
+  it("prefers the lowest-bloom token that has a card", () => {
+    const pick = pickDefaultFocus([
+      token("high-with-card", "d", 4, { state: "review" }),
+      token("low-no-card", "d", 1),
+      token("mid-with-card", "d", 2, { state: "new" }),
+    ]);
+    expect(pick?.slug).toBe("mid-with-card");
+  });
+
+  it("falls back to the lowest-bloom token when nothing has a card", () => {
+    const pick = pickDefaultFocus([
+      token("later", "d", 3),
+      token("first", "d", 1),
+    ]);
+    expect(pick?.slug).toBe("first");
+  });
+
+  it("keeps input order on bloom ties and returns null for empty input", () => {
+    const pick = pickDefaultFocus([
+      token("alpha", "d", 2),
+      token("beta", "d", 2),
+    ]);
+    expect(pick?.slug).toBe("alpha");
+    expect(pickDefaultFocus([])).toBeNull();
+  });
+});

--- a/tests/kernel/token-source-link-filter.test.ts
+++ b/tests/kernel/token-source-link-filter.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createToken,
+  type Database,
+  listTokens,
+  openDatabase,
+} from "../../src/kernel/index.js";
+
+const BASE_A = "https://example.com/okf/output-contract";
+const BASE_B = "https://example.com/okf/queue-design";
+
+describe("listTokens sourceLinkBases filter", () => {
+  let db: Database;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "zam-srclink-"));
+    db = await openDatabase({
+      dbPath: join(tempDir, "zam-test.db"),
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    await createToken(db, {
+      slug: "exact-base",
+      concept: "Exact base",
+      source_link: BASE_A,
+    });
+    await createToken(db, {
+      slug: "anchored",
+      concept: "Anchored",
+      source_link: `${BASE_A}#json-only`,
+    });
+    await createToken(db, {
+      slug: "other-article",
+      concept: "Other article",
+      source_link: `${BASE_B}#interleave`,
+    });
+    await createToken(db, { slug: "unlinked", concept: "No source link" });
+  });
+
+  afterEach(async () => {
+    await db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("matches exact base and anchored forms, OR-ed over multiple bases", async () => {
+    const one = await listTokens(db, { sourceLinkBases: [BASE_A] });
+    expect(one.map((t) => t.slug).sort()).toEqual(["anchored", "exact-base"]);
+
+    const both = await listTokens(db, {
+      sourceLinkBases: [BASE_A, BASE_B],
+    });
+    expect(both.map((t) => t.slug).sort()).toEqual([
+      "anchored",
+      "exact-base",
+      "other-article",
+    ]);
+  });
+
+  it("does not over-match prefixes without the # separator or LIKE wildcards", async () => {
+    await createToken(db, {
+      slug: "prefix-cousin",
+      concept: "Prefix cousin",
+      source_link: `${BASE_A}-v2`,
+    });
+    const tokens = await listTokens(db, { sourceLinkBases: [BASE_A] });
+    expect(tokens.map((t) => t.slug)).not.toContain("prefix-cousin");
+
+    // A base containing LIKE wildcards must be treated literally.
+    const wildcard = await listTokens(db, {
+      sourceLinkBases: ["https://example.com/okf/%"],
+    });
+    expect(wildcard).toEqual([]);
+  });
+
+  it("empty base list matches nothing; omitted filter matches everything", async () => {
+    expect(await listTokens(db, { sourceLinkBases: [] })).toEqual([]);
+    expect((await listTokens(db)).length).toBe(4);
+  });
+
+  it("composes with domain filtering", async () => {
+    await createToken(db, {
+      slug: "domained",
+      concept: "Domained",
+      domain: "zam/okf",
+      source_link: `${BASE_A}#extra`,
+    });
+    const tokens = await listTokens(db, {
+      domainPrefix: "zam",
+      sourceLinkBases: [BASE_A],
+    });
+    expect(tokens.map((t) => t.slug)).toEqual(["domained"]);
+  });
+});


### PR DESCRIPTION
## What

The Learning Graph card no longer dead-ends in \"Kein Fokus\" when opened without a focus token. It gets scope selectors like the desktop app and defaults to the tokens anchored in the current repo's OKF knowledge base — possible since 0.14.0's knowledge-to-learning import writes anchored source links.

- **Kernel**: `listTokens` gains `sourceLinkBases` — matches `source_link = base` or `base#anchor` (same rule as `getTokensBySourceLinkBase`, OR-ed over bases; empty list matches nothing).
- **Bridge**: `zam bridge list-tokens --source-link-base <base>` (repeatable). Already reachable from panels via the `zam_studio_bridge` allowlist.
- **MCP**: `zam_show_graph` resolves the workspace's bundle (MCP roots, like the okf tools), collects each article's source-link base (`resource` frontmatter, else resolved path — the exact rule `importOkfTokens` writes), and ships `repoScope { label, bases }` in the tool result. Best-effort: any failure just omits it.
- **Panel**: without a focus the card bootstraps into scope selectors — repo/all pills, domain pills with `/`-prefix groups, a scrollable clickable token list — and opens on the scope's lowest-Bloom token the learner has a card for. Empty repo scope falls back to all tokens; only a truly empty DB shows an empty state. A navigation-generation guard discards in-flight loads when a late tool result restarts the session (race found in the e2e run). The Voraussetzungen/Aufbauwissen legend is removed.
- **Docs**: `mcp-surfaces.md` updated via `zam_okf_upsert` (also fixes the stale \"server cwd\" default wording from before the roots fix).

## Tests

- New: `tests/kernel/token-source-link-filter.test.ts` (4), `tests/cli/bridge-list-tokens-source-link.test.ts` (2), `tests/desktop/graph-scope.test.ts` (8); extended `okf-bundle.test.ts` (+2) and `mcp.test.ts` (repoScope assertions).
- Full suite: only the 4 known environmental failures on the dev machine (agent-harness, cli-install, mcp stdio smoke, ui-intent live-process bleed).
- E2E in a real VS Code host (Companion + dev server, real DB): no-focus open shows the repo pill \"zam\" active, the imported tokens as pills, and the auto-focused graph with its prerequisite DAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)