### PR TITLE
chore: release 0.22.6

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.5",
+      "version": "0.22.6",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.5",
+  "version": "0.22.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.5"
+version = "0.22.6"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.6.md
+++ b/docs/release-notes-0.22.6.md
@@ -1,0 +1,30 @@
+# ZAM 0.22.6 — the desktop app uses your screen
+
+Three fixes to the desktop app, all found while pairing a tablet.
+
+## Fixed
+
+- **The pairing dialog can be closed again.** With the QR code shown in a
+  smaller window, the dialog grew past the window in both directions at once —
+  the way a centred box does — putting its top edge, and the Close button,
+  out of reach with nothing to scroll. The dialog now stays inside the window
+  and its contents scroll, while the title and the buttons keep their place.
+- **The window no longer wastes most of a large display.** The layout was
+  capped at 950px, which happened to be exactly the old default window width.
+  Maximised on a 1600px-wide screen, 41% of the window was empty margin. The
+  app now uses the width it is given.
+- **ZAM starts maximised.**
+
+## A note on line length
+
+The old width cap was not an oversight — a recall prompt stretched across a
+very wide window is harder to take in, which is why the column was narrow.
+That protection stayed, but it now sits on the text that needed it rather than
+on the whole application, so dashboards, tables and settings can use the
+space while reading stays comfortable.
+
+## Unchanged
+
+The mobile apps, the kernel, and the signed and notarized macOS build from
+[0.22.4](release-notes-0.22.4.md). The iPad fixes from
+[0.22.5](release-notes-0.22.5.md) are unaffected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.5",
+      "version": "0.22.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.5",
+          "User-Agent": "ZAM-Content-Studio/0.22.6",
         },
       });
 


### PR DESCRIPTION
Ships the desktop layout fixes from #246: the pairing dialog fits and scrolls again, the app uses the full window width, and it starts maximized.

Version bumped in all seven documented places; `Cargo.lock` verified with dependency resolution enabled.

Release notes: [`docs/release-notes-0.22.6.md`](docs/release-notes-0.22.6.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)