### PR TITLE
feat: OKF graph — wrapped focus labels and ADRs on left-click

### DIFF
--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -4577,8 +4577,9 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     okf_legend_citation: "Citation (ADR)",
     okf_graph_aria: "OKF knowledge graph",
     okf_graph_aria_focused: "OKF knowledge graph, centered on {title}",
+    okf_back_to_graph: "← Back to the graph",
     okf_graph_hint_overview:
-      "Left-click opens the article · right-click centers it",
+      "Left-click opens the article or ADR · right-click centers it",
     okf_graph_hint_focused:
       "Right-click another node to re-center · Esc for the overview",
     okf_graph_focus_exit: "← Overview",
@@ -5618,8 +5619,9 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     okf_legend_citation: "Zitat (ADR)",
     okf_graph_aria: "OKF Wissensgraph",
     okf_graph_aria_focused: "OKF Wissensgraph, zentriert auf {title}",
+    okf_back_to_graph: "← Zurück zum Graph",
     okf_graph_hint_overview:
-      "Linksklick öffnet den Artikel · Rechtsklick zentriert ihn",
+      "Linksklick öffnet Artikel oder ADR · Rechtsklick zentriert",
     okf_graph_hint_focused:
       "Rechtsklick auf einen anderen Knoten zentriert neu · Esc zur Übersicht",
     okf_graph_focus_exit: "← Übersicht",

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -666,6 +666,31 @@ export function edgeAnchor(box: NodeBox, toward: Point, gap = 5): Point {
   return { x: box.x + dx * scale, y: box.y + dy * scale };
 }
 
+// -- Node geometry -----------------------------------------------------------
+
+/** Article pill height for a single-line label, in unscaled canvas units. */
+export const PILL_HEIGHT = 26;
+/** Vertical step between wrapped label lines, in unscaled canvas units. */
+export const LABEL_LINE_HEIGHT = 14;
+
+/**
+ * Pill geometry for an article node, in unscaled canvas units: 11px labels
+ * measure ~6.2px per character, so the pill grows with its longest line and
+ * by one line height per extra line. `maxWidth` lets the focused mode's
+ * center run wider than the nodes on its rings -- it is the one label the
+ * reader is meant to take in fully.
+ */
+export function articlePillSize(
+  lines: string[],
+  maxWidth = 200,
+): { width: number; height: number } {
+  const longest = lines.reduce((n, line) => Math.max(n, line.length), 0);
+  return {
+    width: Math.min(Math.max(longest * 6.2 + 20, 64), maxWidth),
+    height: PILL_HEIGHT + Math.max(0, lines.length - 1) * LABEL_LINE_HEIGHT,
+  };
+}
+
 // -- Focused (centered) graph layout ------------------------------------------
 
 /** Neighbor ring size relative to the outer (background) ring. */

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -114,6 +114,10 @@ interface CitationView {
   target: string;
   path: string;
   content: string;
+  /** Set while the read is still in flight — the graph opens the view on
+   * click, before the content can possibly have arrived. */
+  loading?: boolean;
+  error?: string;
 }
 
 let contextBar: ContextBarHandle | undefined;
@@ -143,6 +147,13 @@ let viewMode: ViewMode = "reader";
 let graphFocusId: string | null = null;
 let currentFile: string | null = null;
 let citationView: CitationView | null = null;
+/** Where the citation full view was opened from, so its back button returns
+ * there: the graph's citation nodes open it from outside the reader. */
+let citationOrigin: ViewMode = "reader";
+/** target -> citation content, for citations opened from the graph. Separate
+ * from `openCitations`, which doubles as the reader's "expanded inline" set —
+ * opening an ADR from the graph must not silently expand it in the article. */
+const citationCache = new Map<string, { path: string; content: string }>();
 let searchQuery = "";
 /** file -> markdown body, populated by the reader and by the graph view's
  * prefetch; shared by both so navigating never re-fetches. */
