### PR TITLE
feat: okf import handoff — chat delivery + focused-article resolution

### DIFF
--- a/.agent/skills/okf/SKILL.md
+++ b/.agent/skills/okf/SKILL.md
@@ -65,7 +65,13 @@ not the chat — is the durable source a learner returns to.
 When the user wants to LEARN an article ("import this as learning
 content", the visualizer's import button, or any request that ends in
 `zam_okf_import`), **you do the decomposition** — it is a judgment task,
-never mechanical:
+never mechanical.
+
+"Import this okf" / "the currently focused article" / "the open
+article": resolve which article is meant via `zam_okf_focused` — the
+visualizer panel records what its reader shows. Name the resolved
+article in your reply (and double-check with the user if `updatedAt`
+looks stale) before decomposing. Then:
 
 1. Read the FULL article (`zam_okf_read`) before proposing anything.
 2. Extract the concepts a practitioner must produce **from memory** —

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -68,7 +68,13 @@ not the chat — is the durable source a learner returns to.
 When the user wants to LEARN an article ("import this as learning
 content", the visualizer's import button, or any request that ends in
 `zam_okf_import`), **you do the decomposition** — it is a judgment task,
-never mechanical:
+never mechanical.
+
+"Import this okf" / "the currently focused article" / "the open
+article": resolve which article is meant via `zam_okf_focused` — the
+visualizer panel records what its reader shows. Name the resolved
+article in your reply (and double-check with the user if `updatedAt`
+looks stale) before decomposing. Then:
 
 1. Read the FULL article (`zam_okf_read`) before proposing anything.
 2. Extract the concepts a practitioner must produce **from memory** —

--- a/.claude/skills/okf/SKILL.md
+++ b/.claude/skills/okf/SKILL.md
@@ -65,7 +65,13 @@ not the chat — is the durable source a learner returns to.
 When the user wants to LEARN an article ("import this as learning
 content", the visualizer's import button, or any request that ends in
 `zam_okf_import`), **you do the decomposition** — it is a judgment task,
