### PR TITLE
feat: focused mode for the OKF link graph

### DIFF
--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -4569,6 +4569,13 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     okf_legend_article: "Article",
     okf_legend_citation: "Citation (ADR)",
     okf_graph_aria: "OKF knowledge graph",
+    okf_graph_aria_focused: "OKF knowledge graph, centered on {title}",
+    okf_graph_hint_overview:
+      "Left-click opens the article · right-click centers it",
+    okf_graph_hint_focused:
+      "Right-click another node to re-center · Esc for the overview",
+    okf_graph_focus_exit: "← Overview",
+    okf_graph_focus_on: "Centered: {title}",
     okf_log_empty_title: "No log yet",
     okf_log_empty_sub:
       "No log.md has been written for this knowledge base yet.",
@@ -5596,6 +5603,13 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     okf_legend_article: "Artikel",
     okf_legend_citation: "Zitat (ADR)",
     okf_graph_aria: "OKF Wissensgraph",
+    okf_graph_aria_focused: "OKF Wissensgraph, zentriert auf {title}",
+    okf_graph_hint_overview:
+      "Linksklick öffnet den Artikel · Rechtsklick zentriert ihn",
+    okf_graph_hint_focused:
+      "Rechtsklick auf einen anderen Knoten zentriert neu · Esc zur Übersicht",
+    okf_graph_focus_exit: "← Übersicht",
+    okf_graph_focus_on: "Zentriert: {title}",
     okf_log_empty_title: "Kein Log vorhanden",
     okf_log_empty_sub:
       "Für diese Wissensbasis wurde noch kein log.md geschrieben.",

--- a/desktop/src/panel/okf-panel.html
+++ b/desktop/src/panel/okf-panel.html
@@ -446,6 +446,29 @@
         max-height: 74vh;
         display: block;
       }
