### PR TITLE
chore: release 0.22.3

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.2",
+  "version": "0.22.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.2"
+version = "0.22.3"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.3.md
+++ b/docs/release-notes-0.22.3.md
@@ -1,0 +1,37 @@
+# ZAM 0.22.3 — the macOS app is notarized
+
+The macOS app is now signed with an Apple Developer ID certificate and
+notarized by Apple. A downloaded `ZAM.app` opens with a double-click; the
+right-click → Open detour, and the dialog that made the download look damaged,
+are gone.
+
+Nothing else changed. This is the same application as
+[0.22.2](release-notes-0.22.2.md) — see [0.22.0](release-notes-0.22.0.md) for
+what the iPadOS companion does.
+
+## What this covers
+
+- **The app and everything inside it.** Notarization fails if any single
+  executable in the bundle is unsigned, and ZAM ships several: the Node
+  runtime that runs the bridge, the prebuilt SQLite modules, and the observer
+  sidecar. All of them now carry the same signature and run under Apple's
+  hardened runtime.
+- **In-app updates.** The updater payload is notarized and stapled too, so an
+  updated install passes Gatekeeper even offline.
+
+The bundled Node runtime holds exactly one entitlement,
+`com.apple.security.cs.allow-jit`, which it needs because it compiles
+JavaScript at runtime. The two further entitlements that the usual recipe for
+Node applications adds are not included — they were verified to be
+unnecessary, and one of them would have allowed unsigned libraries to be
+loaded into the process that holds your database.
+
+## Not included
+
+- **Windows** installers are still unsigned; SmartScreen still warns.
+- **Intel Macs** are still not built — releases are Apple Silicon only.
+- The **Mac App Store** is not the distribution route, and this does not move
+  towards it. The reason is recorded in
+  [ADR 2026-07-27](adr/2026-07-27-macos-notarization.md): the App Store
+  requires the App Sandbox, and a sandboxed app cannot reach the `~/.zam`
+  database that the desktop app, the CLI and the MCP transport share.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.2",
+          "User-Agent": "ZAM-Content-Studio/0.22.3",
         },
       });
 


### PR DESCRIPTION
Ships the macOS Developer ID signature and notarization from #240. No application changes since 0.22.2.

Version bumped in all seven documented places (root and desktop `package.json` + lockfiles, `desktop/src-tauri/Cargo.toml` + `Cargo.lock`, and the hardcoded User-Agent in `src/cli/adapters/source-reader.ts`).

**One thing worth knowing:** `cargo metadata --locked --no-deps` — the CI step *Verify locked Rust dependency graph* — reports success even when `Cargo.lock` still holds the previous version, because `--no-deps` skips resolution entirely and so has nothing to check. The lockfile here was verified with resolution enabled instead. Worth tightening that step separately.

Release notes: [`docs/release-notes-0.22.3.md`](docs/release-notes-0.22.3.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)