### PR TITLE
release: prepare 0.15.1

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.15.0"
+version = "0.15.1"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.15.1.md
+++ b/docs/release-notes-0.15.1.md
@@ -1,0 +1,28 @@
+# ZAM 0.15.1 — the knowledge base survives Windows
+
+A patch release: OKF bundles checked out on Windows now parse, render,
+and graph.
+
+## Fixed
+
+- **CRLF bundles load.** Git's `autocrlf` delivers CRLF files on Windows
+  checkouts; the OKF frontmatter parser, the panel's frontmatter strip,
+  and the markdown renderer split on `\n` only, so every line kept a
+  trailing `\r` that defeated the `$`-anchored key-value, heading, fence,
+  and list patterns. Every article failed with `frontmatter line 2:
+  expected "key: value"`, and the Companion OKF panel showed neither the
+  catalog nor the graph. All three seams now split CRLF-safe and emit
+  LF-normalized text. Verified against a real 41-article bundle: before,
+  all articles rejected; after, 41 articles, 4 type groups, and a
+  42-node/92-edge graph. (#185)
+- **BOM tolerance.** A UTF-8 BOM (some Windows editors) no longer defeats
+  the `---` fence checks in the parser and the panel reader. (#185)
+- **appendLog normalizes.** Appending to a CRLF or BOM-carrying `log.md`
+  now emits a uniformly LF-normalized log instead of mixed line endings,
+  and the fenced-code scanner that guards graph link extraction splits
+  CRLF-safe. (#185)
+
+## Notes
+
+Rebuild/update the Companion to pick up the panel-side fixes — the OKF
+panel ships inside the app bundle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.15.0",
+          "User-Agent": "ZAM-Content-Studio/0.15.1",
         },
       });
 


### PR DESCRIPTION
7-file version bump + release notes for the 0.15.1 patch: OKF CRLF/BOM resilience (#185). After merge: tag v0.15.1 to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)