### PR TITLE
fix: make the pairing dialog fit, and let the desktop use the window

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -15,8 +15,9 @@
     "windows": [
       {
         "title": "ZAM",
-        "width": 950,
-        "height": 720,
+        "maximized": true,
+        "width": 1280,
+        "height": 860,
         "minWidth": 720,
         "minHeight": 580,
         "theme": "Light"

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -135,12 +135,17 @@ body {
 /* ── CONTAINER & LAYOUT ──────────────────────────────────────────────────── */
 .container {
   width: 100%;
-  max-width: 950px;
+  /* The shell uses the window. The old 950px cap matched the old default
+     window width exactly, so a maximised window on a 1600px display left 650px
+     — 41% of it — as empty margin. Line length is protected where it actually
+     matters (see .question-text and .answer-box) rather than by squeezing
+     every dashboard, table and settings pane into a reading column. */
+  max-width: none;
   height: 100vh;
   max-height: 100vh;
   min-height: 0;
   overflow-y: auto;
-  padding: 22px 30px 30px;
+  padding: 22px clamp(30px, 3vw, 64px) 30px;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -1324,6 +1329,10 @@ textarea:focus-visible {
   color: var(--clr-text-primary);
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+  /* Reading measure. The window may be 2000px wide; a recall prompt read
+     across all of it is measurably worse to take in, which is why the shell
+     lost its width cap and this kept one. */
+  max-width: 70ch;
 }
 
 /* Answer Input capture */
@@ -1512,6 +1521,9 @@ textarea::placeholder {
   border: 1px solid var(--border-soft);
   border-radius: 12px;
   padding: 20px;
+  /* Same reading measure as .question-text: this is prose to be read, not a
+     surface to be filled. */
+  max-width: 80ch;
 }
 
 #lbl-reveal-title {
@@ -2509,6 +2521,8 @@ textarea::placeholder {
   display: none;
   justify-content: center;
   align-items: center;
+  /* Breathing room so a full-height dialog never touches the window edge. */
+  padding: 24px;
   z-index: 1000;
   opacity: 0;
   transition: opacity 0.3s ease;
@@ -2531,6 +2545,19 @@ textarea::placeholder {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  /* Never taller than the window it is centred in. A flex-centred box that
+     outgrows its container overflows in both directions, so the top scrolls
+     out of reach — which is what a 360px QR code plus the pairing form did in
+     a default-sized window. The body below takes the scrolling. */
+  max-height: 100%;
+  overflow: hidden;
+}
+
+.modal-header,
+.modal-actions {
+  /* Title and buttons stay put; scrolling the whole box would carry Close
+     out of the window, which is the one control that must always be there. */
+  flex-shrink: 0;
 }
 
 .pairing-modal {
@@ -2580,6 +2607,11 @@ textarea::placeholder {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* min-height:0 is what actually lets this shrink: a flex item defaults to
+     min-height:auto and refuses to go below its content, so overflow-y alone
+     would do nothing here. */
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .modal-impact-section {


### PR DESCRIPTION
Three things reported from the desktop app while pairing an iPad.

## The pairing dialog could not be closed

`.modal-box` had neither a `max-height` nor anything scrollable, and it is centred with flexbox — a flex-centred box that outgrows its container overflows in **both** directions, so the top goes out of reach rather than simply hanging off the bottom.

Measured at a 600px-tall window, with the QR code shown:

| | shipped | with fix |
| --- | --- | --- |
| dialog top | **−39px** (above the window) | 52px |
| dialog bottom | 639px (below the window) | 548px |
| Close button reachable | **no** | yes |
| scrollable | **no** | yes |

So it was worse than reported: not just unscrollable, but with the Close button off-screen.

The box is now bounded by the window and the *body* scrolls, while the title and the buttons stay put — scrolling the whole box would have carried Close out of view again.

## The window wasted most of a large display

`.container` capped at 950px, which is exactly what the old default window width was. On a 1600px-wide window that left **650px — 41% of it — as empty margin**.

The shell now uses the width it is given.

**That cap was doing one useful job, and it keeps doing it.** A recall prompt read across 2000px is measurably worse to take in, which is why the narrow column was chosen in the first place (ADR 2026-07-26, decision 7). The reading measure moved onto the prose itself — `.question-text` at 70ch, `.answer-box` at 80ch — rather than squeezing every dashboard, table and settings pane into a reading column to protect two paragraphs. If you would rather have no cap at all there either, that is a one-line change.

## The window starts small

`maximized: true`, with the non-maximised fallback raised from 950×860 to 1280×860 for when it is restored down.

## Verification

Measured in the browser, before and after, at 1600×1000 and 950×600; `tsc --noEmit`, `vite build`, and the desktop test suite (206 passed).

One thing I could **not** verify the intended way: `preview_start` runs the dev server from the primary working directory, which is the main checkout, not the worktree this branch lives in — so it served the unmodified stylesheet and my first "after" measurement was really a second "before". The numbers above come from applying the exact declarations to the live page instead. Worth knowing before trusting a preview-based measurement on a branch.

Also checked and **not** a bug: the decorative `.blur-glow` extends past the viewport, but `body` already clips it, so there is no scrollbar and nothing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)