### PR TITLE
fix: hide empty curriculum options and explain Ausprägung tracks

### DIFF
--- a/desktop/src/curriculum-wizard.ts
+++ b/desktop/src/curriculum-wizard.ts
@@ -20,6 +20,7 @@ import { loadStudioData } from "./learning-content.js";
 interface TaxonomyOption {
   id: string;
   label: string;
+  description?: string;
   hours?: number;
   sourceRef?: string;
 }
@@ -557,7 +558,12 @@ function render(): void {
 
   renderBreadcrumb();
   stepLabelEl.textContent = current.label;
-  topicNoteEl.classList.add("hidden");
+  if (current.key === "track") {
+    topicNoteEl.textContent = t("wizard_track_note");
+    topicNoteEl.classList.remove("hidden");
+  } else {
+    topicNoteEl.classList.add("hidden");
+  }
   renderStepBody(current);
 
   btnBack.disabled = false;
@@ -608,9 +614,12 @@ function renderStepBody(step: WizardStep): void {
     const hint = opt.hours
       ? `<span class="wizard-option-hint">${escapeHtml(tf("wizard_hours", { hours: opt.hours }))}</span>`
       : "";
+    const description = opt.description
+      ? `<span class="wizard-option-desc">${escapeHtml(opt.description)}</span>`
+      : "";
     row.innerHTML =
       `<input type="${step.multiSelect ? "checkbox" : "radio"}" ${isSelected ? "checked" : ""} style="pointer-events: none;" />` +
-      `<span class="wizard-option-label">${escapeHtml(opt.label)}</span>${hint}`;
+      `<span class="wizard-option-text"><span class="wizard-option-label">${escapeHtml(opt.label)}</span>${description}</span>${hint}`;
     row.addEventListener("click", () => selectOption(step, opt.id));
     stepBodyEl.appendChild(row);
   }

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -3361,6 +3361,8 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     wizard_step_grade: "Grade",
     wizard_step_subject: "Subject",
     wizard_step_track: "Track",
+    wizard_track_note:
+      "This subject comes in several variants — for example depending on your school's branch, elective group, or course level. Pick the one that matches your class; if you are unsure, your timetable or your teacher can tell you which applies.",
     wizard_step_topic: "Topics",
     wizard_btn_back: "Back",
     wizard_btn_next: "Next",
@@ -3947,6 +3949,8 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     wizard_step_grade: "Jahrgangsstufe",
     wizard_step_subject: "Fach",
     wizard_step_track: "Ausprägung",
+    wizard_track_note:
+      "Dieses Fach gibt es in mehreren Varianten – zum Beispiel je nach Zweig, Wahlpflichtfächergruppe oder Niveau. Wähle die Variante, die zu deiner Klasse passt. Wenn du unsicher bist, hilft ein Blick in deinen Stundenplan oder du fragst deine Lehrkraft.",
     wizard_step_topic: "Themen",
     wizard_btn_back: "Zurück",
     wizard_btn_next: "Weiter",

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2648,6 +2648,20 @@ textarea::placeholder {
   color: var(--clr-text-primary);
 }
 
+.wizard-option-row .wizard-option-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.wizard-option-row .wizard-option-desc {
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--clr-text-secondary);
+}
+
 .wizard-option-row .wizard-option-hint {
   font-size: 0.78rem;
   color: var(--clr-text-secondary);

--- a/src/cli/curriculum/content-filter.ts
+++ b/src/cli/curriculum/content-filter.ts
@@ -1,0 +1,100 @@
+/**
+ * Content-aware view over a curriculum provider.
+ *
+ * Manifests mirror the official curriculum sites' full subject catalogs, but
+ * many school-type × grade × subject combinations have no importable topics
+ * (e.g. FOS Informatik only exists for grades 12/13, and most non-Bavarian
+ * manifests are still sparse seeds). Offering such a dead end in the import
+ * wizard wastes the learner's walk — there is nothing to import at the end.
+ *
+ * `withImportableContentOnly` wraps a provider so every listed option can
+ * reach at least one topic through the provider's own public API: subjects
+ * with neither direct topics nor a topic-bearing track disappear, and grades
+ * or school types whose options all disappear are hidden too. It only uses
+ * the `CurriculumProvider` contract, so it works for every registered
+ * provider regardless of manifest shape.
+ */
+import type { CurriculumProvider, TaxonomyNode } from "./types.js";
+
+function trackHasTopics(
+  provider: CurriculumProvider,
+  schoolType: string,
+  grade: string,
+  subject: string,
+  track: string,
+): boolean {
+  return provider.listTopics({ schoolType, grade, subject, track }).length > 0;
+}
+
+function subjectHasContent(
+  provider: CurriculumProvider,
+  schoolType: string,
+  grade: string,
+  subject: string,
+): boolean {
+  const tracks = provider.listTracks(schoolType, grade, subject);
+  if (tracks.length === 0) {
+    return provider.listTopics({ schoolType, grade, subject }).length > 0;
+  }
+  return tracks.some((track) =>
+    trackHasTopics(provider, schoolType, grade, subject, track.id),
+  );
+}
+
+function gradeHasContent(
+  provider: CurriculumProvider,
+  schoolType: string,
+  grade: string,
+): boolean {
+  return provider
+    .listSubjects(schoolType, grade)
+    .some((subject) =>
+      subjectHasContent(provider, schoolType, grade, subject.id),
+    );
+}
+
+export function withImportableContentOnly(
+  provider: CurriculumProvider,
+): CurriculumProvider {
+  return {
+    ...provider,
+
+    listSchoolTypes(): TaxonomyNode[] {
+      return provider
+        .listSchoolTypes()
+        .filter((schoolType) =>
+          provider
+            .listGrades(schoolType.id)
+            .some((grade) =>
+              gradeHasContent(provider, schoolType.id, grade.id),
+            ),
+        );
+    },
+
+    listGrades(schoolType: string): TaxonomyNode[] {
+      return provider
+        .listGrades(schoolType)
+        .filter((grade) => gradeHasContent(provider, schoolType, grade.id));
+    },
+
+    listSubjects(schoolType: string, grade: string): TaxonomyNode[] {
+      return provider
+        .listSubjects(schoolType, grade)
+        .filter((subject) =>
+          subjectHasContent(provider, schoolType, grade, subject.id),
+        );
+    },
+
+    listTracks(
+      schoolType: string,
+      grade: string,
+      subject: string,
+    ): TaxonomyNode[] {
+      return provider
+        .listTracks(schoolType, grade, subject)
+        .filter((track) =>
+          trackHasTopics(provider, schoolType, grade, subject, track.id),
+        );
+    },
+  };
+}

--- a/src/cli/curriculum/providers/lehrplanplus-bayern/index.ts
+++ b/src/cli/curriculum/providers/lehrplanplus-bayern/index.ts
@@ -7,6 +7,7 @@ import type {
   TopicNode,
 } from "../../types.js";
 import { LEHRPLANPLUS_BAYERN_MANIFEST as MANIFEST } from "./manifest.js";
+import { describeBayernTrack } from "./track-descriptions.js";
 
 function levelKey(
   schoolType: string,
@@ -172,7 +173,12 @@ export const lehrplanplusBayernProvider: CurriculumProvider = {
     grade: string,
     subject: string,
   ): TaxonomyNode[] {
-    return MANIFEST.tracks[levelKey(schoolType, grade, subject)] ?? [];
+    return (MANIFEST.tracks[levelKey(schoolType, grade, subject)] ?? []).map(
+      (track) => {
+        const description = describeBayernTrack(schoolType, track);
+        return description ? { ...track, description } : { ...track };
+      },
+    );
   },
 
   listTopics(selection: CurriculumSelection): TopicNode[] {

--- a/src/cli/curriculum/providers/lehrplanplus-bayern/track-descriptions.ts
+++ b/src/cli/curriculum/providers/lehrplanplus-bayern/track-descriptions.ts
@@ -1,0 +1,257 @@
+/**
+ * Learner-facing explanations for LehrplanPLUS "Ausprägung" (track) options.
+ *
+ * The manifest's track labels mirror the official site verbatim
+ * ("Mathematik 9 (I)", "Chemie 12 (GH)", "Deutsch 8 (vierstufige
+ * Wirtschaftsschule)"), which assumes the reader already knows Bavarian
+ * school-system shorthand. A learner picking a track in the import wizard
+ * often does not, so every recognized pattern gets a short German
+ * description (German on purpose — the whole taxonomy is German curriculum
+ * data). Unrecognized labels get no description and render label-only,
+ * exactly as before.
+ */
+import type { TaxonomyNode } from "../../types.js";
+
+const GYMNASIUM_ZWEIGE: Record<string, string> = {
+  NTG: "Naturwissenschaftlich-technologisches Gymnasium",
+  HG: "Humanistisches Gymnasium",
+  SG: "Sprachliches Gymnasium",
+  MuG: "Musisches Gymnasium",
+  WWG: "Wirtschaftswissenschaftliches Gymnasium",
+  SWG: "Sozialwissenschaftliches Gymnasium",
+};
+
+const FOS_BOS_RICHTUNGEN: Record<string, string> = {
+  ABU: "Agrarwirtschaft, Bio- und Umwelttechnologie",
+  G: "Gestaltung",
+  GH: "Gesundheit",
+  IW: "Internationale Wirtschaft",
+  S: "Sozialwesen",
+  T: "Technik",
+  W: "Wirtschaft und Verwaltung",
+};
+
+/** Codes that appear word-bounded in `label`, in the table's order. */
+function codesInLabel(label: string, table: Record<string, string>): string[] {
+  return Object.keys(table).filter((code) =>
+    new RegExp(`\\b${code}\\b`).test(label),
+  );
+}
+
+/**
+ * FOS/BOS track ids are often a dash-joined list of Ausbildungsrichtung
+ * codes ("abu-g-s-w-gh-iw", "wahl-t-iw"). When every meaningful token is a
+ * known code, the id names the audience more reliably than the label (two
+ * tracks can share one label, e.g. "Künstliche Intelligenz, Informatik und
+ * Technologie 12" for both `t` and `abu`).
+ */
+function fosBosCodesFromId(id: string): string[] {
+  const ignored = new Set(["wahl", "pflicht"]);
+  const tokens = id
+    .toLowerCase()
+    .split(/[-_]/)
+    .filter((token) => token.length > 0 && !ignored.has(token));
+  if (tokens.length === 0) return [];
+  const codes = tokens.map((token) => token.toUpperCase());
+  if (!codes.every((code) => code in FOS_BOS_RICHTUNGEN)) return [];
+  return Object.keys(FOS_BOS_RICHTUNGEN).filter((code) => codes.includes(code));
+}
+
+function richtungenSentence(codes: string[]): string | undefined {
+  if (codes.length === 0) return undefined;
+  const named = codes.map((code) => `${FOS_BOS_RICHTUNGEN[code]} (${code})`);
+  if (named.length === 1) {
+    return `Für die Ausbildungsrichtung ${named[0]}.`;
+  }
+  return `Für die Ausbildungsrichtungen: ${named.join(", ")}.`;
+}
+
+function collectRealschule(label: string, parts: string[]): void {
+  if (/\(I\)\s*$/.test(label)) {
+    parts.push(
+      "Für die Wahlpflichtfächergruppe I (mathematisch-naturwissenschaftlich-technischer Zweig, u. a. mit vertiefter Mathematik).",
+    );
+  } else if (/\(II\/III\)\s*$/.test(label)) {
+    parts.push(
+      "Für die Wahlpflichtfächergruppen II und III (wirtschaftlicher bzw. fremdsprachlicher, gestalterischer oder sozialer Zweig).",
+    );
+  }
+}
+
+function collectGymnasium(label: string, parts: string[]): void {
+  if (label.includes("erhöhtes Anforderungsniveau")) {
+    parts.push(
+      "Erhöhtes Anforderungsniveau: vertieftes Niveau der Oberstufe, z. B. für dein Abiturprüfungsfach mit erhöhten Anforderungen.",
+    );
+  }
+  if (label.includes("grundlegendes Anforderungsniveau")) {
+    parts.push(
+      "Grundlegendes Anforderungsniveau: das Standardniveau der Oberstufe.",
+    );
+  }
+  if (label.includes("Vertiefungskurs")) {
+    parts.push(
+      "Freiwilliger Vertiefungskurs zur Studienvorbereitung in der Oberstufe.",
+    );
+  }
+  if (/spät beginnende/i.test(label)) {
+    parts.push(
+      "„Spät beginnend“: für alle, die das Fach erst in der Oberstufe neu begonnen haben.",
+    );
+  } else if (label.includes("Fremdsprache") && /\d\./.test(label)) {
+    parts.push(
+      "Die Zählung richtet sich danach, als wievielte Fremdsprache du die Sprache begonnen hast (Beginn ab Klasse 5 = 1. Fremdsprache).",
+    );
+  }
+  const zweige = codesInLabel(label, GYMNASIUM_ZWEIGE);
+  if (zweige.length === 1) {
+    parts.push(
+      `Gilt für den Zweig ${GYMNASIUM_ZWEIGE[zweige[0]]} (${zweige[0]}).`,
+    );
+  } else if (zweige.length > 1) {
+    parts.push(
+      `Gilt für diese Zweige: ${zweige
+        .map((code) => `${GYMNASIUM_ZWEIGE[code]} (${code})`)
+        .join(", ")}.`,
+    );
+  }
+}
+
+function collectMittelschule(label: string, parts: string[]): void {
+  if (/\(R und M\)/.test(label)) {
+    parts.push(
+      "Gilt für Regelklassen (R) und Mittlere-Reife-Klassen (M) gleichermaßen.",
+    );
+  } else if (/\bM\d+\b/.test(label)) {
+    parts.push(
+      "M-Klasse (Mittlere-Reife-Zug): erhöhtes Anforderungsniveau auf dem Weg zum mittleren Schulabschluss.",
+    );
+  } else if (/\bR\d+\b/.test(label)) {
+    parts.push("Regelklasse: der reguläre Bildungsgang der Mittelschule.");
+  }
+}
+
+function collectWirtschaftsschule(label: string, parts: string[]): void {
+  if (/(drei- und vier|vier- und drei)stufige/.test(label)) {
+    parts.push(
+      "Gilt für die drei- und die vierstufige Wirtschaftsschule gleichermaßen.",
+    );
+  } else if (label.includes("vierstufig")) {
+    parts.push("Vierstufige Wirtschaftsschule: Einstieg ab Jahrgangsstufe 7.");
+  } else if (label.includes("dreistufig")) {
+    parts.push("Dreistufige Wirtschaftsschule: Einstieg ab Jahrgangsstufe 8.");
+  } else if (label.includes("zweistufig")) {
+    parts.push("Zweistufige Wirtschaftsschule: Einstieg ab Jahrgangsstufe 10.");
+  }
+}
+
+function collectFosBos(track: TaxonomyNode, parts: string[]): void {
+  const { id, label } = track;
+  if (label.includes("Vorklasse")) {
+    parts.push(
+      "Vorklasse: das Vollzeit-Vorbereitungsjahr vor Jahrgangsstufe 11 (FOS) bzw. 12 (BOS).",
+    );
+  }
+  if (label.includes("Vorkurs")) {
+    parts.push(
+      "Vorkurs: vorbereitender Kurs (meist in Teilzeit) vor dem Einstieg in die FOS/BOS.",
+    );
+  }
+  if (/\bAHR\b/.test(label)) {
+    parts.push(
+      "AHR: Weg zur Allgemeinen Hochschulreife (Abitur), in der Regel mit zweiter Fremdsprache bis Jahrgangsstufe 13.",
+    );
+  }
+  if (label.includes("Grundkurs")) {
+    parts.push("Grundkurs: Sprachkurs für Einsteiger ohne Vorkenntnisse.");
+  }
+  if (label.includes("Aufbaukurs")) {
+    parts.push(
+      "Aufbaukurs: setzt Vorkenntnisse aus der vorherigen Schule voraus.",
+    );
+  }
+  if (label.includes("fortgeführt")) {
+    parts.push(
+      "Fortgeführt: Weiterführung einer bereits erlernten Fremdsprache.",
+    );
+  }
+  if (label.includes("fachpraktisch")) {
+    parts.push(
+      "Teil der fachpraktischen Ausbildung (fpA) in Jahrgangsstufe 11.",
+    );
+  }
+  const codes =
+    fosBosCodesFromId(id).length > 0
+      ? fosBosCodesFromId(id)
+      : codesInLabel(label, FOS_BOS_RICHTUNGEN);
+  const richtungen = richtungenSentence(codes);
+  if (richtungen) {
+    parts.push(richtungen);
+  } else {
+    const prefix = label.match(/^(.+?) – /)?.[1];
+    const prefixRichtung = Object.values(FOS_BOS_RICHTUNGEN).find(
+      (name) => prefix === name,
+    );
+    if (prefixRichtung) {
+      parts.push(`Für die Ausbildungsrichtung ${prefixRichtung}.`);
+    }
+  }
+}
+
+const WOCHENSTUNDEN: Record<string, string> = {
+  einstündig: "einer Wochenstunde",
+  zweistündig: "zwei Wochenstunden",
+  dreistündig: "drei Wochenstunden",
+};
+
+function collectShared(track: TaxonomyNode, parts: string[]): void {
+  const { id, label } = track;
+  if (label.includes("Basissport")) {
+    parts.push("Basissport: der verbindliche Sportunterricht für alle.");
+  }
+  if (label.includes("Differenzierter Sport")) {
+    parts.push(
+      "Differenzierter Sport: zusätzlicher Wahlsport in einzelnen Sportarten.",
+    );
+  }
+  const stunden = label.match(/(einstündig|zweistündig|dreistündig)/)?.[1];
+  if (stunden) {
+    parts.push(
+      `Fassung mit ${WOCHENSTUNDEN[stunden]} – welche gilt, hängt von der Stundentafel deiner Schule ab.`,
+    );
+  }
+  const gueltigAb = label.match(/gültig ab (?:SJ )?(\d{4}\/\d{2})/)?.[1];
+  if (gueltigAb) {
+    parts.push(`Neue Lehrplanfassung: gilt ab dem Schuljahr ${gueltigAb}.`);
+  }
+  const gueltigBis = id.match(/gueltig_bis_(\d{2})_(\d{2})/);
+  if (gueltigBis) {
+    parts.push(
+      `Bisherige Lehrplanfassung: gilt noch bis einschließlich Schuljahr 20${gueltigBis[1]}/${gueltigBis[2]}.`,
+    );
+  }
+}
+
+/**
+ * Explains one Ausprägung option of the given school type, or returns
+ * `undefined` when no pattern applies (the option then renders label-only).
+ */
+export function describeBayernTrack(
+  schoolType: string,
+  track: TaxonomyNode,
+): string | undefined {
+  const parts: string[] = [];
+
+  if (schoolType === "realschule") collectRealschule(track.label, parts);
+  else if (schoolType === "gymnasium") collectGymnasium(track.label, parts);
+  else if (schoolType === "mittelschule")
+    collectMittelschule(track.label, parts);
+  else if (schoolType === "wirtschaftsschule")
+    collectWirtschaftsschule(track.label, parts);
+  else if (schoolType === "fos" || schoolType === "bos")
+    collectFosBos(track, parts);
+
+  collectShared(track, parts);
+
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}

--- a/src/cli/curriculum/registry.ts
+++ b/src/cli/curriculum/registry.ts
@@ -1,3 +1,4 @@
+import { withImportableContentOnly } from "./content-filter.js";
 import { bildungsplanBremenProvider } from "./providers/bildungsplan-bremen/index.js";
 import { bildungsplanBwProvider } from "./providers/bildungsplan-bw/index.js";
 import { bildungsplanHamburgProvider } from "./providers/bildungsplan-hamburg/index.js";
@@ -15,7 +16,13 @@ import { rahmenplanMvProvider } from "./providers/rahmenplan-mv/index.js";
 import { rahmenrichtlinienStProvider } from "./providers/rahmenrichtlinien-st/index.js";
 import type { CurriculumProvider, TaxonomyNode } from "./types.js";
 
-/** Registered curriculum providers. Add a new plugin here to extend it. */
+/**
+ * Registered curriculum providers. Add a new plugin here to extend it.
+ *
+ * Every provider is wrapped in `withImportableContentOnly`, so consumers
+ * (bridge, wizard) never see school types, grades, subjects, or tracks that
+ * cannot reach an importable topic.
+ */
 export const CURRICULUM_PROVIDERS: CurriculumProvider[] = [
   lehrplanplusBayernProvider,
   bildungsplanBwProvider,
@@ -32,7 +39,7 @@ export const CURRICULUM_PROVIDERS: CurriculumProvider[] = [
   rahmenrichtlinienStProvider,
   fachanforderungenShProvider,
   lehrplanThueringenProvider,
-];
+].map(withImportableContentOnly);
 
 export function getCurriculumProvider(
   id: string,

--- a/src/cli/curriculum/types.ts
+++ b/src/cli/curriculum/types.ts
@@ -13,6 +13,13 @@
 export interface TaxonomyNode {
   id: string;
   label: string;
+  /**
+   * Optional learner-facing explanation of what picking this option means
+   * (e.g. which Wahlpflichtfächergruppe a Realschule track belongs to).
+   * Plain data in the curriculum's own language, rendered by the wizard
+   * beneath the label.
+   */
+  description?: string;
 }
 
 export interface TopicNode extends TaxonomyNode {

--- a/tests/cli/bridge-curriculum.test.ts
+++ b/tests/cli/bridge-curriculum.test.ts
@@ -120,8 +120,18 @@ describe("bridge curriculum-* commands", () => {
       }),
     ]) as { options: Array<{ id: string; label: string }> };
     expect(tracks.options).toEqual([
-      { id: "wpfg1", label: "Mathematik 9 (I)" },
-      { id: "wpfg2-3", label: "Mathematik 9 (II/III)" },
+      {
+        id: "wpfg1",
+        label: "Mathematik 9 (I)",
+        description: expect.stringContaining("Wahlpflichtfächergruppe I"),
+      },
+      {
+        id: "wpfg2-3",
+        label: "Mathematik 9 (II/III)",
+        description: expect.stringContaining(
+          "Wahlpflichtfächergruppen II und III",
+        ),
+      },
     ]);
 
     const topics = runBridge([

--- a/tests/cli/curriculum-content-filter.test.ts
+++ b/tests/cli/curriculum-content-filter.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { withImportableContentOnly } from "../../src/cli/curriculum/content-filter.js";
+import {
+  CURRICULUM_PROVIDERS,
+  getCurriculumProvider,
+} from "../../src/cli/curriculum/registry.js";
+import type {
+  CurriculumProvider,
+  CurriculumSelection,
+  TopicNode,
+} from "../../src/cli/curriculum/types.js";
+
+/**
+ * Stub provider with every emptiness case: a school type with no content at
+ * all, a grade whose subjects are all empty, a subject without topics, and
+ * a track without topics next to one with topics.
+ */
+const stubProvider: CurriculumProvider = {
+  id: "stub",
+  country: "DE",
+  countryLabel: "Deutschland",
+  region: "XX",
+  regionLabel: "Teststaat",
+  label: "Stub",
+
+  listSchoolTypes: () => [
+    { id: "full", label: "Full" },
+    { id: "hollow", label: "Hollow" },
+  ],
+  listGrades: (schoolType) =>
+    schoolType === "full"
+      ? [
+          { id: "1", label: "1" },
+          { id: "2", label: "2" },
+        ]
+      : [{ id: "1", label: "1" }],
+  listSubjects: (schoolType, grade) => {
+    if (schoolType !== "full" || grade !== "1") {
+      return [{ id: "void", label: "Void" }];
+    }
+    return [
+      { id: "direct", label: "Direct", description: "kept as-is" },
+      { id: "tracked", label: "Tracked" },
+      { id: "void", label: "Void" },
+    ];
+  },
+  listTracks: (schoolType, grade, subject) =>
+    schoolType === "full" && grade === "1" && subject === "tracked"
+      ? [
+          { id: "alive", label: "Alive" },
+          { id: "dead", label: "Dead" },
+        ]
+      : [],
+  listTopics: (selection: CurriculumSelection) => {
+    const reachable =
+      selection.schoolType === "full" &&
+      selection.grade === "1" &&
+      (selection.subject === "direct" ||
+        (selection.subject === "tracked" && selection.track === "alive"));
+    return reachable
+      ? [{ id: "t1", label: "Topic", sourceRef: "ref" }]
+      : [];
+  },
+  resolveTopic: (topic: TopicNode) => ({
+    provider: "stub",
+    topicId: topic.id,
+    uri: "https://example.invalid/topic",
+  }),
+};
+
+describe("withImportableContentOnly", () => {
+  const filtered = withImportableContentOnly(stubProvider);
+
+  it("hides subjects that cannot reach any topic", () => {
+    expect(filtered.listSubjects("full", "1").map((s) => s.id)).toEqual([
+      "direct",
+      "tracked",
+    ]);
+  });
+
+  it("hides tracks without topics but keeps topic-bearing siblings", () => {
+    expect(filtered.listTracks("full", "1", "tracked").map((t) => t.id)).toEqual(
+      ["alive"],
+    );
+  });
+
+  it("hides grades and school types whose options are all empty", () => {
+    expect(filtered.listGrades("full").map((g) => g.id)).toEqual(["1"]);
+    expect(filtered.listSchoolTypes().map((s) => s.id)).toEqual(["full"]);
+  });
+
+  it("passes surviving nodes through untouched", () => {
+    expect(filtered.listSubjects("full", "1")[0]).toEqual({
+      id: "direct",
+      label: "Direct",
+      description: "kept as-is",
+    });
+    expect(filtered.id).toBe("stub");
+    expect(filtered.listTopics({ schoolType: "full", grade: "1", subject: "direct" })).toHaveLength(1);
+  });
+});
+
+describe("registered curriculum providers — no dead ends", () => {
+  it("wraps the registry so empty FOS/Realschule/BOS combos disappear", () => {
+    const bayern = getCurriculumProvider("lehrplanplus-bayern");
+    if (!bayern) throw new Error("lehrplanplus-bayern not registered");
+
+    // The user-reported case: FOS grades 10/11 list no Informatik because
+    // LehrplanPLUS only publishes it for grades 12/13.
+    expect(bayern.listSubjects("fos", "10").map((s) => s.id)).not.toContain(
+      "informatik",
+    );
+    expect(bayern.listSubjects("fos", "11").map((s) => s.id)).not.toContain(
+      "informatik",
+    );
+    expect(bayern.listSubjects("fos", "12").map((s) => s.id)).toContain(
+      "informatik",
+    );
+
+    expect(
+      bayern.listSubjects("realschule", "5").map((s) => s.id),
+    ).not.toContain("chemie");
+    expect(bayern.listSubjects("realschule", "9").map((s) => s.id)).toContain(
+      "mathematik",
+    );
+    expect(bayern.listSubjects("bos", "12").map((s) => s.id)).not.toContain(
+      "deutsch",
+    );
+
+    // Filtering must not cost any school type or grade its place today.
+    expect(bayern.listSchoolTypes()).toHaveLength(8);
+    expect(bayern.listGrades("fos").map((g) => g.id)).toEqual([
+      "10",
+      "11",
+      "12",
+      "13",
+    ]);
+  });
+
+  it("every listed option of every provider reaches a resolvable topic", () => {
+    for (const provider of CURRICULUM_PROVIDERS) {
+      for (const schoolType of provider.listSchoolTypes()) {
+        const grades = provider.listGrades(schoolType.id);
+        expect(
+          grades.length,
+          `${provider.id}: school type ${schoolType.id} lists no grades`,
+        ).toBeGreaterThan(0);
+
+        for (const grade of grades) {
+          const subjects = provider.listSubjects(schoolType.id, grade.id);
+          expect(
+            subjects.length,
+            `${provider.id}: ${schoolType.id}|${grade.id} lists no subjects`,
+          ).toBeGreaterThan(0);
+
+          for (const subject of subjects) {
+            const tracks = provider.listTracks(
+              schoolType.id,
+              grade.id,
+              subject.id,
+            );
+            const selections: CurriculumSelection[] =
+              tracks.length === 0
+                ? [
+                    {
+                      schoolType: schoolType.id,
+                      grade: grade.id,
+                      subject: subject.id,
+                    },
+                  ]
+                : tracks.map((track) => ({
+                    schoolType: schoolType.id,
+                    grade: grade.id,
+                    subject: subject.id,
+                    track: track.id,
+                  }));
+
+            let reachableTopics = 0;
+            for (const selection of selections) {
+              const topics = provider.listTopics(selection);
+              reachableTopics += topics.length;
+              for (const topic of topics) {
+                const resolved = provider.resolveTopic(topic);
+                expect(
+                  resolved.uri,
+                  `${provider.id}: ${JSON.stringify(selection)} topic ${topic.id} has no source URL`,
+                ).toMatch(/^https?:\/\//);
+              }
+            }
+            expect(
+              reachableTopics,
+              `${provider.id}: ${schoolType.id}|${grade.id}|${subject.id} is a dead end`,
+            ).toBeGreaterThan(0);
+          }
+        }
+      }
+    }
+  });
+});

--- a/tests/cli/curriculum-lehrplanplus-bayern.test.ts
+++ b/tests/cli/curriculum-lehrplanplus-bayern.test.ts
@@ -42,9 +42,20 @@ describe("LehrplanPLUS Bayern provider — navigation (real, agent-captured data
   });
 
   it("lists the two Wahlpflichtfächergruppe tracks for Realschule Mathematik 9", () => {
-    expect(provider.listTracks("realschule", "9", "mathematik")).toEqual([
-      { id: "wpfg1", label: "Mathematik 9 (I)" },
-      { id: "wpfg2-3", label: "Mathematik 9 (II/III)" },
+    const tracks = provider.listTracks("realschule", "9", "mathematik");
+    expect(tracks).toEqual([
+      {
+        id: "wpfg1",
+        label: "Mathematik 9 (I)",
+        description: expect.stringContaining("Wahlpflichtfächergruppe I"),
+      },
+      {
+        id: "wpfg2-3",
+        label: "Mathematik 9 (II/III)",
+        description: expect.stringContaining(
+          "Wahlpflichtfächergruppen II und III",
+        ),
+      },
     ]);
   });
 
@@ -136,8 +147,16 @@ describe("LehrplanPLUS Bayern provider — navigation (real, agent-captured data
 
   it("lists Sport 5 tracks and Basissport Lernbereiche", () => {
     expect(provider.listTracks("realschule", "5", "sport")).toEqual([
-      { id: "basis_sport", label: "Basissport 5" },
-      { id: "diff_sport", label: "Differenzierter Sport" },
+      {
+        id: "basis_sport",
+        label: "Basissport 5",
+        description: expect.stringContaining("Basissport"),
+      },
+      {
+        id: "diff_sport",
+        label: "Differenzierter Sport",
+        description: expect.stringContaining("Wahlsport"),
+      },
     ]);
     const topics = provider.listTopics({
       schoolType: "realschule",
@@ -172,8 +191,18 @@ describe("LehrplanPLUS Bayern provider — navigation (real, agent-captured data
 
   it("lists the two Wahlpflichtfächergruppe tracks for Realschule Physik 9", () => {
     expect(provider.listTracks("realschule", "9", "physik")).toEqual([
-      { id: "wpfg1", label: "Physik 9 (I)" },
-      { id: "wpfg2-3", label: "Physik 9 (II/III)" },
+      {
+        id: "wpfg1",
+        label: "Physik 9 (I)",
+        description: expect.stringContaining("Wahlpflichtfächergruppe I"),
+      },
+      {
+        id: "wpfg2-3",
+        label: "Physik 9 (II/III)",
+        description: expect.stringContaining(
+          "Wahlpflichtfächergruppen II und III",
+        ),
+      },
     ]);
   });
 
@@ -539,5 +568,59 @@ describe("LehrplanPLUS Bayern provider — navigation (real, agent-captured data
     expect(resolved.provider).toBe("lehrplanplus-bayern");
     expect(resolved.uri).toContain("foerderschule");
     expect(resolved.uri).toContain("w_foerderschwerpunkt=lernen");
+  });
+});
+
+describe("LehrplanPLUS Bayern provider — Ausprägung descriptions", () => {
+  it("explains FOS Ausbildungsrichtung codes, including shared labels", () => {
+    const tracks = provider.listTracks("fos", "12", "mathematik");
+    const technik = tracks.find((track) => track.id === "t");
+    expect(technik?.description).toContain("Technik (T)");
+    const all = tracks.find((track) => track.id === "abu-g-s-w-gh-iw");
+    expect(all?.description).toContain("Ausbildungsrichtungen");
+    expect(all?.description).toContain("Internationale Wirtschaft (IW)");
+  });
+
+  it("explains Gymnasium Oberstufe Anforderungsniveaus", () => {
+    const tracks = provider.listTracks("gymnasium", "12", "biologie");
+    const erhoeht = tracks.find((track) => track.id === "erhoeht");
+    const grundlegend = tracks.find((track) => track.id === "grundlegend");
+    expect(erhoeht?.description).toMatch(/vertieftes Niveau/);
+    expect(grundlegend?.description).toMatch(/Standardniveau/);
+  });
+
+  it("explains Wirtschaftsschule forms by their entry grade", () => {
+    const tracks = provider.listTracks(
+      "wirtschaftsschule",
+      "10",
+      "mathematik",
+    );
+    expect(
+      tracks.find((track) => track.id === "vierstufig")?.description,
+    ).toContain("Jahrgangsstufe 7");
+    expect(
+      tracks.find((track) => track.id === "dreistufig")?.description,
+    ).toContain("Jahrgangsstufe 8");
+    expect(
+      tracks.find((track) => track.id === "zweistufig")?.description,
+    ).toContain("Jahrgangsstufe 10");
+  });
+
+  it("explains Mittelschule Regelklasse and Mittlere-Reife-Zug", () => {
+    const tracks = provider.listTracks("mittelschule", "8", "mathematik");
+    expect(
+      tracks.find((track) => track.id === "regelklasse")?.description,
+    ).toContain("Regelklasse");
+    expect(
+      tracks.find((track) => track.id === "mittlere-reife-klasse")?.description,
+    ).toContain("Mittlere-Reife-Zug");
+  });
+
+  it("leaves self-explanatory Förderschwerpunkt tracks undescribed", () => {
+    const tracks = provider.listTracks("foerderschule", "7", "mathematik");
+    expect(tracks.length).toBeGreaterThan(0);
+    expect(tracks.every((track) => track.description === undefined)).toBe(
+      true,
+    );
   });
 });

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -169,6 +169,9 @@ const REQUIRED_KEYS = [
 // passed over, so the exhaustive scan below doesn't mask *new* regressions
 // while still not churning unrelated strings.
 const PRE_EXISTING_FALLBACK_KEYS = new Set([
+  // 0.15.6 track-step explainer — en/de shipped; es/fr/pt/zh/ja await
+  // native pack review before translation (see i18n pack backlog).
+  "wizard_track_note",
   "repair_agents_error",
   "repair_agents_ok",
   "repair_cli_error",


### PR DESCRIPTION
## What

Two clarity fixes for the Lehrplan import wizard:

1. **No more dead ends.** Subjects with no importable content (e.g. FOS grade 10/11 Informatik) no longer appear — and neither do grades, school types, or Ausprägungen that cannot reach any topic. The filter (`withImportableContentOnly`) wraps every registered provider in the registry and only uses the public provider contract, so all 15 Länder providers (and future ones) are covered. LehrplanPLUS Bayern alone had 635 empty subject×grade combos; the sparse seed manifests of the other Länder had proportionally more.

2. **Ausprägungen explained for learners.** Options like "Mathematik 9 (I)" vs. "Mathematik 9 (II/III)" now carry a plain-German description under the label (Wahlpflichtfächergruppe I = mathematisch-naturwissenschaftlich-technischer Zweig, …). Covered patterns: Realschule Wahlpflichtfächergruppen, Gymnasium Oberstufen-Anforderungsniveaus/Fremdsprachenfolge/Zweige, FOS/BOS-Ausbildungsrichtungen (incl. id-based disambiguation where two tracks share a label), Wirtschaftsschul-Stufen mit Einstiegsjahrgang, Mittelschule R-/M-Klassen, Sport-, Wochenstunden- und "gültig ab"-Varianten. The Ausprägung step additionally shows a general explainer ("… wenn du unsicher bist, frag deine Lehrkraft"), localized en/de; the other packs fall back to English pending native review.

## How it looks

Ausprägung step now: explainer note under the step title, each option with label + muted description; options without a recognized pattern render label-only exactly as before, and the hours hint on topic rows is unchanged.

## Verification

- `npm test` — 1176 tests green, including a new registry-wide conformance walk (every listed option of every provider reaches a topic that resolves to a source URL) and description assertions.
- Bridge smoke test: `curriculum-list-level` for FOS 10 lists 18 subjects without Informatik, FOS 12 still lists it; Realschule 9 Mathematik tracks return both descriptions.
- Desktop `tsc` clean; wizard markup/styles verified visually against the real stylesheet (label+description wrap, fallback row, hours hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)