### PR TITLE
chore: release 0.22.2

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.1",
+  "version": "0.22.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.1"
+version = "0.22.2"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.2.md
+++ b/docs/release-notes-0.22.2.md
@@ -1,0 +1,8 @@
+# ZAM 0.22.2 — iPadOS companion
+
+Same content as [0.22.0](release-notes-0.22.0.md) — see there for what iPadOS
+support actually does.
+
+This is the first release in the 0.22 line that ships **complete**, including
+the iOS build. In 0.22.0 and 0.22.1 the TestFlight job failed on release
+automation; every other artefact was fine in both.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.1",
+          "User-Agent": "ZAM-Content-Studio/0.22.2",
         },
       });
 


### PR DESCRIPTION
Version 0.22.2. **Inhaltlich identisch mit [0.22.0](https://github.com/zam-os/zam/releases/tag/v0.22.0)** — dort steht, was iPadOS-Unterstützung bedeutet.

Erste Version der 0.22-Reihe, die vollständig erscheinen sollte, einschließlich iOS-Build. Bei 0.22.0 und 0.22.1 scheiterte `publish-ios` an der Release-Automatisierung (drei aufeinanderfolgende Plumbing-Fehler, behoben in #235 und #237); alle übrigen Artefakte waren jeweils in Ordnung.

Version an allen sechs Stellen: root `package.json` + Lock, `desktop/package.json` + Lock, `desktop/src-tauri/Cargo.toml` + `Cargo.lock`, User-Agent in `src/cli/adapters/source-reader.ts`. `cargo metadata --locked` konsistent.

Der letzte Fix ist vorab lokal belegt: derselbe Variablensatz wie CI erzeugt eine gültige, korrekt signierte IPA (`Apple Distribution: Thomas Martin Josefczak`, Profil `ZAM Mobile App Store`, `codesign --verify --deep --strict` sauber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)