### PR TITLE
chore: bump actions/github-script to v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Generate release notes
         id: notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: notes } = await github.rest.repos.generateReleaseNotes({


### PR DESCRIPTION
Removes the Node 20 deprecation warning from release runs — `actions/github-script@v7` declares node20 (force-run on Node 24 since GitHub's Sep 2025 runner deprecation); v8 declares node24. Sweep confirmed this is the only stale action pin across the repo's workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)