### PR TITLE
chore: release 0.22.4

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.3",
+      "version": "0.22.4",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.3",
+  "version": "0.22.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.3"
+version = "0.22.4"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.4.md
+++ b/docs/release-notes-0.22.4.md
@@ -1,0 +1,21 @@
+# ZAM 0.22.4 — QR pairing works on iPadOS
+
+QR pairing on iPhone and iPad failed with *"Command
+plugin:barcode-scanner|check_permissions not allowed by ACL"*. The camera never
+opened, so the only way onto a device was the manual pairing form.
+
+The scanner plugin was built into the iOS app and its permissions were
+declared, but the permission set was still restricted to Android, so iOS
+refused every scanner command. It is now allowed on both platforms.
+
+Found on the first hardware install of the iOS build — an iPad (9th
+generation) running 0.22.3 from TestFlight. No compile gate could have caught
+it: the app builds, links and launches, and only fails the moment someone taps
+*Scan*.
+
+Everything else is unchanged from [0.22.3](release-notes-0.22.3.md), which
+brought the notarized macOS app.
+
+## For Android users
+
+Nothing changes. Android already had the permission and was unaffected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.3",
+      "version": "0.22.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.3",
+          "User-Agent": "ZAM-Content-Studio/0.22.4",
         },
       });
 


### PR DESCRIPTION
Ships the iOS barcode scanner ACL fix from #242, so QR pairing works on iPhone and iPad. No other application changes since 0.22.3.

Version bumped in all seven documented places; `Cargo.lock` verified with dependency resolution enabled (`cargo metadata --locked --no-deps`, the CI step, does not catch a stale lock — see #241).

Release notes: [`docs/release-notes-0.22.4.md`](docs/release-notes-0.22.4.md)

The fix can only be confirmed by scanning a QR code on a device, so it stays unproven until this build reaches TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)