### PR TITLE
chore: release 0.22.7

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.6",
+      "version": "0.22.7",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.6",
+  "version": "0.22.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.6"
+version = "0.22.7"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.22.7.md
+++ b/docs/release-notes-0.22.7.md
@@ -1,0 +1,26 @@
+# ZAM 0.22.7 — evaluations answer in your language
+
+Feedback on an answer came back in English, whatever language the learner was
+working in. The prompt that asks a model to evaluate an answer is written in
+English and never said which language to reply in, so the model used the one
+it was addressed in.
+
+It now names the language, and the mobile app takes that language from
+`system.locale` in the database — the same learner setting the desktop reads,
+so changing it in one place changes it everywhere. An unpaired or offline
+start falls back to the device language.
+
+The command-line path was never affected; it has always named the language in
+its own prompt. What went wrong is that the studio panel and the mobile app
+share a *different* prompt builder, and that one had no language at all.
+
+## Unchanged
+
+Everything else from [0.22.6](release-notes-0.22.6.md): the desktop layout
+fixes, the iPad fixes, and the signed and notarized macOS build.
+
+## Still unproven
+
+Whether the model actually obeys the instruction has only been checked against
+the prompt, not against a real evaluation on a device. That is the next thing
+to confirm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.6",
+      "version": "0.22.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.6",
+          "User-Agent": "ZAM-Content-Studio/0.22.7",
         },
       });
 


### PR DESCRIPTION
Ships the evaluation language fix from #248: feedback is written in the learner's language, taken from `system.locale` in the database, with the device language as fallback.

Version bumped in all seven documented places; `Cargo.lock` verified with dependency resolution enabled.

Release notes: [`docs/release-notes-0.22.7.md`](docs/release-notes-0.22.7.md)

Whether the model obeys the instruction still needs confirming against a real evaluation on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)