### PR TITLE
release: prepare 0.16.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.15.6",
+  "version": "0.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.15.6"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.15.6"
+version = "0.16.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.16.0.md
+++ b/docs/release-notes-0.16.0.md
@@ -1,0 +1,42 @@
+# ZAM 0.16.0 — Curriculum imports that stay out of the way
+
+Curriculum imports are now easier to follow, faster with cloud AI, and ready
+for the next run as soon as an import finishes. New cards also carry a compact
+subject/grade/topic category, so a learner can focus the Studio on the year
+they are currently studying.
+
+## Highlights
+
+- **The curriculum assistant remains reusable**
+  ([#200](https://github.com/zam-os/zam/pull/200)). Closing or completing an
+  import now clears transient loading state, restores navigation, and ignores
+  stale background results. The next assistant run starts cleanly instead of
+  remaining stuck in the previous import state.
+
+- **Useful progress during long generation**
+  ([#200](https://github.com/zam-os/zam/pull/200)). The wizard shows the current
+  topic or save step together with a continuously updated elapsed time. Its
+  wording is model-neutral: card generation can take several minutes per topic
+  with local or cloud AI. Independent competence units use bounded concurrency
+  for cloud providers; local providers remain sequential.
+
+- **All preview cards selected by default**
+  ([#200](https://github.com/zam-os/zam/pull/200)). The final preview starts
+  with every card selected, displays the selected count, and provides one
+  control to select or deselect the complete set.
+
+- **Categories that follow the learner's year**
+  ([#200](https://github.com/zam-os/zam/pull/200)). New curriculum cards use a
+  compact hierarchy such as `Mathematik/9/Systeme linearer Gleichungen`.
+  Country, state, and school type stay implicit. The Learning Content Studio
+  exposes subject, grade, and topic as hierarchical filters, so `Mathematik ›
+  9` shows exactly that year's imported material.
+
+## Notes
+
+- Existing cards keep their stored category. This release does not rewrite
+  previously imported flat domains such as `Mathematik`; new curriculum
+  imports use the hierarchy automatically.
+- The flow was live-tested in ZAM Desktop with Realschule 9 Mathematik II/III
+  and the current cloud-AI configuration, including preview, bulk selection,
+  saving, reopening the assistant, and filtering the resulting cards.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/scripts/capture-bayern-school-types.ts
+++ b/scripts/capture-bayern-school-types.ts
@@ -20,7 +20,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(__dirname, ".cache");
 const BASE = "https://www.lehrplanplus.bayern.de";
 const USER_AGENT =
-  "ZAM-curriculum-capture/0.15.6 (+https://github.com/zam-os/zam)";
+  "ZAM-curriculum-capture/0.16.0 (+https://github.com/zam-os/zam)";
 const DELAY_MS = 120;
 const SCHOOL_YEAR = "2026/2027";
 const CAPTURED_ON = new Date().toISOString().slice(0, 10);

--- a/scripts/capture-bayern-ws-fos-bos.ts
+++ b/scripts/capture-bayern-ws-fos-bos.ts
@@ -21,7 +21,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(__dirname, ".cache");
 const BASE = "https://www.lehrplanplus.bayern.de";
 const USER_AGENT =
-  "ZAM-curriculum-capture/0.15.6 (+https://github.com/zam-os/zam)";
+  "ZAM-curriculum-capture/0.16.0 (+https://github.com/zam-os/zam)";
 const DELAY_MS = 120;
 const SCHOOL_YEAR = "2026/2027";
 const CAPTURED_ON = new Date().toISOString().slice(0, 10);

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.15.6",
+          "User-Agent": "ZAM-Content-Studio/0.16.0",
         },
       });
 


### PR DESCRIPTION
## Release 0.16.0

Prepares the curriculum-import usability release after #200.

### Included

- reusable curriculum assistant state after completion or cancellation
- elapsed, model-neutral progress for long card generation
- bounded cloud-AI concurrency with sequential local generation
- all preview cards selected by default with bulk toggle
- compact `Subject/Grade/Topic` categories and hierarchical Studio filters
- version bump across npm, desktop, Tauri, lockfiles, and runtime user agents
- release notes in `docs/release-notes-0.16.0.md`

### Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test` — 1,184 tests passed
- `npm --prefix desktop run build`
- `cargo metadata --locked --format-version 1 --no-deps`
- `npm pack --dry-run`