### PR TITLE
release: prepare 0.15.2

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.15.1"
+version = "0.15.2"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.15.1.md
+++ b/docs/release-notes-0.15.1.md
@@ -24,5 +24,18 @@ and graph.
 
 ## Notes
 
-Rebuild/update the Companion to pick up the panel-side fixes — the OKF
-panel ships inside the app bundle.
+**Update the `zam-core` CLI, not just the Companion.** The catalog-blocking
+bug is in the OKF frontmatter *parser*, which runs inside the `zam mcp`
+server — i.e. the global `zam-core` CLI, a separate artifact from the
+Companion VSIX. Updating the extension alone leaves a stale CLI parsing
+CRLF bundles, so the OKF panel stays empty. Update the CLI with:
+
+```sh
+npm install -g zam-core@0.15.1
+```
+
+then reload the VS Code window so the Companion respawns `zam mcp`. The
+panel also carries fixes (frontmatter strip and renderer ship in the app
+bundle), so update the Companion too — but the CLI is the one that
+unblocks the catalog. 0.15.2 adds a launch-time guard that warns when the
+two versions drift, so this can't fail silently again.

--- a/docs/release-notes-0.15.2.md
+++ b/docs/release-notes-0.15.2.md
@@ -1,0 +1,26 @@
+# ZAM 0.15.2 — the Companion tells you when its CLI is stale
+
+A patch release: the Companion now detects when the `zam mcp` CLI it
+launches has drifted from its own version, so a stale CLI can't silently
+break panels.
+
+## Fixed
+
+- **Version-drift guard.** The Companion VSIX and the `zam mcp` server it
+  spawns (the global `zam-core` CLI) ship as independent artifacts, so
+  updating one and leaving the other behind failed silently — exactly how
+  the 0.15.0 CRLF-parse bug kept breaking the OKF panel after the VSIX had
+  already been updated to 0.15.1. On connect, the Companion now compares
+  the server's reported version with its own and, on a mismatch, shows one
+  actionable notice: a stale CLI gets a **Copy fix command** button
+  (`npm install -g zam-core@<version>`); a stale extension is told to
+  update the Companion. The check is one-shot, fire-and-forget, and never
+  blocks or fails the connection; it stays silent for dev/source builds
+  whose version is the unreplaced placeholder.
+
+## Notes
+
+If your OKF panel or other Companion surfaces have been misbehaving, this
+release will now tell you when the cause is a stale CLI. The fix it points
+to is always `npm install -g zam-core@<version>` followed by a window
+reload.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.15.1",
+          "User-Agent": "ZAM-Content-Studio/0.15.2",
         },
       });
 

--- a/src/vscode-extension/extension.ts
+++ b/src/vscode-extension/extension.ts
@@ -37,10 +37,19 @@ import {
   type CompanionApp,
   type CompanionAppConfig,
   createSamplingResult,
+  describeServerVersionDrift,
   normalizeSamplingRequest,
   parseCompanionIntent,
   toolUiResourceUri,
 } from "./protocol.js";
+
+/**
+ * This extension's own version, replaced at VSIX-package time by
+ * scripts/prepare-vscode-extension.mjs (same token as the MCP client name
+ * below). It stays the literal placeholder in dev/source runs, where
+ * describeServerVersionDrift then declines to warn.
+ */
+const EXTENSION_VERSION = "__ZAM_VERSION__";
 
 /**
  * Real `vscode.lm` surface for {@link createVscodeLmAdapter}. Only these
@@ -159,11 +168,41 @@ class ZamMcpHost {
   private connectionPromise:
     | Promise<{ client: Client; transport: StdioClientTransport }>
     | undefined;
+  private versionDriftWarned = false;
 
   public constructor(
     private readonly launchConfigPath: string,
     private readonly output: vscode.OutputChannel,
   ) {}
+
+  /**
+   * Compare the version the freshly-connected `zam mcp` server reports against
+   * this extension's own version and, on drift, surface one actionable notice.
+   * The VSIX and the global `zam-core` CLI update independently, so a stale CLI
+   * behind a newer UI otherwise fails silently (see describeServerVersionDrift).
+   * Fire-and-forget and one-shot per host: never blocks or fails the connection.
+   */
+  private warnOnVersionDrift(client: Client): void {
+    if (this.versionDriftWarned) return;
+    const drift = describeServerVersionDrift(
+      EXTENSION_VERSION,
+      client.getServerVersion()?.version,
+    );
+    if (!drift) return;
+    this.versionDriftWarned = true;
+    this.output.appendLine(`[zam] version drift: ${drift.message}`);
+    void (async () => {
+      const copy = "Copy fix command";
+      const actions = drift.updateCommand ? [copy] : [];
+      const choice = await vscode.window.showWarningMessage(
+        `ZAM Companion: ${drift.message}`,
+        ...actions,
+      );
+      if (choice === copy && drift.updateCommand) {
+        await vscode.env.clipboard.writeText(drift.updateCommand);
+      }
+    })();
+  }
 
   private async connect(): Promise<{
     client: Client;
@@ -194,9 +233,10 @@ class ZamMcpHost {
           name: isAntigravity
             ? "antigravity-zam-companion"
             : "vscode-zam-companion",
-          version: "__ZAM_VERSION__",
+          version: EXTENSION_VERSION,
         });
         await client.connect(transport);
