### PR TITLE
fix: duplicate agent models on add, and the misleading agent-harness note

### DIFF
--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -4133,6 +4133,13 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "This agent can do text and vision (OCR/scans) via your subscription.",
     model_agent_hint:
       "Uses the connected agent harness (subscription / OAuth). No API key or URL needed.",
+    model_agent_card_title: "Agent harness as a model source",
+    model_agent_card_body:
+      "Besides an HTTP endpoint, ZAM can reach a model through a connected agent harness — the harness runs the request on its own login.",
+    model_agent_card_no_key: "No API key and no endpoint URL needed.",
+    model_agent_card_active: "In use here: {harnesses}",
+    model_agent_card_available:
+      "Available on this machine: {harnesses} — set one up via “{action}”.",
     model_agent_harness_missing: "not detected",
     model_agent_harness_none: "No agent-text harness available yet",
     model_agent_missing_harness: "Choose an agent harness.",
@@ -5154,6 +5161,13 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "Dieser Agent kann Text und Vision (OCR/Scans) über dein Abo.",
     model_agent_hint:
       "Nutzt den verbundenen Agent-Harness (Abo / OAuth). Kein API-Schlüssel und keine URL nötig.",
+    model_agent_card_title: "Agent-Harness als Modellquelle",
+    model_agent_card_body:
+      "ZAM erreicht ein Modell nicht nur über einen HTTP-Endpunkt, sondern auch über einen verbundenen Agent-Harness — der Harness führt die Anfrage mit seiner eigenen Anmeldung aus.",
+    model_agent_card_no_key: "Kein API-Schlüssel und keine Endpunkt-URL nötig.",
+    model_agent_card_active: "Hier im Einsatz: {harnesses}",
+    model_agent_card_available:
+      "Auf diesem Rechner verfügbar: {harnesses} — per „{action}“ einrichten.",
     model_agent_harness_missing: "nicht erkannt",
     model_agent_harness_none: "Noch kein Agent-Text-Harness verfügbar",
     model_agent_missing_harness: "Agent-Harness wählen.",

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -2286,6 +2286,10 @@ async function showModelForm(id?: string): Promise<void> {
   saveButton.className = "btn primary-btn btn-sm";
   saveButton.textContent = t("model_btn_save");
   saveButton.addEventListener("click", () => {
+    // One submit at a time: the agent probe can take seconds, and a second
+    // click used to fire a second model-upsert that appended another row.
+    if (saveButton.disabled) return;
+    saveButton.disabled = true;
     const kind = selectedKind();
     const capabilities: Record<string, boolean> = {};
     for (const [cap, box] of capBoxes) {
@@ -2308,6 +2312,10 @@ async function showModelForm(id?: string): Promise<void> {
       key: keyInput.value.trim(),
       existingKeyRef: existing?.apiKeyRef,
       capabilities,
+    }).finally(() => {
+      // The form is torn down on success; re-enabling only matters when it
+      // stayed open because the save failed or a field was rejected.
+      saveButton.disabled = false;
     });
   });
   const cancelButton = document.createElement("button");

--- a/desktop/src/panel/settings-panel.html
+++ b/desktop/src/panel/settings-panel.html
@@ -296,6 +296,19 @@
         font-size: 12px;
         margin: 0 0 8px;
       }
+      /* The agent-transport explainer shares the row layout but must never
+         be mistaken for a configured model: dashed border, no actions. */
+      .settings-ai-note {
+        border-style: dashed;
+        background: rgba(168, 85, 247, 0.04);
+        margin-top: 12px;
+      }
+      .settings-ai-note .settings-ai-meta:last-child {
+        margin-bottom: 0;
+      }
+      .settings-ai-note-status {
+        font-weight: 600;
+      }
       .settings-ai-actions {
         display: flex;
         flex-wrap: wrap;

--- a/desktop/src/panel/settings.ts
+++ b/desktop/src/panel/settings.ts
@@ -302,10 +302,26 @@ async function loadAiModels(): Promise<void> {
     const data = (await bridgeCall("model-list")) as {
       models?: SettingsModelRow[];
     };
-    renderAiModels(data.models ?? []);
+    renderAiModels(data.models ?? [], await loadAgentHarnesses());
   } catch (error) {
     clearEl(aiEl);
     renderInlineError(aiEl, errorMessage(error));
+  }
+}
+
+/**
+ * Outbound-text harnesses, for the agent-transport card below the list.
+ * Never fatal: without them the card still explains the option and falls
+ * back to what the configured rows say.
+ */
+async function loadAgentHarnesses(): Promise<SettingsAgentHarness[]> {
+  try {
+    const res = (await bridgeCall("agent-list")) as {
+      harnesses?: SettingsAgentHarness[];
+    };
+    return (res.harnesses ?? []).filter((h) => h.outboundText);
+  } catch {
+    return [];
   }
 }
 
