### PR TITLE
fix(ci): baue iOS auf macos-26 mit dem iOS-26-SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
     # required to have Xcode installed — so this job is the compile gate for
     # everything under gen/apple, the same way the `mobile` job above is the
     # gate for Android-only Rust.
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,7 +374,7 @@ jobs:
     name: 'Upload ZAM Mobile to TestFlight'
     needs: publish-tauri
     if: ${{ always() && needs.publish-tauri.result != 'cancelled' }}
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
Der TestFlight-Upload für v0.22.2 wurde von Apple abgelehnt:

```
Validation failed (409) SDK version issue.
This app was built with the iOS 18.5 SDK. All iOS and iPadOS apps must be
built with the iOS 26 SDK or later, included in Xcode 26 or later.
```

**Kein Plumbing-Fehler mehr, sondern eine Apple-Richtlinie.** Der Runner `macos-15-arm64` bietet nur Xcode 16.4 (iOS-18.5-SDK), und Xcode 26 setzt macOS 26 voraus — das Image muss also wechseln.

Der Job `ios` in `ci.yml` wandert mit. Bliebe er auf 16.4, würde das Gate weiter gegen ein SDK kompilieren, das Apple nicht mehr annimmt — genau die Gate/Realitäts-Lücke, die diesen Job dreimal grün aussehen ließ, während der Release scheiterte.

## Was inzwischen bewiesen ist

Der Lauf von v0.22.2 kam bis `** BUILD SUCCEEDED **` und bis in `altool` hinein. Build, Signatur, Export und Authentifizierung funktionieren in CI; der App-Record in App Store Connect existiert seit heute ebenfalls. Es fehlte nur noch das SDK.

Lokal (Xcode 26.6, iOS-26.5-SDK) entsteht eine gültige, korrekt signierte IPA — das ist der Zustand, den dieser Wechsel in CI herstellt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)