### PR TITLE
chore: release 0.22.8

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.7",
+  "version": "0.22.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.7",
+      "version": "0.22.8",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.7",
+  "version": "0.22.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.7"
+version = "0.22.8"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.7",
+  "version": "0.22.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.7",
+      "version": "0.22.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.7",
+  "version": "0.22.8",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.7",
+          "User-Agent": "ZAM-Content-Studio/0.22.8",
         },
       });
 


### PR DESCRIPTION
Version bump for 0.22.8: root and `desktop/` `package.json` + both lockfiles, the `zam-app` crate version with `Cargo.lock` (verified with `cargo metadata --locked`), and the hardcoded User-Agent in `src/cli/adapters/source-reader.ts`.

## What is in this release

- **OKF graph: a focused mode** (#250) — right-click centers a node, its direct neighbors move onto an enlarged ring, everything else recedes to a faint rim that stays visible and hoverable. Left-click still opens what a node stands for; `Esc`, empty-canvas right-click or the toolbar button returns to the overview. Edges now stop at node borders instead of crossing the boxes.
- **Focused labels wrap, cited ADRs open from the graph** (#252) — the centered node wraps onto a second line and may run wider than its neighbors, which wrap on a tighter line; a left-click on a citation node opens the ADR in the reader's full citation view, with a back button that returns to the graph.
- **Settings: duplicate agent models and a misleading note** (#251) — adding an agent model no longer appends a duplicate row on a re-click, and the agent-harness explanation is a card below the model list instead of a subtitle that read as a claim about the models above it.
- **ADR: name the surrounding host as an answering route** (#253) — docs only, proposed and deliberately not implemented here.

Full suite green, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)