### PR TITLE
chore: release 0.22.5

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.4",
+  "version": "0.22.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.4"
+version = "0.22.5"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.5.md
+++ b/docs/release-notes-0.22.5.md
@@ -1,0 +1,39 @@
+# ZAM 0.22.5 — the iPad build stops promising what it does not have
+
+Everything in this release comes from one hour with the app on a real iPad.
+Nothing here was visible from a compiler, a test suite or CI.
+
+## Fixed
+
+- **Cloud evaluation of answers.** It failed with *"evaluation endpoint
+  returned empty content"*, which reads like a broken endpoint and was not
+  one. The mobile app allowed the model 256 tokens for an evaluation the
+  desktop gives 1200 — a verdict, feedback, a reference answer and a list of
+  gaps do not fit, and a reasoning model spends part of that budget before
+  writing any of it. Every answer was cut off, and nothing checked for
+  truncation, so it was reported as an empty one. Both are fixed: the budget
+  now lives next to the prompt that determines it, and a truncated answer says
+  so.
+- **Voice mode no longer appears on iPadOS.** It is Android-only. iOS reported
+  it as a *denied microphone permission*, which sent people looking through
+  Settings for a switch that does not exist.
+- **"Check for updates" no longer appears on iPadOS.** iOS has no sideload
+  channel; TestFlight does the updating, and the app now says so instead of
+  offering a button that fails.
+- **Settings show the real version.** An 0.22.4 build reported 0.19.0, because
+  the number came from a crate version that release bumps do not touch. It now
+  comes from the app bundle, which cannot drift.
+
+## Changed
+
+- **The minimum supported device is now the iPad (9th generation, A13)**,
+  lowered from the iPhone 14. It is the weaker device in every dimension that
+  matters, and the app is confirmed to install, launch and pair on it. This
+  says nothing about phones: an iPhone 11 has the same chip, but nothing has
+  run there, and a 390pt phone is a different layout question from an 810pt
+  tablet.
+
+## Unchanged
+
+Android, the kernel and the desktop app. The macOS app stays signed and
+notarized as of [0.22.4](release-notes-0.22.4.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.4",
+          "User-Agent": "ZAM-Content-Studio/0.22.5",
         },
       });
 


### PR DESCRIPTION
Ships the iPad field-test fixes from #244. Everything in this release came out of one hour with the app on a real device.

Version bumped in all seven documented places; `Cargo.lock` verified with dependency resolution enabled.

Release notes: [`docs/release-notes-0.22.5.md`](docs/release-notes-0.22.5.md)

The three UI fixes and the evaluation token budget can only be confirmed on hardware, so they stay unproven until this build reaches TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)