-never mechanical:
+never mechanical.
+
+"Import this okf" / "the currently focused article" / "the open
+article": resolve which article is meant via `zam_okf_focused` — the
+visualizer panel records what its reader shows. Name the resolved
+article in your reply (and double-check with the user if `updatedAt`
+looks stale) before decomposing. Then:
 
 1. Read the FULL article (`zam_okf_read`) before proposing anything.
 2. Extract the concepts a practitioner must produce **from memory** —

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -464,6 +464,14 @@ async function openArticle(file: string): Promise<void> {
   citationView = null;
   readErrors.delete(file);
   renderAll();
+  // Record the focused article machine-locally (zam_okf_focus) so a chat
+  // agent can resolve "import this okf" without the panel needing a
+  // conversation surface. Fire-and-forget: hosts that do not allow the
+  // tool, or a failed write, must never break the reader.
+  void callTool("zam_okf_focus", {
+    file,
+    ...(bundleDir ? { bundle_dir: bundleDir } : {}),
+  }).catch(() => {});
   if (!bodyCache.has(file)) {
     try {
       const result = (await callTool("zam_okf_read", {

--- a/docs/adr/2026-07-18b-graph-repo-scope.md
+++ b/docs/adr/2026-07-18b-graph-repo-scope.md
@@ -1,0 +1,81 @@
+# Learning Graph Scope Selectors and the Repo Scope
+
+**Status:** Implemented
+**Date:** 2026-07-18
+**Deciders:** Thomas (project owner), designed with Fable 5
+**Related:**
+[2026-07-18-okf-learning-import.md](2026-07-18-okf-learning-import.md) (anchored source links make the repo scope possible) ·
+[2026-07-17-okf-knowledge-base.md](2026-07-17-okf-knowledge-base.md) (OKF bundles) ·
+[2026-07-06a-mcp-agent-transport-and-surfaces.md](2026-07-06a-mcp-agent-transport-and-surfaces.md) (MCP Apps panels)
+
+---
+
+## Context
+
+The 2D knowledge-graph card (`zam_show_graph`, `ui://zam/graph`) rendered
+only a focus token's 1-hop neighborhood. Opened without a focus — the
+Companion title-bar button, or any host that doesn't pass one — it
+dead-ended in a "Kein Fokus" hint, so in practice the card "stays usually
+empty" (project owner). The desktop app already solved browsing with
+scope selectors (knowledge-context and domain pills, a learner filter,
+and a bootstrap that picks a start token); the card had none of that.
+
+Since the knowledge-to-learning import (ADR 2026-07-18), tokens created
+from OKF articles carry an anchored `source_link`
+(`<article resource>#<anchor>`), which for the first time makes "the
+tokens related to this repo's knowledge base" a queryable set.
+
+## Decision
+
+1. **Repo scope is computed server-side.** `zam_show_graph` resolves the
+   workspace's bundle directory exactly like the `zam_okf_*` tools (MCP
+   `roots/list`, falling back to the server cwd), collects one
+   source-link base per article (frontmatter `resource`, else the
+   resolved article path — the same rule `importOkfTokens` writes), and
+   ships `repoScope { label, bases }` in the tool result. `label` is the
+   repository folder name. Best-effort: any failure omits `repoScope`
+   and must never block opening the card.
+
+2. **The kernel filters by source-link base.**
+   `listTokens({ sourceLinkBases })` matches `source_link = base` or
+   `base#anchor` (LIKE with escaped wildcards, OR-ed over bases; an
+   explicit empty list matches nothing). Exposed as the repeatable
+   `zam bridge list-tokens --source-link-base`, reachable from panels via
+   the existing `zam_studio_bridge` allowlist entry.
+
+3. **The card bootstraps into selectors instead of a hint.** Without a
+   focus it loads the default scope — repo when `repoScope` is present
+   and non-empty, else all tokens — renders scope pills (repo / Alle),
+   domain pills with `/`-prefix groups (ported from the desktop app), and
+   a clickable token list, then opens on the scope's lowest-Bloom token
+   the learner has a card for. Only a truly empty database shows an
+   empty state. With an explicit focus the previous behavior is
+   unchanged; the selector bar still loads for browsing.
+
+4. **Late tool results restart cleanly.** The card's 800ms no-host
+   fallback can bootstrap before the real tool result (with `repoScope`)
+   arrives; a navigation-generation counter discards in-flight
+   navigations and scope loads from a superseded session instead of
+   letting them land as stale breadcrumb entries (found live in the
+   VS Code e2e run).
+
+## Consequences
+
+- The Companion's Learning Graph button is useful without any prior
+  conversation context, and its default view is the current repo's
+  learning surface — the import feature's output becomes visible where
+  the work happens.
+- Tokens imported before anchored source links existed (or created by
+  hand without one) do not appear in the repo scope until they are
+  re-bound (e.g. by a re-import); the "Alle" scope always shows them.
+- The graph card and the desktop app now share selector semantics but
+  not code; the card's pure selector logic lives in
+  `desktop/src/panel/graph-scope.ts` with its own tests.
+
+## Code
+
+`src/kernel/models/token.ts` (listTokens sourceLinkBases),
+`src/cli/commands/bridge.ts` (--source-link-base),
+`src/cli/okf/io.ts` (collectSourceLinkBases),
+`src/cli/commands/mcp.ts` (repoScope in zam_show_graph),
+`desktop/src/panel/graph-scope.ts`, `desktop/src/panel/graph.ts`.

--- a/docs/adr/2026-07-18c-okf-import-handoff.md
+++ b/docs/adr/2026-07-18c-okf-import-handoff.md
@@ -1,0 +1,81 @@
+# OKF Import Handoff — Chat Delivery and the Focused-Article State
+
+**Status:** Implemented
+**Date:** 2026-07-18
+**Deciders:** Thomas (project owner), designed with Fable 5
+**Related:**
+[2026-07-18-okf-learning-import.md](2026-07-18-okf-learning-import.md) (the import contract this hands off to) ·
+[2026-07-17b-okf-visualizer-panel.md](2026-07-17b-okf-visualizer-panel.md) (the panel carrying the action) ·
+[2026-07-11-codex-and-vscode-companion-surfaces.md](2026-07-11-codex-and-vscode-companion-surfaces.md) (Companion webview host)
+
+---
+
+## Context
+
+The visualizer's "import as learning content" action posts the
+decomposition request into the host conversation via MCP Apps
+`ui/message`. The VS Code Companion webview host never advertised the
+`message` capability, so in the Companion — the surface actually in
+front of the user — the action always fell into the copyable-text
+fallback ("Dieser Host hat keinen Chat", project owner's report).
+
+The inverse direction was missing entirely: a user reading an article in
+the panel who types "import this okf" into their chat had no way for the
+agent to know which article is meant. Any solution had to work for every
+connected harness — Claude Code, Copilot, **and Codex** (project owner:
+"Codex also can use the vscode context knowledge") — which rules out
+mechanisms private to one chat (host model context, a single editor
+API).
+
+## Decision
+
+1. **The Companion delivers `ui/message` to VS Code's Chat view.** The
+   webview host advertises `message: { text: {} }` and proxies the
+   request to the extension, which calls
+   `workbench.action.chat.open` with the message text as a submitted
+   query. Any failure (no chat available) returns `{ isError: true }`
+   per the MCP Apps contract, so the panel's copyable-text fallback
+   (with its copy button) remains the safety net. No attempt is made to
+   inject into third-party chat panels (Claude Code, Codex) — they have
+   no public API for it; the built-in Chat view is the one addressable
+   target.
+
+2. **The focused article is machine-local server state, not host
+   context.** The reader records the article it shows through a new
+   app-only tool `zam_okf_focus` (same closed pattern as
+   `zam_studio_bridge`: panel-callable, model-hidden), which writes a
+   last-write-wins snapshot to `~/.zam/okf-focus.json` — mirroring the
+   ui-intent file's design (atomic rename, versioned shape, env
+   override for tests). The zam MCP server is the one place every
+   harness already looks, so the model-visible, read-only
+   `zam_okf_focused` tool makes "import this okf" / "the currently
+   focused article" resolvable from any of them. The write is
+   fire-and-forget from the panel: a host that does not allow the tool,
+   or a failed write, never breaks the reader.
+
+3. **Freshness is judged, not enforced.** The snapshot carries
+   `updatedAt`; the reading agent names the resolved article and
+   double-checks with the user when the timestamp looks stale (okf
+   skill), rather than the server imposing a TTL. A focus from earlier
+   in the session is usually still what the user means.
+
+## Consequences
+
+- In the Companion, the import button now lands in the Chat view; in
+  MCP Apps hosts with their own conversation (Copilot canvas), the
+  existing `sendMessage` path is untouched; in chat-less hosts the
+  fallback still works.
+- "Import this okf" works symmetrically from any harness — the panel
+  and the chat no longer need to be the same surface.
+- The focus file is advisory UI state: it is never written to the
+  shared database and losing it costs one click in the panel.
+- Tool count grows to 26; the pairing (app-only write, model-visible
+  read) is a pattern later panel state can reuse.
+
+## Code
+
+`src/cli/okf-focus.ts`, `src/cli/commands/mcp.ts` (both tools),
+`src/vscode-extension/host.ts` (message capability),
+`src/vscode-extension/extension.ts` (chat.open routing),
+`src/vscode-extension/protocol.ts` / `src/copilot-extension/extension.mjs`
+(allowlists), `desktop/src/panel/okf.ts` (focus recording).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,3 +50,5 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-17](2026-07-17-okf-knowledge-base.md) | OKF Knowledge Base — Living Repo Knowledge as Learning Sources | Implemented |
 | [2026-07-17b](2026-07-17b-okf-visualizer-panel.md) | OKF Visualizer Panel (MCP App) | Implemented |
 | [2026-07-18](2026-07-18-okf-learning-import.md) | Knowledge-to-Learning Import (OKF Articles → Learning Tokens) | Implemented |
+| [2026-07-18b](2026-07-18b-graph-repo-scope.md) | Learning Graph Scope Selectors and the Repo Scope | Implemented |
+| [2026-07-18c](2026-07-18c-okf-import-handoff.md) | OKF Import Handoff — Chat Delivery and the Focused-Article State | Implemented |

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,8 @@
 ## 2026-07-18
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [Token and Card Model](token-card-model.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -4,6 +4,7 @@
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 
 ## 2026-07-17
 

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -104,4 +104,6 @@ available directly.
 - [ADR 2026-07-17 — OKF Knowledge Base](../adr/2026-07-17-okf-knowledge-base.md)
 - [ADR 2026-07-17b — OKF Visualizer Panel](../adr/2026-07-17b-okf-visualizer-panel.md)
 - [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
+- [ADR 2026-07-18b — Learning Graph Scope Selectors and the Repo Scope](../adr/2026-07-18b-graph-repo-scope.md)
+- [ADR 2026-07-18c — OKF Import Handoff](../adr/2026-07-18c-okf-import-handoff.md)
 - Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (importOkfTokens)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -24,8 +24,9 @@ The server exposes ZAM's tool surface (session start/end, queue and
 review actions, token search and registration, prerequisite linking,
 companion context and sampling, and the OKF knowledge-base tools
 `zam_okf_catalog` / `zam_okf_read` / `zam_okf_upsert` /
-`zam_okf_read_citation` / `zam_okf_import`). The authoritative tool list
-with annotations is pinned by `tests/cli/mcp.test.ts`.
+`zam_okf_read_citation` / `zam_okf_import` / `zam_okf_focused`). The
+authoritative tool list with annotations is pinned by
+`tests/cli/mcp.test.ts`.
 
 The `zam_okf_*` tools resolve their default bundle directory as
 `docs/okf` under the MCP client's workspace root (MCP `roots/list`),
@@ -70,11 +71,20 @@ and other citation targets inline via `zam_okf_read_citation`, a link
 graph (articles as nodes, inter-article links as edges, citations as
 visually distinct nodes), and the `log.md` history. The panel always
 opens — a missing or invalid bundle surfaces as `problems` in the panel
-instead of a tool error. The article reader's "import as learning
-content" action posts the decomposition request into the host
-conversation (MCP Apps `sendMessage`) — the agent does the thinking,
-then records via `zam_okf_import`; hosts without a conversation surface
-get the instruction as copyable text instead.
+instead of a tool error.
+
+The reader's "import as learning content" action hands the
+decomposition request to a chat in host order of capability: hosts
+advertising the MCP Apps `message` capability get it via `ui/message`
+(the VS Code Companion routes this into the editor's Chat view through
+`workbench.action.chat.open`); hosts without one show the instruction
+as copyable text with a copy button. Independently, the reader records
+its focused article machine-locally (`zam_okf_focus`, app-only, written
+to `~/.zam/okf-focus.json`), so a request like "import this okf" or
+"import the currently focused article" typed into ANY connected harness
+— Claude Code, Copilot, Codex — resolves through the model-visible
+`zam_okf_focused` tool. The agent does the thinking either way, then
+records via `zam_okf_import`.
 
 The knowledge-graph card (`zam_show_graph`, `ui://zam/graph`) centers
 on a focus token's direct prerequisites and dependents. Opened without
@@ -94,4 +104,4 @@ available directly.
 - [ADR 2026-07-17 — OKF Knowledge Base](../adr/2026-07-17-okf-knowledge-base.md)
 - [ADR 2026-07-17b — OKF Visualizer Panel](../adr/2026-07-17b-okf-visualizer-panel.md)
 - [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/bridge-handlers.ts` (importOkfTokens)
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (importOkfTokens)

--- a/docs/okf/token-card-model.md
+++ b/docs/okf/token-card-model.md
@@ -8,7 +8,7 @@ tags:
   - tokens
   - cards
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/token-card-model.md"
-timestamp: 2026-07-17T00:00:00Z
+timestamp: 2026-07-18
 ---
 
 The central distinction in ZAM's domain model:
@@ -24,6 +24,21 @@ how much of the skill the human should own versus delegate to AI. Token
 metadata is load-bearing: Bloom levels drive prompt generation
 (`src/kernel/recall/prompter.ts`, template-based, not LLM), and
 `symbiosis_mode` drives coaching behavior.
+
+Tokens imported from OKF articles carry an **anchored source link**:
+`<article resource>#<anchor>` (or the bare resource URL without an
+anchor). The base identifies the article, the anchor the heading the
+concept came from. This makes "the tokens anchored in this bundle" a
+queryable set — `listTokens({ sourceLinkBases })`, exposed as
+`zam bridge list-tokens --source-link-base` — which the learning graph's
+repo scope is built on.
+
+A token can be in **maintenance**: `maintenance_at`/`maintenance_reason`
+mark a token whose source binding needs repair (a stale source link, or
+a re-import that did not confirm it). A maintenance token is kept — never
+deleted — with its learning state preserved, but its cards leave the
+review queue and due list until the binding is repaired and maintenance
+cleared.
 
 A **card** is one user's FSRS scheduling state for a token: stability,
 difficulty, due date, state, and block status (see
@@ -49,4 +64,6 @@ layer, stored by the kernel).
 - [ADR 2026-03-26 — Personal Workflow Foundations](../adr/2026-03-26-personal-workflow-foundations.md)
 - [ADR 2026-07-04 — Knowledge Contexts](../adr/2026-07-04-knowledge-contexts.md)
 - [ADR 2026-07-03 — RAG Semantic Token Search](../adr/2026-07-03-rag-semantic-token-search.md)
+- [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
+- [ADR 2026-07-18b — Learning Graph Scope Selectors and the Repo Scope](../adr/2026-07-18b-graph-repo-scope.md)
 - Code: `src/kernel/models/token.ts`, `src/kernel/recall/prompter.ts`

--- a/docs/plans/2026-07-18-okf-import-handoff-plan.md
+++ b/docs/plans/2026-07-18-okf-import-handoff-plan.md
@@ -21,6 +21,7 @@ fallback exactly as-is.
 focused okf" to work from Claude Code, Copilot, AND Codex, the focus must
 live where every harness already looks: the zam MCP server. Mirrors the
 ui-intent pattern:
+
 - `src/cli/okf-focus.ts`: `writeOkfFocus(file, bundleDir)` /
   `readOkfFocus()` on `~/.zam/okf-focus.json` (atomic rename write,
   `ZAM_OKF_FOCUS_PATH` env override for tests, `{version, file, bundleDir,
@@ -39,18 +40,38 @@ ui-intent pattern:
 
 ## Checklist
 
-- [ ] 1. `src/cli/okf-focus.ts` + unit test (write/read round-trip, env override, malformed file → null)
-- [ ] 2. mcp.ts: `zam_okf_focus` (app-only) + `zam_okf_focused` (read-only) tools; mcp.test.ts: count 24→26, annotations, write→read round-trip (env-isolated path)
-- [ ] 3. protocol.ts + copilot APP_CONFIG: allow `zam_okf_focus` for the okf app; contract test update
-- [ ] 4. okf.ts: record focus on article open (fire-and-forget, never breaks the reader)
-- [ ] 5. host.ts: `message` capability + onmessage → "chatMessage" proxy request
-- [ ] 6. extension.ts: chatMessage handler → workbench.action.chat.open; `{isError:true}` on failure
-- [ ] 7. okf skill triplet: focused-article import phrase
-- [ ] 8. Docs: mcp-surfaces.md (tool surface + panel handoff paragraph) via zam_okf_upsert
-- [ ] 9. Build + lint + full tests vs 3-4-failure environmental baseline
-- [ ] 10. E2E: isolated VS Code — open panel, select article, `zam_okf_focused` returns it; button click → chat.open path or graceful fallback; screenshot
-- [ ] 11. Final check vs plan; PR
+- [x] 1. `src/cli/okf-focus.ts` + unit test (write/read round-trip, env override, malformed file → null)
+- [x] 2. mcp.ts: `zam_okf_focus` (app-only) + `zam_okf_focused` (read-only) tools; mcp.test.ts: count 24→26, annotations, write→read round-trip (env-isolated path)
+- [x] 3. protocol.ts + copilot APP_CONFIG: allow `zam_okf_focus` for the okf app; contract test update
+- [x] 4. okf.ts: record focus on article open (fire-and-forget, never breaks the reader)
+- [x] 5. host.ts: `message` capability + onmessage → "chatMessage" proxy request
+- [x] 6. extension.ts: chatMessage handler → workbench.action.chat.open; `{isError:true}` on failure
+- [x] 7. okf skill triplet: focused-article import phrase
+- [x] 8. Docs: mcp-surfaces.md (tool surface + panel handoff paragraph) via zam_okf_upsert
+- [x] 9. Build + lint + full tests vs 3-4-failure environmental baseline
+- [x] 10. E2E: isolated VS Code — open panel, select article, `zam_okf_focused` returns it; button click → chat.open path or graceful fallback; screenshot
+- [x] 11. Final check vs plan; PR
 
 ## Final check record
 
-(fill in before PR)
+- okf-focus module: 5 unit tests (round-trip, supersede, name validation,
+  malformed→null, env override). Tools: mcp.test.ts pins 26 tools, app-only
+  visibility on the write side, readOnly on the read side, write→read
+  round-trip on an env-isolated path, path-separator rejection.
+- Allowlists: COMPANION_APPS.okf + Copilot APP_CONFIG.okf gained
+  zam_okf_focus; contract test asserts the panel can reach it.
+- Skill triplet: .claude/.agent synced; .agents (Codex) variant re-applied
+  by hand after a blind copy briefly clobbered its intentional $okf wording.
+- Full suite: 1122 passed, 3 failures = known environmental baseline.
+- E2E: automation aborted mid-run (real window kept taking focus — clicks
+  were landing in Thomas's session; stopped immediately). Verification
+  completed manually by Thomas in the isolated instance: import button
+  "jumped to the chat properly" (host message capability → chat.open), and
+  his article click wrote ~/.zam/okf-focus.json ({file:
+  prerequisite-blocking.md, bundleDir: c:\src\github\zam\docs\okf}) through
+  panel → proxy allowlist → dev server. His follow-up import created 5
+  tokens with cards from that article — the whole loop ran live.
+- "Skills were adapted": investigated — ~/.agents/skills/zam/SKILL.md is
+  byte-identical to the packaged 0.14.0 Codex variant; no hand edits, no
+  action needed.
+- Launch config restored to the global install after the e2e.

--- a/docs/plans/2026-07-18-okf-import-handoff-plan.md
+++ b/docs/plans/2026-07-18-okf-import-handoff-plan.md
@@ -1,0 +1,56 @@
+# OKF import handoff — chat delivery + focused-article state (2026-07-18)
+
+Request (Thomas): "Is there a chance you could fix the problem to not find
+the chat for learn import? Or could the command come from chat - 'import the
+currently focussed okf'" + "Codex also can use the vscode context knowledge."
+Decision (AskUserQuestion): Both.
+
+## Design
+
+**A. Companion chat delivery.** The Companion webview host does not
+advertise the MCP Apps `message` capability, so `app.sendMessage` always
+rejects there. Fix: `host.ts` advertises `message: { text: {} }` and wires
+`bridge.onmessage` → proxy request `"chatMessage"`; `extension.ts` handles
+it by extracting the text blocks and calling
+`vscode.commands.executeCommand("workbench.action.chat.open", { query })` —
+the built-in Chat view receives the instruction. Any failure (no chat
+available) returns `{ isError: true }`, which keeps the existing copy-text
+fallback exactly as-is.
+
+**B. Focused-article state (harness-agnostic).** For "import the currently
+focused okf" to work from Claude Code, Copilot, AND Codex, the focus must
+live where every harness already looks: the zam MCP server. Mirrors the
+ui-intent pattern:
+- `src/cli/okf-focus.ts`: `writeOkfFocus(file, bundleDir)` /
+  `readOkfFocus()` on `~/.zam/okf-focus.json` (atomic rename write,
+  `ZAM_OKF_FOCUS_PATH` env override for tests, `{version, file, bundleDir,
+  updatedAt}`).
+- MCP tool `zam_okf_focus` (app-only, `visibility: ["app"]`): records
+  `{file, bundle_dir}`; rejects file names with path separators.
+- MCP tool `zam_okf_focused` (model-visible, read-only): returns
+  `{focused: {file, bundle_dir, updatedAt} | null}`; description tells the
+  agent to use it when the user references "the currently focused/open
+  article" and then follow the zam_okf_import contract.
+- Panel `okf.ts`: after an article opens in the reader (`openArticle`),
+  fire-and-forget `callTool("zam_okf_focus", {file, bundle_dir})`.
+- Allowlists: `COMPANION_APPS.okf` (protocol.ts) and Copilot
+  `APP_CONFIG.okf` gain `zam_okf_focus`.
+- okf skill (3 copies): "import the currently focused article" flow.
+
+## Checklist
+
+- [ ] 1. `src/cli/okf-focus.ts` + unit test (write/read round-trip, env override, malformed file → null)
+- [ ] 2. mcp.ts: `zam_okf_focus` (app-only) + `zam_okf_focused` (read-only) tools; mcp.test.ts: count 24→26, annotations, write→read round-trip (env-isolated path)
+- [ ] 3. protocol.ts + copilot APP_CONFIG: allow `zam_okf_focus` for the okf app; contract test update
+- [ ] 4. okf.ts: record focus on article open (fire-and-forget, never breaks the reader)
+- [ ] 5. host.ts: `message` capability + onmessage → "chatMessage" proxy request
+- [ ] 6. extension.ts: chatMessage handler → workbench.action.chat.open; `{isError:true}` on failure
+- [ ] 7. okf skill triplet: focused-article import phrase
+- [ ] 8. Docs: mcp-surfaces.md (tool surface + panel handoff paragraph) via zam_okf_upsert
+- [ ] 9. Build + lint + full tests vs 3-4-failure environmental baseline
+- [ ] 10. E2E: isolated VS Code — open panel, select article, `zam_okf_focused` returns it; button click → chat.open path or graceful fallback; screenshot
+- [ ] 11. Final check vs plan; PR
+
+## Final check record
+
+(fill in before PR)

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1479,6 +1479,70 @@ export function createMcpServer(db: Database): McpServer {
     ),
   );
 
+  // zam_okf_focus / zam_okf_focused — the "currently focused article"
+  // bridge between the OKF panel and whatever chat the user is in. The
+  // panel records which article its reader shows (app-only write, like
+  // zam_studio_bridge); any harness connected to `zam mcp` — Claude Code,
+  // Copilot, Codex — resolves "import this okf" / "the currently focused
+  // article" through the read side. Machine-local snapshot under ~/.zam,
+  // never the shared database (src/cli/okf-focus.ts).
+  registerAppTool(
+    server,
+    "zam_okf_focus",
+    {
+      description:
+        "App-only: record which OKF article the visualizer panel currently shows, so chat agents can resolve 'the currently focused article'. Not intended for direct model use.",
+      inputSchema: {
+        file: z
+          .string()
+          .describe("Article file name inside the bundle (kebab-case .md)"),
+        bundle_dir: z
+          .string()
+          .optional()
+          .describe("Absolute bundle directory the panel is browsing"),
+      },
+      annotations: {
+        ...commonAnnotations,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+      _meta: {
+        ui: { visibility: ["app"] },
+      },
+    },
+    wrapHandler(async (params: { file: string; bundle_dir?: string }) => {
+      const { writeOkfFocus } = await import("../okf-focus.js");
+      const focus = await writeOkfFocus(params.file, params.bundle_dir);
+      return { recorded: { file: focus.file, updatedAt: focus.updatedAt } };
+    }),
+  );
+
+  server.registerTool(
+    "zam_okf_focused",
+    {
+      description:
+        "The OKF article currently focused in the user's visualizer panel — resolve requests like 'import this okf', 'import the currently focused article', or 'the open article'. Returns {focused: {file, bundle_dir?, updatedAt} | null}; check updatedAt and confirm the article by name with the user if it looks stale. To import, read the article (zam_okf_read) and follow the zam_okf_import contract.",
+      inputSchema: {},
+      annotations: {
+        ...commonAnnotations,
+        readOnlyHint: true,
+      },
+    },
+    wrapHandler(async () => {
+      const { readOkfFocus } = await import("../okf-focus.js");
+      const focus = await readOkfFocus();
+      return {
+        focused: focus
+          ? {
+              file: focus.file,
+              ...(focus.bundleDir ? { bundle_dir: focus.bundleDir } : {}),
+              updatedAt: focus.updatedAt,
+            }
+          : null,
+      };
+    }),
+  );
+
   server.registerTool(
     "zam_okf_read_citation",
     {

--- a/src/cli/okf-focus.ts
+++ b/src/cli/okf-focus.ts
@@ -1,0 +1,80 @@
+/**
+ * Machine-local "currently focused OKF article" state.
+ *
+ * The OKF panel records which article its reader is showing; any agent —
+ * Claude Code, Copilot, Codex, whatever else speaks to `zam mcp` — can then
+ * resolve "import the currently focused okf article" without the panel
+ * needing a conversation surface of its own. Mirrors the ui-intent pattern
+ * (src/cli/ui-intent.ts): a last-write-wins snapshot file under `~/.zam`,
+ * written atomically via rename; a newer focus supersedes an older one.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface OkfFocus {
+  version: 1;
+  /** Article file name inside the bundle (flat kebab-case `.md`). */
+  file: string;
+  /** Absolute bundle directory the panel was browsing, when known. */
+  bundleDir?: string;
+  updatedAt: string;
+}
+
+export function getOkfFocusPath(home: string = homedir()): string {
+  return join(home, ".zam", "okf-focus.json");
+}
+
+function resolvePath(explicit?: string): string {
+  return explicit ?? process.env.ZAM_OKF_FOCUS_PATH ?? getOkfFocusPath();
+}
+
+export async function writeOkfFocus(
+  file: string,
+  bundleDir?: string,
+  opts: { path?: string; now?: () => Date } = {},
+): Promise<OkfFocus> {
+  if (file.includes("/") || file.includes("\\") || !file.endsWith(".md")) {
+    throw new Error(`invalid article file name: ${file}`);
+  }
+  const path = resolvePath(opts.path);
+  const focus: OkfFocus = {
+    version: 1,
+    file,
+    ...(bundleDir ? { bundleDir } : {}),
+    updatedAt: (opts.now?.() ?? new Date()).toISOString(),
+  };
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(focus, null, 2)}\n`, "utf8");
+  await rename(tmp, path);
+  return focus;
+}
+
+/** The last recorded focus, or null when absent or unreadable. */
+export async function readOkfFocus(
+  opts: { path?: string } = {},
+): Promise<OkfFocus | null> {
+  try {
+    const raw = await readFile(resolvePath(opts.path), "utf8");
+    const parsed = JSON.parse(raw) as Partial<OkfFocus>;
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.file !== "string" ||
+      typeof parsed.updatedAt !== "string"
+    ) {
+      return null;
+    }
+    return {
+      version: 1,
+      file: parsed.file,
+      ...(typeof parsed.bundleDir === "string"
+        ? { bundleDir: parsed.bundleDir }
+        : {}),
+      updatedAt: parsed.updatedAt,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/copilot-extension/extension.mjs
+++ b/src/copilot-extension/extension.mjs
@@ -38,6 +38,7 @@ const APP_CONFIG = {
       "zam_okf_catalog",
       "zam_okf_read",
       "zam_okf_read_citation",
+      "zam_okf_focus",
     ]),
   },
   settings: {

--- a/src/vscode-extension/extension.ts
+++ b/src/vscode-extension/extension.ts
@@ -368,6 +368,8 @@ class CompanionViewProvider implements vscode.WebviewViewProvider {
         result = await this.sample(message.payload);
       } else if (message.type === "openLink") {
         result = await this.openLink(message.payload);
+      } else if (message.type === "chatMessage") {
+        result = await this.forwardChatMessage(message.payload);
       } else if (message.type === "modelContext") {
         result = {};
       } else if (message.type === "status") {
@@ -386,6 +388,50 @@ class CompanionViewProvider implements vscode.WebviewViewProvider {
         id,
         error: errorMessage(error),
       });
+    }
+  }
+
+  /**
+   * ui/message from a panel: hand the text to VS Code's Chat view via
+   * `workbench.action.chat.open`, which opens the chat and submits the
+   * query. Returns `{isError: true}` instead of throwing when no chat can
+   * take the message — per the MCP Apps contract, the app then falls back
+   * to its own affordance (the OKF panel shows the instruction as
+   * copyable text).
+   */
+  private async forwardChatMessage(
+    payload: unknown,
+  ): Promise<{ isError?: boolean }> {
+    const content =
+      payload && typeof payload === "object"
+        ? (payload as { content?: unknown }).content
+        : undefined;
+    const blocks = Array.isArray(content) ? content : [];
+    const text = blocks
+      .flatMap((block) =>
+        block &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+          ? [(block as { text: string }).text]
+          : [],
+      )
+      .join("\n")
+      .trim();
+    if (!text) return { isError: true };
+    try {
+      await vscode.commands.executeCommand("workbench.action.chat.open", {
+        query: text,
+      });
+      this.output.appendLine(
+        `[${new Date().toISOString()}] forwarded ui/message to the chat view (${text.length} chars)`,
+      );
+      return {};
+    } catch (error) {
+      this.output.appendLine(
+        `[${new Date().toISOString()}] ui/message could not reach a chat: ${errorMessage(error)}`,
+      );
+      return { isError: true };
     }
   }
 

--- a/src/vscode-extension/host.ts
+++ b/src/vscode-extension/host.ts
@@ -24,6 +24,7 @@ interface BootstrapPayload {
 
 type HostRequestType =
   | "callTool"
+  | "chatMessage"
   | "modelContext"
   | "openLink"
   | "sampling"
@@ -112,6 +113,11 @@ async function mount(payload: BootstrapPayload): Promise<void> {
       logging: {},
       updateModelContext: { text: {}, structuredContent: {} },
       sampling: {},
+      // ui/message: apps hand a user message to "the chat". The extension
+      // side routes it into VS Code's Chat view (workbench.action.chat.open)
+      // and reports isError when no chat can take it — the app then falls
+      // back to its copyable-text path.
+      message: { text: {} },
     },
     { hostContext: hostContext(payload.tool) },
   );
@@ -119,6 +125,8 @@ async function mount(payload: BootstrapPayload): Promise<void> {
 
   bridge.oncalltool = async (params) =>
     request<CallToolResult>("callTool", params);
+  bridge.onmessage = async (params) =>
+    request<{ isError?: boolean }>("chatMessage", params);
   bridge.onupdatemodelcontext = async (params) =>
     request<Record<string, never>>("modelContext", params);
   bridge.oncreatesamplingmessage = async (params) =>

--- a/src/vscode-extension/protocol.ts
+++ b/src/vscode-extension/protocol.ts
@@ -59,6 +59,7 @@ export const COMPANION_APPS: Record<CompanionApp, CompanionAppConfig> = {
       "zam_okf_catalog",
       "zam_okf_read",
       "zam_okf_read_citation",
+      "zam_okf_focus",
       "zam_companion_context",
     ]),
   },

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -89,9 +89,9 @@ describe("MCP stdio server tests", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("lists all 24 tools with correct annotations", async () => {
+  it("lists all 26 tools with correct annotations", async () => {
     const response = await client.listTools();
-    expect(response.tools).toHaveLength(24);
+    expect(response.tools).toHaveLength(26);
 
     const toolNames = response.tools.map((t) => t.name).sort();
     const expectedNames = [
@@ -119,6 +119,8 @@ describe("MCP stdio server tests", () => {
       "zam_okf_read_citation",
       "zam_okf_visualize",
       "zam_okf_import",
+      "zam_okf_focus",
+      "zam_okf_focused",
     ].sort();
     expect(toolNames).toEqual(expectedNames);
 
@@ -1132,6 +1134,70 @@ describe("MCP stdio server tests", () => {
       expect(res.isError).toBeUndefined();
       const data = JSON.parse(res.content[0].text);
       expect(data.log).toBe("");
+    });
+  });
+
+  describe("zam_okf_focus / zam_okf_focused", () => {
+    let previousFocusPath: string | undefined;
+
+    beforeEach(() => {
+      previousFocusPath = process.env.ZAM_OKF_FOCUS_PATH;
+      process.env.ZAM_OKF_FOCUS_PATH = join(tempDir, "okf-focus.json");
+    });
+
+    afterEach(() => {
+      if (previousFocusPath === undefined) {
+        delete process.env.ZAM_OKF_FOCUS_PATH;
+      } else {
+        process.env.ZAM_OKF_FOCUS_PATH = previousFocusPath;
+      }
+    });
+
+    it("marks the write side app-only and the read side read-only", async () => {
+      const response = await client.listTools();
+      const focus = response.tools.find((t) => t.name === "zam_okf_focus");
+      const focusMeta = focus?._meta as
+        | { ui?: { visibility?: string[] } }
+        | undefined;
+      expect(focusMeta?.ui?.visibility).toEqual(["app"]);
+
+      const focused = response.tools.find((t) => t.name === "zam_okf_focused");
+      expect((focused as any).annotations).toEqual({
+        openWorldHint: false,
+        readOnlyHint: true,
+      });
+    });
+
+    it("round-trips the focused article and reports null before any focus", async () => {
+      const before = await client.callTool({
+        name: "zam_okf_focused",
+        arguments: {},
+      });
+      expect(before.isError).toBeUndefined();
+      expect(JSON.parse((before as any).content[0].text).focused).toBeNull();
+
+      const write = await client.callTool({
+        name: "zam_okf_focus",
+        arguments: { file: "mcp-surfaces.md", bundle_dir: "C:/repo/docs/okf" },
+      });
+      expect(write.isError).toBeUndefined();
+
+      const after = await client.callTool({
+        name: "zam_okf_focused",
+        arguments: {},
+      });
+      const focused = JSON.parse((after as any).content[0].text).focused;
+      expect(focused.file).toBe("mcp-surfaces.md");
+      expect(focused.bundle_dir).toBe("C:/repo/docs/okf");
+      expect(typeof focused.updatedAt).toBe("string");
+    });
+
+    it("rejects article names with path separators", async () => {
+      const res = await client.callTool({
+        name: "zam_okf_focus",
+        arguments: { file: "../evil.md" },
+      });
+      expect(res.isError).toBe(true);
     });
   });
 

--- a/tests/cli/okf-focus.test.ts
+++ b/tests/cli/okf-focus.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readOkfFocus,
+  writeOkfFocus,
+} from "../../src/cli/okf-focus.js";
+
+describe("okf-focus state file", () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "zam-okf-focus-"));
+    path = join(dir, "okf-focus.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("round-trips file + bundleDir and stamps updatedAt", async () => {
+    const now = new Date("2026-07-18T12:00:00.000Z");
+    const written = await writeOkfFocus("mcp-surfaces.md", "C:/repo/docs/okf", {
+      path,
+      now: () => now,
+    });
+    expect(written.updatedAt).toBe("2026-07-18T12:00:00.000Z");
+
+    const read = await readOkfFocus({ path });
+    expect(read).toEqual({
+      version: 1,
+      file: "mcp-surfaces.md",
+      bundleDir: "C:/repo/docs/okf",
+      updatedAt: "2026-07-18T12:00:00.000Z",
+    });
+  });
+
+  it("a newer focus supersedes the older one; bundleDir stays optional", async () => {
+    await writeOkfFocus("first.md", "C:/repo/docs/okf", { path });
+    await writeOkfFocus("second.md", undefined, { path });
+    const read = await readOkfFocus({ path });
+    expect(read?.file).toBe("second.md");
+    expect(read?.bundleDir).toBeUndefined();
+  });
+
+  it("rejects path separators and non-md names", async () => {
+    await expect(writeOkfFocus("../evil.md", undefined, { path })).rejects.toThrow(
+      /invalid/,
+    );
+    await expect(writeOkfFocus("sub\\evil.md", undefined, { path })).rejects.toThrow(
+      /invalid/,
+    );
+    await expect(writeOkfFocus("notes.txt", undefined, { path })).rejects.toThrow(
+      /invalid/,
+    );
+  });
+
+  it("returns null for a missing or malformed file", async () => {
+    expect(await readOkfFocus({ path })).toBeNull();
+    writeFileSync(path, "not json", "utf8");
+    expect(await readOkfFocus({ path })).toBeNull();
+    writeFileSync(path, JSON.stringify({ version: 2, file: "x.md" }), "utf8");
+    expect(await readOkfFocus({ path })).toBeNull();
+  });
+
+  it("honors the ZAM_OKF_FOCUS_PATH env override", async () => {
+    const envPath = join(dir, "env-focus.json");
+    const previous = process.env.ZAM_OKF_FOCUS_PATH;
+    process.env.ZAM_OKF_FOCUS_PATH = envPath;
+    try {
+      await writeOkfFocus("env.md");
+      const read = await readOkfFocus();
+      expect(read?.file).toBe("env.md");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ZAM_OKF_FOCUS_PATH;
+      } else {
+        process.env.ZAM_OKF_FOCUS_PATH = previous;
+      }
+    }
+  });
+});

--- a/tests/cli/vscode-companion-protocol.test.ts
+++ b/tests/cli/vscode-companion-protocol.test.ts
@@ -96,6 +96,9 @@ describe("VS Code companion protocol", () => {
       }),
     ).toEqual({ bundle_dir: "C:/src/dw/Cops.AI/docs/okf" });
     expect(COMPANION_APPS.okf.toolName).toBe("zam_okf_visualize");