+        this.warnOnVersionDrift(client);
         return { client, transport };
       })().catch((error) => {
         this.connectionPromise = undefined;

--- a/src/vscode-extension/protocol.ts
+++ b/src/vscode-extension/protocol.ts
@@ -208,3 +208,90 @@ export function toolUiResourceUri(tool: Tool): string | undefined {
       ? legacy
       : undefined;
 }
+
+// ── Companion / CLI version-drift guard ────────────────────────────────────
+
+/**
+ * The Companion VSIX (this extension) and the `zam mcp` server it spawns (the
+ * global `zam-core` CLI) ship as independent artifacts, so a user can update
+ * one and silently leave the other behind. That is exactly how the 0.15.0
+ * CRLF-parse bug kept breaking the OKF panel after the VSIX had already been
+ * updated to 0.15.1: the Companion kept launching the stale global server, and
+ * nothing said so. This guard turns that silent drift into a loud, actionable
+ * notice at connect time.
+ */
+export interface ServerVersionDrift {
+  /** `server-older` is the dangerous case: a stale CLI behind a newer UI. */
+  kind: "server-older" | "server-newer";
+  extensionVersion: string;
+  serverVersion: string;
+  /** Ready-to-show sentence naming both versions and how to reconcile them. */
+  message: string;
+  /** The npm command that fixes a `server-older` drift; absent otherwise (the
+   *  fix for `server-newer` is to update the extension, not run a command). */
+  updateCommand?: string;
+}
+
+/**
+ * Numeric `major.minor.patch` core of a semver, ignoring any prerelease/build
+ * suffix. Returns null for anything without that core (e.g. an unreplaced
+ * `__ZAM_VERSION__` in a dev build) so the guard degrades to "no opinion"
+ * rather than raising a false alarm.
+ */
+function semverCore(
+  version: string | undefined,
+): [number, number, number] | null {
+  if (typeof version !== "string") return null;
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+function compareSemverCore(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Compare the Companion extension's own version with the version the spawned
+ * `zam mcp` server reports. Returns a drift descriptor when they differ, or
+ * null when they match or either version is unreadable (never block or warn on
+ * a version we cannot parse).
+ */
+export function describeServerVersionDrift(
+  extensionVersion: string,
+  serverVersion: string | undefined,
+): ServerVersionDrift | null {
+  const ext = semverCore(extensionVersion);
+  const srv = semverCore(serverVersion);
+  if (!ext || !srv) return null;
+  const cmp = compareSemverCore(srv, ext);
+  if (cmp === 0) return null;
+  if (cmp < 0) {
+    const updateCommand = `npm install -g zam-core@${extensionVersion}`;
+    return {
+      kind: "server-older",
+      extensionVersion,
+      serverVersion,
+      updateCommand,
+      message:
+        `ZAM Companion is ${extensionVersion} but its "zam mcp" CLI is ` +
+        `${serverVersion}. The panels run against the CLI, so features can ` +
+        `silently misbehave until it matches — update it with ` +
+        `\`${updateCommand}\`, then reload the window.`,
+    };
+  }
+  return {
+    kind: "server-newer",
+    extensionVersion,
+    serverVersion,
+    message:
+      `ZAM Companion is ${extensionVersion} but its "zam mcp" CLI is already ` +
+      `${serverVersion}. Update the ZAM Companion extension to ${serverVersion} ` +
+      `and reload the window so the UI matches the CLI.`,
+  };
+}

--- a/src/vscode-extension/protocol.ts
+++ b/src/vscode-extension/protocol.ts
@@ -266,6 +266,7 @@ export function describeServerVersionDrift(
   extensionVersion: string,
   serverVersion: string | undefined,
 ): ServerVersionDrift | null {
+  if (serverVersion === undefined) return null;
   const ext = semverCore(extensionVersion);
   const srv = semverCore(serverVersion);
   if (!ext || !srv) return null;

--- a/src/vscode-extension/vscode.d.ts
+++ b/src/vscode-extension/vscode.d.ts
@@ -102,6 +102,7 @@ declare module "vscode" {
   export const env: {
     openExternal(uri: Uri): Promise<boolean>;
     appName: string;
+    clipboard: { writeText(value: string): Promise<void> };
   };
 
   export const workspace: {

--- a/tests/cli/vscode-companion-protocol.test.ts
+++ b/tests/cli/vscode-companion-protocol.test.ts
@@ -10,6 +10,7 @@ import {
   buildOpeningArguments,
   COMPANION_APPS,
   createSamplingResult,
+  describeServerVersionDrift,
   normalizeSamplingRequest,
   parseCompanionIntent,
   toolUiResourceUri,
@@ -184,5 +185,47 @@ describe("VS Code companion protocol", () => {
       content: { type: "text", text: "model reply" },
       stopReason: "endTurn",
     });
+  });
+});
+
+describe("describeServerVersionDrift", () => {
+  it("returns null when the versions match", () => {
+    expect(describeServerVersionDrift("0.15.1", "0.15.1")).toBeNull();
+  });
+
+  it("ignores prerelease/build suffixes when comparing the core", () => {
+    expect(describeServerVersionDrift("0.15.1", "0.15.1-rc.1")).toBeNull();
+  });
+
+  it("flags a stale CLI (server older) with an npm fix command", () => {
+    const drift = describeServerVersionDrift("0.15.1", "0.15.0");
+    expect(drift?.kind).toBe("server-older");
+    expect(drift?.updateCommand).toBe("npm install -g zam-core@0.15.1");
+    expect(drift?.message).toContain("0.15.1");
+    expect(drift?.message).toContain("0.15.0");
+    expect(drift?.message).toContain("npm install -g zam-core@0.15.1");
+  });
+
+  it("orders by minor and major, not just patch", () => {
+    expect(describeServerVersionDrift("0.16.0", "0.15.9")?.kind).toBe(
+      "server-older",
+    );
+    expect(describeServerVersionDrift("1.0.0", "0.99.99")?.kind).toBe(
+      "server-older",
+    );
+  });
+
+  it("flags an outdated extension (server newer) without a CLI command", () => {
+    const drift = describeServerVersionDrift("0.15.0", "0.15.1");
+    expect(drift?.kind).toBe("server-newer");
+    expect(drift?.updateCommand).toBeUndefined();
+    expect(drift?.message).toContain("Update the ZAM Companion extension");
+  });
+
+  it("declines to warn when either version is unreadable", () => {
+    // Dev/source builds carry the unreplaced placeholder.
+    expect(describeServerVersionDrift("__ZAM_VERSION__", "0.15.0")).toBeNull();
+    expect(describeServerVersionDrift("0.15.1", undefined)).toBeNull();
+    expect(describeServerVersionDrift("0.15.1", "not-a-version")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

0.15.2 patch: a **launch-time version-drift guard** so the Companion warns when the global `zam-core` CLI it launches has drifted from the extension's own version — instead of failing silently.

### Why
The Companion VSIX and the `zam mcp` server (the global `zam-core` CLI) are independent artifacts. Updating one and leaving the other stale fails silently — exactly how the 0.15.0 CRLF-parse bug kept breaking the OKF panel in CRLF (Windows) repos *after* the VSIX was already updated to 0.15.1. The parser runs server-side, in the CLI.

### Changes
- **feat:** `describeServerVersionDrift` (pure, tested) + `warnOnVersionDrift` in the Companion host. On connect, compares server vs extension version; on mismatch shows one actionable notice — stale CLI → **Copy fix command** (`npm install -g zam-core@<version>`), stale extension → update the Companion. One-shot, never blocks the connection, silent for dev/placeholder builds.
- **release:** 7-file version bump to 0.15.2 + `docs/release-notes-0.15.2.md`.
- **docs:** rewrote the 0.15.1 release notes, whose "update the Companion" advice was misleading — the CRLF fix is in the CLI, so `zam-core` must be updated, not just the VSIX.

### Tests
- 6 new cases in `vscode-companion-protocol.test.ts` (match / prerelease-core / stale-CLI / stale-extension / minor+major ordering / unreadable-version). 26 tests pass across the extension suites; VSIX builds and stamps 0.15.2.

### Verification still owed
Per repo convention, the guard should be driven in the real host (install the 0.15.2 VSIX against a deliberately-older CLI, confirm the notice + Copy-fix-command fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)