### PR TITLE
fix: unblock Android release assembly (consumer rules, no R8)

### DIFF
--- a/mobile/src-tauri/gen/android/app/build.gradle.kts
+++ b/mobile/src-tauri/gen/android/app/build.gradle.kts
@@ -53,7 +53,10 @@ android {
             }
         }
         getByName("release") {
-            isMinifyEnabled = true
+            // Alpha ships unminified: Tauri's Kotlin plugin IPC parses
+            // @InvokeArg classes reflectively and no R8 keep rules exist yet;
+            // a first-ever minified build risks silent runtime breakage.
+            isMinifyEnabled = false
             val releaseSigning = signingConfigs.getByName("release")
             signingConfig = if (releaseSigning.storeFile != null) {
                 releaseSigning

--- a/mobile/src-tauri/gen/android/build.gradle.kts
+++ b/mobile/src-tauri/gen/android/build.gradle.kts
@@ -14,6 +14,18 @@ allprojects {
         google()
         mavenCentral()
     }
+    // tauri-plugin-barcode-scanner declares consumerProguardFiles("consumer-rules.pro")
+    // but neither the crate nor its upstream repo ships the file, so
+    // merge*ConsumerProguardFiles fails on release builds. Create the empty
+    // file for plugin projects resolved from the cargo registry.
+    afterEvaluate {
+        if (projectDir.path.contains("tauri-plugin-")) {
+            val consumerRules = File(projectDir, "consumer-rules.pro")
+            if (!consumerRules.exists()) {
+                consumerRules.createNewFile()
+            }
+        }
+    }
 }
 
 tasks.register("clean").configure {


### PR DESCRIPTION
Second `publish-android` failure layer ([run](https://github.com/zam-os/zam/actions/runs/29989742975)): the SDK install now passes, Rust cross-compile + Kotlin succeed, but Gradle release packaging fails in `:tauri-plugin-barcode-scanner:mergeReleaseConsumerProguardFiles` — the crate declares `consumerProguardFiles("consumer-rules.pro")` yet neither the crate nor upstream ships the file ([verified against tauri-apps/plugins-workspace v2](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/barcode-scanner/android)). Debug builds never run this merge, which is why all device builds passed.

- Root `gen/android/build.gradle.kts`: create the missing empty `consumer-rules.pro` for cargo-registry plugin projects at configuration time (fixes CI and fresh dev machines alike)
- `app/build.gradle.kts`: ship the alpha with `isMinifyEnabled = false` — this would have been the first-ever R8 build; Tauri's Kotlin IPC resolves `@InvokeArg` classes reflectively and no keep rules exist yet, so minification risks silent runtime breakage on the field-test devices. Revisit with proper keep rules before a store build.

After merge: move the `v0.17.0` tag once more (release still draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)