### PR TITLE
chore: release 0.21.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.20.1",
+  "version": "0.21.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.20.1"
+version = "0.21.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.20.1",
+          "User-Agent": "ZAM-Content-Studio/0.21.0",
         },
       });
 


### PR DESCRIPTION
Version bump only — all functional work is already on `main`.

Touches the seven files a release bump has to keep in sync: root `package.json` + lockfile, `desktop/package.json` + lockfile, `desktop/src-tauri/Cargo.toml` + `Cargo.lock` (verified with `cargo metadata --locked`), and the hardcoded User-Agent in `src/cli/adapters/source-reader.ts`.

## What ships in 0.21.0

**Closed-group learning library** (ADR 2026-07-04, accepted in #104) — a group shares curated content while each learner's own learning data stays theirs:

- Content versioning, so a correction reaches learners who already studied the old version
- Editorial state on tokens; only published content is scheduled
- A Studio release step that forces a material/cosmetic classification rather than defaulting one
- Re-test provenance and a notice on affected recall cards
- Knowledge assignments that bind a card while the assignment is active
- "Not for me" — detach a card without destroying its history, and reattach later
- A PostgreSQL provider, with row-level security policies that ship as deployable SQL and resolve the learner from `current_user`

**Fix:** the Recall panel honours the evaluator you selected (#209, via #226).

**Dev:** `npm run pg:up` brings up a local PostgreSQL 17 matching CI, so the Postgres-backed suites run without a cloud database.

Not included: the Azure/Entra deployment path itself. That work is still open — see #228.