### PR TITLE
chore: release 0.22.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.21.0"
+version = "0.22.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.0.md
+++ b/docs/release-notes-0.22.0.md
@@ -1,0 +1,60 @@
+# ZAM 0.22.0 — iPadOS companion
+
+ZAM Mobile now runs on **iPadOS** as well, as a second target on the same
+Tauri shell. The kernel, the frontend and the libsql database path are shared
+unchanged — there is no second app and no second kernel.
+
+The reason is the school day: where a class is issued iPads, iPadOS decides
+whether ZAM is part of lessons or only of the evening.
+
+This is an **alpha**. The iOS target builds, signs and is wired into the
+release pipeline, but it has **not been installed on a device**, and
+TestFlight distribution is untested.
+
+## Highlights
+
+- **iPadOS target (ADR 2026-07-26).** QR pairing with Keychain-backed
+  credential storage, sync, offline review, de/en, daily reminders. Reference
+  device is the iPad (A16, 11th generation); the intended minimum is an
+  iPhone 14. Deployment target is iOS/iPadOS 17.0.
+
+- **Responsive tablet layout.** Breakpoints at 700 px and 1000 px widen the
+  reading column to 680/760 px and put all four FSRS ratings on one row. The
+  column stays deliberately narrow — a full 11-inch measure hurts recall. This
+  applies to Android tablets too.
+
+- **No on-device evaluation on iOS.** The iPad (A16) and iPhone 14 (A15) are
+  both below the Apple Intelligence floor, so the Foundation Models framework
+  is unavailable and Gemini Nano has no counterpart. Evaluation uses a
+  configured cloud endpoint, or self-rating. This is a hardware fact, not a
+  scheduling decision.
+
+- **Also not ported:** voice mode, in-app update, and share-sheet quick
+  capture. Each for a platform reason rather than a time reason; iOS has no
+  sideload channel at all, so updates go through TestFlight.
+
+- **Curriculum import creates prerequisite edges automatically** (#231).
+  Imported topics arrive already linked, instead of needing the dependencies
+  wired up afterwards.
+
+- **Central curriculum service: scope decided** (ADR 2026-07-26b). The planned
+  service will carry **content only** — no cards, no review logs, no sessions.
+  Learner state has no table in its schema, so the boundary is structural
+  rather than a promise, which also keeps third-party hosting uncomplicated.
+
+## Android
+
+Unchanged. The Pixel 9 remains the reference device, and a **Pixel 10 passed
+validation on 2026-07-26** with no changes required.
+
+## Under the hood
+
+- Swift plugins live in a SwiftPM package that the Rust build links
+  (`mobile/src-tauri/ios/`), not in the Xcode app target — the Rust staticlib
+  links before Swift compiles, so `@_cdecl` symbols in the app target are
+  invisible to it. Android needs no equivalent because it loads its plugin
+  class reflectively at runtime.
+- CI gained an `ios` job that compiles the Swift against the simulator SDK
+  without code signing, so the gate needs no secrets and works on forks.
+- `secure_store` and `reminder` now gate on Tauri's `mobile` cfg and differ
+  only at plugin registration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.21.0",
+          "User-Agent": "ZAM-Content-Studio/0.22.0",
         },
       });
 


### PR DESCRIPTION
Version bump auf **0.22.0** plus Release-Notes.

Alle sechs dokumentierten Stellen sind angefasst — das ist die Stelle, an der bei v0.10.8 drei Versionsfelder liegen blieben:

| Datei | |
|---|---|
| `package.json` + `package-lock.json` | ✅ |
| `desktop/package.json` + `desktop/package-lock.json` | ✅ |
| `desktop/src-tauri/Cargo.toml` + `Cargo.lock` | ✅ |
| User-Agent in `src/cli/adapters/source-reader.ts` | ✅ |

Verifiziert: `cargo metadata --locked` konsistent, `packages[""].version` in beiden Lockfiles mitgezogen, Build ✓, **1587 Tests** ✓, Biome ✓.

## Inhalt des Releases

- **iPadOS-Companion** (#232) — zweites Tauri-Ziel, responsives Tablet-Layout, `ios`-CI-Gate, TestFlight-Job
- **Content-only-ADR** (#233) — zentrale Lehrplan-Datenbank trägt ausschließlich Inhalte
- **Prerequisite-Kanten beim Lehrplan-Import** (#231, bereits auf main)

## Bekannte Einschränkung

Das iOS-Ziel baut und signiert, ist aber **auf keinem Gerät installiert** worden, und die TestFlight-Verteilung ist ungetestet. `publish-ios` läuft mit diesem Tag zum ersten Mal scharf. Schlägt der Export dort fehl, ist das nachziehbar, ohne neu zu taggen — das Release selbst entsteht in einem früheren Job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)