@@ -322,14 +338,12 @@ function modelKindBadge(row: SettingsModelRow): {
   return { className: "cloud", text: t("model_cloud_badge") };
 }
 
-function renderAiModels(models: SettingsModelRow[]): void {
+function renderAiModels(
+  models: SettingsModelRow[],
+  harnesses: SettingsAgentHarness[] = [],
+): void {
   if (!aiEl) return;
   clearEl(aiEl);
-
-  const hint = document.createElement("div");
-  hint.className = "settings-hint";
-  hint.textContent = t("model_agent_hint");
-  aiEl.appendChild(hint);
 
   if (models.length === 0) {
     const empty = document.createElement("div");
@@ -356,6 +370,69 @@ function renderAiModels(models: SettingsModelRow[]): void {
   formHost.id = "settings-ai-form";
   formHost.className = "settings-ai-form hidden";
   aiEl.appendChild(formHost);
+
+  // The agent-transport explanation used to sit above the list as a bare
+  // subtitle, where it read as a claim about the models listed under it --
+  // confusing next to plain cloud/local entries. It is its own card now, in
+  // the same visual language as the rows, and it comes last.
+  aiEl.appendChild(buildAgentTransportCard(models, harnesses));
+}
+
+/**
+ * Explains the agent transport (ADR 2026-07-12a) as a card rather than a
+ * section subtitle: what it is, why it needs no key or URL, and which
+ * harness is actually in use or available on this machine.
+ */
+function buildAgentTransportCard(
+  models: SettingsModelRow[],
+  harnesses: SettingsAgentHarness[],
+): HTMLElement {
+  const card = document.createElement("div");
+  card.className = "settings-ai-row settings-ai-note";
+
+  const head = document.createElement("div");
+  head.className = "settings-ai-row-head";
+  const title = document.createElement("span");
+  title.className = "settings-ai-label";
+  title.textContent = t("model_agent_card_title");
+  const badge = document.createElement("span");
+  badge.className = "settings-ai-badge agent";
+  badge.textContent = t("model_agent_badge");
+  head.append(title, badge);
+
+  const body = document.createElement("p");
+  body.className = "settings-ai-meta";
+  body.textContent = `${t("model_agent_card_body")} ${t("model_agent_card_no_key")}`;
+
+  const labelOf = (id: string): string =>
+    harnesses.find((h) => h.id === id)?.label ?? id;
+  const inUse = [
+    ...new Set(
+      models
+        .filter((m) => m.transport === "agent")
+        .map((m) => m.agentHarness)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  const detected = harnesses.filter((h) => h.detected);
+
+  const status = document.createElement("p");
+  status.className = "settings-ai-meta settings-ai-note-status";
+  if (inUse.length > 0) {
+    status.textContent = tf("model_agent_card_active", {
+      harnesses: inUse.map(labelOf).join(", "),
+    });
+  } else if (detected.length > 0) {
+    status.textContent = tf("model_agent_card_available", {
+      harnesses: detected.map((h) => h.label).join(", "),
+      action: t("btn_add_model"),
+    });
+  } else {
+    status.textContent = t("model_agent_harness_none");
+  }
+
+  card.append(head, body, status);
+  return card;
 }
 
 function renderAiModelRow(row: SettingsModelRow): HTMLElement {

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -2902,6 +2902,22 @@ bridgeCommand
         opts.model as string | undefined,
         prev?.model,
       );
+      // An agent entry is identified by (harness, model id): the same pair
+      // twice is one registry row, not two. Without --id -- which the add
+      // forms have nothing to send -- every submit used to append, so a
+      // re-click while the probe below was still running left the user with
+      // duplicate rows competing for the same fallback order (issue: three
+      // identical "Claude Code · haiku" entries from one add attempt).
+      const targetIndex =
+        existingIndex >= 0
+          ? existingIndex
+          : models.findIndex(
+              (m) =>
+                m.transport === "agent" &&
+                m.agentHarness === agentHarness &&
+                m.model === modelId,
+            );
+      const target = targetIndex >= 0 ? models[targetIndex] : undefined;
       const probe = await adapter.probe();
       const now = new Date().toISOString();
       const modalities = adapter.modalities ?? { text: true };
@@ -2917,7 +2933,7 @@ bridgeCommand
       };
       const requested = opts.capabilities
         ? parseCapabilityFlags(opts.capabilities)
-        : (prev?.capabilities ?? defaultCaps);
+        : (target?.capabilities ?? defaultCaps);
       // User intent for text/image; resolveCapability still requires both
       // capabilities and detectedCapabilities for runtime selection.
       const capabilities = emptyCapabilityFlags();
@@ -2934,7 +2950,7 @@ bridgeCommand
         "max",
       ]);
       // --effort auto (or empty) clears a stored override; omit keeps previous.
-      let effort: ModelEntry["effort"] | undefined = prev?.effort;
+      let effort: ModelEntry["effort"] | undefined = target?.effort;
       if (opts.effort !== undefined) {
         const raw = String(opts.effort).trim().toLowerCase();
         if (raw === "" || raw === "auto") {
@@ -2948,14 +2964,16 @@ bridgeCommand
         }
       }
       const entry: ModelEntry = {
-        id: opts.id ?? ulid(),
-        label: opts.label ?? prev?.label ?? harnessMeta?.label ?? agentHarness,
+        id: opts.id ?? target?.id ?? ulid(),
+        label:
+          opts.label ?? target?.label ?? harnessMeta?.label ?? agentHarness,
         url: "",
         // Real harness model id (e.g. haiku, gpt-5.4-mini) — not a placeholder.
         model: modelId,
         local: false,
         apiFlavor: "chat-completions",
-        order,
+        // Keep the matched row's slot; only a genuinely new entry lands last.
+        order: opts.order !== undefined ? order : (target?.order ?? order),
         capabilities,
         detectedCapabilities: detected,
         probedAt: now,
@@ -2964,11 +2982,12 @@ bridgeCommand
         ...(effort ? { effort } : {}),
       };
       const next = [...models];
-      if (existingIndex >= 0) next[existingIndex] = entry;
+      if (targetIndex >= 0) next[targetIndex] = entry;
       else next.push(entry);
       saveMachineAiModels(next);
       jsonOut({
         ok: true,
+        created: targetIndex < 0,
         model: modelRow(entry),
         probe: {
           reachable: probe.available,

--- a/tests/cli/bridge-model-registry.test.ts
+++ b/tests/cli/bridge-model-registry.test.ts
@@ -258,6 +258,74 @@ describe("bridge model-* registry commands", () => {
     });
   });
 
+  it("updates the same agent entry instead of appending a duplicate", async () => {
+    // The add forms have no id to send, so a re-click (or a retry while the
+    // probe was still running) used to append another identical row -- one
+    // add attempt left three "Claude Code · haiku" entries in the registry.
+    const args = [
+      "model-upsert",
+      "--transport",
+      "agent",
+      "--agent-harness",
+      "claude-code",
+      "--label",
+      "Claude Code",
+      "--capabilities",
+      JSON.stringify({ text: true }),
+    ];
+    const first = (await runBridge(args)) as {
+      parsed: { ok?: boolean; created?: boolean; model?: { id: string } };
+    };
+    const second = (await runBridge(args)) as {
+      parsed: { ok?: boolean; created?: boolean; model?: { id: string } };
+    };
+    const third = (await runBridge([...args, "--label", "Renamed"])) as {
+      parsed: { ok?: boolean; model?: { id: string; label: string } };
+    };
+
+    expect(first.parsed.created).toBe(true);
+    expect(second.parsed.created).toBe(false);
+    // Same registry row throughout, and a later label edits it in place.
+    expect(second.parsed.model?.id).toBe(first.parsed.model?.id);
+    expect(third.parsed.model?.id).toBe(first.parsed.model?.id);
+    expect(third.parsed.model?.label).toBe("Renamed");
+
+    const models = readConfig().ai?.models ?? [];
+    expect(models).toHaveLength(1);
+    expect(models[0]).toMatchObject({
+      transport: "agent",
+      agentHarness: "claude-code",
+      model: "haiku",
+      order: 0,
+    });
+  });
+
+  it("keeps a second model on the same harness as its own entry", async () => {
+    // Deduplication is per (harness, model id) -- two models from one harness
+    // are two genuine registry rows, not a duplicate.
+    const base = [
+      "model-upsert",
+      "--transport",
+      "agent",
+      "--agent-harness",
+      "claude-code",
+      "--capabilities",
+      JSON.stringify({ text: true }),
+    ];
+    await runBridge([...base, "--label", "Claude Code", "--model", "haiku"]);
+    await runBridge([
+      ...base,
+      "--label",
+      "Claude Code Opus",
+      "--model",
+      "opus",
+    ]);
+
+    const models = readConfig().ai?.models ?? [];
+    expect(models.map((m) => m.model)).toEqual(["haiku", "opus"]);
+    expect(models.map((m) => m.order)).toEqual([0, 1]);
+  });
+
   it("rejects agent upsert for a harness without an outbound adapter", async () => {
     const res = (await runBridge([
       "model-upsert",

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -421,6 +421,14 @@ const PRE_EXISTING_FALLBACK_KEYS = new Set([
   // Closed-group library Phase 1 re-test notice strings (en/de shipped)
   "recall_retest_notice_date",
   "recall_retest_notice_author_date",
+  // Agent-transport explainer card under the AI model list (replaces the
+  // section subtitle that read as a claim about the listed models) — en/de
+  // shipped; es/fr/pt/zh/ja await native pack review.
+  "model_agent_card_title",
+  "model_agent_card_body",
+  "model_agent_card_no_key",
+  "model_agent_card_active",
+  "model_agent_card_available",
   // Closed-group library Phase 2 Studio release step strings (en/de shipped)
   "btn_release_revision",
   "lbl_release_modal_title",


### PR DESCRIPTION
Two findings from the desktop settings "KI-Modelle" section (2026-07-29), one commit each.

## 1. Adding an agent model created three identical rows

`zam bridge model-upsert` only updated an entry when `--id` was passed. The add forms have no id to send, so every submit appended a new row — and the agent probe takes seconds, during which the desktop dialog left its save button live, so a re-click fired a second upsert.

- Agent entries are now identified by **(harness, model id)**: an upsert matching an existing pair updates that row in place, keeping its id and its slot in the fallback order. Two different models from the same harness remain two entries. HTTP entries are unchanged.
- The response gained a `created` flag so a caller can tell an add from an update.
- The add/edit dialog guards against re-entry while a save is in flight.

Two regression tests in `tests/cli/bridge-model-registry.test.ts`: three identical adds leave one row (same id, a later label edits it in place); two models on one harness stay two rows with `order` 0 and 1.

Note for existing installs: the fix is not retroactive — duplicates already in `~/.zam/config.json` are removed with the row's "Entfernen" button or `zam bridge model-remove --id <id>`.

## 2. The agent-harness note read as a claim about the listed models

"Nutzt den verbundenen Agent-Harness (Abo / OAuth). Kein API-Schlüssel und keine URL nötig." was the section subtitle, above every configured model — confusing when the list holds a cloud model and two local Ollama entries, none of which use an agent harness.

It is now its own card at the bottom of the section, in the same visual language as the model rows (dashed border, AGENT badge, no actions), and it explains more than it did: what the agent transport is (ADR 2026-07-12a), that the harness runs the request on its own subscription/OAuth so no API key or endpoint URL is needed, and which harness is actually involved — "in use here" for configured agent rows, otherwise the outbound-text harnesses detected on this machine, otherwise the existing "no agent-text harness available yet" line.

The two correctly scoped usages of the same string — the add/edit dialog and the per-row kind note — are unchanged.

## Verification

Full suite green (1589 passed), `npm run lint` clean, `cd desktop && npx tsc --noEmit` clean, panels built and `dist/ui/settings-panel.html` checked for the new keys. New strings ship in en/de; the other packs stay on the fallback allowlist for native review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)