### PR TITLE
fix: make curriculum imports resilient and grade-scoped

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -780,7 +780,7 @@
 
             <div id="curriculum-wizard-progress-container" class="hidden" style="margin-top: 10px;">
               <div class="modal-impact-title" id="lbl-curriculum-wizard-progress-status" style="color: var(--clr-accent-purple);">Importing…</div>
-              <p style="font-size: 0.85rem; color: var(--clr-text-secondary);" id="lbl-curriculum-wizard-progress-detail">This may take up to a minute depending on your local LLM speed.</p>
+              <p style="font-size: 0.85rem; color: var(--clr-text-secondary);" id="lbl-curriculum-wizard-progress-detail">Card generation can take several minutes per topic — progress updates continuously below.</p>
             </div>
           </div>
           <div class="modal-actions" style="justify-content: space-between;">

--- a/desktop/src/curriculum-wizard-session.ts
+++ b/desktop/src/curriculum-wizard-session.ts
@@ -25,3 +25,53 @@ export class CurriculumWizardSession {
     return snapshot !== this.generation;
   }
 }
+
+interface ToggleableClassList {
+  add(token: string): void;
+  remove(token: string): void;
+}
+
+interface DisableableControl {
+  disabled: boolean;
+}
+
+/** Restore controls that may have been left busy by a canceled/stale run. */
+export function resetCurriculumWizardTransientUi(input: {
+  buttons: DisableableControl[];
+  progressContainer: { classList: ToggleableClassList };
+  stepBody: { classList: ToggleableClassList };
+}): void {
+  for (const button of input.buttons) button.disabled = false;
+  input.progressContainer.classList.add("hidden");
+  input.stepBody.classList.remove("hidden");
+}
+
+/** Apply the card-preview bulk selection without replacing item identities. */
+export function setCurriculumPreviewSelection<T extends { selected: boolean }>(
+  items: T[],
+  selected: boolean,
+): void {
+  for (const item of items) item.selected = selected;
+}
+
+export function areAllCurriculumPreviewItemsSelected(
+  items: Array<{ selected: boolean }>,
+): boolean {
+  return items.length > 0 && items.every((item) => item.selected);
+}
+
+function curriculumCategorySegment(value: string): string {
+  return value.trim().split("/").join("／");
+}
+
+/** Compact learner-facing hierarchy: subject / grade / curriculum topic. */
+export function buildCurriculumCategoryPath(input: {
+  subject: string;
+  grade: string;
+  topic: string;
+}): string {
+  return [input.subject, input.grade, input.topic]
+    .map(curriculumCategorySegment)
+    .filter(Boolean)
+    .join("/");
+}

--- a/desktop/src/curriculum-wizard.ts
+++ b/desktop/src/curriculum-wizard.ts
@@ -12,10 +12,15 @@
  * text extraction is Phase 3. The topic step tells the learner this.
  */
 import { runBridge } from "./bridge-transport.js";
-import { CurriculumWizardSession } from "./curriculum-wizard-session.js";
+import {
+  areAllCurriculumPreviewItemsSelected,
+  buildCurriculumCategoryPath,
+  CurriculumWizardSession,
+  resetCurriculumWizardTransientUi,
+  setCurriculumPreviewSelection,
+} from "./curriculum-wizard-session.js";
 import { t, tf } from "./i18n.js";
