### PR TITLE
fix(ci): erzeuge das Xcode-Projekt auch im Release-Job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,16 @@ jobs:
           npm ci
           npm ci --prefix mobile
 
+      - name: Generate Xcode project
+        if: steps.apple.outputs.configured == 'true'
+        working-directory: mobile
+        # gen/apple/*.xcodeproj ist bewusst nicht versioniert (reines
+        # xcodegen-Ergebnis, siehe mobile/.gitignore) und muss deshalb hier
+        # erzeugt werden. Ohne diesen Schritt bricht der Build mit
+        # "failed to locate xcodeproj ... No file found matching *.xcodeproj"
+        # ab. Der CI-Job `ios` in ci.yml hat denselben Schritt.
+        run: npx tauri ios init
+
       - name: Build and upload to TestFlight
         if: steps.apple.outputs.configured == 'true'
         working-directory: mobile

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -87,6 +87,14 @@ targets:
         # der bräuchte jedoch einen Admin-Key in den CI-Secrets, während für
         # den Upload sonst App-Manager genügt.
         # Simulatorbauten (CI-Job `ios`) bleiben unberührt und signaturfrei.
+        # DEVELOPMENT_TEAM muss hier stehen, auch wenn Tauri den Wert aus
+        # APPLE_DEVELOPMENT_TEAM setzt: Tauri fügt den Schlüssel sonst per
+        # Texteinfügung *hinter* die schließende Klammer von buildSettings ein,
+        # wo Xcode ihn ignoriert ("requires a development team"). Existiert der
+        # Schlüssel bereits, überschreibt Tauri sauber nur den Wert — so wie
+        # beim PROVISIONING_PROFILE_SPECIFIER darunter. Der Wert hier ist also
+        # nur der Vorgabewert; APPLE_DEVELOPMENT_TEAM sticht ihn.
+        DEVELOPMENT_TEAM: 3KZ69XA25D
         CODE_SIGN_STYLE[sdk=iphoneos*]: Manual
         CODE_SIGN_IDENTITY[sdk=iphoneos*]: Apple Distribution
         PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]: ZAM Mobile App Store


### PR DESCRIPTION
`publish-ios` ist bei **v0.22.0** gescheitert:

```
Error failed to locate xcodeproj in .../mobile/src-tauri/gen/apple:
      No file found matching *.xcodeproj
```

Die `.xcodeproj` ist bewusst **nicht versioniert** — sie ist reines xcodegen-Ergebnis aus `project.yml` (siehe `mobile/.gitignore`). Der CI-Job `ios` in `ci.yml` erzeugt sie deshalb per `tauri ios init` neu. Im Release-Job fehlte genau dieser Schritt.

Das erklärt auch, warum der Fehler durch alle Gates gerutscht ist: `ios` war grün, weil er die Datei selbst erzeugt — nur der Release-Job griff ins Leere.

Alle übrigen Jobs von v0.22.0 waren erfolgreich (Desktop ×4, Android-APK, VSIX, npm), das Release selbst ist intakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)