### PR TITLE
fix: close live-test gaps for 0.15.3

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.15.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.15.2"
+version = "0.15.3"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/okf/bridge-protocol.md
+++ b/docs/okf/bridge-protocol.md
@@ -7,7 +7,7 @@ tags:
   - bridge
   - agents
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/bridge-protocol.md"
-timestamp: 2026-07-17T00:00:00Z
+timestamp: 2026-07-19T08:50:00Z
 ---
 
 `zam bridge <command>` is ZAM's machine-facing CLI transport: an agent
@@ -20,9 +20,13 @@ drive.
 The hard contract:
 
 - **JSON only.** Every bridge response is JSON, including errors — all
-  output goes through the `jsonOut`/`jsonError` helpers in
-  `src/cli/commands/bridge.ts`; a stray `console.log` is a bug. (This is
-  stricter than the `--json` flag other commands offer.)
+  action output goes through the `jsonOut`/`jsonError` helpers in
+  `src/cli/commands/bridge.ts`; a stray `console.log` is a bug. Commander
+  errors that occur before an action runs, such as an unknown flag or a
+  missing required option, are intercepted by `src/cli/app.ts` and emitted
+  through the same `{"error":"..."}` stdout envelope with a non-zero exit
+  status and no plain-text stderr. (This is stricter than the `--json` flag
+  other commands offer.)
 - **`src/bridge/protocol.ts` types are the stable contract.** Agents and
   the desktop panels program against these shapes; breaking them breaks
   external callers.
@@ -39,4 +43,4 @@ execute.
 # Citations
 
 - [ADR 2026-07-06a — MCP as the Canonical Agent Transport](../adr/2026-07-06a-mcp-agent-transport-and-surfaces.md)
-- Code: `src/cli/commands/bridge.ts`, `src/bridge/protocol.ts`
+- Code: `src/cli/app.ts`, `src/cli/commands/bridge.ts`, `src/bridge/protocol.ts`

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## 2026-07-19
+
+- **Update** — [Prerequisite Graph and Blocking](prerequisite-blocking.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [Bridge CLI Protocol](bridge-protocol.md)
+
 ## 2026-07-18
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-07-18
+timestamp: 2026-07-19T08:50:00Z
 ---
 
 `zam mcp` starts a stdio **Model Context Protocol** server
@@ -49,10 +49,14 @@ transaction. The agent judges (concepts worth remembering, Bloom level
 and domain per token, prerequisite order); the tool only validates and
 writes. Re-imports are classified per token: `new` adds, `update`
 refreshes content and keeps learning state, `replace` refreshes content
-and resets learning state to the beginning; previously imported tokens
-absent from a re-import move to token maintenance (kept, excluded from
-scheduling) instead of being deleted. Also available as
-`zam bridge okf-import`.
+and resets learning state to the beginning. For every confirmed token,
+the submitted prerequisite list is the complete desired set: re-import
+adds new edges and removes obsolete ones, including clearing the set
+with an empty or omitted list. Cycle validation and all edge changes are
+part of the same transaction, so a rejected graph restores the previous
+content and DAG. Previously imported tokens absent from a re-import move
+to token maintenance (kept, excluded from scheduling) instead of being
+deleted. Also available as `zam bridge okf-import`.
 
 # MCP Apps panels
 
@@ -62,7 +66,11 @@ in hosts that support them: `ui://zam/studio`, `ui://zam/recall`,
 `npm run build:panel`, served from `dist/ui/`). The VS Code /
 Antigravity Companion extension (`src/vscode-extension/`) hosts the
 same panels in a webview and routes recall evaluation through
-per-IDE evaluator selections.
+per-IDE evaluator selections. Replacement requests in that shared
+webview are serialized and coalesced by recency: a mount already in
+flight may finish, then the latest requested panel mounts last and owns
+the final iframe. This makes rapid toolbar or command switches
+deterministic.
 
 `zam_okf_visualize` opens the OKF panel on any OKF bundle (default
 resolved like the other `zam_okf_*` tools — see above): articles