@@ -396,6 +407,7 @@ async function retargetBundle(dir: string): Promise<string | null> {
     bodyCache.clear();
     readErrors.clear();
     openCitations.clear();
+    citationCache.clear();
     currentFile = null;
     citationView = null;
     graphFocusId = null;
@@ -687,9 +699,13 @@ function renderCitationFullView(container: HTMLElement, view: CitationView): voi
   const back = document.createElement("button");
   back.type = "button";
   back.className = "okf-citation-view-back";
-  back.textContent = t("okf_back_to_article");
+  back.textContent =
+    citationOrigin === "graph"
+      ? t("okf_back_to_graph")
+      : t("okf_back_to_article");
   back.addEventListener("click", () => {
     citationView = null;
+    viewMode = citationOrigin;
     renderAll();
   });
   container.appendChild(back);
@@ -706,12 +722,67 @@ function renderCitationFullView(container: HTMLElement, view: CitationView): voi
   strip.append(badge, pathEl);
   container.appendChild(strip);
 
+  if (view.loading || view.error) {
+    const note = document.createElement("div");
+    note.className = view.error ? "okf-citation-error" : "okf-citation-inline";
+    note.textContent = view.error
+      ? tf("okf_citation_unavailable", { message: view.error })
+      : t("okf_citation_loading");
+    container.appendChild(note);
+    return;
+  }
+
   const bodyEl = document.createElement("div");
   bodyEl.className = "okf-article-body zam-card";
   bodyEl.innerHTML = renderMarkdown(stripFrontmatter(view.content));
   attachContentClickDelegation(bodyEl);
   decorateCitationLinks(bodyEl, new Set());
   container.appendChild(bodyEl);
+}
+
+/**
+ * Open a citation target — an ADR, typically — in the reader's full view,
+ * from wherever the user clicked it. The graph's citation nodes are the
+ * caller that matters: they sit outside the reader, so the view opens in a
+ * loading state and the back button returns to the graph (with its focused
+ * layout intact) instead of to an article the user may never have opened.
+ */
+async function openCitationFullView(target: string): Promise<void> {
+  citationOrigin = viewMode;
+  viewMode = "reader";
+
+  const inline = openCitations.get(target);
+  const cached =
+    inline?.status === "ok"
+      ? { path: inline.path ?? target, content: inline.content ?? "" }
+      : citationCache.get(target);
+  if (cached) {
+    citationView = { target, ...cached };
+    renderAll();
+    return;
+  }
+
+  citationView = { target, path: target, content: "", loading: true };
+  renderAll();
+  try {
+    const result = (await callTool("zam_okf_read_citation", {
+      bundle_dir: bundleDir ?? undefined,
+      target,
+    })) as { target: string; path: string; content: string };
+    citationCache.set(target, { path: result.path, content: result.content });
+    // The user may have navigated on while the read was in flight.
+    if (citationView?.target !== target) return;
+    citationView = { target, path: result.path, content: result.content };
+  } catch (error) {
+    if (citationView?.target !== target) return;
+    citationView = {
+      target,
+      path: target,
+      content: "",
+      error: errorMessage(error),
+    };
+  }
+  renderAll();
 }
 
 /** Click delegation for the two link kinds okf-render.ts's renderMarkdown
@@ -820,6 +891,7 @@ function buildCitationBox(
   openBtn.textContent = t("okf_citation_open_full");
   openBtn.addEventListener("click", (event) => {
     event.preventDefault();
+    citationOrigin = "reader";
     citationView = {
       target,
       path: state.path ?? target,
@@ -1056,6 +1128,12 @@ function buildGraphNodeEl(node: RenderNode): SVGGElement {
     const circle = document.createElementNS(SVG_NS, "circle");
     circle.setAttribute("r", String(NODE_R * 0.45));
     g.appendChild(circle);
+    g.style.cursor = "pointer";
+    g.addEventListener("click", (event) => {
+      // Same ctrl+click caveat as the article pills above.
+      if (event.ctrlKey) return;
+      void openCitationFullView(node.file ?? node.id);
+    });
   }
 
   const label = document.createElementNS(SVG_NS, "text");
@@ -1423,6 +1501,7 @@ app.ontoolresult = (params) => {
     bodyCache.clear();
     readErrors.clear();
     openCitations.clear();
+    citationCache.clear();
     currentFile = null;
     citationView = null;
     graphFocusId = null;

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -39,6 +39,7 @@ import {
   fallbackContextBarState,
   showConnectionNotice as showConnectionNoticeShared,
 } from "./context-bar.js";
+import { wrapGraphLabel } from "./graph-layout.js";
 import {
   type CatalogEntry,
   type FocusRing,
@@ -46,6 +47,9 @@ import {
   type GraphNode,
   type NodeBox,
   type PositionedNode,
+  LABEL_LINE_HEIGHT,
+  PILL_HEIGHT,
+  articlePillSize,
   edgeAnchor,
   extractLinks,
   filterCatalog,
@@ -931,26 +935,57 @@ const RING_SCALE: Record<FocusRing, number> = {
   background: 0.72,
 };
 
-const PILL_H = 26;
+/**
+ * Label room per prominence band. The centered node may wrap onto a second
+ * line and run widest — it is the one title meant to be read in full. Its
+ * neighbors wrap too, but on a tighter line so they stay visibly smaller
+ * than the center. Everything else keeps a single line: the rim must not
+ * compete for reading attention, and the overview stays as it was.
+ */
+const LABEL_BUDGET: Record<FocusRing, { maxChars: number; maxWidth: number }> =
+  {
+    focus: { maxChars: 22, maxWidth: 280 },
+    neighbor: { maxChars: 18, maxWidth: 210 },
+    background: { maxChars: 16, maxWidth: 200 },
+  };
+const WRAPPED_RINGS = new Set<FocusRing>(["focus", "neighbor"]);
 
 function ringScale(node: RenderNode): number {
   return node.ring ? RING_SCALE[node.ring] : 1;
 }
 