+    // The reader records its focused article so chat agents can resolve
+    // "import this okf" — the write tool must be reachable from the panel.
+    expect(COMPANION_APPS.okf.allowedTools.has("zam_okf_focus")).toBe(true);
   });
 
   // Regression guard for the 0.13.0 gap: `zam_okf_visualize` published a UI


### PR DESCRIPTION
Two complementary fixes for the knowledge-import handoff (Thomas's report: the Companion \"has no chat\", and \"import the currently focussed okf\" should work from chat — including Codex).

## A. The import button reaches the chat

The Companion webview host never advertised the MCP Apps `message` capability, so `app.sendMessage` always rejected there. It now advertises `message: {text: {}}` and routes `ui/message` to VS Code's Chat view via `workbench.action.chat.open` (query submitted). Failure returns `{isError: true}` per the MCP Apps contract — chat-less hosts keep the copyable-text fallback (with #182's copy button).

## B. \"Import this okf\" from any harness

The OKF reader records its focused article through a new app-only `zam_okf_focus` tool into `~/.zam/okf-focus.json` (ui-intent pattern: atomic last-write-wins snapshot, `ZAM_OKF_FOCUS_PATH` test override). The model-visible `zam_okf_focused` tool resolves \"import this okf\" / \"the currently focused article\" from **any** connected harness — Claude Code, Copilot, Codex. Allowlists (Companion + Copilot extension), the okf skill triplet (Codex `$okf` variant preserved), and `mcp-surfaces.md` (via `zam_okf_upsert`) updated. Tool count 24→26.

## Tests & verification

- New `tests/cli/okf-focus.test.ts` (5); mcp.test.ts pins 26 tools, app-only visibility, an isolated write→read round-trip, and path-separator rejection; companion-protocol contract test covers the new allowlist entry.
- Full suite: 1122 passed; the 3 failures are the known environmental baseline.
- Live-verified by Thomas in an isolated VS Code with the dev build: the import button \"jumped to the chat properly\", the article click wrote the focus file (`prerequisite-blocking.md`), and the subsequent chat-driven import created 5 tokens with cards — the full loop end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)