@@ -106,4 +114,4 @@ available directly.
 - [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
 - [ADR 2026-07-18b — Learning Graph Scope Selectors and the Repo Scope](../adr/2026-07-18b-graph-repo-scope.md)
 - [ADR 2026-07-18c — OKF Import Handoff](../adr/2026-07-18c-okf-import-handoff.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (importOkfTokens)
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/host.ts`, `src/vscode-extension/latest-task-queue.ts`

--- a/docs/okf/prerequisite-blocking.md
+++ b/docs/okf/prerequisite-blocking.md
@@ -7,7 +7,7 @@ tags:
   - scheduling
   - prerequisites
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/prerequisite-blocking.md"
-timestamp: 2026-07-17T00:00:00Z
+timestamp: 2026-07-19T08:50:00Z
 ---
 
 Tokens are connected by a **directed prerequisite graph** (table
@@ -33,10 +33,20 @@ review queue; unblocking re-admits them.
 Prerequisite edges can be suggested semantically: the kernel ranks
 candidate foundations from stored embeddings (`suggestFoundations`), and
 agents link them explicitly (`zam_link_prereq` over MCP, or
-`zam bridge`'s prerequisite commands).
+`zam bridge`'s prerequisite commands). Kernel callers add and remove
+individual edges through `addPrerequisite()` and `removePrerequisite()`.
+Operations that reconcile several edges perform those calls inside one
+database transaction.
+
+An OKF learning re-import treats each confirmed token's submitted
+prerequisite list as its complete desired direct-neighbor set. It removes
+obsolete edges before adding declared edges inside the import transaction.
+If an addition would create a cycle, the transaction restores the prior
+content and graph rather than leaving a partial reconciliation.
 
 # Citations
 
 - [ADR 2026-03-27 — Stabilization and Workflow Integrity](../adr/2026-03-27-stabilization-and-workflow-integrity.md)
 - [ADR 2026-07-03 — RAG Semantic Token Search](../adr/2026-07-03-rag-semantic-token-search.md)
-- Code: `src/kernel/scheduler/blocker.ts`, `src/kernel/scheduler/queue.ts`
+- [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
+- Code: `src/kernel/models/prerequisite.ts`, `src/kernel/scheduler/blocker.ts`, `src/kernel/scheduler/queue.ts`, `src/cli/bridge-handlers.ts`

--- a/docs/release-notes-0.15.3.md
+++ b/docs/release-notes-0.15.3.md
@@ -1,0 +1,34 @@
+# ZAM 0.15.3 — reliable OKF switching, re-imports, and bridge errors
+
+A patch release that closes the live-test findings from issue #188 across
+the VS Code Companion, OKF learning import, the JSON bridge, and the local
+verification workflow.
+
+## Fixed
+
+- **Deterministic Companion panel switching.** Overlapping Recall, Graph,
+  Settings, and OKF webview replacements are now serialized and coalesced by
+  recency. The latest requested panel always mounts last, so switching from
+  Recall to the OKF Knowledge Base can no longer leave the stale Recall iframe
+  visible.
+- **Exact prerequisite reconciliation on OKF re-import.** Each confirmed
+  token's submitted prerequisite list is now its complete desired set.
+  Re-import removes obsolete edges as well as adding new ones; an empty list
+  clears the set. Reconciliation remains inside the import transaction, so a
+  cycle rejection restores both the prior token content and graph.
+- **JSON-only bridge parse failures.** Missing required options and unknown
+  flags are intercepted before Commander writes human-readable stderr. They
+  now return the standard JSON error envelope on stdout with a non-zero exit
+  status.
+- **Clean-checkout test reliability.** `npm test` now builds the CLI and MCP
+  App resources it exercises before Vitest starts. Test results no longer
+  depend on an ignored, possibly stale `dist/` directory.
+
+## Verification
+
+The release includes regression coverage for an overlapping Recall-to-OKF
+mount, prerequisite removal and cycle rollback, both Commander error classes,
+and a test invocation that prepares its own production bundles.
+
+See [issue #188](https://github.com/zam-os/zam/issues/188) for the original
+live reproductions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {
@@ -33,6 +33,7 @@
     "build:panel": "vite build --config vite.config.panel.mts && vite build --config vite.config.panel.mts --mode recall && vite build --config vite.config.panel.mts --mode graph && vite build --config vite.config.panel.mts --mode settings && vite build --config vite.config.panel.mts --mode okf",
     "prepare": "npm run build",
     "dev": "tsx src/cli/index.ts",
+    "pretest": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.15.2",
+          "User-Agent": "ZAM-Content-Studio/0.15.3",
         },
       });
 

--- a/src/cli/app.ts
+++ b/src/cli/app.ts
@@ -81,4 +81,35 @@ program.addCommand(goalCommand);
 program.addCommand(gitSyncCommand);
 program.addCommand(workspaceCommand);
 
-await program.parseAsync();
+const isBridgeInvocation = process.argv[2] === "bridge";
+let bridgeParseOutput = "";
+if (isBridgeInvocation) {
+  const captureBridgeParseOutput = (value: string): void => {
+    bridgeParseOutput += value;
+  };
+  bridgeCommand.exitOverride();
+  bridgeCommand.configureOutput({ writeErr: captureBridgeParseOutput });
+  for (const command of bridgeCommand.commands) {
+    command.exitOverride();
+    command.configureOutput({ writeErr: captureBridgeParseOutput });
+  }
+}
+
+try {
+  await program.parseAsync();
+} catch (error) {
+  const commanderCode = (error as { code?: string })?.code;
+  if (isBridgeInvocation && commanderCode === "commander.helpDisplayed") {
+    // Commander implements --help by throwing after it writes the requested
+    // help text. It is successful control flow, not a bridge failure.
+  } else if (isBridgeInvocation && commanderCode?.startsWith("commander.")) {
+    const message = (
+      bridgeParseOutput.trim() ||
+      (error instanceof Error ? error.message : String(error))
+    ).replace(/^error:\s*/i, "");
+    process.stdout.write(`${JSON.stringify({ error: message }, null, 2)}\n`);
+    process.exitCode = 1;
+  } else {
+    throw error;
+  }
+}

--- a/src/cli/bridge-handlers.ts
+++ b/src/cli/bridge-handlers.ts
@@ -34,6 +34,7 @@ import {
   getDisplayTitle,
   getDueCards,
   getInstallChannel,
+  getPrerequisites,
   getSessionSummary,
   getSetting,
   getTokenById,
@@ -51,6 +52,7 @@ import {
   pairCommands,
   prepareSessionSynthesis,
   readMonitorLog,
+  removePrerequisite,
   resetCardsForToken,
   resolveReviewContext,
   searchTokensHybrid,
@@ -879,6 +881,13 @@ export async function importOkfTokens(db: Database, params: ImportOkfParams) {
           (input.prerequisites ?? []).map((s) => s.trim()).filter(Boolean),
         ),
       ];
+      const desiredPrerequisites = new Set(prereqSlugs);
+      const existingPrerequisites = await getPrerequisites(tx, token.id);
+      for (const existing of existingPrerequisites) {
+        if (!desiredPrerequisites.has(existing.slug)) {
+          await removePrerequisite(tx, token.id, existing.requires_id);
+        }
+      }
       for (const prereqSlug of prereqSlugs) {
         const target =
           inImport.get(prereqSlug) ?? (await getTokenBySlug(tx, prereqSlug));

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -134,6 +134,7 @@ export {
   getDependents,
   getPrerequisites,
   getTokenNeighborhood,
+  removePrerequisite,
   wouldCreateCycle,
 } from "./models/prerequisite.js";
 export type { CreateReviewInput, ReviewLog } from "./models/review.js";

--- a/src/kernel/models/prerequisite.ts
+++ b/src/kernel/models/prerequisite.ts
@@ -117,6 +117,21 @@ export async function addPrerequisite(
 }
 
 /**
+ * Remove one prerequisite edge. Idempotent when the edge does not exist.
+ * Callers that reconcile several edges should wrap the full change in one
+ * Database transaction so a later validation failure restores the old graph.
+ */
+export async function removePrerequisite(
+  db: Database,
+  tokenId: string,
+  requiresId: string,
+): Promise<void> {
+  await db
+    .prepare("DELETE FROM prerequisites WHERE token_id = ? AND requires_id = ?")
+    .run(tokenId, requiresId);
+}
+
+/**
  * Get the direct prerequisites of a token — "what does token X require?"
  *
  * Returns prerequisite rows joined with the required token's details.

--- a/src/vscode-extension/host.ts
+++ b/src/vscode-extension/host.ts
@@ -9,6 +9,7 @@ import type {
   CreateMessageResult,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
+import { createLatestTaskQueue } from "./latest-task-queue.js";
 
 declare function acquireVsCodeApi(): {
   postMessage(message: unknown): void;
@@ -159,30 +160,46 @@ async function mount(payload: BootstrapPayload): Promise<void> {
   frame.src = activeBlobUrl;
 }
 
+type RenderRequest =
+  | { type: "bootstrap"; payload: BootstrapPayload }
+  | { type: "empty"; message: string };
+
+const renderLatest = createLatestTaskQueue<RenderRequest>(async (render) => {
+  if (render.type === "bootstrap") {
+    await mount(render.payload);
+    return;
+  }
+  await teardownActiveBridge();
+  status.textContent = render.message;
+});
+
+function reportRenderError(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  status.textContent = `MCP App konnte nicht gestartet werden: ${message}`;
+  void request("status", { phase: "error", message }).catch(() => {});
+}
+
 window.addEventListener("message", (event: MessageEvent<unknown>) => {
   const message = event.data;
   if (!message || typeof message !== "object") return;
   const value = message as Record<string, unknown>;
 
   if (value.type === "bootstrap") {
-    void mount(value.payload as BootstrapPayload).catch((error) => {
-      status.textContent = `MCP App konnte nicht gestartet werden: ${
-        error instanceof Error ? error.message : String(error)
-      }`;
-      void request("status", {
-        phase: "error",
-        message: error instanceof Error ? error.message : String(error),
-      }).catch(() => {});
-    });
+    void renderLatest({
+      type: "bootstrap",
+      payload: value.payload as BootstrapPayload,
+    }).catch(reportRenderError);
     return;
   }
 
   if (value.type === "empty") {
-    void teardownActiveBridge();
-    status.textContent =
-      typeof value.message === "string"
-        ? value.message
-        : "ZAM wartet auf eine Auswahl im Agent-Chat.";
+    void renderLatest({
+      type: "empty",
+      message:
+        typeof value.message === "string"
+          ? value.message
+          : "ZAM wartet auf eine Auswahl im Agent-Chat.",
+    }).catch(reportRenderError);
     return;
   }
 

--- a/src/vscode-extension/latest-task-queue.ts
+++ b/src/vscode-extension/latest-task-queue.ts
@@ -1,0 +1,28 @@
+/**
+ * Serialize UI replacement work while coalescing requests that have not
+ * started yet. A task already in flight is allowed to finish, but every newer
+ * request runs afterwards, so the last request deterministically owns the
+ * final mounted state.
+ */
+export function createLatestTaskQueue<T>(
+  task: (value: T) => Promise<void>,
+): (value: T) => Promise<void> {
+  let latestRequest = 0;
+  let tail: Promise<void> = Promise.resolve();
+
+  return (value: T): Promise<void> => {
+    const request = ++latestRequest;
+    const run = tail.then(async () => {
+      if (request !== latestRequest) return;
+      try {
+        await task(value);
+      } catch (error) {
+        // A newer request supersedes both the result and any failure from the
+        // stale task. Its own task will provide the visible final state.
+        if (request === latestRequest) throw error;
+      }
+    });
+    tail = run.catch(() => {});
+    return run;
+  };
+}

--- a/tests/cli/bridge-json-errors.test.ts
+++ b/tests/cli/bridge-json-errors.test.ts
@@ -1,0 +1,45 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("zam bridge Commander errors", () => {
+  const cliPath = join(process.cwd(), "dist", "cli", "index.js");
+
+  function run(args: string[]) {
+    return spawnSync(process.execPath, [cliPath, ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, ZAM_NO_AUTO_HEAL: "1" },
+    });
+  }
+
+  it.each([
+    {
+      name: "missing required option",
+      args: ["bridge", "get-neighborhood"],
+      message: /required option '--focus <slug>' not specified/,
+    },
+    {
+      name: "unknown option",
+      args: ["bridge", "check-due", "--unknown-option"],
+      message: /unknown option '--unknown-option'/,
+    },
+  ])("returns JSON for $name", ({ args, message }) => {
+    const result = run(args);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({
+      error: expect.stringMatching(message),
+    });
+  });
+
+  it("does not append an error envelope to requested help", () => {
+    const result = run(["bridge", "get-neighborhood", "--help"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage: zam bridge get-neighborhood");
+    expect(result.stdout).not.toContain('"error"');
+  });
+});

--- a/tests/cli/okf-import.test.ts
+++ b/tests/cli/okf-import.test.ts
@@ -7,6 +7,7 @@ import {
   type Database,
   evaluateRating,
   getCard,
+  getPrerequisites,
   getTokenBySlug,
   openDatabase,
 } from "../../src/kernel/index.js";
@@ -152,6 +153,35 @@ describe("importOkfTokens (ADR 2026-07-18)", () => {
     expect(cardAfter?.state).not.toBe("new");
   });
 
+  it("update reconciles the prerequisite set and can clear it", async () => {
+    await importSample([
+      { slug: "first-concept", concept: "Foundation." },
+      {
+        slug: "second-concept",
+        concept: "Initially dependent.",
+        prerequisites: ["first-concept"],
+      },
+    ]);
+
+    await importSample([
+      {
+        slug: "first-concept",
+        concept: "Foundation refreshed.",
+        mode: "update",
+      },
+      {
+        slug: "second-concept",
+        concept: "Now independent.",
+        mode: "update",
+        prerequisites: [],
+      },
+    ]);
+
+    const second = await getTokenBySlug(db, "second-concept");
+    if (!second) throw new Error("token missing");
+    expect(await getPrerequisites(db, second.id)).toEqual([]);
+  });
+
   it("replace refreshes content and resets learning state to the beginning", async () => {
     await importSample([{ slug: "first-concept", concept: "Old meaning." }]);
     const token = await getTokenBySlug(db, "first-concept");
@@ -239,7 +269,13 @@ describe("importOkfTokens (ADR 2026-07-18)", () => {
     ).rejects.toThrow(/cycle/i);
     // Rolled back: alpha's concept unchanged.
     const alpha = await getTokenBySlug(db, "alpha");
+    const beta = await getTokenBySlug(db, "beta");
+    if (!alpha || !beta) throw new Error("tokens missing");
     expect(alpha?.concept).toBe("A.");
+    expect(await getPrerequisites(db, alpha.id)).toEqual([]);
+    expect(
+      (await getPrerequisites(db, beta.id)).map((edge) => edge.requires_id),
+    ).toEqual([alpha.id]);
   });
 
   it("rejects an unknown article and an empty token list", async () => {

--- a/tests/cli/vscode-companion-protocol.test.ts
+++ b/tests/cli/vscode-companion-protocol.test.ts
@@ -6,6 +6,7 @@ import {
   type UiIntentApp,
   writeUiIntent,
 } from "../../src/cli/ui-intent.js";
+import { createLatestTaskQueue } from "../../src/vscode-extension/latest-task-queue.js";
 import {
   buildOpeningArguments,
   COMPANION_APPS,
@@ -100,6 +101,40 @@ describe("VS Code companion protocol", () => {
     // The reader records its focused article so chat agents can resolve
     // "import this okf" — the write tool must be reachable from the panel.
     expect(COMPANION_APPS.okf.allowedTools.has("zam_okf_focus")).toBe(true);
+  });
+
+  it("serializes overlapping app mounts so the latest request wins", async () => {
+    let markRecallStarted: () => void = () => {};
+    let releaseRecall: () => void = () => {};
+    const recallStarted = new Promise<void>((resolve) => {
+      markRecallStarted = resolve;
+    });
+    const recallGate = new Promise<void>((resolve) => {
+      releaseRecall = resolve;
+    });
+    const events: string[] = [];
+    const render = createLatestTaskQueue(async (app: "recall" | "okf") => {
+      events.push(`${app}:start`);
+      if (app === "recall") {
+        markRecallStarted();
+        await recallGate;
+      }
+      events.push(`${app}:mounted`);
+    });
+
+    const recall = render("recall");
+    await recallStarted;
+    const okf = render("okf");
+    releaseRecall();
+    await Promise.all([recall, okf]);
+
+    expect(events).toEqual([
+      "recall:start",
+      "recall:mounted",
+      "okf:start",
+      "okf:mounted",
+    ]);
+    expect(events.at(-1)).toBe("okf:mounted");
   });
 
   // Regression guard for the 0.13.0 gap: `zam_okf_visualize` published a UI


### PR DESCRIPTION
## Summary

- serialize Companion MCP App replacements so the latest panel request wins
- reconcile OKF re-import prerequisite sets exactly and atomically
- return JSON for pre-action Bridge parser errors
- build production artifacts automatically before the test suite
- update OKF reference articles and prepare version 0.15.3

Closes #188.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 111 files, 1144 tests
- `npm run build`
- `npm run observer:check`
- `npm run observer:test` — 62 tests
- `npm pack --dry-run`
- live Bridge error-process smoke
- live stdio MCP OKF import/re-import smoke
- VS Code Companion 0.15.3 Recall → OKF overlapping-bootstrap smoke