-function nodeLabelText(node: RenderNode): string {
+function nodeLabelLines(node: RenderNode): string[] {
   const raw = node.label ?? node.file ?? node.id;
-  // The focused mode's rim carries many labels at once and must not compete
-  // with the neighbors for reading attention — clip it harder.
-  const max = node.ring === "background" ? 16 : undefined;
-  return node.kind === "article"
-    ? truncateLabel(raw, "head", max)
-    : truncateLabel(raw, "tail", max);
+  if (node.ring && WRAPPED_RINGS.has(node.ring)) {
+    // wrapGraphLabel is the 2D graph panel's pure label helper: it balances
+    // the two lines and ellipsizes whatever still does not fit.
+    return wrapGraphLabel(
+      raw.replace(/\.md$/, ""),
+      LABEL_BUDGET[node.ring].maxChars,
+      2,
+    );
+  }
+  const max = node.ring ? LABEL_BUDGET[node.ring].maxChars : undefined;
+  return [
+    node.kind === "article"
+      ? truncateLabel(raw, "head", max)
+      : truncateLabel(raw, "tail", max),
+  ];
 }
 
-/** Pill sized to its label (11px font ≈ 6.2px/char) so titles sit inside the
- * shape instead of overflowing a fixed-width box. */
-function pillWidth(labelText: string): number {
-  return Math.min(Math.max(labelText.length * 6.2 + 20, 64), 200);
+/** Label lines plus the footprint they need, in unscaled canvas units. */
+function nodeShape(node: RenderNode): {
+  lines: string[];
+  width: number;
+  height: number;
+} {
+  const lines = nodeLabelLines(node);
+  if (node.kind !== "article") {
+    // Citation labels sit beside the glyph, so only the glyph is a footprint.
+    return { lines, width: NODE_R * 0.9, height: NODE_R * 0.9 };
+  }
+  const maxWidth = node.ring ? LABEL_BUDGET[node.ring].maxWidth : 200;
+  return { lines, ...articlePillSize(lines, maxWidth) };
 }
 
 /**
@@ -959,15 +994,12 @@ function pillWidth(labelText: string): number {
  */
 function nodeBox(node: RenderNode): NodeBox {
   const scale = ringScale(node);
-  const size =
-    node.kind === "article"
-      ? { width: pillWidth(nodeLabelText(node)), height: PILL_H }
-      : { width: NODE_R * 0.9, height: NODE_R * 0.9 };
+  const shape = nodeShape(node);
   return {
     x: node.x,
     y: node.y,
-    width: size.width * scale,
-    height: size.height * scale,
+    width: shape.width * scale,
+    height: shape.height * scale,
   };
 }
 
@@ -988,17 +1020,18 @@ function buildGraphNodeEl(node: RenderNode): SVGGElement {
   title.textContent = node.file ?? node.id;
   g.appendChild(title);
 
-  const labelText = nodeLabelText(node);
+  const { lines, width: pillW, height: pillH } = nodeShape(node);
 
   if (node.kind === "article") {
-    const pillW = pillWidth(labelText);
     const pill = (): SVGRectElement => {
       const rect = document.createElementNS(SVG_NS, "rect");
       rect.setAttribute("x", String(-pillW / 2));
-      rect.setAttribute("y", String(-PILL_H / 2));
+      rect.setAttribute("y", String(-pillH / 2));
       rect.setAttribute("width", String(pillW));
-      rect.setAttribute("height", String(PILL_H));
-      rect.setAttribute("rx", String(PILL_H / 2));
+      rect.setAttribute("height", String(pillH));
+      // Stadium ends for a one-line pill; a wrapped one keeps the same
+      // corner radius instead of turning into a lozenge.
+      rect.setAttribute("rx", String(Math.min(PILL_HEIGHT / 2, pillH / 2)));
       return rect;
     };
     // The type tint is translucent, so an unrelated edge passing behind the
@@ -1028,9 +1061,12 @@ function buildGraphNodeEl(node: RenderNode): SVGGElement {
   const label = document.createElementNS(SVG_NS, "text");
   label.setAttribute("class", "okf-graph-node-label");
   label.setAttribute("dominant-baseline", "central");
+  // Wrapped labels are centered on the node: the first line starts half a
+  // block above the middle, each following line steps down one line height.
+  const firstLineY = (-(lines.length - 1) * LABEL_LINE_HEIGHT) / 2;
+  let labelX = "0";
   if (node.kind === "article") {
     label.setAttribute("text-anchor", "middle");
-    label.setAttribute("y", "0");
   } else {
     // Citation labels grow away from the crowded side of their ring: on an
     // outer ring inward (so text never runs past the viewBox edge), on the
@@ -1043,10 +1079,17 @@ function buildGraphNodeEl(node: RenderNode): SVGGElement {
     const toTheRight = outward ? onRightHalf : !onRightHalf;
     const gap = 14 / scale;
     label.setAttribute("text-anchor", toTheRight ? "start" : "end");
-    label.setAttribute("x", String(toTheRight ? gap : -gap));
-    label.setAttribute("y", "0");
+    labelX = String(toTheRight ? gap : -gap);
   }
-  label.textContent = labelText;
+  label.setAttribute("x", labelX);
+  label.setAttribute("y", String(firstLineY));
+  for (const [index, line] of lines.entries()) {
+    const tspan = document.createElementNS(SVG_NS, "tspan");
+    tspan.setAttribute("x", labelX);
+    if (index > 0) tspan.setAttribute("dy", String(LABEL_LINE_HEIGHT));
+    tspan.textContent = line;
+    label.appendChild(tspan);
+  }
   g.appendChild(label);
 
   return g;

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,7 @@
 ## 2026-07-29
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 
 ## 2026-07-22
 

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-07-29T18:35:00Z
+timestamp: 2026-07-29T19:30:00Z
 ---
 
 `zam mcp` starts a stdio **Model Context Protocol** server
@@ -93,13 +93,25 @@ and still hoverable, because the surrounding knowledge base is context,
 not noise. Ring angles are carried over from the overview, so a node
 keeps its direction across the switch.
 
-Left-click keeps its meaning in both modes: it opens the article in the
-reader. Right-clicking the centered node again, right-clicking empty
-canvas, `Esc`, or the toolbar's overview button returns to the
-overview; right-clicking a different node re-centers on it. Hovering
-any node still lights its edges and neighbors and dims the rest, in
-both modes. Edges are drawn between node borders rather than centers,
-so no line crosses a node box.
+Left-click opens what the node stands for, in both modes: an article
+node opens the article in the reader, a citation node opens its target
+— usually an ADR — in the reader's full citation view, read through
+`zam_okf_read_citation`. That view's back button returns to the graph
+(focused layout intact) when the graph is where it was opened from, and
+to the article otherwise.
+
+Right-clicking the centered node again, right-clicking empty canvas,
+`Esc`, or the toolbar's overview button returns to the overview;
+right-clicking a different node re-centers on it. Hovering any node
+still lights its edges and neighbors and dims the rest, in both modes.
+Edges are drawn between node borders rather than centers, so no line
+crosses a node box.
+
+Labels are sized by band: the centered node may wrap onto a second line
+and run widest — it is the one title meant to be read in full — its
+neighbors wrap on a tighter line, and the rim stays on a single, harder
+clipped line so it does not compete for reading attention. The overview
+keeps one line per node.
 
 The reader's "import as learning content" action hands the
 decomposition request to a chat in host order of capability: hosts

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -431,6 +431,7 @@ const PRE_EXISTING_FALLBACK_KEYS = new Set([
   "model_agent_card_available",
   // OKF graph focus mode (right-click centers a node) — en/de shipped;
   // es/fr/pt/zh/ja await native pack review.
+  "okf_back_to_graph",
   "okf_graph_aria_focused",
   "okf_graph_hint_overview",
   "okf_graph_hint_focused",

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  articlePillSize,
   type CatalogEntry,
   edgeAnchor,
   extractLinks,
@@ -674,5 +675,29 @@ describe("edgeAnchor", () => {
 
   it("returns the center when the target is the center (no direction to leave in)", () => {
     expect(edgeAnchor(box, { x: 100, y: 100 }, 5)).toEqual({ x: 100, y: 100 });
+  });
+});
+
+describe("articlePillSize", () => {
+  it("grows with the longest line, not the line count, in width", () => {
+    const one = articlePillSize(["MCP Transport and Surfaces"]);
+    const two = articlePillSize(["MCP Transport", "and Surfaces"]);
+    expect(two.width).toBeLessThan(one.width);
+  });
+
+  it("adds one line height per wrapped line", () => {
+    const one = articlePillSize(["Token and Card Model"]);
+    const two = articlePillSize(["Token and", "Card Model"]);
+    expect(two.height - one.height).toBe(14);
+  });
+
+  it("keeps a floor so a short label still reads as a pill", () => {
+    expect(articlePillSize(["A"]).width).toBe(64);
+  });
+
+  it("honours the wider cap the centered node gets", () => {
+    const long = ["x".repeat(60)];
+    expect(articlePillSize(long).width).toBe(200);
+    expect(articlePillSize(long, 280).width).toBe(280);
   });
 });


### PR DESCRIPTION
Two follow-ups to #250, both from using the focused mode on the real bundle.

## 1. Labels wrap in the focused mode

The centered node carried the same 26-character single-line label as every other node — so the one title the focused mode exists to show was the one getting clipped ("MCP Transport and Surfa…").

- **The center** wraps onto up to two lines (22 characters each) and may run wider than the ring nodes. Its pill grows with the longest line and by one line height per extra line, keeping its corner radius instead of turning into a lozenge.
- **Direct neighbors** wrap too, on a tighter line (18 characters), so they stay visibly smaller than the center — long ADR names now read in full instead of ending in an ellipsis.
- **The receding rim and the whole overview** keep their single line.

Wrapping reuses `graph-layout.ts`'s `wrapGraphLabel` — the 2D graph panel's pure label helper, which already balances the lines and ellipsizes the rest. Pill geometry moved into `okf-render.ts` as `articlePillSize` (with tests), since the same box feeds the edge clipping from #250: a taller, wider pill has to push its edges out with it.

## 2. Cited ADRs open on left-click

The graph drew citation nodes but left them inert — an ADR was reachable only by finding an article that cites it and expanding the link inline.

A left-click on a citation node now opens its target in the reader's full citation view, read through `zam_okf_read_citation` (the path the reader already used, so nothing new reaches the filesystem). The view opens in a loading state — the click happens outside the reader, before the read can land — and its back button returns to the graph with the focused layout intact, rather than to an article the user may never have opened. Content fetched this way is cached separately from the reader's "expanded inline" set, so opening an ADR from the graph does not silently expand it inside the citing article.

`docs/okf/mcp-surfaces.md` is updated for both (written through `zam_okf_upsert`).

## Verification

Full suite green (1608 passed), `npm run lint` clean, `cd desktop && npx tsc --noEmit` clean, panels built and the new keys checked in `dist/ui/okf-panel.html`. Layout verified by rendering both modes from the real `docs/okf` bundle through the same pure functions; the overview was re-rendered to confirm it is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)