### PR TITLE
feat: okf panel — copy button on the import-instruction fallback

### DIFF
--- a/desktop/src/panel/okf-panel.html
+++ b/desktop/src/panel/okf-panel.html
@@ -571,6 +571,31 @@
         font-size: 11px;
         resize: vertical;
       }
+      .okf-import-fallback-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .okf-import-copy-btn {
+        border: 1px solid var(--border);
+        background: var(--card);
+        color: var(--fg);
+        border-radius: 6px;
+        padding: 3px 10px;
+        font: inherit;
+        font-size: 12px;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .okf-import-copy-btn:hover:not(:disabled) {
+        background: var(--hover, rgba(130, 125, 189, 0.1));
+      }
+      .okf-import-copy-btn:disabled {
+        cursor: default;
+        opacity: 0.85;
+      }
       .okf-empty-emoji {
         font-size: 2rem;
       }

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -536,6 +536,39 @@ function importInstruction(file: string): string {
   );
 }
 
+/**
+ * Copy the fallback instruction to the clipboard. Webviews differ in what
+ * they allow: try the async clipboard API first, fall back to the
+ * selection-based path (`document.execCommand("copy")`) — deprecated but
+ * still the reliable route in webviews without clipboard-write permission.
+ * The button itself reports success/failure so the user never guesses.
+ */
+async function copyInstruction(
+  copyable: HTMLTextAreaElement,
+  button: HTMLButtonElement,
+): Promise<void> {
+  let copied = false;
+  try {
+    await navigator.clipboard.writeText(copyable.value);
+    copied = true;
+  } catch {
+    copyable.focus();
+    copyable.select();
+    try {
+      copied = document.execCommand("copy");
+    } catch {
+      copied = false;
+    }
+  }
+  const original = "📋 Kopieren";
+  button.textContent = copied ? "✓ Kopiert" : "⚠️ Kopieren fehlgeschlagen";
+  button.disabled = true;
+  window.setTimeout(() => {
+    button.textContent = original;
+    button.disabled = false;
+  }, 2000);
+}
+
 function buildImportAction(file: string): HTMLElement {
   const wrap = document.createElement("div");
   wrap.className = "okf-import-action";
@@ -572,7 +605,17 @@ function buildImportAction(file: string): HTMLElement {
         copyable.className = "okf-import-fallback";
         copyable.value = importInstruction(file);
         copyable.addEventListener("focus", () => copyable.select());
-        hint.append(note, copyable);
+        const copyBtn = document.createElement("button");
+        copyBtn.type = "button";
+        copyBtn.className = "okf-import-copy-btn";
+        copyBtn.textContent = "📋 Kopieren";
+        copyBtn.addEventListener("click", () => {
+          void copyInstruction(copyable, copyBtn);
+        });
+        const noteRow = document.createElement("div");
+        noteRow.className = "okf-import-fallback-row";
+        noteRow.append(note, copyBtn);
+        hint.append(noteRow, copyable);
       } finally {
         btn.disabled = false;
       }


### PR DESCRIPTION
The Companion sidebar has no conversation surface, so the article reader's \"Als Lerninhalt importieren\" action always lands in the copyable-text fallback there — and selecting the whole instruction by hand is clumsy (Thomas's report, with screenshot).

- A **📋 Kopieren** button now sits next to the fallback note: async clipboard API first, selection + `document.execCommand(\"copy\")` as the webview fallback; the button reports **✓ Kopiert** / failure on itself for 2s.
- The textarea keeps its select-on-focus behavior as the last resort.

Verified: desktop typecheck, panel build, all 162 desktop tests. Interactive click-through in the Companion host is pending — the machine locked mid-verification; the change is additive to the existing fallback rendering (same code path the screenshot shows working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)