### PR TITLE
fix: allow the barcode scanner on iOS

### DIFF
--- a/docs/adr/2026-07-26-ipados-companion-target.md
+++ b/docs/adr/2026-07-26-ipados-companion-target.md
@@ -2,8 +2,10 @@
 
 **Status:** Accepted — scope and distribution decided (Thomas, 2026-07-26).
 The iOS target builds: both Swift plugins compile and link, verified locally
-(Xcode 26.6) and in CI (Xcode 16.4). **Not yet validated on hardware** — no
-build has been installed on a device, and TestFlight distribution is untested. **Supersedes the "iOS" and
+(Xcode 26.6) and in CI (Xcode 16.4). **First hardware install done 2026-07-28**
+(0.22.2 via TestFlight, iPad 9th generation): the app installs and launches,
+and QR pairing failed on an ACL gap that no compile gate could see — fixed in
+decision 2 below. Pairing end-to-end is still unproven on a device. **Supersedes the "iOS" and
 "tablet/large-screen layouts" non-goals** in
 `docs/plans/2026-07-21-android-companion-app.md`.
 **Deciders:** Thomas (project owner)
@@ -51,6 +53,14 @@ Tauri already injects a `mobile` cfg meaning android-or-iOS. `secure_store` and
 still serve desktop builds. Cargo target specifications cannot see Tauri's
 injected cfg, so `Cargo.toml` spells out
 `cfg(any(target_os = "android", target_os = "ios"))` for `hyper-rustls`.
+
+There is a third place that has to move with the cfg, and it is not Rust at
+all: the **capability files** in `src-tauri/capabilities/` carry their own
+`platforms` list. Registering a plugin for `cfg(mobile)` while its capability
+still says `["android"]` produces an app where the command exists and is
+refused — `Command plugin:… not allowed by ACL`, at runtime, on the device
+only. That is exactly what happened to the barcode scanner and it survived
+every compile gate we have.
 
 ### 3. Scope of the first increment: the Android Phase-0 set, no more
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,6 +58,6 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-23](2026-07-23-online-only-server-db-and-mobile-gating.md) | Online-Only Server Database, Mobile Gating, and Cloud Config in the DB | Accepted |
 | [2026-07-24](2026-07-24-first-run-onboarding.md) | First-Run Onboarding: Personas, Goal-Driven Import, Cloud LLM Connect, and Agent Choice | Accepted |
 | [2026-07-25](2026-07-25-shared-curated-learning-content.md) | Shared Curated Learning Content — Review Once, Serve Many | Accepted |
-| [2026-07-26](2026-07-26-ipados-companion-target.md) | iPadOS Companion: Second Mobile Target on the Existing Tauri Shell | Accepted — builds; not yet validated on hardware |
+| [2026-07-26](2026-07-26-ipados-companion-target.md) | iPadOS Companion: Second Mobile Target on the Existing Tauri Shell | Accepted — installs on hardware; pairing not yet proven on a device |
 | [2026-07-26b](2026-07-26b-central-curriculum-content-service.md) | Central Curriculum Content Service: Content Only, Pulled Forward | Accepted |
 | [2026-07-27](2026-07-27-macos-notarization.md) | macOS Distribution: Developer ID Notarization, Not the Mac App Store | Accepted — verified on a local notarized build |

--- a/mobile/src-tauri/capabilities/mobile.json
+++ b/mobile/src-tauri/capabilities/mobile.json
@@ -1,8 +1,8 @@
 {
   "identifier": "mobile-pairing",
-  "description": "Android camera access for QR pairing",
+  "description": "Camera access for QR pairing on Android and iOS",
   "windows": ["main"],
-  "platforms": ["android"],
+  "platforms": ["android", "iOS"],
   "permissions": [
     "barcode-scanner:allow-scan",
     "barcode-scanner:allow-check-permissions",


### PR DESCRIPTION
QR pairing fails on the iPad with:

```
Scan fehlgeschlagen: Command plugin:barcode-scanner|check_permissions not allowed by ACL
```

## Cause

The barcode scanner plugin is registered for `cfg(mobile)` — it was moved there during the iPadOS work — but its capability file still read `"platforms": ["android"]`. On iOS every scanner command is therefore refused by the ACL.

The capability platform list is a **third place** that has to move together with `cfg(mobile)`, alongside the plugin registration and the `Cargo.toml` target specification. Unlike those two it is not Rust, so nothing at compile time can catch it: the app builds, links, launches, and only fails when the user taps *Scan*. This is recorded in decision 2 of the iPadOS ADR so the next plugin does not repeat it.

## Scope check

I verified no second ACL wall follows this one. The barcode scanner is the only third-party plugin the frontend imports (`@tauri-apps/plugin-barcode-scanner`); `secure-pairing`, `reminder`, `voice`, `on-device-llm` and `update` expose their JavaScript surface as app-level `#[tauri::command]`s, which the ACL does not gate. `NSCameraUsageDescription` is already present in `project.yml`, and all four scanner permissions were already listed — only the platform gate was wrong.

## What this does not prove

CI compiles the iOS target, which validates that `"iOS"` is a legal platform token, but the actual fix can only be confirmed by scanning a QR code on a device. That needs a TestFlight build, so it will be verifiable after the next release.

Found by Thomas on an iPad (9th generation) running 0.22.2 from TestFlight — the first hardware install of the iOS target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)