-import { escapeHtml } from "./learning-content.js";
-import { loadStudioData } from "./learning-content.js";
+import { escapeHtml, loadStudioData } from "./learning-content.js";
 
 interface TaxonomyOption {
   id: string;
@@ -28,7 +33,6 @@ interface TaxonomyOption {
 /** Per-topic LLM preview — must exceed CLI bridge hard timeout (10 min local). */
 const LOCAL_LLM_PREVIEW_TIMEOUT_MS = 660_000;
 const CLOUD_LLM_PREVIEW_TIMEOUT_MS = 240_000;
-
 
 interface CurriculumProviderInfo {
   id: string;
@@ -118,6 +122,9 @@ interface WizardStep {
 let importTopicQueue: TaxonomyOption[] = [];
 let importTopicIndex = 0;
 const wizardSession = new CurriculumWizardSession();
+let importProgressTimer: ReturnType<typeof setInterval> | undefined;
+let importProgressBaseDetail = "";
+let importProgressStartedAt = 0;
 
 // DOM cache
 let overlay: HTMLElement;
@@ -143,7 +150,13 @@ let btnOpen: HTMLButtonElement;
 let providers: CurriculumProviderInfo[] = [];
 let history: WizardStep[] = [];
 let chosenCountry: string | undefined;
-let selection: { providerId?: string; schoolType?: string; grade?: string; subject?: string; track?: string } = {};
+let selection: {
+  providerId?: string;
+  schoolType?: string;
+  grade?: string;
+  subject?: string;
+  track?: string;
+} = {};
 
 export function initCurriculumWizard(): void {
   overlay = document.getElementById("curriculum-wizard-modal-overlay")!;
@@ -197,6 +210,7 @@ function isWizardStale(generation: number): boolean {
 
 async function showCurriculumWizard(): Promise<void> {
   wizardSession.begin();
+  resetTransientUi();
   history = [];
   chosenCountry = undefined;
   selection = {};
@@ -208,7 +222,9 @@ async function showCurriculumWizard(): Promise<void> {
   showLoading(true);
 
   try {
-    const wizardCtxSelect = document.getElementById("wizard-context-select") as HTMLSelectElement;
+    const wizardCtxSelect = document.getElementById(
+      "wizard-context-select",
+    ) as HTMLSelectElement;
     if (wizardCtxSelect) {
       try {
         const activeRes = await runBridge<any>("get-active-knowledge-context");
@@ -243,7 +259,10 @@ async function showCurriculumWizard(): Promise<void> {
       breadcrumb: CurriculumBreadcrumb | null;
     }>("curriculum-get-last-selection");
 
-    if (lastRes.breadcrumb && providers.some((p) => p.id === lastRes.breadcrumb!.providerId)) {
+    if (
+      lastRes.breadcrumb &&
+      providers.some((p) => p.id === lastRes.breadcrumb!.providerId)
+    ) {
       await showResumeOffer(lastRes.breadcrumb);
     } else {
       await advanceToNextStep();
@@ -258,6 +277,7 @@ async function showCurriculumWizard(): Promise<void> {
 
 function hideCurriculumWizard(): void {
   wizardSession.invalidate();
+  resetTransientUi();
   importTopicQueue = [];
   importTopicIndex = 0;
   overlay.classList.remove("active");
@@ -265,15 +285,19 @@ function hideCurriculumWizard(): void {
 
 // ── Resume banner ────────────────────────────────────────────────────────
 
-async function showResumeOffer(breadcrumb: CurriculumBreadcrumb): Promise<void> {
+async function showResumeOffer(
+  breadcrumb: CurriculumBreadcrumb,
+): Promise<void> {
   const provider = providers.find((p) => p.id === breadcrumb.providerId)!;
   const labels: string[] = [provider.countryLabel, provider.regionLabel];
 
   chosenCountry = provider.country;
   const preview: { key: StepKey; id: string }[] = [];
-  if (breadcrumb.schoolType) preview.push({ key: "schoolType", id: breadcrumb.schoolType });
+  if (breadcrumb.schoolType)
+    preview.push({ key: "schoolType", id: breadcrumb.schoolType });
   if (breadcrumb.grade) preview.push({ key: "grade", id: breadcrumb.grade });
-  if (breadcrumb.subject) preview.push({ key: "subject", id: breadcrumb.subject });
+  if (breadcrumb.subject)
+    preview.push({ key: "subject", id: breadcrumb.subject });
   if (breadcrumb.track) preview.push({ key: "track", id: breadcrumb.track });
 
   let sel: typeof selection = { providerId: provider.id };
@@ -369,7 +393,8 @@ async function pushConfirmedStep(key: StepKey, id: string): Promise<void> {
 function countryOptions(): TaxonomyOption[] {
   const seen = new Map<string, TaxonomyOption>();
   for (const p of providers) {
-    if (!seen.has(p.country)) seen.set(p.country, { id: p.country, label: p.countryLabel });
+    if (!seen.has(p.country))
+      seen.set(p.country, { id: p.country, label: p.countryLabel });
   }
   return [...seen.values()];
 }
@@ -413,7 +438,9 @@ function applySelectionValue(key: StepKey, id: string): void {
     return;
   }
   if (key === "region") {
-    const provider = providers.find((p) => p.country === chosenCountry && p.region === id);
+    const provider = providers.find(
+      (p) => p.country === chosenCountry && p.region === id,
+    );
     selection.providerId = provider?.id;
     return;
   }
@@ -440,7 +467,8 @@ async function advanceToNextStep(): Promise<void> {
       key = nextKeyAfter(key);
       continue;
     }
-    const preselect = key !== "topic" && options.length === 1 ? [options[0].id] : [];
+    const preselect =
+      key !== "topic" && options.length === 1 ? [options[0].id] : [];
     if (preselect.length) applySelectionValue(key, preselect[0]);
     history.push({
       key,
@@ -580,7 +608,9 @@ function renderBreadcrumb(): void {
   breadcrumbEl.innerHTML = history
     .filter((step) => step.key !== "topic" && step.selectedIds.length > 0)
     .map((step) => {
-      const label = step.options.find((o) => o.id === step.selectedIds[0])?.label ?? step.selectedIds[0];
+      const label =
+        step.options.find((o) => o.id === step.selectedIds[0])?.label ??
+        step.selectedIds[0];
       return `<span class="wizard-breadcrumb-chip">${escapeHtml(label)}</span>`;
     })
     .join("");
@@ -596,7 +626,9 @@ function renderStepBody(step: WizardStep): void {
     const note = document.createElement("p");
     note.className = "wizard-topic-note";
     note.style.marginBottom = "10px";
-    note.textContent = tf("wizard_subtopic_note", { topic: step.topicOption.label });
+    note.textContent = tf("wizard_subtopic_note", {
+      topic: step.topicOption.label,
+    });
     stepBodyEl.appendChild(note);
   }
   if (step.options.length === 0) {
@@ -673,14 +705,20 @@ function settingsAiPathLabel(): string {
 function formatImportError(err: unknown, localLlm: boolean): string {
   const base = describeError(err);
   if (isTextLlmOfflineError(base)) {
-    return `${t("wizard_import_text_llm_offline")}\n\n${tf("wizard_import_text_llm_hint", {
-      settingsPath: settingsAiPathLabel(),
-    })}`;
+    return `${t("wizard_import_text_llm_offline")}\n\n${tf(
+      "wizard_import_text_llm_hint",
+      {
+        settingsPath: settingsAiPathLabel(),
+      },
+    )}`;
   }
   if (localLlm && isLlmTimeoutError(base)) {
-    return `${t("wizard_import_llm_timeout_local")}\n\n${tf("wizard_import_cloud_hint", {
-      settingsPath: settingsAiPathLabel(),
-    })}`;
+    return `${t("wizard_import_llm_timeout_local")}\n\n${tf(
+      "wizard_import_cloud_hint",
+      {
+        settingsPath: settingsAiPathLabel(),
+      },
+    )}`;
   }
   return base;
 }
@@ -706,13 +744,76 @@ async function assertTextLlmReady(): Promise<void> {
 function setImportProgress(status: string, detail?: string): void {
   progressStatusEl.textContent = status;
   if (detail !== undefined) {
-    progressDetailEl.textContent = detail;
+    importProgressBaseDetail = detail;
   }
+  renderImportProgressDetail();
+}
+
+function renderImportProgressDetail(): void {
+  if (!importProgressStartedAt) {
+    progressDetailEl.textContent = importProgressBaseDetail;
+    return;
+  }
+
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - importProgressStartedAt) / 1000),
+  );
+  const minutes = Math.floor(elapsedSeconds / 60);
+  const seconds = elapsedSeconds % 60;
+  const elapsed = minutes
+    ? `${minutes}m ${String(seconds).padStart(2, "0")}s`
+    : `${seconds}s`;
+  const elapsedLabel = tf("wizard_import_elapsed", { elapsed });
+  progressDetailEl.textContent = importProgressBaseDetail
+    ? `${importProgressBaseDetail} · ${elapsedLabel}`
+    : elapsedLabel;
+}
+
+function startImportProgressTimer(): () => void {
+  stopImportProgressTimer();
+  importProgressStartedAt = Date.now();
+  renderImportProgressDetail();
+  const timer = setInterval(renderImportProgressDetail, 1_000);
+  importProgressTimer = timer;
+
+  return () => {
+    if (importProgressTimer !== timer) return;
+    clearInterval(timer);
+    importProgressTimer = undefined;
+    importProgressStartedAt = 0;
+  };
+}
+
+function stopImportProgressTimer(): void {
+  if (importProgressTimer) clearInterval(importProgressTimer);
+  importProgressTimer = undefined;
+  importProgressStartedAt = 0;
+}
+
+function resetTransientUi(): void {
+  stopImportProgressTimer();
+  importProgressBaseDetail = t("lbl_curriculum_wizard_progress_detail");
+  resetCurriculumWizardTransientUi({
+    buttons: [btnNext, btnBack, btnCancel],
+    progressContainer,
+    stepBody: stepBodyEl,
+  });
+  breadcrumbEl.innerHTML = "";
+  stepLabelEl.textContent = t("wizard_step_country");
+  topicNoteEl.classList.add("hidden");
+  btnNext.textContent = t("wizard_btn_next");
+  setImportProgress(
+    t("lbl_curriculum_wizard_progress_status"),
+    importProgressBaseDetail,
+  );
 }
 
 async function isLocalLlm(): Promise<boolean> {
   try {
-    const settings = await runBridge<{ llm?: { url?: string } }>("get-settings");
+    const settings = await runBridge<{ llm?: { url?: string } }>(
+      "get-settings",
+    );
     const url = settings?.llm?.url ?? "";
     return /localhost|127\.0\.0\.1/i.test(url);
   } catch {
@@ -752,6 +853,26 @@ function subjectLabel(): string {
     selection.subject ??
     ""
   );
+}
+
+function selectedStepLabel(
+  key: StepKey,
+  selectedId: string | undefined,
+): string {
+  if (!selectedId) return "";
+  return (
+    history
+      .find((step) => step.key === key)
+      ?.options.find((option) => option.id === selectedId)?.label ?? selectedId
+  );
+}
+
+function curriculumCategory(topic: TaxonomyOption): string {
+  return buildCurriculumCategoryPath({
+    subject: subjectLabel(),
+    grade: selectedStepLabel("grade", selection.grade),
+    topic: topic.label,
+  });
 }
 
 function selectedKnowledgeContext(): string {
@@ -814,6 +935,7 @@ async function beginNextTopicImport(): Promise<void> {
     tf("wizard_import_listing_subtopics", { topic: topic.label }),
     "",
   );
+  const stopProgressTimer = startImportProgressTimer();
 
   try {
     const subRes = await runBridge<{
@@ -855,6 +977,7 @@ async function beginNextTopicImport(): Promise<void> {
     };
     await loadCardPreview(syntheticStep, { pushHistory: true, generation });
   } finally {
+    stopProgressTimer();
     if (!isWizardStale(generation)) {
       btnNext.disabled = false;
       btnBack.disabled = false;
@@ -878,6 +1001,14 @@ async function loadMultiTopicCardPreview(
   hideStepError();
   progressContainer.classList.remove("hidden");
   stepBodyEl.classList.add("hidden");
+  setImportProgress(
+    tf("wizard_import_previewing", { topic: topics[0]?.label ?? "" }),
+    tf("wizard_import_step", {
+      current: "1",
+      total: String(topics.length),
+    }),
+  );
+  const stopProgressTimer = startImportProgressTimer();
 
   try {
     await assertTextLlmReady();
@@ -916,7 +1047,7 @@ async function loadMultiTopicCardPreview(
         "--topic",
         JSON.stringify(topicNodeFromOption(topic)),
         "--domain",
-        subjectLabel(),
+        curriculumCategory(topic),
       ];
       if (ctx) previewArgs.push("--knowledge-context", ctx);
       if (subTopicIds.length > 0) {
@@ -934,6 +1065,8 @@ async function loadMultiTopicCardPreview(
       if (!previewRes.success || !Array.isArray(previewRes.items)) {
         throw new Error(`Card preview failed for ${topic.label}.`);
       }
+
+      setCurriculumPreviewSelection(previewRes.items, true);
 
       batches.push({
         sourceId: previewRes.sourceId,
@@ -969,6 +1102,7 @@ async function loadMultiTopicCardPreview(
       throw new Error(formatImportError(err, localLlm));
     }
   } finally {
+    stopProgressTimer();
     if (!isWizardStale(generation)) {
       btnNext.disabled = false;
       btnBack.disabled = false;
@@ -1000,10 +1134,9 @@ async function loadCardPreview(
   stepBodyEl.classList.add("hidden");
   setImportProgress(
     tf("wizard_import_previewing", { topic: topic.label }),
-    localLlm
-      ? t("lbl_curriculum_wizard_progress_detail_local")
-      : t("lbl_curriculum_wizard_progress_detail"),
+    t("lbl_curriculum_wizard_progress_detail"),
   );
+  const stopProgressTimer = startImportProgressTimer();
 
   try {
     await assertTextLlmReady();
@@ -1014,7 +1147,7 @@ async function loadCardPreview(
       "--topic",
       JSON.stringify(topicNodeFromOption(topic)),
       "--domain",
-      subjectLabel(),
+      curriculumCategory(topic),
     ];
     const ctx = selectedKnowledgeContext();
     if (ctx) {
@@ -1036,6 +1169,8 @@ async function loadCardPreview(
     if (!previewRes.success || !Array.isArray(previewRes.items)) {
       throw new Error(`Card preview failed for ${topic.label}.`);
     }
+
+    setCurriculumPreviewSelection(previewRes.items, true);
 
     if (opts?.pushHistory && subTopicStep.options.length > 1) {
       history.push(subTopicStep);
@@ -1061,6 +1196,7 @@ async function loadCardPreview(
       throw new Error(formatImportError(err, localLlm));
     }
   } finally {
+    stopProgressTimer();
     if (!isWizardStale(generation)) {
       btnNext.disabled = false;
       btnBack.disabled = false;
@@ -1085,11 +1221,38 @@ function renderCardPreviewBody(step: WizardStep): void {
     return;
   }
 
+  const selectionActions = document.createElement("div");
+  selectionActions.className = "wizard-card-selection-actions";
+  const selectionCount = document.createElement("span");
+  const selectedCount = items.filter((item) => item.selected).length;
+  selectionCount.textContent = tf("wizard_card_selection_count", {
+    selected: String(selectedCount),
+    total: String(items.length),
+  });
+  const toggleAllButton = document.createElement("button");
+  toggleAllButton.type = "button";
+  toggleAllButton.className = "btn secondary-btn btn-xs";
+  const allSelected = areAllCurriculumPreviewItemsSelected(items);
+  toggleAllButton.textContent = allSelected
+    ? t("wizard_btn_deselect_all_cards")
+    : t("wizard_btn_select_all_cards");
+  toggleAllButton.addEventListener("click", () => {
+    setCurriculumPreviewSelection(items, !allSelected);
+    hideStepError();
+    renderStepBody(step);
+  });
+  selectionActions.append(selectionCount, toggleAllButton);
+  stepBodyEl.appendChild(selectionActions);
+
   const showTopicHeaders = (step.previewBatches?.length ?? 0) > 1;
   let lastTopicLabel = "";
 
   for (const item of items) {
-    if (showTopicHeaders && item.topicLabel && item.topicLabel !== lastTopicLabel) {
+    if (
+      showTopicHeaders &&
+      item.topicLabel &&
+      item.topicLabel !== lastTopicLabel
+    ) {
       lastTopicLabel = item.topicLabel;
       const heading = document.createElement("p");
       heading.className = "wizard-topic-note";
@@ -1099,8 +1262,7 @@ function renderCardPreviewBody(step: WizardStep): void {
     }
 
     const row = document.createElement("div");
-    row.className =
-      "wizard-option-row" + (item.selected ? " selected" : "");
+    row.className = "wizard-option-row" + (item.selected ? " selected" : "");
     const title = item.question.trim() || item.concept;
     const badge = item.isExisting
       ? `<span class="wizard-option-hint">${escapeHtml(t("wizard_card_existing_badge"))}</span>`
@@ -1194,7 +1356,14 @@ async function confirmCardPreview(step: WizardStep): Promise<void> {
   btnCancel.disabled = true;
   progressContainer.classList.remove("hidden");
   stepBodyEl.classList.add("hidden");
-  setImportProgress(t("wizard_import_saving"));
+  const selectedCount = (step.previewItems ?? []).filter(
+    (item) => item.selected,
+  ).length;
+  setImportProgress(
+    t("wizard_import_saving"),
+    tf("wizard_import_saving_count", { count: String(selectedCount) }),
+  );
+  const stopProgressTimer = startImportProgressTimer();
 
   const ctx = selectedKnowledgeContext();
   const confirmArgs: string[] = [];
@@ -1251,6 +1420,7 @@ async function confirmCardPreview(step: WizardStep): Promise<void> {
         ensuredCount: String(result.ensuredCount),
         removedCount: String(result.removedCount),
       }),
+      "",
     );
     await loadStudioData();
     await new Promise((resolve) => setTimeout(resolve, 2500));
@@ -1258,6 +1428,7 @@ async function confirmCardPreview(step: WizardStep): Promise<void> {
       hideCurriculumWizard();
     }
   } finally {
+    stopProgressTimer();
     if (!isWizardStale(generation)) {
       stepBodyEl.classList.remove("hidden");
       btnNext.disabled = false;

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -365,6 +365,9 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     model_status_unprobed: "Sin comprobar",
     wizard_btn_confirm_import: "Guardar selección",
     wizard_btn_preview_cards: "Vista previa de tarjetas",
+    wizard_btn_select_all_cards: "Seleccionar todas",
+    wizard_btn_deselect_all_cards: "Deseleccionar todas",
+    wizard_card_selection_count: "{selected} de {total} seleccionadas",
     wizard_card_existing_badge: "importada",
     wizard_card_new_badge: "nueva",
     wizard_card_preview_empty: "No se encontraron tarjetas para este tema.",
@@ -375,6 +378,7 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
       "Se guardaron {createdCount} tarjetas nuevas y {ensuredCount} existentes. Se quitaron {removedCount} tarjeta(s) de tu cola.",
     wizard_import_listing_subtopics: "Cargando unidades: {topic}",
     wizard_import_previewing: "Generando vista previa de tarjetas: {topic}",
+    wizard_import_elapsed: "Transcurrido: {elapsed}",
     wizard_import_text_llm_hint:
       "Abre {settingsPath}, asegúrate de que el modelo de texto aparezca listo y vuelve a intentarlo.",
     wizard_import_text_llm_offline:
@@ -480,9 +484,9 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     wizard_hours: "{hours} h",
     lbl_curriculum_wizard_progress_status: "Importando…",
     lbl_curriculum_wizard_progress_detail:
-      "Puede tardar un minuto según la velocidad de la IA.",
+      "La generación de tarjetas puede tardar varios minutos por tema; el progreso se actualiza continuamente abajo.",
     lbl_curriculum_wizard_progress_detail_local:
-      "La IA local puede tardar varios minutos por tema — el progreso aparece abajo.",
+      "La generación de tarjetas puede tardar varios minutos por tema; el progreso se actualiza continuamente abajo.",
     wizard_import_extracting: "Extrayendo texto del plan de estudios…",
     wizard_import_generating: "Generando tarjetas: {topic}",
     wizard_import_step: "Tema {current} de {total}",
@@ -947,6 +951,9 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     model_status_unprobed: "Pas encore vérifié",
     wizard_btn_confirm_import: "Enregistrer la sélection",
     wizard_btn_preview_cards: "Aperçu des cartes",
+    wizard_btn_select_all_cards: "Tout sélectionner",
+    wizard_btn_deselect_all_cards: "Tout désélectionner",
+    wizard_card_selection_count: "{selected} sur {total} sélectionnées",
     wizard_card_existing_badge: "importée",
     wizard_card_new_badge: "nouvelle",
     wizard_card_preview_empty: "Aucune carte trouvée pour ce sujet.",
@@ -957,6 +964,7 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
       "{createdCount} nouvelles cartes et {ensuredCount} existantes enregistrées. {removedCount} carte(s) retirée(s) de votre file.",
     wizard_import_listing_subtopics: "Chargement des unités : {topic}",
     wizard_import_previewing: "Génération de l'aperçu des cartes : {topic}",
+    wizard_import_elapsed: "Temps écoulé : {elapsed}",
     wizard_import_text_llm_hint:
       "Ouvrez {settingsPath}, vérifiez que le modèle de texte est prêt, puis réessayez.",
     wizard_import_text_llm_offline:
@@ -1064,9 +1072,9 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     wizard_hours: "{hours} h",
     lbl_curriculum_wizard_progress_status: "Importation…",
     lbl_curriculum_wizard_progress_detail:
-      "Cela peut prendre une minute selon la vitesse de l'IA.",
+      "La génération des cartes peut prendre plusieurs minutes par sujet — la progression est actualisée en continu ci-dessous.",
     lbl_curriculum_wizard_progress_detail_local:
-      "L'IA locale peut prendre plusieurs minutes par sujet — la progression s'affiche ci-dessous.",
+      "La génération des cartes peut prendre plusieurs minutes par sujet — la progression est actualisée en continu ci-dessous.",
     wizard_import_extracting: "Extraction du texte du programme…",
     wizard_import_generating: "Génération des cartes : {topic}",
     wizard_import_step: "Sujet {current} sur {total}",
@@ -1529,6 +1537,9 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     model_status_unprobed: "Ainda não verificado",
     wizard_btn_confirm_import: "Salvar seleção",
     wizard_btn_preview_cards: "Pré-visualizar cartões",
+    wizard_btn_select_all_cards: "Selecionar tudo",
+    wizard_btn_deselect_all_cards: "Desmarcar tudo",
+    wizard_card_selection_count: "{selected} de {total} selecionados",
     wizard_card_existing_badge: "importado",
     wizard_card_new_badge: "novo",
     wizard_card_preview_empty: "Nenhum cartão encontrado para este tópico.",
@@ -1539,6 +1550,7 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
       "Salvos {createdCount} cartões novos e {ensuredCount} existentes. Removido(s) {removedCount} cartão(ões) da sua fila.",
     wizard_import_listing_subtopics: "Carregando unidades: {topic}",
     wizard_import_previewing: "Gerando pré-visualização de cartões: {topic}",
+    wizard_import_elapsed: "Decorrido: {elapsed}",
     wizard_import_text_llm_hint:
       "Abra {settingsPath}, verifique se o modelo de texto está pronto e tente novamente.",
     wizard_import_text_llm_offline:
@@ -1644,9 +1656,9 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     wizard_hours: "{hours} h",
     lbl_curriculum_wizard_progress_status: "Importando…",
     lbl_curriculum_wizard_progress_detail:
-      "Puede tardar un minuto según la velocidad de la IA.",
+      "A geração de cartões pode levar vários minutos por tópico — o progresso é atualizado continuamente abaixo.",
     lbl_curriculum_wizard_progress_detail_local:
-      "La IA local puede tardar varios minutos por tema — el progreso aparece abajo.",
+      "A geração de cartões pode levar vários minutos por tópico — o progresso é atualizado continuamente abaixo.",
     wizard_import_extracting: "Extrayendo texto del plan de estudios…",
     wizard_import_generating: "Generando tarjetas: {topic}",
     wizard_import_step: "Tema {current} de {total}",
@@ -2170,9 +2182,10 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     lbl_curriculum_wizard_loading: "加载中…",
     wizard_hours: "{hours} 小时",
     lbl_curriculum_wizard_progress_status: "正在导入…",
-    lbl_curriculum_wizard_progress_detail: "根据 AI 速度，这可能需要一分钟。",
+    lbl_curriculum_wizard_progress_detail:
+      "每个主题的卡片生成可能需要几分钟——下方会持续更新进度。",
     lbl_curriculum_wizard_progress_detail_local:
-      "本地 AI 每个主题可能需要几分钟——下方显示进度。",
+      "每个主题的卡片生成可能需要几分钟——下方会持续更新进度。",
     wizard_import_extracting: "正在提取课程标准文本…",
     wizard_import_generating: "正在生成卡片：{topic}",
     wizard_import_step: "第 {current} 个主题，共 {total} 个",
@@ -2203,8 +2216,12 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     wizard_err_no_subtopics: "请至少选择一个能力单元。",
     wizard_btn_preview_cards: "预览卡片",
     wizard_btn_confirm_import: "保存选择",
+    wizard_btn_select_all_cards: "全选",
+    wizard_btn_deselect_all_cards: "全部取消选择",
+    wizard_card_selection_count: "已选择 {selected}/{total}",
     wizard_import_listing_subtopics: "正在加载单元：{topic}",
     wizard_import_previewing: "正在生成卡片预览：{topic}",
+    wizard_import_elapsed: "已用时：{elapsed}",
     wizard_import_confirm_success:
       "已保存 {createdCount} 张新卡片和 {ensuredCount} 张已有卡片。已从队列中移除 {removedCount} 张卡片。",
     wizard_import_text_llm_offline:
@@ -2724,9 +2741,9 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     wizard_hours: "{hours}時間",
     lbl_curriculum_wizard_progress_status: "インポート中…",
     lbl_curriculum_wizard_progress_detail:
-      "AI の速度により 1 分ほどかかる場合があります。",
+      "カード生成にはトピックごとに数分かかることがあります。進捗は下に継続的に表示されます。",
     lbl_curriculum_wizard_progress_detail_local:
-      "ローカル AI はトピックごとに数分かかることがあります。進捗は下に表示されます。",
+      "カード生成にはトピックごとに数分かかることがあります。進捗は下に継続的に表示されます。",
     wizard_import_extracting: "カリキュラムテキストを取得中…",
     wizard_import_generating: "カードを生成中: {topic}",
     wizard_import_step: "トピック {current}/{total}",
@@ -2760,8 +2777,12 @@ export const TRANSLATION_PACKS: Record<string, Record<string, string>> = {
     wizard_err_no_subtopics: "少なくとも1つの能力単元を選択してください。",
     wizard_btn_preview_cards: "カードをプレビュー",
     wizard_btn_confirm_import: "選択を保存",
+    wizard_btn_select_all_cards: "すべて選択",
+    wizard_btn_deselect_all_cards: "すべて選択解除",
+    wizard_card_selection_count: "{total} 枚中 {selected} 枚を選択",
     wizard_import_listing_subtopics: "単元を読み込み中: {topic}",
     wizard_import_previewing: "カードプレビューを生成中: {topic}",
+    wizard_import_elapsed: "経過時間: {elapsed}",
     wizard_import_confirm_success:
       "新規 {createdCount} 枚・既存 {ensuredCount} 枚を保存しました。キューから {removedCount} 枚のカードを削除しました。",
     wizard_import_text_llm_offline:
@@ -3378,9 +3399,9 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     wizard_hours: "{hours} hrs",
     lbl_curriculum_wizard_progress_status: "Importing…",
     lbl_curriculum_wizard_progress_detail:
-      "This may take a minute depending on your AI speed.",
+      "Card generation can take several minutes per topic — progress updates continuously below.",
     lbl_curriculum_wizard_progress_detail_local:
-      "Local AI can take several minutes per topic — progress updates below.",
+      "Card generation can take several minutes per topic — progress updates continuously below.",
     wizard_import_extracting: "Extracting curriculum text…",
     wizard_import_generating: "Generating cards: {topic}",
     wizard_import_step: "Topic {current} of {total}",
@@ -3413,8 +3434,12 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     wizard_err_no_subtopics: "Select at least one competence unit.",
     wizard_btn_preview_cards: "Preview cards",
     wizard_btn_confirm_import: "Save selection",
+    wizard_btn_select_all_cards: "Select all",
+    wizard_btn_deselect_all_cards: "Deselect all",
+    wizard_card_selection_count: "{selected} of {total} selected",
     wizard_import_listing_subtopics: "Loading units: {topic}",
     wizard_import_previewing: "Generating card preview: {topic}",
+    wizard_import_elapsed: "Elapsed: {elapsed}",
     wizard_import_confirm_success:
       "Saved {createdCount} new and {ensuredCount} existing cards. Removed {removedCount} card(s) from your queue.",
     wizard_import_text_llm_offline:
@@ -3966,9 +3991,9 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     wizard_hours: "{hours} Std.",
     lbl_curriculum_wizard_progress_status: "Importiere…",
     lbl_curriculum_wizard_progress_detail:
-      "Das kann je nach KI-Geschwindigkeit eine Minute dauern.",
+      "Die Kartenerzeugung kann pro Thema mehrere Minuten dauern — der Fortschritt wird unten laufend aktualisiert.",
     lbl_curriculum_wizard_progress_detail_local:
-      "Lokale KI kann pro Thema mehrere Minuten brauchen — Fortschritt siehe unten.",
+      "Die Kartenerzeugung kann pro Thema mehrere Minuten dauern — der Fortschritt wird unten laufend aktualisiert.",
     wizard_import_extracting: "Lehrplantext wird geladen…",
     wizard_import_generating: "Karten werden erzeugt: {topic}",
     wizard_import_step: "Thema {current} von {total}",
@@ -4003,8 +4028,12 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "Bitte mindestens einen Kompetenzabschnitt auswählen.",
     wizard_btn_preview_cards: "Karten vorschauen",
     wizard_btn_confirm_import: "Auswahl speichern",
+    wizard_btn_select_all_cards: "Alle auswählen",
+    wizard_btn_deselect_all_cards: "Alle abwählen",
+    wizard_card_selection_count: "{selected} von {total} ausgewählt",
     wizard_import_listing_subtopics: "Lade Abschnitte: {topic}",
     wizard_import_previewing: "Erzeuge Kartenvorschau: {topic}",
+    wizard_import_elapsed: "Vergangen: {elapsed}",
     wizard_import_confirm_success:
       "{createdCount} neue und {ensuredCount} bestehende Karten gespeichert. {removedCount} Karte(n) aus deiner Warteschlange entfernt.",
     wizard_import_text_llm_offline:

--- a/desktop/src/learning-content.ts
+++ b/desktop/src/learning-content.ts
@@ -1,5 +1,6 @@
 import { runBridge } from "./bridge-transport.js";
 import { t, tf } from "./i18n.js";
+import { buildDomainOptions, domainMatches } from "./panel/graph-scope.js";
 
 export interface PersonalCard {
   tokenId: string;
@@ -449,23 +450,23 @@ export async function loadStudioData(): Promise<void> {
     );
     cardsList = listRes.cards;
 
-    // Populated category dropdown options dynamically
-    const categories = new Set<string>();
-    for (const c of cardsList) {
-      if (c.domain) categories.add(c.domain);
-    }
-    const sortedCategories = Array.from(categories).sort();
+    const categoryOptions = buildDomainOptions(cardsList);
 
     // Clear and reset dropdown
     const currentVal = categoryFilter.value;
     categoryFilter.innerHTML = `<option value="all">${t("lbl_all_categories")}</option>`;
-    for (const cat of sortedCategories) {
+    for (const category of categoryOptions) {
       const opt = document.createElement("option");
-      opt.value = cat;
-      opt.textContent = cat;
+      opt.value = category.value;
+      opt.textContent = category.value.split("/").join(" › ");
+      opt.dataset.categoryGroup = String(category.isGroup);
       categoryFilter.appendChild(opt);
     }
-    categoryFilter.value = currentVal || "all";
+    categoryFilter.value = categoryOptions.some(
+      (category) => category.value === currentVal,
+    )
+      ? currentVal
+      : "all";
 
     refreshCardsList();
     updateUIForSelection();
@@ -483,7 +484,7 @@ function refreshCardsList(): void {
 
   const filtered = cardsList.filter((card) => {
     // 1. Category Filter
-    if (filterCat !== "all" && card.domain !== filterCat) {
+    if (filterCat !== "all" && !domainMatches(card.domain, filterCat)) {
       return false;
     }
     // 2. Query Search (Fuzzy over slug, concept, domain, question)
@@ -493,7 +494,9 @@ function refreshCardsList(): void {
       const conceptMatch = card.concept?.toLowerCase().includes(query);
       const domainMatch = card.domain?.toLowerCase().includes(query);
       const questionMatch = card.question?.toLowerCase().includes(query);
-      return titleMatch || slugMatch || conceptMatch || domainMatch || questionMatch;
+      return (
+        titleMatch || slugMatch || conceptMatch || domainMatch || questionMatch
+      );
     }
     return true;
   });

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2621,6 +2621,16 @@ textarea::placeholder {
   gap: 6px;
 }
 
+.wizard-card-selection-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+  color: var(--clr-text-secondary);
+  font-size: 0.8rem;
+}
+
 .wizard-option-row {
   display: flex;
   align-items: center;

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -133,6 +133,7 @@ import {
   type ImportOkfTokenInput,
 } from "../bridge-handlers.js";
 import { installCliShim } from "../cli-install.js";
+import { mapWithConcurrency } from "../curriculum/concurrency.js";
 import {
   CURRICULUM_PROVIDERS,
   type CurriculumBreadcrumb,
@@ -5030,25 +5031,35 @@ bridgeCommand
         });
       }
 
+      const generationChunks = chunks.filter((chunk) => chunk.text.trim());
+      const textProvider = await getProviderForRole(db, "text");
+      const generatedChunks = await mapWithConcurrency(
+        generationChunks,
+        textProvider.local ? 1 : 3,
+        async (chunk) => ({
+          chunk,
+          cards: await importCurriculumViaLLM(
+            db,
+            chunk.text,
+            opts.domain,
+            item.uri,
+            { knowledgeContext: firstContext },
+          ),
+        }),
+      );
+
       let proposalIndex = 0;
-      for (const chunk of chunks) {
-        if (!chunk.text.trim()) continue;
-
-        const cards = await importCurriculumViaLLM(
-          db,
-          chunk.text,
-          opts.domain,
-          item.uri,
-          { knowledgeContext: firstContext },
-        );
-
+      for (const { chunk, cards } of generatedChunks) {
         const scopedTopicId = chunk.subTopicId
           ? `${resolved.topicId}@${chunk.subTopicId}`
           : resolved.topicId;
 
         for (const card of cards) {
+          const targetDomain =
+            (typeof opts.domain === "string" ? opts.domain.trim() : "") ||
+            card.domain;
           const slug = proposalBaseSlug(
-            card.domain,
+            targetDomain.split("/")[0] || targetDomain,
             card.question,
             card.concept,
           );
@@ -5059,7 +5070,7 @@ bridgeCommand
           const proposal = {
             question: card.question,
             concept: card.concept,
-            domain: card.domain,
+            domain: targetDomain,
             bloom_level: card.bloom_level,
             symbiosis_mode: card.symbiosis_mode || "none",
             excerpt: card.context || "",
@@ -5078,7 +5089,7 @@ bridgeCommand
             symbiosis_mode: proposal.symbiosis_mode,
             excerpt: proposal.excerpt,
             isExisting: false,
-            selected: false,
+            selected: true,
             subTopicId: chunk.subTopicId,
             parentTopicId: resolved.topicId,
             proposal,

--- a/src/cli/curriculum/concurrency.ts
+++ b/src/cli/curriculum/concurrency.ts
@@ -1,0 +1,36 @@
+/**
+ * Map items with bounded concurrency while preserving their input order.
+ * Curriculum preview uses one worker for local models and a small worker pool
+ * for cloud models, which can handle independent competence units in parallel.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+
+  const workerCount = Math.max(
+    1,
+    Math.min(items.length, Math.floor(concurrency) || 1),
+  );
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  let failure: { error: unknown } | undefined;
+
+  async function worker(): Promise<void> {
+    while (!failure) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      try {
+        results[index] = await mapper(items[index]!, index);
+      } catch (error) {
+        failure ??= { error };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  if (failure) throw failure.error;
+  return results;
+}

--- a/tests/cli/curriculum-concurrency.test.ts
+++ b/tests/cli/curriculum-concurrency.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "../../src/cli/curriculum/concurrency.js";
+
+describe("mapWithConcurrency", () => {
+  it("bounds active work and preserves input order", async () => {
+    let active = 0;
+    let peak = 0;
+
+    const results = await mapWithConcurrency(
+      [1, 2, 3, 4, 5],
+      2,
+      async (item) => {
+        active++;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 5 * (6 - item)));
+        active--;
+        return item * 10;
+      },
+    );
+
+    expect(peak).toBe(2);
+    expect(results).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it("uses one worker when concurrency is non-positive", async () => {
+    let active = 0;
+    let peak = 0;
+
+    await mapWithConcurrency([1, 2, 3], 0, async (item) => {
+      active++;
+      peak = Math.max(peak, active);
+      await Promise.resolve();
+      active--;
+      return item;
+    });
+
+    expect(peak).toBe(1);
+  });
+
+  it("waits for active work and stops scheduling after a failure", async () => {
+    const started: number[] = [];
+    let activeWorkerFinished = false;
+
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (item) => {
+        started.push(item);
+        if (item === 1) throw new Error("generation failed");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        activeWorkerFinished = true;
+        return item;
+      }),
+    ).rejects.toThrow("generation failed");
+
+    expect(activeWorkerFinished).toBe(true);
+    expect(started).toEqual([1, 2]);
+  });
+});

--- a/tests/desktop/curriculum-wizard-session.test.ts
+++ b/tests/desktop/curriculum-wizard-session.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { CurriculumWizardSession } from "../../desktop/src/curriculum-wizard-session.js";
+import {
+  areAllCurriculumPreviewItemsSelected,
+  buildCurriculumCategoryPath,
+  CurriculumWizardSession,
+  resetCurriculumWizardTransientUi,
+  setCurriculumPreviewSelection,
+} from "../../desktop/src/curriculum-wizard-session.js";
+
+describe("curriculum category path", () => {
+  it("keeps only subject, grade, and topic", () => {
+    expect(
+      buildCurriculumCategoryPath({
+        subject: "Mathematik",
+        grade: "9",
+        topic: "Kreis",
+      }),
+    ).toBe("Mathematik/9/Kreis");
+  });
+
+  it("keeps a slash in a label from creating another hierarchy level", () => {
+    expect(
+      buildCurriculumCategoryPath({
+        subject: "Mathematik",
+        grade: "9",
+        topic: "Daten / Zufall",
+      }),
+    ).toBe("Mathematik/9/Daten ／ Zufall");
+  });
+});
 
 describe("CurriculumWizardSession cancel guard", () => {
   it("treats completions as stale after invalidate (cancel/reopen)", () => {
@@ -22,5 +50,48 @@ describe("CurriculumWizardSession cancel guard", () => {
 
     session.begin();
     expect(session.isStale(firstVisit)).toBe(true);
+  });
+});
+
+describe("curriculum wizard transient UI", () => {
+  it("restores navigation after a stale successful import closes the wizard", () => {
+    const buttons = [
+      { disabled: true },
+      { disabled: true },
+      { disabled: true },
+    ];
+    const progressClasses = new Set<string>();
+    const bodyClasses = new Set(["hidden"]);
+
+    resetCurriculumWizardTransientUi({
+      buttons,
+      progressContainer: {
+        classList: {
+          add: (token) => progressClasses.add(token),
+          remove: (token) => progressClasses.delete(token),
+        },
+      },
+      stepBody: {
+        classList: {
+          add: (token) => bodyClasses.add(token),
+          remove: (token) => bodyClasses.delete(token),
+        },
+      },
+    });
+
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+    expect(progressClasses.has("hidden")).toBe(true);
+    expect(bodyClasses.has("hidden")).toBe(false);
+  });
+
+  it("supports selecting and deselecting every preview card", () => {
+    const items = [{ selected: false }, { selected: true }];
+
+    setCurriculumPreviewSelection(items, true);
+    expect(areAllCurriculumPreviewItemsSelected(items)).toBe(true);
+
+    setCurriculumPreviewSelection(items, false);
+    expect(items.every((item) => !item.selected)).toBe(true);
+    expect(areAllCurriculumPreviewItemsSelected(items)).toBe(false);
   });
 });

--- a/tests/desktop/graph-scope.test.ts
+++ b/tests/desktop/graph-scope.test.ts
@@ -41,6 +41,19 @@ describe("graph-scope buildDomainOptions", () => {
     ]);
   });
 
+  it("makes subject and grade selectable for curriculum categories", () => {
+    const options = buildDomainOptions([
+      { domain: "Mathematik/9/Kreis" },
+      { domain: "Mathematik/9/Geometrie" },
+    ]);
+    expect(options).toEqual([
+      { value: "Mathematik", isGroup: true },
+      { value: "Mathematik/9", isGroup: true },
+      { value: "Mathematik/9/Geometrie", isGroup: false },
+      { value: "Mathematik/9/Kreis", isGroup: false },
+    ]);
+  });
+
   it("does not mark a prefix as group when a token carries it verbatim", () => {
     const options = buildDomainOptions([
       { domain: "company-team" },

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -62,6 +62,10 @@ const WIZARD_KEYS = [
   "wizard_import_skipping",
   "wizard_import_all_skipped",
   "wizard_import_skipped_summary",
+  "wizard_btn_select_all_cards",
+  "wizard_btn_deselect_all_cards",
+  "wizard_card_selection_count",
+  "wizard_import_elapsed",
 ] as const;
 
 const DATABASE_SETTINGS_KEYS = [


### PR DESCRIPTION
## What changed

- reset transient curriculum-wizard state after completed or cancelled imports
- show elapsed, model-neutral progress during long card generation and saving
- select every preview card by default with bulk select/deselect controls
- generate cloud previews with bounded concurrency while keeping local providers sequential
- categorize new curriculum cards as `Subject/Grade/Topic`
- expose subject, grade, and topic levels as hierarchical Studio filters

## Why

A completed wizard run could leave the assistant unusable, long imports had no meaningful progress feedback, preview selection required unnecessary manual work, and the flat `Mathematik` category became unmanageable across grades.

## Validation

- live-tested in ZAM Desktop with the current learner and MiMo cloud settings
- imported six cards for Realschule 9 `Systeme linearer Gleichungen`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 1,184 tests passed
- `npm run build`
- `npm --prefix desktop run build`