+      .okf-graph-hint {
+        margin-left: auto;
+        font-size: 0.72rem;
+        opacity: 0.85;
+      }
+      .okf-graph-focus-exit {
+        font: inherit;
+        font-size: 0.72rem;
+        padding: 2px 9px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--card);
+        color: var(--fg);
+        cursor: pointer;
+      }
+      .okf-graph-focus-exit:hover {
+        background: var(--hover);
+      }
+      .okf-graph-focus-label {
+        font-size: 0.76rem;
+        color: var(--fg);
+        font-weight: 600;
+      }
       .okf-graph-edge {
         fill: none;
         stroke: var(--border);
@@ -464,9 +487,36 @@
       .okf-graph-edge.okf-edge-dim {
         opacity: 0.1;
       }
+      /* Focused mode: edges at the center read strongest, edges among the
+         direct neighbors stay legible, the rest recede without vanishing —
+         the surrounding knowledge base must remain visible. */
+      .okf-graph-edge.okf-edge-ring-focus {
+        stroke: var(--accent);
+        stroke-width: 2;
+        opacity: 0.95;
+      }
+      .okf-graph-edge.okf-edge-ring-neighbor {
+        opacity: 0.5;
+      }
+      .okf-graph-edge.okf-edge-ring-background {
+        opacity: 0.18;
+      }
       .okf-graph-node-article,
       .okf-graph-node-citation {
         transition: opacity 0.15s ease;
+      }
+      .okf-ring-background {
+        opacity: 0.42;
+      }
+      .okf-ring-focus .okf-graph-node-label {
+        font-weight: 700;
+      }
+      .okf-ring-focus rect,
+      .okf-ring-neighbor rect {
+        stroke-width: 2;
+      }
+      .okf-ring-focus rect {
+        filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.28));
       }
       .okf-node-dim {
         opacity: 0.25;
@@ -480,6 +530,12 @@
       .okf-graph-node-article rect {
         stroke-width: 1.6;
         transition: filter 0.15s ease;
+      }
+      /* Opaque plate under the translucent type tint, so edges passing
+         behind a pill never show through it. */
+      .okf-graph-pill-backing {
+        fill: var(--card);
+        stroke: none;
       }
       .okf-graph-node-article:hover rect {
         filter: brightness(1.12);

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -44,6 +44,16 @@ export interface PositionedNode extends GraphNode {
   y: number;
 }
 
+/**
+ * Prominence band in the focused graph layout: the centered node, its direct
+ * neighbors (one hop, either direction), everything else.
+ */
+export type FocusRing = "focus" | "neighbor" | "background";
+
+export interface FocusPositionedNode extends PositionedNode {
+  ring: FocusRing;
+}
+
 // -- HTML escaping ---------------------------------------------------------
 
 function escapeHtml(text: string): string {
@@ -508,6 +518,46 @@ function sortArticles(nodes: GraphNode[]): GraphNode[] {
   });
 }
 
+interface AngularSlot {
+  node: GraphNode;
+  angle: number;
+}
+
+/**
+ * Order slots by angle and push them apart to at least `minSeparation`, so
+ * nodes placed at a *desired* angle (next to what they relate to) still keep
+ * their labels readable. If the separation pass fans the ring past a full
+ * turn, proximity is hopeless anyway -- fall back to an even spread instead
+ * of overlapping the first nodes.
+ *
+ * Returns fresh slot objects; neither the array nor its items are mutated.
+ */
+function spreadAngles(
+  slots: AngularSlot[],
+  minSeparation: number,
+): AngularSlot[] {
+  const ordered = slots
+    .map((slot) => ({ ...slot }))
+    .sort(
+      (a, b) =>
+        a.angle - b.angle || sortKey(a.node).localeCompare(sortKey(b.node)),
+    );
+  for (let i = 1; i < ordered.length; i++) {
+    const minAngle = ordered[i - 1].angle + minSeparation;
+    if (ordered[i].angle < minAngle) ordered[i].angle = minAngle;
+  }
+  if (
+    ordered.length > 1 &&
+    ordered[ordered.length - 1].angle - ordered[0].angle >
+      2 * Math.PI - minSeparation
+  ) {
+    for (let i = 0; i < ordered.length; i++) {
+      ordered[i].angle = (2 * Math.PI * i) / ordered.length - Math.PI / 2;
+    }
+  }
+  return ordered;
+}
+
 /**
  * Deterministic two-ring ellipse layout. Articles sit on an inner ellipse
  * ordered by (type, file) -- same-type articles are angular neighbors, so
@@ -548,43 +598,26 @@ export function layoutGraph(
     };
   });
 
-  const desired = citations.map((node, index) => {
-    const citerAngles = edges
-      .filter((edge) => edge.to === node.id)
-      .map((edge) => articleAngle.get(edge.from))
-      .filter((angle): angle is number => angle !== undefined);
-    if (citerAngles.length === 0) {
-      // Unreachable from buildFullGraph (citation nodes exist because an
-      // article links them), but a hand-built graph stays well-defined.
-      return {
-        node,
-        angle: (2 * Math.PI * index) / citations.length - Math.PI / 2,
-      };
-    }
-    const sumSin = citerAngles.reduce((sum, a) => sum + Math.sin(a), 0);
-    const sumCos = citerAngles.reduce((sum, a) => sum + Math.cos(a), 0);
-    return { node, angle: Math.atan2(sumSin, sumCos) };
-  });
-  desired.sort(
-    (a, b) =>
-      a.angle - b.angle || sortKey(a.node).localeCompare(sortKey(b.node)),
+  const desired = spreadAngles(
+    citations.map((node, index) => {
+      const citerAngles = edges
+        .filter((edge) => edge.to === node.id)
+        .map((edge) => articleAngle.get(edge.from))
+        .filter((angle): angle is number => angle !== undefined);
+      if (citerAngles.length === 0) {
+        // Unreachable from buildFullGraph (citation nodes exist because an
+        // article links them), but a hand-built graph stays well-defined.
+        return {
+          node,
+          angle: (2 * Math.PI * index) / citations.length - Math.PI / 2,
+        };
+      }
+      const sumSin = citerAngles.reduce((sum, a) => sum + Math.sin(a), 0);
+      const sumCos = citerAngles.reduce((sum, a) => sum + Math.cos(a), 0);
+      return { node, angle: Math.atan2(sumSin, sumCos) };
+    }),
+    MIN_CITATION_SEPARATION,
   );
-  for (let i = 1; i < desired.length; i++) {
-    const minAngle = desired[i - 1].angle + MIN_CITATION_SEPARATION;
-    if (desired[i].angle < minAngle) desired[i].angle = minAngle;
-  }
-  // If the separation pass pushed the fan past a full turn, proximity is
-  // hopeless anyway -- fall back to an even spread instead of overlapping
-  // the first nodes.
-  if (
-    desired.length > 1 &&
-    desired[desired.length - 1].angle - desired[0].angle >
-      2 * Math.PI - MIN_CITATION_SEPARATION
-  ) {
-    for (let i = 0; i < desired.length; i++) {
-      desired[i].angle = (2 * Math.PI * i) / desired.length - Math.PI / 2;
-    }
-  }
 
   const positionedCitations = desired.map(({ node, angle }) => ({
     ...node,
@@ -593,4 +626,146 @@ export function layoutGraph(
   }));
 
   return [...positionedArticles, ...positionedCitations];
+}
+
+// -- Edge geometry ------------------------------------------------------------
+
+/** A node's drawn footprint on the canvas, centered on (x, y). */
+export interface NodeBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Where an edge should meet a node: the point at which the ray from the
+ * node's center toward `toward` leaves the node's box, pushed out by `gap`.
+ * Edges drawn between two such anchors stop at the shapes instead of running
+ * across them (a line crossing a pill reads as a mistake, and the pill's
+ * translucent fill does not hide it).
+ *
+ * Pure geometry -- the caller supplies the boxes, so the same helper serves
+ * the overview and the focused layout, whatever their node scales.
+ */
+export function edgeAnchor(box: NodeBox, toward: Point, gap = 5): Point {
+  const dx = toward.x - box.x;
+  const dy = toward.y - box.y;
+  if (dx === 0 && dy === 0) return { x: box.x, y: box.y };
+
+  const halfWidth = box.width / 2 + gap;
+  const halfHeight = box.height / 2 + gap;
+  // Scale the direction vector until it hits whichever side it reaches first.
+  const scale =
+    1 / Math.max(Math.abs(dx) / halfWidth, Math.abs(dy) / halfHeight);
+  return { x: box.x + dx * scale, y: box.y + dy * scale };
+}
+
+// -- Focused (centered) graph layout ------------------------------------------
+
+/** Neighbor ring size relative to the outer (background) ring. */
+const NEIGHBOR_RING_FRACTION = 0.56;
+/**
+ * Minimum angular gap between neighbor nodes (radians). Wider than the
+ * citation ring's: these carry enlarged labels, and near the top and bottom
+ * of the ellipse adjacent nodes separate mostly horizontally, which is the
+ * direction a label needs room in.
+ */
+const MIN_NEIGHBOR_SEPARATION = 0.52;
+/** Minimum angular gap between background nodes (radians) -- smaller nodes, tighter rim. */
+const MIN_BACKGROUND_SEPARATION = 0.15;
+
+/** Every node one hop from `id`, in either edge direction (excluding `id`). */
+export function neighborIdsOf(edges: GraphEdge[], id: string): Set<string> {
+  const ids = new Set<string>();
+  for (const edge of edges) {
+    if (edge.from === id) ids.add(edge.to);
+    else if (edge.to === id) ids.add(edge.from);
+  }
+  ids.delete(id);
+  return ids;
+}
+
+/**
+ * Focused counterpart to `layoutGraph`: the node the user centered sits at
+ * the canvas center, its direct neighbors form a readable inner ring, and
+ * every other node recedes to a rim ring (drawn small and faint by the
+ * panel, deliberately still visible -- the wider knowledge base must not
+ * vanish just because one article is in focus).
+ *
+ * Ring angles come from each node's position in the *overview* layout, so a
+ * node keeps the direction it already had when the user switches modes and
+ * the two views stay mentally superimposable. Angles are read
+ * aspect-normalized (against the layout's own ellipse radii), so the wide
+ * canvas doesn't skew the ordering.
+ *
+ * An unknown `focusId` is well-defined rather than an error: every node
+ * keeps its overview position and the `"neighbor"` ring, i.e. a plain
+ * overview with nothing centered and nothing pushed back.
+ *
+ * Pure function of its inputs -- no randomness, no input mutation.
+ */
+export function layoutFocusGraph(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  focusId: string,
+  width: number,
+  height: number,
+): FocusPositionedNode[] {
+  const base = layoutGraph(nodes, edges, width, height);
+  const focused = base.find((node) => node.id === focusId);
+  if (!focused) {
+    return base.map((node) => ({ ...node, ring: "neighbor" as const }));
+  }
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const rxOuter = width / 2 - width * MARGIN_X_FRACTION;
+  const ryOuter = height / 2 - height * MARGIN_Y_FRACTION;
+  const rxNeighbor = rxOuter * NEIGHBOR_RING_FRACTION;
+  const ryNeighbor = ryOuter * NEIGHBOR_RING_FRACTION;
+
+  const neighborIds = neighborIdsOf(edges, focusId);
+  const baseAngle = (node: PositionedNode): number =>
+    Math.atan2((node.y - centerY) / ryOuter, (node.x - centerX) / rxOuter);
+
+  const onRing = (
+    ring: FocusRing,
+    members: PositionedNode[],
+    minSeparation: number,
+    rx: number,
+    ry: number,
+  ): FocusPositionedNode[] =>
+    spreadAngles(
+      members.map((node) => ({ node, angle: baseAngle(node) })),
+      minSeparation,
+    ).map(({ node, angle }) => ({
+      ...(node as PositionedNode),
+      ring,
+      x: centerX + rx * Math.cos(angle),
+      y: centerY + ry * Math.sin(angle),
+    }));
+
+  return [
+    { ...focused, ring: "focus", x: centerX, y: centerY },
+    ...onRing(
+      "neighbor",
+      base.filter((node) => neighborIds.has(node.id)),
+      MIN_NEIGHBOR_SEPARATION,
+      rxNeighbor,
+      ryNeighbor,
+    ),
+    ...onRing(
+      "background",
+      base.filter((node) => node.id !== focusId && !neighborIds.has(node.id)),
+      MIN_BACKGROUND_SEPARATION,
+      rxOuter,
+      ryOuter,
+    ),
+  ];
 }

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -41,13 +41,18 @@ import {
 } from "./context-bar.js";
 import {
   type CatalogEntry,
+  type FocusRing,
   type GraphEdge,
   type GraphNode,
+  type NodeBox,
   type PositionedNode,
+  edgeAnchor,
   extractLinks,
   filterCatalog,
   groupCatalog,
+  layoutFocusGraph,
   layoutGraph,
+  neighborIdsOf,
   renderMarkdown,
   stripFrontmatter,
 } from "./okf-render.js";
@@ -128,6 +133,10 @@ let catalog: CatalogEntry[] = [];
 let typeOrder: string[] = [];
 let logText = "";
 let viewMode: ViewMode = "reader";
+/** Graph view: the node the focused layout centers on; null = overview mode.
+ * Set by right-clicking a node, cleared by right-clicking it again, the
+ * canvas background, the toolbar's exit button, or Escape. */
+let graphFocusId: string | null = null;
 let currentFile: string | null = null;
 let citationView: CitationView | null = null;
 let searchQuery = "";
@@ -385,6 +394,7 @@ async function retargetBundle(dir: string): Promise<string | null> {
     openCitations.clear();
     currentFile = null;
     citationView = null;
+    graphFocusId = null;
     return null;
   } catch (error) {
     return errorMessage(error);
@@ -907,37 +917,105 @@ function truncateLabel(text: string, keep: "head" | "tail", max = 26): string {
     : `…${base.slice(-(max - 1))}`;
 }
 
-function buildGraphNodeEl(node: PositionedNode): SVGGElement {
+/**
+ * A node as the SVG builder wants it: overview nodes carry `ring: null`
+ * (uniform prominence), focused-mode nodes carry the band layoutFocusGraph
+ * assigned them.
+ */
+type RenderNode = PositionedNode & { ring: FocusRing | null };
+
+/** Node scale per prominence band — 1 is the overview's uniform size. */
+const RING_SCALE: Record<FocusRing, number> = {
+  focus: 1.3,
+  neighbor: 1.12,
+  background: 0.72,
+};
+
+const PILL_H = 26;
+
+function ringScale(node: RenderNode): number {
+  return node.ring ? RING_SCALE[node.ring] : 1;
+}
+
+function nodeLabelText(node: RenderNode): string {
+  const raw = node.label ?? node.file ?? node.id;
+  // The focused mode's rim carries many labels at once and must not compete
+  // with the neighbors for reading attention — clip it harder.
+  const max = node.ring === "background" ? 16 : undefined;
+  return node.kind === "article"
+    ? truncateLabel(raw, "head", max)
+    : truncateLabel(raw, "tail", max);
+}
+
+/** Pill sized to its label (11px font ≈ 6.2px/char) so titles sit inside the
+ * shape instead of overflowing a fixed-width box. */
+function pillWidth(labelText: string): number {
+  return Math.min(Math.max(labelText.length * 6.2 + 20, 64), 200);
+}
+
+/**
+ * The node's drawn footprint in canvas coordinates (ring scale applied), so
+ * edges can be clipped to it — see okf-render.ts's edgeAnchor.
+ */
+function nodeBox(node: RenderNode): NodeBox {
+  const scale = ringScale(node);
+  const size =
+    node.kind === "article"
+      ? { width: pillWidth(nodeLabelText(node)), height: PILL_H }
+      : { width: NODE_R * 0.9, height: NODE_R * 0.9 };
+  return {
+    x: node.x,
+    y: node.y,
+    width: size.width * scale,
+    height: size.height * scale,
+  };
+}
+
+function buildGraphNodeEl(node: RenderNode): SVGGElement {
+  const scale = ringScale(node);
   const g = document.createElementNS(SVG_NS, "g") as SVGGElement;
-  g.setAttribute("transform", `translate(${node.x}, ${node.y})`);
-  g.setAttribute("class", `okf-graph-node-${node.kind}`);
+  g.setAttribute(
+    "transform",
+    `translate(${node.x}, ${node.y})${scale === 1 ? "" : ` scale(${scale})`}`,
+  );
+  g.setAttribute(
+    "class",
+    `okf-graph-node-${node.kind}${node.ring ? ` okf-ring-${node.ring}` : ""}`,
+  );
   g.setAttribute("data-node-id", node.id);
 
   const title = document.createElementNS(SVG_NS, "title");
   title.textContent = node.file ?? node.id;
   g.appendChild(title);
 
-  const labelText =
-    node.kind === "article"
-      ? truncateLabel(node.label ?? node.file ?? node.id, "head")
-      : truncateLabel(node.label ?? node.file ?? node.id, "tail");
+  const labelText = nodeLabelText(node);
 
   if (node.kind === "article") {
-    // Pill sized to its label (11px font ≈ 6.2px/char) so titles sit inside
-    // the shape instead of overflowing a fixed-width box.
-    const pillW = Math.min(Math.max(labelText.length * 6.2 + 20, 64), 200);
-    const pillH = 26;
-    const rect = document.createElementNS(SVG_NS, "rect");
-    rect.setAttribute("x", String(-pillW / 2));
-    rect.setAttribute("y", String(-pillH / 2));
-    rect.setAttribute("width", String(pillW));
-    rect.setAttribute("height", String(pillH));
-    rect.setAttribute("rx", String(pillH / 2));
+    const pillW = pillWidth(labelText);
+    const pill = (): SVGRectElement => {
+      const rect = document.createElementNS(SVG_NS, "rect");
+      rect.setAttribute("x", String(-pillW / 2));
+      rect.setAttribute("y", String(-PILL_H / 2));
+      rect.setAttribute("width", String(pillW));
+      rect.setAttribute("height", String(PILL_H));
+      rect.setAttribute("rx", String(PILL_H / 2));
+      return rect;
+    };
+    // The type tint is translucent, so an unrelated edge passing behind the
+    // pill would show through it. An opaque backing plate in the panel's
+    // surface color keeps every pill reading as a solid object.
+    const backing = pill();
+    backing.setAttribute("class", "okf-graph-pill-backing");
+    g.appendChild(backing);
+    const rect = pill();
     rect.style.fill = typeColorVar(node.type ?? "", "-bg");
     rect.style.stroke = typeColorVar(node.type ?? "");
     g.appendChild(rect);
     g.style.cursor = "pointer";
-    g.addEventListener("click", () => {
+    g.addEventListener("click", (event) => {
+      // macOS fires a click alongside ctrl+click's contextmenu — that
+      // gesture means "center this node", not "open the article".
+      if (event.ctrlKey) return;
       viewMode = "reader";
       void openArticle(node.file ?? node.id);
     });
@@ -954,11 +1032,18 @@ function buildGraphNodeEl(node: PositionedNode): SVGGElement {
     label.setAttribute("text-anchor", "middle");
     label.setAttribute("y", "0");
   } else {
-    // Citations sit on the outer ring: grow their labels inward (toward the
-    // center) so text never runs past the viewBox edge.
+    // Citation labels grow away from the crowded side of their ring: on an
+    // outer ring inward (so text never runs past the viewBox edge), on the
+    // focused mode's inner neighbor ring outward — growing inward there
+    // would lay every neighbor's label across the centered node and its
+    // edges. The offset is in the node's own (possibly scaled) coordinates,
+    // hence divided by the scale.
     const onRightHalf = node.x > GRAPH_W / 2;
-    label.setAttribute("text-anchor", onRightHalf ? "end" : "start");
-    label.setAttribute("x", onRightHalf ? "-14" : "14");
+    const outward = node.ring === "neighbor";
+    const toTheRight = outward ? onRightHalf : !onRightHalf;
+    const gap = 14 / scale;
+    label.setAttribute("text-anchor", toTheRight ? "start" : "end");
+    label.setAttribute("x", String(toTheRight ? gap : -gap));
     label.setAttribute("y", "0");
   }
   label.textContent = labelText;
@@ -967,31 +1052,33 @@ function buildGraphNodeEl(node: PositionedNode): SVGGElement {
   return g;
 }
 
-async function renderGraphView(): Promise<void> {
-  if (!contentEl) return;
-  contentEl.replaceChildren();
-  const loading = document.createElement("div");
-  loading.className = "okf-empty";
-  loading.textContent = t("okf_graph_loading");
-  contentEl.appendChild(loading);
+/**
+ * Enter (or leave, with `null`) the focused layout and repaint. Bodies are
+ * already cached by the time a node exists to right-click, so this repaints
+ * synchronously — no loading flash between modes.
+ */
+function setGraphFocus(id: string | null): void {
+  if (graphFocusId === id) return;
+  graphFocusId = id;
+  if (viewMode === "graph" && contentEl) paintGraphInto(contentEl);
+}
 
-  await ensureAllBodiesLoaded();
-  if (viewMode !== "graph" || !contentEl) return; // user switched away while loading
+/** Prominence band of an edge in the focused layout, mirroring RenderNode's. */
+function edgeRing(
+  edge: GraphEdge,
+  focusId: string | null,
+  neighbors: Set<string>,
+): FocusRing | null {
+  if (focusId === null) return null;
+  if (edge.from === focusId || edge.to === focusId) return "focus";
+  if (neighbors.has(edge.from) || neighbors.has(edge.to)) return "neighbor";
+  return "background";
+}
 
-  const { nodes, edges } = buildFullGraph();
-  contentEl.replaceChildren();
-  if (nodes.length === 0) {
-    renderEmptyInto(
-      contentEl,
-      "🕸️",
-      t("okf_graph_empty_title"),
-      t("okf_graph_empty_sub"),
-    );
-    return;
-  }
+function buildGraphToolbar(focused: GraphNode | undefined): HTMLElement {
+  const bar = document.createElement("div");
+  bar.className = "okf-graph-legend";
 
-  const legend = document.createElement("div");
-  legend.className = "okf-graph-legend";
   const legendItem = (markClass: string, label: string): HTMLElement => {
     const item = document.createElement("span");
     item.className = "okf-graph-legend-item";
@@ -1000,14 +1087,81 @@ async function renderGraphView(): Promise<void> {
     item.append(mark, label);
     return item;
   };
-  legend.append(
+  bar.append(
     legendItem("article", t("okf_legend_article")),
     legendItem("citation", t("okf_legend_citation")),
   );
-  contentEl.appendChild(legend);
 
-  const positioned = layoutGraph(nodes, edges, GRAPH_W, GRAPH_H);
-  const byId = new Map(positioned.map((n): [string, PositionedNode] => [n.id, n]));
+  if (focused) {
+    const back = document.createElement("button");
+    back.type = "button";
+    back.className = "okf-graph-focus-exit";
+    back.textContent = t("okf_graph_focus_exit");
+    back.addEventListener("click", () => setGraphFocus(null));
+    const label = document.createElement("span");
+    label.className = "okf-graph-focus-label";
+    label.textContent = tf("okf_graph_focus_on", {
+      title: focused.label ?? focused.file ?? focused.id,
+    });
+    bar.append(back, label);
+  }
+
+  const hint = document.createElement("span");
+  hint.className = "okf-graph-hint";
+  hint.textContent = focused
+    ? t("okf_graph_hint_focused")
+    : t("okf_graph_hint_overview");
+  bar.appendChild(hint);
+  return bar;
+}
+
+/**
+ * Paint the graph from already-loaded bodies, in whichever of the two modes
+ * is active: the overview (every node on the type-clustered rings) or the
+ * focused layout centered on `graphFocusId`. Both modes share node building,
+ * edge drawing and hover emphasis; only positions, prominence bands and the
+ * toolbar differ.
+ */
+function paintGraphInto(container: HTMLElement): void {
+  const { nodes, edges } = buildFullGraph();
+  container.replaceChildren();
+  if (nodes.length === 0) {
+    graphFocusId = null;
+    renderEmptyInto(
+      container,
+      "🕸️",
+      t("okf_graph_empty_title"),
+      t("okf_graph_empty_sub"),
+    );
+    return;
+  }
+
+  // A focus id can outlive its node (the bundle was re-targeted while the
+  // graph was focused) — fall back to the overview rather than centering on
+  // something that is no longer there.
+  const focusId =
+    graphFocusId !== null && nodes.some((n) => n.id === graphFocusId)
+      ? graphFocusId
+      : null;
+  graphFocusId = focusId;
+  const focusNeighbors =
+    focusId === null ? new Set<string>() : neighborIdsOf(edges, focusId);
+
+  const positioned: RenderNode[] =
+    focusId === null
+      ? layoutGraph(nodes, edges, GRAPH_W, GRAPH_H).map((node) => ({
+          ...node,
+          ring: null,
+        }))
+      : layoutFocusGraph(nodes, edges, focusId, GRAPH_W, GRAPH_H);
+  const byId = new Map(positioned.map((n): [string, RenderNode] => [n.id, n]));
+  const boxes = new Map(
+    positioned.map((n): [string, NodeBox] => [n.id, nodeBox(n)]),
+  );
+
+  container.appendChild(
+    buildGraphToolbar(focusId === null ? undefined : byId.get(focusId)),
+  );
 
   const wrap = document.createElement("div");
   wrap.className = "graph-canvas-wrap";
@@ -1015,7 +1169,20 @@ async function renderGraphView(): Promise<void> {
   svg.setAttribute("viewBox", `0 0 ${GRAPH_W} ${GRAPH_H}`);
   svg.setAttribute("class", "okf-graph-svg");
   svg.setAttribute("role", "img");
-  svg.setAttribute("aria-label", t("okf_graph_aria"));
+  svg.setAttribute(
+    "aria-label",
+    focusId === null
+      ? t("okf_graph_aria")
+      : tf("okf_graph_aria_focused", {
+          title: byId.get(focusId)?.label ?? focusId,
+        }),
+  );
+  // Right-clicking empty canvas leaves the focused mode; without this the
+  // host's own context menu would open over the graph instead.
+  svg.addEventListener("contextmenu", (event) => {
+    event.preventDefault();
+    setGraphFocus(null);
+  });
   wrap.appendChild(svg);
 
   const edgesGroup = document.createElementNS(SVG_NS, "g") as SVGGElement;
@@ -1028,14 +1195,23 @@ async function renderGraphView(): Promise<void> {
     // center: edges bow gently inward instead of slicing straight across.
     const midX = (from.x + to.x) / 2;
     const midY = (from.y + to.y) / 2;
-    const ctrlX = midX + (GRAPH_W / 2 - midX) * 0.22;
-    const ctrlY = midY + (GRAPH_H / 2 - midY) * 0.22;
+    const ctrl = {
+      x: midX + (GRAPH_W / 2 - midX) * 0.22,
+      y: midY + (GRAPH_H / 2 - midY) * 0.22,
+    };
+    // Meet the shapes at their borders, along the curve's own direction —
+    // an edge must never run across a node box.
+    const start = edgeAnchor(boxes.get(edge.from) ?? nodeBox(from), ctrl);
+    const end = edgeAnchor(boxes.get(edge.to) ?? nodeBox(to), ctrl);
     const path = document.createElementNS(SVG_NS, "path");
     path.setAttribute(
       "d",
-      `M ${from.x} ${from.y} Q ${ctrlX} ${ctrlY} ${to.x} ${to.y}`,
+      `M ${start.x} ${start.y} Q ${ctrl.x} ${ctrl.y} ${end.x} ${end.y}`,
     );
-    path.setAttribute("class", "okf-graph-edge");
+    const ring = edgeRing(edge, focusId, focusNeighbors);
+    const baseClass = `okf-graph-edge${ring ? ` okf-edge-ring-${ring}` : ""}`;
+    path.setAttribute("class", baseClass);
+    path.dataset.baseClass = baseClass;
     path.setAttribute("data-from", edge.from);
     path.setAttribute("data-to", edge.to);
     path.setAttribute("aria-hidden", "true");
@@ -1046,16 +1222,19 @@ async function renderGraphView(): Promise<void> {
   svg.appendChild(nodesGroup);
 
   // Hovering a node lights up its edges and neighbors and dims the rest;
-  // hover-out restores the neutral state.
+  // hover-out restores the neutral state. Both modes keep this — in the
+  // focused layout it is how the receded rim stays explorable.
   const emphasize = (id: string | null): void => {
     const neighbors = new Set<string>();
-    for (const el of Array.from(edgesGroup.children)) {
+    for (const el of Array.from(edgesGroup.children) as SVGPathElement[]) {
       const from = el.getAttribute("data-from");
       const to = el.getAttribute("data-to");
       const hot = id !== null && (from === id || to === id);
       el.setAttribute(
         "class",
-        `okf-graph-edge${hot ? " okf-edge-hot" : id !== null ? " okf-edge-dim" : ""}`,
+        `${el.dataset.baseClass ?? "okf-graph-edge"}${
+          hot ? " okf-edge-hot" : id !== null ? " okf-edge-dim" : ""
+        }`,
       );
       if (hot) {
         if (from) neighbors.add(from);
@@ -1064,8 +1243,7 @@ async function renderGraphView(): Promise<void> {
     }
     for (const el of Array.from(nodesGroup.children)) {
       const nodeId = el.getAttribute("data-node-id");
-      const dim =
-        id !== null && nodeId !== id && !neighbors.has(nodeId ?? "");
+      const dim = id !== null && nodeId !== id && !neighbors.has(nodeId ?? "");
       el.classList.toggle("okf-node-dim", dim);
     }
   };
@@ -1073,10 +1251,36 @@ async function renderGraphView(): Promise<void> {
     const el = buildGraphNodeEl(node);
     el.addEventListener("mouseenter", () => emphasize(node.id));
     el.addEventListener("mouseleave", () => emphasize(null));
+    // Right-click centers this node (and re-centers from within the focused
+    // mode); right-clicking the centered node again returns to the overview.
+    el.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setGraphFocus(focusId === node.id ? null : node.id);
+    });
     nodesGroup.appendChild(el);
   }
 
-  contentEl.appendChild(wrap);
+  container.appendChild(wrap);
+}
+
+async function renderGraphView(): Promise<void> {
+  if (!contentEl) return;
+  const pending = catalog.some(
+    (entry) => !bodyCache.has(entry.file) && !readErrors.has(entry.file),
+  );
+  if (pending) {
+    contentEl.replaceChildren();
+    const loading = document.createElement("div");
+    loading.className = "okf-empty";
+    loading.textContent = t("okf_graph_loading");
+    contentEl.appendChild(loading);
+
+    await ensureAllBodiesLoaded();
+    if (viewMode !== "graph" || !contentEl) return; // user switched away while loading
+  }
+
+  paintGraphInto(contentEl);
 }
 
 // ── Log view ─────────────────────────────────────────────────────────────
@@ -1141,6 +1345,16 @@ searchInputEl?.addEventListener("input", () => {
   renderSidebar();
 });
 
+// Keyboard counterpart to right-clicking the canvas: leave the focused
+// graph. Registered once for the panel's lifetime (the graph is repainted,
+// never re-listened), and a no-op outside the focused graph.
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape" || viewMode !== "graph" || graphFocusId === null)
+    return;
+  event.preventDefault();
+  setGraphFocus(null);
+});
+
 // ── Host lifecycle (mirrors graph.ts) ───────────────────────────────────
 
 app.ontoolresult = (params) => {
@@ -1168,6 +1382,7 @@ app.ontoolresult = (params) => {
     openCitations.clear();
     currentFile = null;
     citationView = null;
+    graphFocusId = null;
   }
   clearConnectionNotice();
 

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-07-29
+
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+
 ## 2026-07-22
 
 - **Update** — [FSRS-5 Scheduling](fsrs-scheduling.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-07-19T08:50:00Z
+timestamp: 2026-07-29T18:35:00Z
 ---
 
 `zam mcp` starts a stdio **Model Context Protocol** server
@@ -81,6 +81,26 @@ visually distinct nodes), and the `log.md` history. The panel always
 opens — a missing or invalid bundle surfaces as `problems` in the panel
 instead of a tool error.
 
+# OKF link graph: overview and focused mode
+
+The graph view has two modes over the same nodes and edges. The
+**overview** places every article on a type-clustered inner ellipse and
+every citation on an outer one. Right-clicking a node switches to the
+**focused** mode: that node moves to the canvas center, its direct
+neighbors (one hop, either edge direction) form an enlarged inner ring,
+and every remaining node recedes to a small, faint rim — still visible
+and still hoverable, because the surrounding knowledge base is context,
+not noise. Ring angles are carried over from the overview, so a node
+keeps its direction across the switch.
+
+Left-click keeps its meaning in both modes: it opens the article in the
+reader. Right-clicking the centered node again, right-clicking empty
+canvas, `Esc`, or the toolbar's overview button returns to the
+overview; right-clicking a different node re-centers on it. Hovering
+any node still lights its edges and neighbors and dims the rest, in
+both modes. Edges are drawn between node borders rather than centers,
+so no line crosses a node box.
+
 The reader's "import as learning content" action hands the
 decomposition request to a chat in host order of capability: hosts
 advertising the MCP Apps `message` capability get it via `ui/message`
@@ -114,4 +134,4 @@ available directly.
 - [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
 - [ADR 2026-07-18b — Learning Graph Scope Selectors and the Repo Scope](../adr/2026-07-18b-graph-repo-scope.md)
 - [ADR 2026-07-18c — OKF Import Handoff](../adr/2026-07-18c-okf-import-handoff.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/host.ts`, `src/vscode-extension/latest-task-queue.ts`
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/host.ts`, `src/vscode-extension/latest-task-queue.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -421,6 +421,13 @@ const PRE_EXISTING_FALLBACK_KEYS = new Set([
   // Closed-group library Phase 1 re-test notice strings (en/de shipped)
   "recall_retest_notice_date",
   "recall_retest_notice_author_date",
+  // OKF graph focus mode (right-click centers a node) — en/de shipped;
+  // es/fr/pt/zh/ja await native pack review.
+  "okf_graph_aria_focused",
+  "okf_graph_hint_overview",
+  "okf_graph_hint_focused",
+  "okf_graph_focus_exit",
+  "okf_graph_focus_on",
   // Closed-group library Phase 2 Studio release step strings (en/de shipped)
   "btn_release_revision",
   "lbl_release_modal_title",

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   type CatalogEntry,
+  edgeAnchor,
   extractLinks,
   filterCatalog,
   type GraphEdge,
   type GraphNode,
   groupCatalog,
+  layoutFocusGraph,
   layoutGraph,
+  neighborIdsOf,
   renderMarkdown,
   stripFrontmatter,
 } from "../../desktop/src/panel/okf-render.js";
@@ -493,5 +496,183 @@ describe("layoutGraph", () => {
 
   it("handles an empty graph without dividing by zero", () => {
     expect(layoutGraph([], [], 200, 200)).toEqual([]);
+  });
+});
+
+describe("neighborIdsOf", () => {
+  const edges: GraphEdge[] = [
+    { from: "a.md", to: "b.md" },
+    { from: "c.md", to: "a.md" },
+    { from: "b.md", to: "d.md" },
+    { from: "a.md", to: "a.md" },
+  ];
+
+  it("collects one-hop neighbors in both edge directions", () => {
+    expect([...neighborIdsOf(edges, "a.md")].sort()).toEqual(["b.md", "c.md"]);
+  });
+
+  it("never reports a node as its own neighbor, even with a self-edge", () => {
+    expect(neighborIdsOf(edges, "a.md").has("a.md")).toBe(false);
+  });
+
+  it("returns an empty set for an unconnected id", () => {
+    expect([...neighborIdsOf(edges, "zzz.md")]).toEqual([]);
+  });
+});
+
+describe("layoutFocusGraph", () => {
+  const width = 960;
+  const height = 620;
+  const nodes: GraphNode[] = [
+    { id: "a.md", kind: "article", type: "algorithm", file: "a.md" },
+    { id: "b.md", kind: "article", type: "guide", file: "b.md" },
+    { id: "c.md", kind: "article", type: "guide", file: "c.md" },
+    { id: "d.md", kind: "article", type: "reference", file: "d.md" },
+    { id: "../adr/x.md", kind: "citation", file: "../adr/x.md" },
+  ];
+  const edges: GraphEdge[] = [
+    { from: "a.md", to: "b.md" },
+    { from: "a.md", to: "../adr/x.md" },
+    { from: "c.md", to: "d.md" },
+  ];
+
+  // Aspect-normalized radial distance, so the wide canvas doesn't make
+  // "further out" depend on which side of the ellipse a node sits.
+  const radial = (n: { x: number; y: number }) =>
+    Math.hypot((n.x - width / 2) / width, (n.y - height / 2) / height);
+
+  it("centers the focused node and bands the rest by hop distance", () => {
+    const positioned = layoutFocusGraph(nodes, edges, "a.md", width, height);
+    const byId = new Map(positioned.map((n) => [n.id, n]));
+
+    expect(byId.get("a.md")).toMatchObject({
+      ring: "focus",
+      x: width / 2,
+      y: height / 2,
+    });
+    expect(byId.get("b.md")?.ring).toBe("neighbor");
+    expect(byId.get("../adr/x.md")?.ring).toBe("neighbor");
+    expect(byId.get("c.md")?.ring).toBe("background");
+    expect(byId.get("d.md")?.ring).toBe("background");
+    expect(positioned).toHaveLength(nodes.length);
+  });
+
+  it("keeps neighbors nearer the center than every background node", () => {
+    const positioned = layoutFocusGraph(nodes, edges, "a.md", width, height);
+    const neighbors = positioned.filter((n) => n.ring === "neighbor");
+    const background = positioned.filter((n) => n.ring === "background");
+
+    expect(neighbors).not.toHaveLength(0);
+    expect(background).not.toHaveLength(0);
+    for (const near of neighbors) {
+      for (const far of background) {
+        expect(radial(near)).toBeLessThan(radial(far));
+      }
+    }
+  });
+
+  it("keeps every node inside the label margins", () => {
+    for (const node of layoutFocusGraph(nodes, edges, "a.md", width, height)) {
+      expect(node.x).toBeGreaterThanOrEqual(width * 0.1);
+      expect(node.x).toBeLessThanOrEqual(width * 0.9);
+      expect(node.y).toBeGreaterThanOrEqual(height * 0.05);
+      expect(node.y).toBeLessThanOrEqual(height * 0.95);
+    }
+  });
+
+  it("keeps each node roughly in the direction it had in the overview", () => {
+    const overview = layoutGraph(nodes, edges, width, height);
+    const focused = layoutFocusGraph(nodes, edges, "a.md", width, height);
+    const angleOf = (n: { x: number; y: number }) =>
+      Math.atan2((n.y - height / 2) / height, (n.x - width / 2) / width);
+
+    for (const node of focused) {
+      if (node.ring === "focus") continue;
+      const before = overview.find((n) => n.id === node.id);
+      if (!before) throw new Error(`${node.id} missing from the overview`);
+      const diff = Math.abs(angleOf(before) - angleOf(node));
+      expect(Math.min(diff, 2 * Math.PI - diff)).toBeLessThan(0.5);
+    }
+  });
+
+  it("falls back to the overview layout for an unknown focus id", () => {
+    const overview = layoutGraph(nodes, edges, width, height);
+    const focused = layoutFocusGraph(nodes, edges, "gone.md", width, height);
+
+    expect(focused).toEqual(
+      overview.map((node) => ({ ...node, ring: "neighbor" })),
+    );
+  });
+
+  it("places an isolated focus node alone at the center", () => {
+    const positioned = layoutFocusGraph(nodes, edges, "d.md", width, height);
+    expect(
+      positioned.filter((n) => n.ring === "neighbor").map((n) => n.id),
+    ).toEqual(["c.md"]);
+    expect(positioned.find((n) => n.id === "d.md")).toMatchObject({
+      ring: "focus",
+      x: width / 2,
+      y: height / 2,
+    });
+  });
+
+  it("is deterministic and does not mutate its input", () => {
+    const inputNodes = nodes.map((n) => ({ ...n }));
+    const inputEdges = edges.map((e) => ({ ...e }));
+    const first = layoutFocusGraph(
+      inputNodes,
+      inputEdges,
+      "a.md",
+      width,
+      height,
+    );
+    const second = layoutFocusGraph(
+      inputNodes,
+      inputEdges,
+      "a.md",
+      width,
+      height,
+    );
+
+    expect(second).toEqual(first);
+    expect(inputNodes).toEqual(nodes);
+    expect(inputEdges).toEqual(edges);
+  });
+});
+
+describe("edgeAnchor", () => {
+  const box = { x: 100, y: 100, width: 80, height: 20 };
+
+  it("meets the box on the side the target lies toward, plus the gap", () => {
+    // Straight to the right: leaves through the right edge.
+    expect(edgeAnchor(box, { x: 500, y: 100 }, 5)).toEqual({ x: 145, y: 100 });
+    // Straight down: leaves through the bottom edge.
+    expect(edgeAnchor(box, { x: 100, y: 500 }, 5)).toEqual({ x: 100, y: 115 });
+  });
+
+  it("never returns a point inside the box, in any direction", () => {
+    for (let angle = 0; angle < 2 * Math.PI; angle += Math.PI / 12) {
+      const anchor = edgeAnchor(
+        box,
+        { x: box.x + 400 * Math.cos(angle), y: box.y + 400 * Math.sin(angle) },
+        4,
+      );
+      const outsideX = Math.abs(anchor.x - box.x) >= box.width / 2;
+      const outsideY = Math.abs(anchor.y - box.y) >= box.height / 2;
+      expect(outsideX || outsideY).toBe(true);
+    }
+  });
+
+  it("stays on the segment toward the target", () => {
+    const target = { x: 400, y: 300 };
+    const anchor = edgeAnchor(box, target, 5);
+    const cross =
+      (anchor.x - box.x) * (target.y - box.y) -
+      (anchor.y - box.y) * (target.x - box.x);
+    expect(Math.abs(cross)).toBeLessThan(1e-9);
+  });
+
+  it("returns the center when the target is the center (no direction to leave in)", () => {
+    expect(edgeAnchor(box, { x: 100, y: 100 }, 5)).toEqual({ x: 100, y: 100 });
   });
 });


### PR DESCRIPTION
The OKF graph view had one fixed picture; hovering only re-drew the edges. It gains a second visualization over the same nodes and edges.

## What changed

**Focused mode.** Right-clicking a node centers it, enlarges its direct neighbors (one hop, either edge direction) on an inner ring, and lets everything else recede to a small, faint rim — still visible and still hoverable, because the surrounding knowledge base is context, not noise. Ring angles carry over from the overview, so a node keeps its direction across the switch.

**Interaction** (unchanged where it existed):
- Left-click opens the article in the reader, in both modes.
- Right-click centers a node; right-clicking the centered node again, right-clicking empty canvas, `Esc`, or the toolbar's overview button returns to the overview; right-clicking a different node re-centers.
- Hover still lights a node's edges and neighbors and dims the rest, in both modes.

**Edges no longer cross node boxes.** They meet node borders instead of centers (`edgeAnchor`), and article pills get an opaque backing plate so an edge passing behind one cannot show through its translucent type tint. This also cleans up the existing overview.

## Structure

Layout and geometry are pure functions in `desktop/src/panel/okf-render.ts` — `layoutFocusGraph`, `neighborIdsOf`, `edgeAnchor` — with 21 new tests; the citation ring's angular-separation pass is now shared with the focused mode's rings. The panel entry keeps only the DOM work, per the module's existing split.

`docs/okf/mcp-surfaces.md` documents both modes (written through `zam_okf_upsert`).

## Verification

`tests/desktop` 221/221, full suite green, `cd desktop && npx tsc --noEmit` clean, panel built and `dist/ui/okf-panel.html` checked for the new classes and i18n keys. MCP Apps panels cannot be rendered in a plain browser, so the layout was verified by rendering both modes from the real `docs/okf` bundle through the same pure functions.

New strings ship in en/de; the es/fr/pt/zh/ja packs stay on the fallback allowlist for native review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)