### PR TITLE
fix: make npm test honestly green on Windows; release: prepare 0.15.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,15 +143,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build and test
-        run: |
-          npm run typecheck
-          npm run build
-          npm test
-          cargo test --manifest-path observer/Cargo.toml --target aarch64-pc-windows-msvc
-          cargo build --manifest-path observer/Cargo.toml --release --target aarch64-pc-windows-msvc
+      # One command per step: in a multi-line pwsh `run` block only the LAST
+      # command's exit code decides the step result, so a red `npm test` used
+      # to ship green as long as the cargo build after it passed (issue #190).
+      - name: Type-check project
+        run: npm run typecheck
 
+      - name: Build project
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Test native ARM64 observer
+        run: cargo test --manifest-path observer/Cargo.toml --target aarch64-pc-windows-msvc
+
+      - name: Build native ARM64 observer
+        run: cargo build --manifest-path observer/Cargo.toml --release --target aarch64-pc-windows-msvc
+
+      # bash, not pwsh: `-e` makes any failing CLI call fail the step, so the
+      # three-command smoke sequence cannot mask an early failure either.
       - name: Smoke-test local database
+        shell: bash
         run: |
           node dist/cli/index.js setup --skip-claude-md --skip-agents-md
           node dist/cli/index.js whoami --set ci

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.15.3",
+  "version": "0.15.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.15.3"
+version = "0.15.4"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.15.4.md
+++ b/docs/release-notes-0.15.4.md
@@ -1,0 +1,39 @@
+# ZAM 0.15.4 — an honest green on Windows
+
+A patch release with no product-code changes: it repairs the project's
+Windows verification so that "tests pass" means the same thing on every
+platform. Found while live-testing 0.15.3 for release
+([issue #190](https://github.com/zam-os/zam/issues/190)).
+
+## Fixed
+
+- **The `windows-arm64` CI job can no longer mask test failures.** The job
+  ran typecheck, build, `npm test`, and two cargo commands in a single
+  PowerShell block, where only the last command's exit code decides the
+  step result — the v0.15.3 run shows `Tests 3 failed` in its log yet
+  concluded green. Each command is now its own step, and the CLI smoke
+  sequence runs under `bash -e`.
+- **`npm test` is genuinely green on Windows again.** Three tests failed
+  deterministically on win32 behind that masking:
+  - *ui-intent*: the `/dev/null/…` "unwritable" sentinel is a perfectly
+    creatable directory name on Windows — every run silently deposited a
+    stray `C:\dev\null\…\ui-intent.json` on the system drive. The test now
+    blocks the write with a path beneath a regular file, which no platform
+    can create.
+  - *agent-harness*: Copilot detection compared `path.join` output against
+    POSIX literals; separators are normalized before comparing (closes
+    [#159](https://github.com/zam-os/zam/issues/159)).
+  - *cli-install*: the unix-shim execute-bit assertion is meaningless on
+    Windows (`chmod` is a no-op) and now runs only off-Windows; the shim
+    content and profile-append behavior stay asserted everywhere.
+- **MCP test cleanup no longer races Windows file locks.** The stdio-server
+  suite's temp-dir removal retries (`rmSync` with `maxRetries`) instead of
+  failing the whole file when a handle closes a beat late.
+
+## Verification
+
+Full suite on Windows 11 x64: 111 files, 1144 tests, 0 failures — the
+first honest all-green Windows run since the ARM64 job was added. The
+0.15.3 live-test pass (OKF import lifecycle, re-import classification,
+cycle rollback, CRLF+BOM articles, bridge JSON error envelopes, FSRS
+reset-on-replace) was re-run against this tree unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.15.3",
+          "User-Agent": "ZAM-Content-Studio/0.15.4",
         },
       });
 

--- a/tests/cli/agent-harness.test.ts
+++ b/tests/cli/agent-harness.test.ts
@@ -151,10 +151,16 @@ describe("detectInstalledConnectHarnesses", () => {
         command === "codex" || command === "claude"
           ? `/usr/local/bin/${command}`
           : null,
-      exists: (path) =>
-        path ===
-          "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ||
-        path === "/home/user/.copilot",
+      // The source builds candidate paths with path.join, which uses
+      // backslashes on Windows — normalize before comparing (issue #159).
+      exists: (path) => {
+        const key = path.replaceAll("\\", "/");
+        return (
+          key ===
+            "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ||
+          key === "/home/user/.copilot"
+        );
+      },
     });
 
     expect(detected).toEqual(["codex", "vscode", "copilot"]);

--- a/tests/cli/cli-install.test.ts
+++ b/tests/cli/cli-install.test.ts
@@ -173,7 +173,11 @@ describe("installCliShim", () => {
     expect(readFileSync(report.shimPath, "utf8")).toBe(
       unixShimContent(nodePath, cliPath),
     );
-    expect(statSync(report.shimPath).mode & 0o111).not.toBe(0);
+    if (process.platform !== "win32") {
+      // POSIX execute bits do not exist on Windows (chmod is a no-op and
+      // stat reports no x-bits), so the mode assertion only runs elsewhere.
+      expect(statSync(report.shimPath).mode & 0o111).not.toBe(0);
+    }
     const profile = join(home, ".zprofile");
     expect(readFileSync(profile, "utf8")).toContain(".zam/bin");
     expect(report.pathUpdated).toBe(true);

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -734,6 +734,23 @@ describe("MCP stdio server tests", () => {
       });
     });
     child.kill("SIGTERM");
+    // Wait for the child to actually die: it holds its database inside
+    // tempDir, and on Windows an unawaited kill lets afterEach's rmSync
+    // race the file locks of the exiting process (issue #190).
+    await new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        resolve();
+        return;
+      }
+      const fallback = setTimeout(() => {
+        child.kill("SIGKILL");
+        resolve();
+      }, 5_000);
+      child.once("exit", () => {
+        clearTimeout(fallback);
+        resolve();
+      });
+    });
 
     if (!stdoutData.includes("jsonrpc")) {
       console.error("Child stderr was:", stderrData);

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -86,7 +86,14 @@ describe("MCP stdio server tests", () => {
     if (db) {
       await db.close();
     }
-    rmSync(tempDir, { recursive: true, force: true });
+    // Windows can hold file locks for a beat after the server/DB close —
+    // retry instead of failing the whole suite on cleanup (issue #190).
+    rmSync(tempDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 8,
+      retryDelay: 100,
+    });
   });
 
   it("lists all 26 tools with correct annotations", async () => {

--- a/tests/cli/ui-intent.test.ts
+++ b/tests/cli/ui-intent.test.ts
@@ -59,10 +59,18 @@ describe("VS Code UI intent", () => {
   });
 
   it("keeps UI publication best-effort for hosts without the companion", async () => {
+    // Sentinel: a path beneath a regular *file* cannot be created on any
+    // platform. The previous POSIX sentinel (/dev/null/…) is a perfectly
+    // creatable directory name on Windows and left stray C:\dev droppings
+    // on every test run (issue #190).
+    const home = tempHome();
+    const blocker = join(home, "blocker-file");
+    writeFileSync(blocker, "", "utf8");
+
     const intent = await publishUiIntent(
       "graph",
       { focus: "zam-mcp-server-architecture" },
-      { path: "/dev/null/not-a-directory/ui-intent.json" },
+      { path: join(blocker, "not-a-directory", "ui-intent.json") },
     );
 
     expect(intent).toBeUndefined();


### PR DESCRIPTION
Closes #190. Closes #159.

## What

**CI honesty** — the `windows-arm64` job ran typecheck/build/`npm test`/cargo in one multi-line pwsh `run` block, where only the last command's exit code decides the step result. The v0.15.3 run logged `Tests 3 failed | 1141 passed` and still concluded green. Each command is now its own step; the CLI smoke sequence runs under `bash -e`.

**Windows-portable tests** — with the masking gone, fix what it hid (all deterministic on win32):

- `ui-intent.test.ts`: `/dev/null/…` is a creatable directory name on Windows, so the "unwritable path" sentinel wrote a real intent file and deposited stray `C:\dev\null\…` droppings on every run. The sentinel is now a path beneath a regular *file* — unwritable on every platform.
- `agent-harness.test.ts`: normalize `path.join` output before comparing against POSIX literals in the injected `exists` stub (the fix #159 proposed).
- `cli-install.test.ts`: the unix-shim execute-bit assertion runs only off-Windows (`chmod` is a no-op there); content and profile-append assertions still run everywhere.
- `mcp.test.ts`: the smoke test now awaits the killed child's exit before cleanup, and the shared `rmSync` retries against late Windows file locks.

**Release prep 0.15.4** — version bumps (root, desktop, Cargo, source-reader User-Agent) + `docs/release-notes-0.15.4.md`. No product-code changes.

## Verification

- Windows 11 x64, this branch: `npm test` → **111 files / 1144 tests, 0 failures** (previously 4 files red locally, 3 on the ARM64 runner behind the masking).
- `npm run lint`, `npm run typecheck` clean.
- The masking fix is observable in this PR's own CI: the windows-arm64 job now runs `Run tests` as a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
