### PR TITLE
release: prepare 0.15.5

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.15.4",
+  "version": "0.15.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.15.4"
+version = "0.15.5"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.15.5.md
+++ b/docs/release-notes-0.15.5.md
@@ -1,0 +1,38 @@
+# ZAM 0.15.5 — Bayern LehrplanPLUS complete
+
+Every Bavarian school type in the curriculum import wizard now has a
+live-captured Fachlehrplan taxonomy. Learners can walk Land → Bayern →
+Schulform → Klasse → Fach (→ Ausprägung / Förderschwerpunkt) → Lernbereich
+for **all eight** school types published on LehrplanPLUS.
+
+## Added
+
+- **Full LehrplanPLUS (Bayern) coverage for the remaining school types**
+  ([#194](https://github.com/zam-os/zam/pull/194)):
+  - Wirtschaftsschule (grades 5–11)
+  - Fachoberschule (10–13)
+  - Berufsoberschule (10, 12, 13)
+  - Grundschule (2–4)
+  - Mittelschule (5–10)
+  - Förderschule (2–12), with **Förderschwerpunkte** as tracks
+    (`lernen`, `sehen`, `hören`, …)
+  - Realschule and Gymnasium were already complete; the bundled manifest
+    now holds **2095** navigable topic paths with content URLs for school
+    year 2026/2027.
+- Capture/apply tooling for future school-year refreshes
+  (`scripts/capture-bayern-school-types.ts`,
+  `scripts/apply-bayern-capture.ts`) plus extended audit/probe scripts.
+
+## Changed
+
+- OKF import contract: display titles on generated learning cards must be
+  *judged* (not raw headings) — docs/skill wording aligned with the import
+  tools ([#193](https://github.com/zam-os/zam/pull/193)).
+
+## Notes
+
+- Catalog “gaps” (a subject listed for a grade that has no Fachlehrplan on
+  LehrplanPLUS for that year) still show an empty topic list — intentional,
+  same as Chemie in Realschule 5.
+- Future-dated editions (e.g. `gueltig_ab_27_28`) are not included for
+  2026/27; re-run capture after the next school-year switch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/scripts/capture-bayern-school-types.ts
+++ b/scripts/capture-bayern-school-types.ts
@@ -20,7 +20,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(__dirname, ".cache");
 const BASE = "https://www.lehrplanplus.bayern.de";
 const USER_AGENT =
-  "ZAM-curriculum-capture/0.15.4 (+https://github.com/zam-os/zam)";
+  "ZAM-curriculum-capture/0.15.5 (+https://github.com/zam-os/zam)";
 const DELAY_MS = 120;
 const SCHOOL_YEAR = "2026/2027";
 const CAPTURED_ON = new Date().toISOString().slice(0, 10);

--- a/scripts/capture-bayern-ws-fos-bos.ts
+++ b/scripts/capture-bayern-ws-fos-bos.ts
@@ -21,7 +21,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(__dirname, ".cache");
 const BASE = "https://www.lehrplanplus.bayern.de";
 const USER_AGENT =
-  "ZAM-curriculum-capture/0.15.4 (+https://github.com/zam-os/zam)";
+  "ZAM-curriculum-capture/0.15.5 (+https://github.com/zam-os/zam)";
 const DELAY_MS = 120;
 const SCHOOL_YEAR = "2026/2027";
 const CAPTURED_ON = new Date().toISOString().slice(0, 10);

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.15.4",
+          "User-Agent": "ZAM-Content-Studio/0.15.5",
         },
       });
 


### PR DESCRIPTION
## Summary

- Bump **zam-core**, desktop, and Tauri app to **0.15.5**
- Release notes: full Bayern LehrplanPLUS coverage (all eight school types)
- Ships [#194](https://github.com/zam-os/zam/pull/194) and the OKF judged-title docs from [#193](https://github.com/zam-os/zam/pull/193)

## Test plan

- [x] `npm run typecheck`
- [ ] After merge: tag `v0.15.5` and push to trigger `.github/workflows/release.yml` (npm + Tauri + Companion VSIX)