### PR TITLE
fix: okf parser and renderer tolerate CRLF line endings

### DIFF
--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -113,9 +113,10 @@ function safeHref(target: string): string | null {
  * unterminated fence is not frontmatter; the source is returned unchanged.
  */
 export function stripFrontmatter(source: string): string {
-  // CRLF sources (Windows checkouts) are normalized by the split + join,
-  // so downstream renderMarkdown gets LF regardless of the checkout.
-  const lines = source.split(/\r\n|\n/);
+  // CRLF sources (Windows checkouts) are normalized by the split + join, so
+  // downstream renderMarkdown gets LF regardless of the checkout; a UTF-8
+  // BOM (Windows editors) would defeat the fence check, so drop it too.
+  const lines = source.replace(/^﻿/, "").split(/\r\n|\n/);
   if (lines[0]?.trim() !== "---") return source;
   for (let i = 1; i < lines.length; i++) {
     if (lines[i].trim() === "---") return lines.slice(i + 1).join("\n");
@@ -439,7 +440,7 @@ export function filterCatalog(
 function stripFencedCodeBlocks(text: string): string {
   const out: string[] = [];
   let inFence = false;
-  for (const line of text.split("\n")) {
+  for (const line of text.split(/\r\n|\n/)) {
     if (/^```/.test(line.trim())) {
       inFence = !inFence;
       continue;

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -113,7 +113,9 @@ function safeHref(target: string): string | null {
  * unterminated fence is not frontmatter; the source is returned unchanged.
  */
 export function stripFrontmatter(source: string): string {
-  const lines = source.split("\n");
+  // CRLF sources (Windows checkouts) are normalized by the split + join,
+  // so downstream renderMarkdown gets LF regardless of the checkout.
+  const lines = source.split(/\r\n|\n/);
   if (lines[0]?.trim() !== "---") return source;
   for (let i = 1; i < lines.length; i++) {
     if (lines[i].trim() === "---") return lines.slice(i + 1).join("\n");
@@ -285,7 +287,9 @@ function isBlockStart(line: string): boolean {
  * classified per the panel's link contract (see classifyLink above).
  */
 export function renderMarkdown(source: string): string {
-  const lines = escapeHtml(source).split("\n");
+  // Split on CRLF too: a trailing \r would defeat the $-anchored heading,
+  // fence, and list patterns below on Windows-checkout content.
+  const lines = escapeHtml(source).split(/\r\n|\n/);
   const blocks: string[] = [];
   let i = 0;
 

--- a/src/cli/okf/bundle.ts
+++ b/src/cli/okf/bundle.ts
@@ -59,7 +59,10 @@ function unquote(raw: string): string {
  * of silently dropped fields.
  */
 export function parseFrontmatter(markdown: string): ParsedArticle {
-  const lines = markdown.split("\n");
+  // Windows checkouts (git autocrlf) deliver CRLF files; a trailing \r
+  // would defeat every $-anchored pattern below, so normalize up front.
+  // The body is rebuilt from these lines, so it comes out LF-normalized.
+  const lines = markdown.split(/\r\n|\n/);
   if (lines[0]?.trim() !== "---") {
     throw new Error("frontmatter: file must start with a --- fence");
   }

--- a/src/cli/okf/bundle.ts
+++ b/src/cli/okf/bundle.ts
@@ -59,10 +59,11 @@ function unquote(raw: string): string {
  * of silently dropped fields.
  */
 export function parseFrontmatter(markdown: string): ParsedArticle {
-  // Windows checkouts (git autocrlf) deliver CRLF files; a trailing \r
-  // would defeat every $-anchored pattern below, so normalize up front.
-  // The body is rebuilt from these lines, so it comes out LF-normalized.
-  const lines = markdown.split(/\r\n|\n/);
+  // Windows checkouts (git autocrlf) deliver CRLF files and Windows editors
+  // sometimes prepend a UTF-8 BOM; either would defeat the fence check and
+  // every $-anchored pattern below, so normalize up front. The body is
+  // rebuilt from these lines, so it comes out LF-normalized.
+  const lines = markdown.replace(/^﻿/, "").split(/\r\n|\n/);
   if (lines[0]?.trim() !== "---") {
     throw new Error("frontmatter: file must start with a --- fence");
   }
@@ -219,7 +220,9 @@ export function appendLog(
 ): string {
   const header = `## ${date}`;
   const entry = `- ${line}`;
-  const trimmed = existing.trim();
+  // A hand-edited or Windows-checkout log may arrive with CRLF endings;
+  // normalize so the rebuilt log is uniformly LF instead of mixed.
+  const trimmed = existing.replace(/^﻿/, "").replace(/\r\n/g, "\n").trim();
   if (trimmed === "") {
     return `# Log\n\n${header}\n\n${entry}\n`;
   }

--- a/tests/cli/okf-bundle.test.ts
+++ b/tests/cli/okf-bundle.test.ts
@@ -54,6 +54,23 @@ describe("okf/bundle parseFrontmatter", () => {
     expect(parsed.body).toContain("FSRS-5 drives the queue.");
   });
 
+  it("parses CRLF line endings (Windows checkouts with autocrlf)", () => {
+    const parsed = parseFrontmatter(article().replace(/\n/g, "\r\n"));
+    expect(parsed.fields.type).toBe("concept");
+    expect(parsed.fields.tags).toEqual(["kernel", "fsrs"]);
+    expect(parsed.body).toContain("FSRS-5 drives the queue.");
+    expect(parsed.body).not.toContain("\r");
+  });
+
+  it("validates a CRLF article as conformant", () => {
+    const result = validateArticle(
+      "fsrs-scheduling.md",
+      article().replace(/\n/g, "\r\n"),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.problems).toEqual([]);
+  });
+
   it("rejects a missing opening fence", () => {
     expect(() => parseFrontmatter("type: concept\n---\n")).toThrow(
       /must start with a --- fence/,

--- a/tests/cli/okf-bundle.test.ts
+++ b/tests/cli/okf-bundle.test.ts
@@ -71,6 +71,12 @@ describe("okf/bundle parseFrontmatter", () => {
     expect(result.problems).toEqual([]);
   });
 
+  it("strips a leading UTF-8 BOM (Windows editors) before the fence check", () => {
+    const parsed = parseFrontmatter(`﻿${article().replace(/\n/g, "\r\n")}`);
+    expect(parsed.fields.type).toBe("concept");
+    expect(parsed.body).toContain("FSRS-5 drives the queue.");
+  });
+
   it("rejects a missing opening fence", () => {
     expect(() => parseFrontmatter("type: concept\n---\n")).toThrow(
       /must start with a --- fence/,
@@ -148,6 +154,14 @@ describe("okf/bundle index and log rendering", () => {
     expect(seventeenth.indexOf("**Update**")).toBeLessThan(
       seventeenth.indexOf("**Creation**"),
     );
+  });
+
+  it("merges into a CRLF log and emits LF-normalized output", () => {
+    const crlfLog = "# Log\r\n\r\n## 2026-07-18\r\n\r\n- old entry\r\n";
+    const next = appendLog(crlfLog, "2026-07-18", "new entry");
+    expect(next).not.toContain("\r");
+    const day = next.slice(next.indexOf("## 2026-07-18"));
+    expect(day.indexOf("new entry")).toBeLessThan(day.indexOf("old entry"));
   });
 });
 

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -391,6 +391,20 @@ describe("stripFrontmatter", () => {
     const source = "---\r\ntype: reference\r\n---\r\n\r\n# Title\r\nBody.";
     expect(stripFrontmatter(source)).toBe("\n# Title\nBody.");
   });
+
+  it("strips a leading UTF-8 BOM before the fence check", () => {
+    const source = "﻿---\r\ntype: reference\r\n---\r\n\r\nBody.";
+    expect(stripFrontmatter(source)).toBe("\nBody.");
+  });
+});
+
+describe("extractLinks with CRLF sources", () => {
+  it("still ignores links inside CRLF fenced code blocks", () => {
+    const body =
+      "See [real](workload-resource-rights.md).\r\n\r\n```\r\n[fake](inside-fence.md)\r\n```\r\n";
+    const { articles } = extractLinks(body);
+    expect(articles).toEqual(["workload-resource-rights.md"]);
+  });
 });
 
 describe("renderMarkdown with CRLF sources", () => {

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -386,6 +386,19 @@ describe("stripFrontmatter", () => {
     const source = "---\ntype: reference\nno closing fence";
     expect(stripFrontmatter(source)).toBe(source);
   });
+
+  it("strips CRLF frontmatter and normalizes the body (Windows checkouts)", () => {
+    const source = "---\r\ntype: reference\r\n---\r\n\r\n# Title\r\nBody.";
+    expect(stripFrontmatter(source)).toBe("\n# Title\nBody.");
+  });
+});
+
+describe("renderMarkdown with CRLF sources", () => {
+  it("renders headings and lists despite trailing carriage returns", () => {
+    const html = renderMarkdown("# Title\r\n\r\n- item one\r\n- item two\r\n");
+    expect(html).toContain("<h1>Title</h1>");
+    expect(html).toContain("<li>item one</li>");
+  });
 });
 
 describe("layoutGraph", () => {


### PR DESCRIPTION
The Companion OKF panel showed no catalog/graph for bundles checked out on Windows (git autocrlf → CRLF files): parseFrontmatter/stripFrontmatter/renderMarkdown split on \n only, leaving a trailing \r that defeats every $-anchored pattern — each article throws 'frontmatter line 2: expected "key: value"'. The --- fence checks survived only because they trim().

Fix: split on /\r\n|\n/ at the three public seams (bundle parser, frontmatter strip, markdown renderer); bodies come out LF-normalized. TDD: 4 new tests (CRLF frontmatter parse + validate, CRLF strip, CRLF headings/lists) failed before, pass after; full OKF test set green (the 6 unrelated full-suite failures reproduce on unmodified main — environment-dependent install/bridge/mcp tests).

Verified against the real 41-article Cops.AI bundle: before — all 41 articles rejected; after — 41 articles, 4 types, 42 nodes / 92 edges, finite layout in 1ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)