### PR TITLE
fix(ci): schreibe den API-Key vor dem iOS-Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,8 +445,17 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
         run: |
           set -euo pipefail
+          # Die .p8 muss VOR dem Build liegen: Tauri reicht APPLE_API_KEY_PATH
+          # als -authenticationKeyPath an xcodebuild durch, und xcodebuild
+          # bricht ab, wenn die Datei dann noch nicht existiert
+          # ("must be an absolute path to an existing file").
+          printf %s "$APPLE_API_KEY_CONTENT" | base64 -d > "$APPLE_API_KEY_PATH"
+          mkdir -p ~/.appstoreconnect/private_keys
+          cp "$APPLE_API_KEY_PATH" ~/.appstoreconnect/private_keys/"AuthKey_${APPLE_API_KEY}.p8"
+
           npm run ios:build -- --export-method app-store-connect --ci
           IPA="$(find src-tauri/gen/apple/build -type f -name '*.ipa' | head -n 1)"
           if [ -z "$IPA" ]; then
@@ -454,9 +463,6 @@ jobs:
             find src-tauri/gen/apple/build -type f -name '*.ipa' -o -name '*.xcarchive' | head -20
             exit 1
           fi
-          echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 -d > "$APPLE_API_KEY_PATH"
-          mkdir -p ~/.appstoreconnect/private_keys
-          cp "$APPLE_API_KEY_PATH" ~/.appstoreconnect/private_keys/"AuthKey_${APPLE_API_KEY}.p8"
           # TestFlight is the only install path on iOS; there is no equivalent
           # of the APK + mobile-latest.json sideload channel to publish here.
           xcrun altool --upload-app \


### PR DESCRIPTION
Dritter und — diesmal belegt — letzter Fehler in `publish-ios`.

```
xcodebuild: error: The -authenticationKeyPath flag must be an absolute path to an existing file.
```

`APPLE_API_KEY_PATH` war als `env` gesetzt, die `.p8` wurde im Skript aber erst **nach** `npm run ios:build` geschrieben. Tauri reicht den Pfad als `-authenticationKeyPath` an xcodebuild durch, wo er zu diesem Zeitpunkt ins Leere zeigt.

Nebenbei wandert `APPLE_API_KEY_CONTENT` in den `env`-Block, statt per `${{ }}` direkt ins Skript interpoliert zu werden — so steht der Wert nicht in der Kommandozeile.

## Diesmal vorher verifiziert

Lokal mit **denselben Variablen wie CI** durchgespielt (`APPLE_API_KEY`, `APPLE_API_ISSUER`, `APPLE_API_KEY_PATH`, `IOS_MOBILE_PROVISION`, `APPLE_DEVELOPMENT_TEAM`):

- IPA erzeugt
- `Authority=Apple Distribution: Thomas Martin Josefczak (3KZ69XA25D)`, Kette bis Apple Root CA
- eingebettetes Profil `ZAM Mobile App Store`, `3KZ69XA25D.org.zamos.zam`
- `codesign --verify --deep --strict` sauber

Die drei Fehler dieses Jobs waren allesamt Reihenfolge- bzw. Plumbing-Fehler in einem Workflow, der nie ausgeführt worden war. Der lokale Lauf hätte sie alle drei sofort gezeigt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)