### PR TITLE
docs: require judged display titles in the OKF import contract

### DIFF
--- a/.agent/skills/okf/SKILL.md
+++ b/.agent/skills/okf/SKILL.md
@@ -77,8 +77,10 @@ looks stale) before decomposing. Then:
 2. Extract the concepts a practitioner must produce **from memory** —
    recall-speed knowledge. Facts one would reasonably look up stay in the
    article; do not tokenize structure (headings are not concepts).
-3. One atomic concept per token; judge a Bloom level (1–5) and a domain
-   per token, reusing existing domains where they fit.
+3. One atomic concept per token; judge a Bloom level (1–5), a domain
+   (reuse existing domains where they fit), and a concise display
+   `title` per token — titles label the token's node in the Learning
+   Graph; an untitled token shows its de-kebabed slug there.
 4. Arrange a prerequisite DAG from foundational to dependent.
 5. Check existing tokens first (`zam_find_tokens`); link them as
    prerequisites instead of duplicating them.

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -80,8 +80,10 @@ looks stale) before decomposing. Then:
 2. Extract the concepts a practitioner must produce **from memory** —
    recall-speed knowledge. Facts one would reasonably look up stay in the
    article; do not tokenize structure (headings are not concepts).
-3. One atomic concept per token; judge a Bloom level (1–5) and a domain
-   per token, reusing existing domains where they fit.
+3. One atomic concept per token; judge a Bloom level (1–5), a domain
+   (reuse existing domains where they fit), and a concise display
+   `title` per token — titles label the token's node in the Learning
+   Graph; an untitled token shows its de-kebabed slug there.
 4. Arrange a prerequisite DAG from foundational to dependent.
 5. Check existing tokens first (`zam_find_tokens`); link them as
    prerequisites instead of duplicating them.

--- a/.claude/skills/okf/SKILL.md
+++ b/.claude/skills/okf/SKILL.md
@@ -77,8 +77,10 @@ looks stale) before decomposing. Then:
 2. Extract the concepts a practitioner must produce **from memory** —
    recall-speed knowledge. Facts one would reasonably look up stay in the
    article; do not tokenize structure (headings are not concepts).
-3. One atomic concept per token; judge a Bloom level (1–5) and a domain
-   per token, reusing existing domains where they fit.
+3. One atomic concept per token; judge a Bloom level (1–5), a domain
+   (reuse existing domains where they fit), and a concise display
+   `title` per token — titles label the token's node in the Learning
+   Graph; an untitled token shows its de-kebabed slug there.
 4. Arrange a prerequisite DAG from foundational to dependent.
 5. Check existing tokens first (`zam_find_tokens`); link them as
    prerequisites instead of duplicating them.

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1393,8 +1393,9 @@ export function createMcpServer(db: Database): McpServer {
         "Record YOUR finished decomposition of one OKF article as learning tokens + cards (ADR 2026-07-18). " +
         "Decomposition is your job, not this tool's — before calling: (1) read the FULL article (zam_okf_read); " +
         "(2) extract the concepts a practitioner must produce FROM MEMORY — recall-speed knowledge only; facts one " +
-        "would look up stay in the article; (3) one atomic concept per token, with a JUDGED bloom level and a JUDGED " +
-        "domain per token (reuse existing domains where they fit); (4) arrange a prerequisite DAG from foundational " +
+        "would look up stay in the article; (3) one atomic concept per token, with a JUDGED bloom level, a JUDGED " +
+        "domain (reuse existing domains where they fit), and a concise JUDGED display title per token — titles " +
+        "label the token's node in the Learning Graph; (4) arrange a prerequisite DAG from foundational " +
         "to dependent (in-import slugs and existing tokens both allowed); (5) check for existing tokens first " +
         "(zam_find_tokens) and link them as prerequisites instead of duplicating. Multiple tokens are the expected " +
         "outcome for real articles. On RE-import classify each token via mode: 'new' adds, 'update' refreshes " +
@@ -1411,7 +1412,12 @@ export function createMcpServer(db: Database): McpServer {
           .array(
             z.object({
               slug: z.string().describe("Unique kebab-case token slug"),
-              title: z.string().optional().describe("Display title"),
+              title: z
+                .string()
+                .optional()
+                .describe(
+                  "Concise display title — labels this token's node in the Learning Graph; omitted, the de-kebabed slug shows instead",
+                ),
               concept: z
                 .string()
                 .describe("The memorable concept, stated precisely"),


### PR DESCRIPTION
## Why

Titles for learning content are load-bearing, not cosmetic: the Learning Graph labels every node with the token's display title, and `getDisplayTitle` falls back to the de-kebabed slug when no title exists. The `zam_okf_import` quality contract demanded a *judged* Bloom level and a *judged* domain per token — but said nothing about titles, so an agent following the contract to the letter could deliver slug-labeled graph nodes.

## What

Text-only change on the two contract surfaces (same-PR rule, ADR 2026-07-18) plus the field itself:

- **`zam_okf_import` tool description** (`src/cli/commands/mcp.ts`): point (3) now reads "…a JUDGED bloom level, a JUDGED domain (reuse existing domains where they fit), and a concise JUDGED display title per token — titles label the token's node in the Learning Graph".
- **`title` field description**: explains what the title is for and what happens when it is omitted.
- **okf skill, step 3** (`.claude`/`.agent`/`.agents` copies kept in step): same requirement with the same rationale.

No behavior changes, no version bump — this can sit on main until the next release train. Left open for further review passes (Grok / Antigravity welcome).

## Verification

`npm run lint`, `npm run typecheck` clean; `tests/cli/okf-import.test.ts` + `tests/cli/mcp.test.ts` (55 tests) green — no test asserts the contract wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
