### PR TITLE
Honor the selected evaluator in the Recall panel (#209)

### DIFF
--- a/desktop/src/panel/recall-evaluation.ts
+++ b/desktop/src/panel/recall-evaluation.ts
@@ -94,3 +94,93 @@ Prior feedback: ${evaluation.feedback}
 Identified gaps: ${evaluation.gaps.join("; ") || "none"}
 Learner follow-up: ${followUp}`;
 }
+
+/** How the Recall card should evaluate a typed answer (issue #209). */
+export type RecallEvaluationRoute =
+  /** Call `zam_companion_sample` — ZAM's own recall model, in-card. */
+  | { kind: "zam-text-model" }
+  /** Host-provided MCP sampling (`createSamplingMessage`). */
+  | { kind: "host-sampling" }
+  /** `ui/message` detour into the host conversation. */
+  | { kind: "host-message" }
+  /** Nothing honest to route to; `reason` is shown in-card verbatim. */
+  | { kind: "unavailable"; reason: string };
+
+/** The subset of a companion evaluator route this decision needs. */
+export interface RecallEvaluatorRouteLike {
+  id: string;
+  routable: boolean;
+  reason?: string;
+}
+
+export interface RecallRouteInput {
+  selectedEvaluatorId?: string;
+  evaluators?: RecallEvaluatorRouteLike[];
+  /**
+   * Host capabilities as reported by `getHostCapabilities()`. The MCP-Apps
+   * shape carries objects (e.g. `sampling: { tools?: {} }`), so presence is
+   * read truthily rather than as a boolean.
+   */
+  capabilities?: { sampling?: unknown; message?: unknown } | null;
+}
+
+/**
+ * Decide how to evaluate an answer, honoring the Agent pill's selection before
+ * falling back to host capabilities (issue #209).
+ *
+ * Before this, the card routed purely on capabilities: an explicit, routable
+ * `zam-text-model` selection was ignored and the answer took the `ui/message`
+ * detour into the host chat. Selection now wins, and a selection that cannot
+ * be served on this surface produces an honest reason instead of silently
+ * falling through the ladder — the same principle
+ * `companion-dispatch.assertSamplingRoutableToVscodeLm` enforces extension-side.
+ *
+ * Only an absent selection or `native-mcp-host` uses the capability ladder.
+ */
+export function resolveRecallEvaluationRoute(
+  input: RecallRouteInput,
+): RecallEvaluationRoute {
+  const selected = input.selectedEvaluatorId;
+  const route = selected
+    ? input.evaluators?.find((candidate) => candidate.id === selected)
+    : undefined;
+
+  // Quick mode is model-free by design; the card short-circuits before ever
+  // asking for an evaluation, so reaching here means inconsistent state.
+  if (selected === "quick-mode") {
+    return {
+      kind: "unavailable",
+      reason:
+        "Quick mode is model-free by design and must never be asked to evaluate an answer.",
+    };
+  }
+
+  if (selected && selected !== "native-mcp-host") {
+    if (route && !route.routable) {
+      return {
+        kind: "unavailable",
+        reason:
+          route.reason ??
+          `Evaluator "${selected}" is not routable on this surface.`,
+      };
+    }
+    if (selected === "zam-text-model") return { kind: "zam-text-model" };
+    // Any other routable selection (e.g. `vscode-lm` inside the VS Code
+    // Companion, where the extension intercepts sampling) is served by the
+    // host's own sampling path.
+    if (input.capabilities?.sampling) return { kind: "host-sampling" };
+    return {
+      kind: "unavailable",
+      reason: `Evaluator "${selected}" needs host sampling, which this host does not provide.`,
+    };
+  }
+
+  if (input.capabilities?.sampling) return { kind: "host-sampling" };
+  if (input.capabilities?.message) return { kind: "host-message" };
+  return {
+    kind: "unavailable",
+    reason:
+      "This host provides neither sampling nor messages. Enable quick mode " +
+      "in Settings or use a host with model support.",
+  };
+}

--- a/desktop/src/panel/recall.ts
+++ b/desktop/src/panel/recall.ts
@@ -44,6 +44,8 @@ import {
   buildRecallFollowUpPrompt,
   parseRecallEvaluation,
   type RecallEvaluation,
+  type RecallEvaluationRoute,
+  resolveRecallEvaluationRoute,
 } from "./recall-evaluation.js";
 
 const contextBarRoot = document.getElementById("zam-contextbar-root");
@@ -135,6 +137,13 @@ const tally = {
 
 const SURFACE = "recall";
 
+/**
+ * The last companion context this panel received. Kept whole (not just the
+ * derived `quickMode`) so answer evaluation can honor the Agent pill's
+ * selection instead of routing purely on host capabilities (issue #209).
+ */
+let companionContext: CompanionContextBarState | undefined;
+
 const callTool = createCallTool(app);
 const writeCompanionContext = createContextWriter(callTool, SURFACE);
 const readCompanionContext = createContextReader(callTool, SURFACE);
@@ -158,6 +167,7 @@ function hasUnsavedRecallState(): boolean {
  */
 function reloadForContext(newState: CompanionContextBarState): void {
   currentUser = newState.user.currentId ?? null;
+  companionContext = newState;
   quickMode = deriveQuickMode(newState, quickMode);
   started = false;
   finished = false;
@@ -308,9 +318,53 @@ function samplingText(content: unknown): string {
     .trim();
 }
 
+/** The evaluation route implied by the Agent pill plus this host (issue #209). */
+function currentEvaluationRoute(): RecallEvaluationRoute {
+  return resolveRecallEvaluationRoute({
+    selectedEvaluatorId: companionContext?.selectedEvaluatorId,
+    evaluators: companionContext?.evaluators,
+    capabilities: app.getHostCapabilities(),
+  });
+}
+
+/**
+ * Sample through ZAM's own recall model via `zam_companion_sample` — the path
+ * that makes an explicit "ZAM text model" selection real on hosts without
+ * bridge sampling (Claude Code). The VS Code extension already routes this id
+ * through the same tool.
+ */
+async function sampleViaZamTextModel(
+  messages: Array<{ role: "user" | "assistant"; text: string }>,
+): Promise<string> {
+  const result = (await callTool("zam_companion_sample", { messages })) as {
+    text?: unknown;
+  };
+  const text = typeof result?.text === "string" ? result.text.trim() : "";
+  if (!text) throw new Error("The ZAM text model returned no text");
+  return text;
+}
+
+/**
+ * Sample using the effective evaluator. Both the first evaluation and every
+ * follow-up turn go through here, so a discussion never silently changes
+ * model mid-thread.
+ */
 async function sampleRecall(
   messages: Array<{ role: "user" | "assistant"; text: string }>,
   maxTokens = 800,
+): Promise<string> {
+  const route = currentEvaluationRoute();
+  if (route.kind === "zam-text-model") return sampleViaZamTextModel(messages);
+  if (route.kind === "unavailable") throw new Error(route.reason);
+  if (route.kind !== "host-sampling") {
+    throw new Error("This evaluator cannot answer a follow-up in the card.");
+  }
+  return sampleViaHost(messages, maxTokens);
+}
+
+async function sampleViaHost(
+  messages: Array<{ role: "user" | "assistant"; text: string }>,
+  maxTokens: number,
 ): Promise<string> {
   const result = await app.createSamplingMessage({
     systemPrompt:
@@ -715,9 +769,12 @@ function renderCard(): void {
   }
 
   async function evaluateAnswer(learnerAnswer: string): Promise<void> {
-    const capabilities = app.getHostCapabilities();
+    // Selection first, capabilities second (issue #209): an explicit, routable
+    // "ZAM text model" must evaluate in-card instead of taking the ui/message
+    // detour just because the host happens to expose messaging.
+    const route = currentEvaluationRoute();
     pushContext(card, "evaluating");
-    if (capabilities?.sampling) {
+    if (route.kind === "zam-text-model" || route.kind === "host-sampling") {
       const prompt = buildRecallEvaluationPrompt(
         {
           ...card,
@@ -731,17 +788,14 @@ function renderCard(): void {
       pushContext(card, "answered");
       return;
     }
-    if (capabilities?.message) {
+    if (route.kind === "host-message") {
       await sendToHostConversation(learnerAnswer);
       showReveal(learnerAnswer);
       showNotice(t("recall_sent_to_host"));
       pushContext(card, "answered", { learnerAnswer });
       return;
     }
-    throw new Error(
-      "This host provides neither sampling nor messages. Enable quick mode " +
-        "in Settings or use a host with model support.",
-    );
+    throw new Error(route.reason);
   }
 
   actionBtn.addEventListener("click", () => {
@@ -808,6 +862,7 @@ app.ontoolresult = (params) => {
   const previousDomain = focusDomain;
   currentUser = structured.user ?? null;
   focusDomain = structured.domain ?? null;
+  companionContext = structured.companionContext ?? companionContext;
   quickMode = deriveQuickMode(
     structured.companionContext,
     structured.quickMode === true,

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -1433,8 +1433,7 @@ export async function importCurriculumViaLLM(
     }
   }
 
-  // Agent transport (ADR 2026-07-12a) is wired for every generating text
-  // caller; only `sampleViaLocalLLM` stays deliberately local-only.
+  // Agent transport (ADR 2026-07-12a) is wired for every generating caller.
   const endpoint = await resolveUsableTextEndpoint(db, { allowAgent: true });
   const langName = LANGUAGE_NAMES[locale] || "English";
 
@@ -2023,7 +2022,36 @@ export async function sampleViaLocalLLM(
   messages: Array<{ role: string; content: string }>,
 ): Promise<LlmTextResult> {
   const cfg = await getProviderForRole(db, "recall");
-  const endpoint = await resolveUsableRecallEndpoint(db);
+  const endpoint = await resolveUsableRecallEndpoint(db, { allowAgent: true });
+
+  // Agent transport (ADR 2026-07-12a): this is the recall role like every other
+  // recall caller, so an agent-backed recall model must serve it too. It backs
+  // `zam_companion_sample`, which the Recall panel uses for an explicit
+  // "ZAM text model" selection (issue #209) — leaving it HTTP-only would break
+  // that path for anyone whose recall model is harness-backed.
+  if (endpoint.transport === "agent") {
+    const system = messages
+      .filter((m) => m.role === "system")
+      .map((m) => m.content)
+      .join("\n\n");
+    const transcript = messages
+      .filter((m) => m.role !== "system")
+      .map(
+        (m) => `${m.role === "assistant" ? "Assistant" : "User"}: ${m.content}`,
+      )
+      .join("\n\n");
+    const text = await requestAgentCompletion(endpoint, {
+      system:
+        system ||
+        "You are the intelligence behind ZAM active recall. Be grounded, concise, and pedagogically useful.",
+      user: transcript,
+    });
+    return {
+      text,
+      model: endpoint.model,
+      providerName: endpoint.providerName,
+    };
+  }
 
   const res = await fetchWithInteractiveTimeout(
     `${endpoint.url}/chat/completions`,

--- a/tests/cli/agent-llm/recall-agent.test.ts
+++ b/tests/cli/agent-llm/recall-agent.test.ts
@@ -157,12 +157,48 @@ describe("recall via the agent transport", () => {
     expect(seenUser).toContain("Richtig, München ist die Hauptstadt.");
   });
 
-  it("rejects the agent transport for recall callers not wired for it", async () => {
+  // Issue #209: `sampleViaLocalLLM` backs `zam_companion_sample`, which the
+  // Recall panel uses for an explicit "ZAM text model" selection. It resolves
+  // the recall role like every other recall caller, so an agent-backed recall
+  // model has to serve it too — it previously threw "does not support yet".
+  it("samples through the harness for an agent-backed recall model", async () => {
+    vi.mocked(getAgentAdapter).mockReturnValue(
+      fakeAdapter(async () => ({ text: "Munich is the capital of Bavaria." })),
+    );
     const db = await seedDb();
 
-    await expect(
-      sampleViaLocalLLM(db, [{ role: "user", content: "hi" }]),
-    ).rejects.toThrow(/agent transport/i);
+    const result = await sampleViaLocalLLM(db, [
+      { role: "system", content: "You are ZAM." },
+      { role: "user", content: "Which city is the capital of Bavaria?" },
+    ]);
+
+    expect(result.text).toContain("Munich");
+    expect(vi.mocked(getAgentAdapter)).toHaveBeenCalledWith("claude-code");
+  });
+
+  it("flattens the sampling turns into one harness prompt", async () => {
+    let seen: { system: string; user: string } | undefined;
+    vi.mocked(getAgentAdapter).mockReturnValue(
+      fakeAdapter(async (req) => {
+        seen = { system: req.system, user: req.user };
+        return { text: "ok" };
+      }),
+    );
+    const db = await seedDb();
+
+    await sampleViaLocalLLM(db, [
+      { role: "system", content: "Grade strictly." },
+      { role: "user", content: "Answer: Munich" },
+      { role: "assistant", content: "Correct." },
+      { role: "user", content: "Why?" },
+    ]);
+
+    // The system turn frames the request; the rest becomes one transcript.
+    expect(seen?.system).toContain("Grade strictly.");
+    expect(seen?.user).toContain("Answer: Munich");
+    expect(seen?.user).toContain("Correct.");
+    expect(seen?.user).toContain("Why?");
+    expect(seen?.user).not.toContain("Grade strictly.");
   });
 
   it("reports the agent as the ready recall model (no HTTP fall-through)", async () => {

--- a/tests/desktop/recall-evaluation.test.ts
+++ b/tests/desktop/recall-evaluation.test.ts
@@ -3,6 +3,7 @@ import {
   buildRecallEvaluationPrompt,
   buildRecallFollowUpPrompt,
   parseRecallEvaluation,
+  resolveRecallEvaluationRoute,
 } from "../../desktop/src/panel/recall-evaluation.js";
 
 describe("Recall smart evaluation", () => {
@@ -54,5 +55,114 @@ describe("Recall smart evaluation", () => {
     expect(prompt).toContain("Can you give me an example?");
     expect(prompt).toContain("One important distinction is missing.");
     expect(prompt).toContain(card.concept);
+  });
+});
+
+// Issue #209: the card routed purely on host capabilities, so an explicit and
+// routable "ZAM text model" selection was ignored and the answer took the
+// ui/message detour into the host chat instead of evaluating in-card.
+describe("resolveRecallEvaluationRoute", () => {
+  const routable = (id: string) => ({ id, routable: true });
+  const unroutable = (id: string, reason?: string) => ({
+    id,
+    routable: false,
+    reason,
+  });
+
+  it("honors a routable zam-text-model over the host's message capability", () => {
+    expect(
+      resolveRecallEvaluationRoute({
+        selectedEvaluatorId: "zam-text-model",
+        evaluators: [routable("zam-text-model")],
+        // Claude Code today: messaging but no bridge sampling.
+        capabilities: { message: {} },
+      }),
+    ).toEqual({ kind: "zam-text-model" });
+  });
+
+  it("prefers zam-text-model even when the host also offers sampling", () => {
+    expect(
+      resolveRecallEvaluationRoute({
+        selectedEvaluatorId: "zam-text-model",
+        evaluators: [routable("zam-text-model")],
+        capabilities: { sampling: {}, message: {} },
+      }),
+    ).toEqual({ kind: "zam-text-model" });
+  });
+
+  it("surfaces an honest reason for a surface-foreign selection", () => {
+    const route = resolveRecallEvaluationRoute({
+      selectedEvaluatorId: "vscode-lm",
+      evaluators: [
+        unroutable("vscode-lm", "VS Code language models need the Companion."),
+      ],
+      capabilities: { message: {} },
+    });
+    expect(route).toEqual({
+      kind: "unavailable",
+      reason: "VS Code language models need the Companion.",
+    });
+  });
+
+  it("never silently falls back to ui/message for an unroutable selection", () => {
+    const route = resolveRecallEvaluationRoute({
+      selectedEvaluatorId: "vscode-lm",
+      evaluators: [unroutable("vscode-lm")],
+      capabilities: { sampling: {}, message: {} },
+    });
+    expect(route.kind).toBe("unavailable");
+  });
+
+  it("keeps the capability ladder for native-mcp-host", () => {
+    expect(
+      resolveRecallEvaluationRoute({
+        selectedEvaluatorId: "native-mcp-host",
+        evaluators: [routable("native-mcp-host")],
+        capabilities: { sampling: {} },
+      }),
+    ).toEqual({ kind: "host-sampling" });
+
+    expect(
+      resolveRecallEvaluationRoute({
+        selectedEvaluatorId: "native-mcp-host",
+        evaluators: [routable("native-mcp-host")],
+        capabilities: { message: {} },
+      }),
+    ).toEqual({ kind: "host-message" });
+  });
+
+  it("keeps the capability ladder when nothing is selected", () => {
+    expect(
+      resolveRecallEvaluationRoute({ capabilities: { sampling: {} } }),
+    ).toEqual({ kind: "host-sampling" });
+    expect(
+      resolveRecallEvaluationRoute({ capabilities: { message: {} } }),
+    ).toEqual({ kind: "host-message" });
+  });
+
+  it("explains a host that offers neither capability", () => {
+    const route = resolveRecallEvaluationRoute({ capabilities: {} });
+    expect(route.kind).toBe("unavailable");
+    expect(route).toMatchObject({ reason: expect.stringMatching(/quick mode/i) });
+  });
+
+  it("refuses to evaluate under quick mode", () => {
+    const route = resolveRecallEvaluationRoute({
+      selectedEvaluatorId: "quick-mode",
+      capabilities: { sampling: {} },
+    });
+    expect(route.kind).toBe("unavailable");
+    expect(route).toMatchObject({
+      reason: expect.stringMatching(/model-free by design/i),
+    });
+  });
+
+  it("routes a routable zam-text-model even if the context omits the route list", () => {
+    expect(
+      resolveRecallEvaluationRoute({
+        selectedEvaluatorId: "zam-text-model",
+        capabilities: { message: {} },
+      }),
+    ).toEqual({ kind: "zam-text-model" });
   });
 });


### PR DESCRIPTION
Closes #209.

The Recall card routed answer evaluation purely on host capabilities:

```
if (capabilities?.sampling)     → in-card host sampling
else if (capabilities?.message) → ui/message into the host chat
else                            → error
```

`selectedEvaluatorId` was never consulted, so on a host with messaging but no
bridge sampling (Claude Code) an explicit, routable **ZAM text model** was
ignored and the answer took the chat detour. The Agent pill was honest UI over
routing that ignored it.

## Change

A pure `resolveRecallEvaluationRoute()` in `recall-evaluation.ts` decides the
route from the selection, the companion context's routability, and host
capabilities — in that order:

1. `zam-text-model` and routable → `zam_companion_sample`, the same path the
   VS Code extension already uses for that id.
2. Selected but unroutable here (e.g. `vscode-lm` persisted from VS Code) →
   the route's own reason, shown in-card. Never a silent fallback, matching
   `companion-dispatch.assertSamplingRoutableToVscodeLm` extension-side.
3. `native-mcp-host` or no selection → today's capability ladder, unchanged.
4. `quick-mode` → refused; it is model-free by design.

`sampleRecall` is the single sampling entry point for both the first
evaluation and every follow-up turn, so a discussion cannot switch model
mid-thread.

## One change beyond the issue

`sampleViaLocalLLM` backs `zam_companion_sample`, and it was **not** wired for
the agent transport — I had excluded it in #224 as "deliberately local-only",
which was wrong: it resolves the *recall* role exactly like the recall callers
that are wired. Leaving it would have made this fix throw "does not support
yet" for anyone whose recall model is harness-backed, which is now a
first-class 0.20.x configuration. It is wired here, and the stale test that
asserted the rejection is replaced with coverage of the working path.

## Verification

- 1555 tests pass (164 files), up from 1545. New: eight routing cases covering
  selection-over-capability, unroutable notices, ladder preservation, and
  quick-mode refusal, plus two for agent-backed sampling.
- Biome clean; root and desktop `tsc --noEmit` clean.
- Desktop builds; `zam_companion_sample` is present in the built
  `dist/ui/recall-panel.html`.

No new i18n keys — the unroutable notice reuses the existing
`recall_check_failed` path, which ships in all seven packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)