### PR TITLE
fix: skip crashing lintVital on Android release builds

### DIFF
--- a/mobile/src-tauri/gen/android/app/build.gradle.kts
+++ b/mobile/src-tauri/gen/android/app/build.gradle.kts
@@ -80,6 +80,12 @@ android {
     buildFeatures {
         buildConfig = true
     }
+    lint {
+        // AGP 9.2.1's bundled lint crashes analyzing Kotlin build scripts
+        // (findFirCompiledSymbol FIR bug) during lintVital on release builds.
+        // Quality gates run in CI (Biome/tsc/cargo/Vitest) and on-device.
+        checkReleaseBuilds = false
+    }
 }
 
 rust {


### PR DESCRIPTION
Third `publish-android` layer ([run](https://github.com/zam-os/zam/actions/runs/29992148001)): consumer-rules fix worked, Rust + Kotlin + packaging prep all pass, then `:app:lintVitalAnalyzeUniversalRelease` dies inside lint itself — `findFirCompiledSymbol only works on compiled declarations`, an AGP 9.2.1 lint FIR bug hit while analyzing Kotlin build scripts (lint's own message: *this is a bug in lint or one of the libraries it depends on*).

Set `lint.checkReleaseBuilds = false`: the alpha's quality gates are CI (Biome/tsc/cargo/Vitest) and on-device validation; a crashing lint pass adds nothing.

After merge: move `v0.17.0` once more (release still draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)