### PR TITLE
docs: polish 0.15.5 release notes

### DIFF
--- a/docs/release-notes-0.15.5.md
+++ b/docs/release-notes-0.15.5.md
@@ -3,36 +3,47 @@
 Every Bavarian school type in the curriculum import wizard now has a
 live-captured Fachlehrplan taxonomy. Learners can walk Land → Bayern →
 Schulform → Klasse → Fach (→ Ausprägung / Förderschwerpunkt) → Lernbereich
-for **all eight** school types published on LehrplanPLUS.
+for **all eight** school types published on LehrplanPLUS — not only
+Realschule and Gymnasium.
 
-## Added
+## Highlights
 
-- **Full LehrplanPLUS (Bayern) coverage for the remaining school types**
-  ([#194](https://github.com/zam-os/zam/pull/194)):
-  - Wirtschaftsschule (grades 5–11)
-  - Fachoberschule (10–13)
-  - Berufsoberschule (10, 12, 13)
-  - Grundschule (2–4)
-  - Mittelschule (5–10)
-  - Förderschule (2–12), with **Förderschwerpunkte** as tracks
-    (`lernen`, `sehen`, `hören`, …)
-  - Realschule and Gymnasium were already complete; the bundled manifest
-    now holds **2095** navigable topic paths with content URLs for school
-    year 2026/2027.
-- Capture/apply tooling for future school-year refreshes
-  (`scripts/capture-bayern-school-types.ts`,
-  `scripts/apply-bayern-capture.ts`) plus extended audit/probe scripts.
+- **Full LehrplanPLUS (Bayern) coverage**
+  ([#194](https://github.com/zam-os/zam/pull/194)). The bundled manifest
+  now holds **2095** navigable topic paths with content URLs for school
+  year 2026/2027:
 
-## Changed
+  | Schulart | Grades | Topic paths |
+  |----------|--------|-------------|
+  | Grundschule | 2–4 | 49 |
+  | Mittelschule | 5–10 | 168 |
+  | Förderschule | 2–12 | 885 |
+  | Realschule | 5–10 | 144 (already complete) |
+  | Gymnasium | 5–13 | 341 (already complete) |
+  | Wirtschaftsschule | 5–11 | 166 |
+  | Fachoberschule | 10–13 | 202 |
+  | Berufsoberschule | 10, 12, 13 | 140 |
 
-- OKF import contract: display titles on generated learning cards must be
-  *judged* (not raw headings) — docs/skill wording aligned with the import
-  tools ([#193](https://github.com/zam-os/zam/pull/193)).
+- **Förderschule tracks are Förderschwerpunkte** (`lernen`, `sehen`,
+  `hören`, `geistige-entwicklung`, …) resolved via
+  `w_foerderschwerpunkt` — the same Ausprägung step in the wizard, the
+  official site's second dimension under the hood.
+- **Capture/apply tooling for school-year refreshes** —
+  `scripts/capture-bayern-school-types.ts` and
+  `scripts/apply-bayern-capture.ts`, plus audit/probe coverage for all
+  eight school types.
+
+## Also in this release
+
+- **OKF import contract: judged display titles**
+  ([#193](https://github.com/zam-os/zam/pull/193)). Skill and tool docs
+  now require *judged* card titles on knowledge-to-learning import, not
+  raw article headings.
 
 ## Notes
 
-- Catalog “gaps” (a subject listed for a grade that has no Fachlehrplan on
-  LehrplanPLUS for that year) still show an empty topic list — intentional,
-  same as Chemie in Realschule 5.
+- Catalog “gaps” (a subject listed for a grade with no Fachlehrplan on
+  LehrplanPLUS for that year) still show an empty topic list —
+  intentional, same as Chemie in Realschule 5.
 - Future-dated editions (e.g. `gueltig_ab_27_28`) are not included for
   2026/27; re-run capture after the next school-year switch.


### PR DESCRIPTION
## Summary

- Polish `docs/release-notes-0.15.5.md` to match the 0.15.x release prose style.
- GitHub release draft already updated with Install section that correctly says **Already on 0.10.8 or later** for in-app auto-update (auto-update shipped in 0.10.8, not only from the previous patch).

## Test plan

- [x] Compare against v0.15.4 / v0.15.3 GitHub release bodies
- [ ] After release workflow finishes: re-confirm draft notes were not overwritten; publish