### PR TITLE
chore: release 0.22.1

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.22.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.0"
+version = "0.22.1"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.1.md
+++ b/docs/release-notes-0.22.1.md
@@ -1,0 +1,35 @@
+# ZAM 0.22.1 — iOS ships from the pipeline
+
+A release-plumbing fix. **Nothing about the product changed** — see
+[0.22.0](release-notes-0.22.0.md) for what iPadOS support actually does.
+
+In 0.22.0 every artefact published except the iOS build: desktop on four
+platforms, the Android APK, the VS Code extension and the npm package all
+succeeded, and `publish-ios` failed. This release makes that job work.
+
+## What was wrong
+
+- **The release job never generated the Xcode project.** `gen/apple/*.xcodeproj`
+  is deliberately unversioned — it is pure xcodegen output from `project.yml` —
+  and the `ios` CI job regenerates it with `tauri ios init`. The release job was
+  missing that step and failed with `failed to locate xcodeproj`. The CI gate
+  stayed green precisely because it created the file itself.
+
+- **`DEVELOPMENT_TEAM` was written outside the settings block.** Tauri injects
+  it into the generated `project.pbxproj` by text insertion, and placed it
+  *after* the closing brace of `buildSettings`, where Xcode ignores it —
+  `Signing requires a development team that matches the selected profile`.
+  Giving the key an anchor in `project.yml` fixes it: when the key already
+  exists, Tauri cleanly overwrites only its value, which is why
+  `PROVISIONING_PROFILE_SPECIFIER` had worked all along. The value in the repo
+  is only a default; `APPLE_DEVELOPMENT_TEAM` overrides it.
+
+Only the second one would have survived a green CI run, and it was found by
+building locally rather than by any gate.
+
+## Status of the iOS build
+
+It compiles, signs and exports a valid App Store IPA (`org.zamos.zam`,
+minimum iOS 17.0, chain Apple Distribution → WWDR → Apple Root CA). It has
+still **not been installed on a device**, and TestFlight distribution remains
+unproven end to end — this release is the first run that exercises it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.0",
+          "User-Agent": "ZAM-Content-Studio/0.22.1",
         },
       });
 


### PR DESCRIPTION
Reiner Release-Plumbing-Fix — **am Produkt ändert sich nichts**. iPadOS-Inhalt siehe [0.22.0](https://github.com/zam-os/zam/releases/tag/v0.22.0).

Zweck: `publish-ios` scheiterte bei v0.22.0, während alle übrigen Artefakte veröffentlicht wurden. Die beiden Ursachen sind in #235 behoben; dieser Tag lässt iOS erstmals regulär aus der Pipeline laufen.

Version an allen sechs Stellen: root `package.json` + Lock, `desktop/package.json` + Lock, `desktop/src-tauri/Cargo.toml` + `Cargo.lock`, User-Agent in `src/cli/adapters/source-reader.ts`. `cargo metadata --locked` konsistent, Build ✓, **1587 Tests** ✓, Biome ✓.

Lokal ist der Weg bereits bewiesen: der Build erzeugt eine gültige signierte IPA (28 MB, `org.zamos.zam`, Mindest-iOS 17.0, Kette Apple Distribution → WWDR → Apple Root CA). Was dieser Tag zusätzlich prüft, ist der Upload aus CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)