### PR TITLE
feat: release OKF freshness radar in 0.23.0

### DIFF
--- a/.agent/skills/zam/SKILL.md
+++ b/.agent/skills/zam/SKILL.md
@@ -36,7 +36,8 @@ This detects installed user-scoped harnesses, registers the `zam` MCP server, in
 | `zam_suggest_foundations` | Suggest existing prerequisite tokens for a newly failed or registered token. |
 | `zam_monitor` | Read or analyze shell-monitor evidence for a session. |
 | `zam_open_recall` | Open the spoiler-free Recall app; answering, reveal, and rating stay inside the card. |
-| `zam_show_graph` | Open the focused knowledge-graph app, usually with a token slug from the conversation. |
+| `zam_show_graph` | Open the learning-token graph, usually with a token slug from the conversation. |
+| `zam_okf_visualize` | Open repo knowledge articles (OKFs and cited ADRs) in reader, graph, or log view. |
 | `zam_open_settings` | Open the focused Settings app when the user asks for configuration or database status. |
 
 ---
@@ -58,7 +59,9 @@ When the user invokes `/zam` without a task or mode, do not choose a workflow on
 ### Purpose-built visual surfaces
 
 - After the user chooses Recall or a topic, call `zam_open_recall`, passing the selected domain when applicable. Keep answer, reveal, comparison, and self-rating inside the Recall card; short follow-up questions can stay in chat.
-- When the user asks to visualize knowledge, call `zam_show_graph` with the most relevant known token slug as `focus`. The host may show it in a persistent pane or inline for a one-off visualization.
+- When the user asks for the **knowledge graph**, **learning graph**, or **Wissensgraph**, call `zam_show_graph` with the most relevant known token slug as `focus`. This surface shows learning tokens and prerequisite relations.
+- When the user asks for **knowledge articles**, **Wissensartikel**, **OKFs**, or **ADRs**, call `zam_okf_visualize` with `view: "graph"`. Use `view: "reader"` when they ask to read an article and `view: "log"` for bundle history.
+- A host may place an MCP App in a persistent pane or inline. Recall requests standard picture-in-picture only when the host advertises it; never claim control over a host-specific right sidebar.
 - Call `zam_open_settings` only for relevant setup, workspace, backup, or database-status work.
 - Never call `zam_open_studio` as part of an agent-harness ZAM menu or ordinary ZAM workflow.
 

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -21,8 +21,9 @@ release-level care. Contract: ADR 2026-07-17.
 path is the `zam_okf_upsert` MCP tool (server: `zam mcp`): it validates
 the frontmatter contract, regenerates `index.md`, and appends the `log.md`
 entry. `zam_okf_catalog` lists articles plus conformance problems;
-`zam_okf_read` returns one article. CI enforces bundle conformance
-(`tests/cli/okf-conformance.test.ts`).
+`zam_okf_read` returns one article; `zam_okf_audit` reports conservative
+freshness hints from declared code citations and Git history. CI enforces
+bundle conformance (`tests/cli/okf-conformance.test.ts`).
 
 ## ADR vs OKF
 
@@ -54,8 +55,12 @@ one.
 
 If a PR changes behavior that an OKF article describes, update the
 article via `zam_okf_upsert` **in the same PR**. Check
-`zam_okf_catalog` when touching kernel scheduling, the token/card model,
-prerequisite blocking, the bridge protocol, or MCP surfaces.
+`zam_okf_catalog` and run `zam_okf_audit` when touching kernel
+scheduling, the token/card model, prerequisite blocking, the bridge
+protocol, or MCP surfaces. Treat `review-recommended` as a prompt to read
+the code and article, not permission to rewrite automatically; `current`
+means only that no declared code citation is newer, and `unknown` is an
+honest request for manual inspection.
 
 ## Articles as learning sources
 

--- a/.agents/skills/zam/SKILL.md
+++ b/.agents/skills/zam/SKILL.md
@@ -39,7 +39,8 @@ This detects installed user-scoped harnesses, registers the `zam` MCP server, in
 | `zam_suggest_foundations` | Suggest existing prerequisite tokens for a newly failed or registered token. |
 | `zam_monitor` | Read or analyze shell-monitor evidence for a session. |
 | `zam_open_recall` | Open the spoiler-free Recall app; answering, reveal, and rating stay inside the card. |
-| `zam_show_graph` | Open the focused knowledge-graph app, usually with a token slug from the conversation. |
+| `zam_show_graph` | Open the learning-token graph, usually with a token slug from the conversation. |
+| `zam_okf_visualize` | Open repo knowledge articles (OKFs and cited ADRs) in reader, graph, or log view. |
 | `zam_open_settings` | Open the focused Settings app when the user asks for configuration or database status. |
 
 ---
@@ -61,7 +62,9 @@ When the user invokes `$zam` without a task or mode, do not choose a workflow on
 ### Purpose-built visual surfaces
 
 - After the user chooses Recall or a topic, call `zam_open_recall`, passing the selected domain when applicable. Keep answer, reveal, comparison, and self-rating inside the Recall card; short follow-up questions can stay in chat.
-- When the user asks to visualize knowledge, call `zam_show_graph` with the most relevant known token slug as `focus`. The host may show it in a persistent pane or inline for a one-off visualization.
+- When the user asks for the **knowledge graph**, **learning graph**, or **Wissensgraph**, call `zam_show_graph` with the most relevant known token slug as `focus`. This surface shows learning tokens and prerequisite relations.
+- When the user asks for **knowledge articles**, **Wissensartikel**, **OKFs**, or **ADRs**, call `zam_okf_visualize` with `view: "graph"`. Use `view: "reader"` when they ask to read an article and `view: "log"` for bundle history.
+- A host may place an MCP App in a persistent pane or inline. Recall requests standard picture-in-picture only when the host advertises it; never claim control over a host-specific right sidebar.
 - Call `zam_open_settings` only for relevant setup, workspace, backup, or database-status work.
 - Never call `zam_open_studio` as part of an agent-harness ZAM menu or ordinary ZAM workflow.
 

--- a/.claude/skills/zam/SKILL.md
+++ b/.claude/skills/zam/SKILL.md
@@ -36,7 +36,8 @@ This detects installed user-scoped harnesses, registers the `zam` MCP server, in
 | `zam_suggest_foundations` | Suggest existing prerequisite tokens for a newly failed or registered token. |
 | `zam_monitor` | Read or analyze shell-monitor evidence for a session. |
 | `zam_open_recall` | Open the spoiler-free Recall app; answering, reveal, and rating stay inside the card. |
-| `zam_show_graph` | Open the focused knowledge-graph app, usually with a token slug from the conversation. |
+| `zam_show_graph` | Open the learning-token graph, usually with a token slug from the conversation. |
+| `zam_okf_visualize` | Open repo knowledge articles (OKFs and cited ADRs) in reader, graph, or log view. |
 | `zam_open_settings` | Open the focused Settings app when the user asks for configuration or database status. |
 
 ---
@@ -58,7 +59,9 @@ When the user invokes `/zam` without a task or mode, do not choose a workflow on
 ### Purpose-built visual surfaces
 
 - After the user chooses Recall or a topic, call `zam_open_recall`, passing the selected domain when applicable. Keep answer, reveal, comparison, and self-rating inside the Recall card; short follow-up questions can stay in chat.
-- When the user asks to visualize knowledge, call `zam_show_graph` with the most relevant known token slug as `focus`. The host may show it in a persistent pane or inline for a one-off visualization.
+- When the user asks for the **knowledge graph**, **learning graph**, or **Wissensgraph**, call `zam_show_graph` with the most relevant known token slug as `focus`. This surface shows learning tokens and prerequisite relations.
+- When the user asks for **knowledge articles**, **Wissensartikel**, **OKFs**, or **ADRs**, call `zam_okf_visualize` with `view: "graph"`. Use `view: "reader"` when they ask to read an article and `view: "log"` for bundle history.
+- A host may place an MCP App in a persistent pane or inline. Recall requests standard picture-in-picture only when the host advertises it; never claim control over a host-specific right sidebar.
 - Call `zam_open_settings` only for relevant setup, workspace, backup, or database-status work.
 - Never call `zam_open_studio` as part of an agent-harness ZAM menu or ordinary ZAM workflow.
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.22.8",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.22.8",
+      "version": "0.23.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.22.8",
+  "version": "0.23.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "qrcode",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.22.8"
+version = "0.23.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -4553,6 +4553,15 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     okf_bundle_valid_but_empty:
       "The folder is a valid bundle but contains no articles.",
     okf_resource_link: "Source ↗",
+    okf_freshness_current: "Knowledge current",
+    okf_freshness_review: "Review recommended",
+    okf_freshness_unknown: "Freshness unknown",
+    okf_freshness_current_title: "No cited code changed after this article.",
+    okf_freshness_review_title:
+      "Cited code changed after this article; review the article when convenient.",
+    okf_freshness_review_paths: "Code changed after this article: {paths}",
+    okf_freshness_unknown_title:
+      "Git history or code citations were insufficient to determine freshness.",
     okf_copy: "📋 Copy",
     okf_copied: "✓ Copied",
     okf_copy_failed: "⚠️ Copy failed",
@@ -5596,6 +5605,17 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     okf_bundle_valid_but_empty:
       "Der Ordner ist ein gültiges Bundle, enthält aber keine Artikel.",
     okf_resource_link: "Quelle ↗",
+    okf_freshness_current: "Wissen aktuell",
+    okf_freshness_review: "Prüfung empfohlen",
+    okf_freshness_unknown: "Aktualität unbekannt",
+    okf_freshness_current_title:
+      "Seit diesem Artikel wurde kein zitierter Code geändert.",
+    okf_freshness_review_title:
+      "Zitierter Code wurde nach diesem Artikel geändert; prüfe den Artikel bei Gelegenheit.",
+    okf_freshness_review_paths:
+      "Code wurde nach diesem Artikel geändert: {paths}",
+    okf_freshness_unknown_title:
+      "Git-Historie oder Code-Zitate reichen nicht aus, um die Aktualität zu bestimmen.",
     okf_copy: "📋 Kopieren",
     okf_copied: "✓ Kopiert",
     okf_copy_failed: "⚠️ Kopieren fehlgeschlagen",

--- a/desktop/src/panel/context-bar.ts
+++ b/desktop/src/panel/context-bar.ts
@@ -2,8 +2,8 @@
  * Shared compact Companion context bar (ADR 2026-07-16 §Decision 1–4,
  * 0.11.0 Phase 4).
  *
- * One framework-free DOM component mounted by all four panel entries
- * (recall.ts, graph.ts, settings.ts, panel.ts) in place of the old
+ * One framework-free DOM component mounted by all five panel entries
+ * (recall.ts, graph.ts, okf.ts, settings.ts, panel.ts) in place of the old
  * `.zam-header` + permanent "Connected to zam mcp" status row. Layout:
  * collapse/expand affordance + app title on the left, an **Agent** pill and
  * a **User** pill (both native `<select>` elements styled as pills, so
@@ -91,6 +91,16 @@ export interface CompanionContextBarState {
 export interface CompanionContextWriteResult {
   read: CompanionContextBarState;
   reloadRequired: boolean;
+}
+
+/**
+ * Evaluator choice affects generation/evaluation surfaces, but neither
+ * read-only graph: the learning graph renders stored tokens and the OKF graph
+ * renders repo articles/citations. Hiding the control there avoids presenting
+ * a host model as if it influenced the result.
+ */
+export function surfaceUsesEvaluator(surface: CompanionSurface): boolean {
+  return surface !== "graph" && surface !== "okf";
 }
 
 function errorMessage(error: unknown): string {
@@ -545,6 +555,9 @@ const CONTEXT_BAR_CSS = `
   color: var(--muted);
   max-width: 220px;
 }
+.zam-pill[hidden] {
+  display: none;
+}
 .zam-pill-label {
   font-weight: 700;
   text-transform: uppercase;
@@ -778,6 +791,7 @@ export function mountContextBar(
     );
     titleEl.title = version ? `${title} · v${version} · zam mcp` : title;
 
+    agentPill.wrapper.hidden = !surfaceUsesEvaluator(state.surface);
     applyOptions(agentPill.select, buildEvaluatorOptions(state));
     const agent = agentPillSummary(state);
     agentPill.select.classList.toggle(

--- a/desktop/src/panel/display-mode.ts
+++ b/desktop/src/panel/display-mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Standard MCP Apps display-mode policy for focused ZAM surfaces.
+ *
+ * A host owns placement. Recall only asks for picture-in-picture when the host
+ * explicitly advertises it, because an ongoing learning session benefits from
+ * staying beside the conversation. Hosts that expose only inline mode keep
+ * their native layout.
+ */
+
+export type AppDisplayMode = "inline" | "fullscreen" | "pip";
+
+export interface AppDisplayContext {
+  displayMode?: AppDisplayMode;
+  availableDisplayModes?: readonly AppDisplayMode[];
+}
+
+export function preferredRecallDisplayMode(
+  context: AppDisplayContext | undefined,
+): "pip" | undefined {
+  if (
+    context?.displayMode !== "pip" &&
+    context?.availableDisplayModes?.includes("pip")
+  ) {
+    return "pip";
+  }
+  return undefined;
+}

--- a/desktop/src/panel/graph-panel.html
+++ b/desktop/src/panel/graph-panel.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>ZAM Graph</title>
+    <title>ZAM Learning Graph</title>
     <style>
       :root {
         color-scheme: light dark;

--- a/desktop/src/panel/graph.ts
+++ b/desktop/src/panel/graph.ts
@@ -126,7 +126,7 @@ interface Neighborhood {
   dependents: GraphNode[];
 }
 
-const app = new App({ name: "ZAM Graph", version: "0.1.0" });
+const app = new App({ name: "ZAM Learning Graph", version: "0.1.0" });
 
 let currentUser: string | null = null;
 let connected = false;
@@ -728,7 +728,7 @@ app.ontoolresult = (params) => {
   contextBar = ensureContextBar(
     contextBar,
     contextBarRoot,
-    "ZAM Graph",
+    "ZAM Learning Graph",
     panelVersion,
     contextState,
     {
@@ -748,7 +748,7 @@ app.ontoolresult = (params) => {
 contextBar = ensureContextBar(
   contextBar,
   contextBarRoot,
-  "ZAM Graph",
+  "ZAM Learning Graph",
   panelVersion,
   fallbackContextBarState(SURFACE, currentUser),
   {
@@ -786,5 +786,7 @@ app
   })
   .catch((error: unknown) => {
     clearTimeout(noHostTimer);
-    showConnectionNotice(`ZAM Graph failed to start: ${errorMessage(error)}`);
+    showConnectionNotice(
+      `ZAM Learning Graph failed to start: ${errorMessage(error)}`,
+    );
   });

--- a/desktop/src/panel/okf-panel.html
+++ b/desktop/src/panel/okf-panel.html
@@ -19,6 +19,8 @@
         --hover: rgba(130, 125, 189, 0.1);
         --ok: #2fbf71;
         --ok-bg: rgba(47, 191, 113, 0.12);
+        --warning: #9a6700;
+        --warning-bg: rgba(237, 161, 0, 0.16);
 
         /* OKF article-type palette — dataviz skill's validated 8-hue
            categorical order, first 4 slots only (the "all-pairs" safe
@@ -62,6 +64,8 @@
           --hover: rgba(130, 125, 189, 0.18);
           --ok: #34d399;
           --ok-bg: rgba(52, 211, 153, 0.16);
+          --warning: #f0b429;
+          --warning-bg: rgba(240, 180, 41, 0.16);
 
           --okf-type-1: #3987e5;
           --okf-type-1-bg: rgba(57, 135, 229, 0.18);
@@ -201,7 +205,9 @@
         flex-shrink: 0;
       }
       .okf-catalog-item {
-        display: block;
+        display: flex;
+        align-items: center;
+        gap: 7px;
         width: 100%;
         text-align: left;
         font: inherit;
@@ -212,6 +218,18 @@
         background: transparent;
         color: var(--fg);
         cursor: pointer;
+      }
+      .okf-catalog-item-label {
+        flex: 1;
+        min-width: 0;
+      }
+      .okf-freshness-dot {
+        width: 7px;
+        height: 7px;
+        flex: 0 0 7px;
+        border-radius: 50%;
+        background: var(--warning);
+        box-shadow: 0 0 0 3px var(--warning-bg);
       }
       .okf-catalog-item:hover {
         background: var(--hover);
@@ -261,6 +279,27 @@
       .okf-resource-link {
         color: var(--accent);
         text-decoration: underline;
+      }
+      .okf-freshness-badge {
+        display: inline-flex;
+        align-items: center;
+        margin-left: auto;
+        border-radius: 999px;
+        padding: 3px 9px;
+        font-size: 0.7rem;
+        font-weight: 650;
+      }
+      .okf-freshness-badge.current {
+        color: var(--ok);
+        background: var(--ok-bg);
+      }
+      .okf-freshness-badge.review-recommended {
+        color: var(--warning);
+        background: var(--warning-bg);
+      }
+      .okf-freshness-badge.unknown {
+        color: var(--muted);
+        background: var(--hover);
       }
 
       /* Typography for renderMarkdown's plain semantic HTML — shared by the
@@ -670,6 +709,9 @@
           flex-direction: column;
         }
         .okf-sidebar {
+          width: 100%;
+        }
+        .okf-content {
           width: 100%;
         }
         .okf-catalog-groups {

--- a/desktop/src/panel/okf-render.ts
+++ b/desktop/src/panel/okf-render.ts
@@ -23,6 +23,46 @@ export interface CatalogEntry {
   timestamp?: string;
 }
 
+/** Mirrors the read-only `zam_okf_audit` wire shape. */
+export type OkfFreshnessStatus = "current" | "review-recommended" | "unknown";
+
+export interface OkfCodeReferenceFreshness {
+  path: string;
+  status: OkfFreshnessStatus;
+  reason?: string;
+}
+
+export interface OkfArticleFreshness {
+  file: string;
+  status: OkfFreshnessStatus;
+  codeReferences: OkfCodeReferenceFreshness[];
+  reason?: string;
+}
+
+export interface OkfFreshnessAudit {
+  articles: OkfArticleFreshness[];
+}
+
+/** Index an audit snapshot once so sidebar and reader lookups stay cheap. */
+export function indexFreshnessByFile(
+  audit: OkfFreshnessAudit | null | undefined,
+): Map<string, OkfArticleFreshness> {
+  return new Map(
+    (audit?.articles ?? []).map((article) => [article.file, article]),
+  );
+}
+
+/** Code paths that make an article's freshness badge actionable. */
+export function reviewRecommendedPaths(
+  article: OkfArticleFreshness | undefined,
+): string[] {
+  return (
+    article?.codeReferences
+      .filter((reference) => reference.status === "review-recommended")
+      .map((reference) => reference.path) ?? []
+  );
+}
+
 export interface GraphNode {
   id: string;
   kind: "article" | "citation";

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -94,8 +94,13 @@ function errorMessage(error: unknown): string {
 
 type ViewMode = "reader" | "graph" | "log";
 
+function isViewMode(value: unknown): value is ViewMode {
+  return value === "reader" || value === "graph" || value === "log";
+}
+
 interface OpenOkfResult {
   bundleDir?: string | null;
+  view?: ViewMode;
   /** The OKF bundle-format version (index.md's `okf_version` frontmatter),
    * not the zam app/package version — see `zam_okf_visualize`'s `okfVersion`
    * field (src/cli/commands/mcp.ts). `null` when the bundle failed to load
@@ -1579,6 +1584,14 @@ document.addEventListener("keydown", (event) => {
 
 // ── Host lifecycle (mirrors graph.ts) ───────────────────────────────────
 
+app.ontoolinput = (params) => {
+  const input = (params.arguments ?? {}) as { view?: unknown };
+  if (!isViewMode(input.view)) return;
+  viewMode = input.view;
+  updateViewToggleActiveState();
+  if (catalogLoaded) renderAll();
+};
+
 app.ontoolresult = (params) => {
   const structured = (params.structuredContent ?? {}) as OpenOkfResult;
   panelVersion = structured.version;
@@ -1591,6 +1604,7 @@ app.ontoolresult = (params) => {
   const previousBundleDir = bundleDir;
   currentUser = structured.user ?? null;
   if (structured.bundleDir !== undefined) bundleDir = structured.bundleDir;
+  if (isViewMode(structured.view)) viewMode = structured.view;
   if (structured.okfVersion !== undefined)
     bundleOkfVersion = structured.okfVersion;
   if (structured.catalog) {
@@ -1638,6 +1652,14 @@ app.ontoolresult = (params) => {
     },
   );
   start();
+  if (
+    structured.freshness === undefined &&
+    structured.bundleDir !== undefined
+  ) {
+    // Newer servers keep Git inspection off the opening tool's critical
+    // path. Older results may still carry freshness and skip this request.
+    void loadFreshness(bundleDir).then(renderAll);
+  }
 };
 
 // Mount the bar immediately — before any tool result — so the title and an

--- a/desktop/src/panel/okf.ts
+++ b/desktop/src/panel/okf.ts
@@ -46,6 +46,9 @@ import {
   type GraphEdge,
   type GraphNode,
   type NodeBox,
+  type OkfArticleFreshness,
+  type OkfFreshnessAudit,
+  type OkfFreshnessStatus,
   type PositionedNode,
   LABEL_LINE_HEIGHT,
   PILL_HEIGHT,
@@ -54,10 +57,12 @@ import {
   extractLinks,
   filterCatalog,
   groupCatalog,
+  indexFreshnessByFile,
   layoutFocusGraph,
   layoutGraph,
   neighborIdsOf,
   renderMarkdown,
+  reviewRecommendedPaths,
   stripFrontmatter,
 } from "./okf-render.js";
 
@@ -98,6 +103,7 @@ interface OpenOkfResult {
   okfVersion?: string | null;
   catalog?: CatalogEntry[];
   log?: string;
+  freshness?: OkfFreshnessAudit | null;
   version?: string;
   user?: string | null;
   companionContext?: CompanionContextBarState;
@@ -134,6 +140,7 @@ let bundleDir: string | null = null;
  * doesn't return it. */
 let bundleOkfVersion: string | null = null;
 let catalog: CatalogEntry[] = [];
+let freshnessByFile = indexFreshnessByFile(null);
 /** First-seen `type` order across the full (unfiltered) catalog, fixed once
  * per catalog load — the categorical-color assignment must never reshuffle
  * while the user types in the search box (dataviz skill: fixed order, never
@@ -179,6 +186,23 @@ function reloadForContext(newState: CompanionContextBarState): void {
 function setCatalog(next: CatalogEntry[]): void {
   catalog = next;
   typeOrder = [...groupCatalog(catalog).keys()];
+}
+
+function setFreshness(next: OkfFreshnessAudit | null | undefined): void {
+  freshnessByFile = indexFreshnessByFile(next);
+}
+
+async function loadFreshness(bundle: string | null): Promise<void> {
+  try {
+    const result = (await callTool("zam_okf_audit", {
+      bundle_dir: bundle ?? undefined,
+    })) as OkfFreshnessAudit;
+    if (bundle === bundleDir) setFreshness(result);
+  } catch {
+    // Freshness is an advisory layer. Older hosts or unavailable Git must
+    // not block the catalog; the reader renders an honest "unknown" badge.
+    if (bundle === bundleDir) setFreshness(null);
+  }
 }
 
 /**
@@ -229,8 +253,13 @@ async function loadCatalogFallback(): Promise<void> {
     bundleDir = result.dir;
     setCatalog(result.articles);
     logText = result.log ?? "";
+    setFreshness(null);
     catalogLoaded = true;
     renderAll();
+    // Advisory only: paint the catalog immediately and let Git inspection
+    // arrive independently. A slow/older host must never hold the reader
+    // behind the freshness layer.
+    void loadFreshness(bundleDir).then(renderAll);
   } catch (error) {
     renderTopLevelError(errorMessage(error));
   }
@@ -288,7 +317,9 @@ function updateViewToggleActiveState(): void {
 
 function viewButtons(): HTMLButtonElement[] {
   return viewToggleEl
-    ? Array.from(viewToggleEl.querySelectorAll<HTMLButtonElement>(".okf-view-btn"))
+    ? Array.from(
+        viewToggleEl.querySelectorAll<HTMLButtonElement>(".okf-view-btn"),
+      )
     : [];
 }
 
@@ -321,6 +352,27 @@ function renderTopLevelError(message: string): void {
   }
 }
 
+function freshnessLabel(status: OkfFreshnessStatus): string {
+  switch (status) {
+    case "current":
+      return t("okf_freshness_current");
+    case "review-recommended":
+      return t("okf_freshness_review");
+    default:
+      return t("okf_freshness_unknown");
+  }
+}
+
+function freshnessTitle(article: OkfArticleFreshness | undefined): string {
+  const status = article?.status ?? "unknown";
+  if (status === "current") return t("okf_freshness_current_title");
+  if (status === "unknown") return t("okf_freshness_unknown_title");
+  const paths = reviewRecommendedPaths(article);
+  return paths.length > 0
+    ? tf("okf_freshness_review_paths", { paths: paths.join(", ") })
+    : t("okf_freshness_review_title");
+}
+
 function renderSidebar(): void {
   if (!catalogGroupsEl) return;
   catalogGroupsEl.replaceChildren();
@@ -328,7 +380,9 @@ function renderSidebar(): void {
   if (filtered.length === 0) {
     const empty = document.createElement("div");
     empty.className = "okf-catalog-empty";
-    empty.textContent = searchQuery ? t("okf_no_matches") : t("okf_no_articles");
+    empty.textContent = searchQuery
+      ? t("okf_no_matches")
+      : t("okf_no_articles");
     catalogGroupsEl.appendChild(empty);
     return;
   }
@@ -347,11 +401,37 @@ function renderSidebar(): void {
       const item = document.createElement("button");
       item.type = "button";
       item.className = "okf-catalog-item";
-      if (viewMode === "reader" && !citationView && currentFile === entry.file) {
+      if (
+        viewMode === "reader" &&
+        !citationView &&
+        currentFile === entry.file
+      ) {
         item.classList.add("active");
       }
-      item.textContent = entry.title;
-      item.title = entry.description;
+      const label = document.createElement("span");
+      label.className = "okf-catalog-item-label";
+      label.textContent = entry.title;
+      item.appendChild(label);
+      const articleFreshness = freshnessByFile.get(entry.file);
+      if (articleFreshness?.status === "review-recommended") {
+        const marker = document.createElement("span");
+        marker.className = "okf-freshness-dot";
+        marker.title = freshnessTitle(articleFreshness);
+        marker.setAttribute("aria-hidden", "true");
+        item.appendChild(marker);
+        item.setAttribute(
+          "aria-label",
+          `${entry.title} — ${freshnessLabel(articleFreshness.status)}`,
+        );
+      }
+      item.title = [
+        entry.description,
+        ...(articleFreshness?.status === "review-recommended"
+          ? [freshnessTitle(articleFreshness)]
+          : []),
+      ]
+        .filter(Boolean)
+        .join("\n");
       item.addEventListener("click", () => {
         viewMode = "reader";
         void openArticle(entry.file);
@@ -403,6 +483,7 @@ async function retargetBundle(dir: string): Promise<string | null> {
     bundleOkfVersion = null;
     setCatalog(result.articles);
     logText = result.log ?? "";
+    setFreshness(null);
     catalogLoaded = true;
     bodyCache.clear();
     readErrors.clear();
@@ -411,6 +492,8 @@ async function retargetBundle(dir: string): Promise<string | null> {
     currentFile = null;
     citationView = null;
     graphFocusId = null;
+    renderAll();
+    void loadFreshness(bundleDir).then(renderAll);
     return null;
   } catch (error) {
     return errorMessage(error);
@@ -548,6 +631,15 @@ function buildMetaStrip(entry: CatalogEntry | undefined): HTMLElement {
       strip.appendChild(link);
     }
   }
+  if (entry) {
+    const articleFreshness = freshnessByFile.get(entry.file);
+    const status = articleFreshness?.status ?? "unknown";
+    const freshness = document.createElement("span");
+    freshness.className = `okf-freshness-badge ${status}`;
+    freshness.textContent = freshnessLabel(status);
+    freshness.title = freshnessTitle(articleFreshness);
+    strip.appendChild(freshness);
+  }
   return strip;
 }
 
@@ -682,7 +774,9 @@ function renderReaderBody(container: HTMLElement): void {
     return;
   }
   container.replaceChildren();
-  container.appendChild(buildMetaStrip(catalog.find((e) => e.file === currentFile)));
+  container.appendChild(
+    buildMetaStrip(catalog.find((e) => e.file === currentFile)),
+  );
   container.appendChild(buildImportAction(currentFile));
   const bodyEl = document.createElement("div");
   bodyEl.className = "okf-article-body zam-card";
@@ -694,7 +788,10 @@ function renderReaderBody(container: HTMLElement): void {
   container.appendChild(bodyEl);
 }
 
-function renderCitationFullView(container: HTMLElement, view: CitationView): void {
+function renderCitationFullView(
+  container: HTMLElement,
+  view: CitationView,
+): void {
   container.replaceChildren();
   const back = document.createElement("button");
   back.type = "button";
@@ -901,7 +998,9 @@ function buildCitationBox(
   });
   const contentBodyEl = document.createElement("div");
   contentBodyEl.className = "okf-article-body";
-  contentBodyEl.innerHTML = renderMarkdown(stripFrontmatter(state.content ?? ""));
+  contentBodyEl.innerHTML = renderMarkdown(
+    stripFrontmatter(state.content ?? ""),
+  );
   attachContentClickDelegation(contentBodyEl);
   decorateCitationLinks(contentBodyEl, new Set([...ancestors, target]));
   box.append(badge, pathEl, openBtn, contentBodyEl);
@@ -930,7 +1029,9 @@ async function ensureAllBodiesLoaded(): Promise<void> {
 }
 
 function buildFullGraph(): { nodes: GraphNode[]; edges: GraphEdge[] } {
-  const byFile = new Map(catalog.map((e): [string, CatalogEntry] => [e.file, e]));
+  const byFile = new Map(
+    catalog.map((e): [string, CatalogEntry] => [e.file, e]),
+  );
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
   const seen = new Set<string>();
@@ -1490,13 +1591,25 @@ app.ontoolresult = (params) => {
   const previousBundleDir = bundleDir;
   currentUser = structured.user ?? null;
   if (structured.bundleDir !== undefined) bundleDir = structured.bundleDir;
-  if (structured.okfVersion !== undefined) bundleOkfVersion = structured.okfVersion;
+  if (structured.okfVersion !== undefined)
+    bundleOkfVersion = structured.okfVersion;
   if (structured.catalog) {
     setCatalog(structured.catalog);
     catalogLoaded = true;
   }
   if (structured.log !== undefined) logText = structured.log;
-  if (started && (previousUser !== currentUser || previousBundleDir !== bundleDir)) {
+  if (structured.freshness !== undefined) {
+    setFreshness(structured.freshness);
+  } else if (
+    structured.bundleDir !== undefined &&
+    previousBundleDir !== bundleDir
+  ) {
+    setFreshness(null);
+  }
+  if (
+    started &&
+    (previousUser !== currentUser || previousBundleDir !== bundleDir)
+  ) {
     started = false;
     bodyCache.clear();
     readErrors.clear();
@@ -1509,7 +1622,8 @@ app.ontoolresult = (params) => {
   clearConnectionNotice();
 
   const contextState =
-    structured.companionContext ?? fallbackContextBarState(SURFACE, currentUser);
+    structured.companionContext ??
+    fallbackContextBarState(SURFACE, currentUser);
   contextBar = ensureContextBar(
     contextBar,
     contextBarRoot,
@@ -1550,7 +1664,10 @@ contextBar = ensureContextBar(
 const NO_HOST_NOTICE =
   "Kein MCP-Apps-Host — diese Karte braucht einen Host mit ui/initialize " +
   "(z. B. basic-host oder Copilot-Panel).";
-const noHostTimer = setTimeout(() => showConnectionNotice(NO_HOST_NOTICE), 4000);
+const noHostTimer = setTimeout(
+  () => showConnectionNotice(NO_HOST_NOTICE),
+  4000,
+);
 
 app
   .connect()

--- a/desktop/src/panel/recall.ts
+++ b/desktop/src/panel/recall.ts
@@ -39,6 +39,7 @@ import {
   fallbackContextBarState,
   showConnectionNotice as showConnectionNoticeShared,
 } from "./context-bar.js";
+import { preferredRecallDisplayMode } from "./display-mode.js";
 import {
   buildRecallEvaluationPrompt,
   buildRecallFollowUpPrompt,
@@ -953,6 +954,12 @@ app
   .then(() => {
     clearTimeout(noHostTimer);
     connected = true;
+    const preferredMode = preferredRecallDisplayMode(app.getHostContext());
+    if (preferredMode) {
+      // Placement remains host-owned. This is a capability-gated request,
+      // and rejection must never prevent a review session from opening.
+      void app.requestDisplayMode({ mode: preferredMode }).catch(() => {});
+    }
     if (navigator.language.startsWith("de")) {
       setCurrentLocale("de");
     }

--- a/docs/adr/2026-07-11-codex-and-vscode-companion-surfaces.md
+++ b/docs/adr/2026-07-11-codex-and-vscode-companion-surfaces.md
@@ -5,7 +5,9 @@
 **Deciders:** Thomas (project owner)
 **Related:**
 [2026-07-06a-mcp-agent-transport-and-surfaces.md](2026-07-06a-mcp-agent-transport-and-surfaces.md) ·
-[2026-06-30-learning-content-studio.md](2026-06-30-learning-content-studio.md)
+[2026-06-30-learning-content-studio.md](2026-06-30-learning-content-studio.md) ·
+[2026-07-17b-okf-visualizer-panel.md](2026-07-17b-okf-visualizer-panel.md) ·
+[2026-07-18b-graph-repo-scope.md](2026-07-18b-graph-repo-scope.md)
 
 ---
 
@@ -46,6 +48,29 @@ bus for answers. Recall answers, reveal, and ratings remain inside the Recall
 card. Short or complex follow-up questions remain in the user's chosen agent
 chat. One-off requests such as “visualize this” may still render an inline MCP
 App when the host supports it.
+
+### 0.23 portable-host clarification
+
+MCP Apps hosts do not share VS Code's navigation icons or panel topology, so
+the server exposes intent rather than assuming a particular mount:
+
+- `zam_show_graph` is explicitly the **learning-token graph**. Requests for a
+  knowledge graph, learning graph, or *Wissensgraph* route here.
+- `zam_okf_visualize` is the **repo-knowledge surface**. Requests for knowledge
+  articles, *Wissensartikel*, OKFs, or ADRs route here with the new
+  `view: "graph"` opening argument. `reader` and `log` remain addressable
+  initial views, and the argument passes through the VS Code intent and
+  Copilot canvas adapters.
+- Server-wide MCP instructions and the shipped ZAM skill repeat that mapping
+  so hosts can choose the correct tool even when they offer only one inline
+  app at a time.
+- Evaluator/model controls are hidden on both read-only graph surfaces because
+  no model participates in rendering stored tokens, articles, or citations.
+  The learner control remains meaningful on the learning graph.
+- Recall asks for the standard MCP Apps `pip` display mode only when the host
+  advertises it. The host owns the actual placement; ZAM cannot force a
+  Codex-, Claude-, or ChatGPT-specific right sidebar. Hosts that advertise
+  only inline mode keep their native rendering.
 
 There is one ZAM Companion extension, not separate Codex, Copilot, or Claude
 variants. Users normally run one agent harness at a time. Concurrent ownership

--- a/docs/adr/2026-07-29b-okf-freshness-radar.md
+++ b/docs/adr/2026-07-29b-okf-freshness-radar.md
@@ -1,0 +1,84 @@
+# OKF Freshness Radar
+
+**Status:** Implemented
+**Date:** 2026-07-29
+**Deciders:** Thomas (project owner), implemented with Codex
+**Related:**
+[2026-07-17-okf-knowledge-base.md](2026-07-17-okf-knowledge-base.md) (living repo knowledge) ·
+[2026-07-17b-okf-visualizer-panel.md](2026-07-17b-okf-visualizer-panel.md) (OKF panel) ·
+[2026-07-18-okf-learning-import.md](2026-07-18-okf-learning-import.md) (articles as learning sources)
+
+---
+
+## Context
+
+An engineering team's OKF articles describe behavior that continues to change
+in code. The existing `timestamp` says when an article was authored, but gives
+no actionable signal when a cited implementation changes later. Finding that
+drift by memory does not scale, while automatically rewriting the article would
+mistake textual recency for reviewed knowledge.
+
+The articles already declare their implementation anchors in a structured
+enough place: repo-relative paths enclosed in backticks on `- Code:` rows under
+`# Citations`. Git records both the article revision and the cited code
+revision. Together they can provide a useful review hint without adding an LLM,
+a watcher, or learning-state coupling.
+
+## Decision
+
+1. **ZAM exposes a read-only `zam_okf_audit` MCP tool.** It audits every
+   article in a bundle and reports `current`, `review-recommended`, or
+   `unknown`, plus per-code-reference evidence and aggregate counts.
+2. **Only explicit, safe code citations are audit targets.** The audit reads
+   backtick paths from `- Code:` rows under `# Citations` and keeps paths
+   contained by the repository root (including realpath containment for
+   existing targets). A missing path-shaped citation recommends review;
+   descriptive identifiers without path syntax are ignored.
+3. **Git ancestry is the primary baseline.** The article's latest commit is
+   compared with each cited path's latest commit:
+   - cited code at the same commit or at an ancestor of the article commit is
+     `current`;
+   - cited code at a descendant of the article commit is
+     `review-recommended`;
+   - unrelated or unavailable history is `unknown`.
+   An untracked article may fall back to its valid frontmatter `timestamp`.
+   An uncommitted change under a cited path recommends review immediately.
+4. **The signal never mutates knowledge or learning state.** The audit does not
+   update an article, invalidate imported tokens, create or suspend cards, or
+   touch FSRS scheduling. A human or agent reviews the changed behavior and
+   uses `zam_okf_upsert` deliberately.
+5. **The visualizer presents the signal quietly.** A small amber sidebar dot
+   marks only articles that merit review. The reader meta strip labels all
+   three states and names the changed paths in the review tooltip. Missing Git
+   or incomplete citations degrade to a neutral `unknown` badge and never
+   prevent the panel from opening.
+6. **This remains CLI-layer repository tooling.** No kernel API, database
+   migration, background watcher, network call, or dependency is added.
+
+## Options considered
+
+- **Compare code commit time only with the frontmatter timestamp** — rejected
+  as the primary rule: an article and its code commonly land in the same PR,
+  whose commit timestamp is later than the authored timestamp. Git ancestry
+  represents the reviewed ordering more accurately; the timestamp remains a
+  fallback for untracked articles.
+- **Use filesystem modification times** — rejected: checkouts, rebases, and
+  generated files make them unstable and machine-specific.
+- **Automatically mark imported cards stale or reset their schedules** —
+  rejected: code movement does not prove a memorized concept changed, and
+  scheduling state belongs to each learner.
+- **Ask an LLM whether the prose still matches the diff** — deferred: it adds
+  cost, non-determinism, and a model dependency where a conservative local
+  signal already removes the main discovery burden.
+
+## Consequences
+
+- Teams get an immediate, explainable list of articles worth reviewing during
+  normal development work.
+- A `current` result means no cited path is newer in the inspected Git history;
+  it is not a proof that citations are complete or prose is semantically
+  correct.
+- Articles without code citations and bundles outside a usable Git checkout
+  remain visible with `unknown` freshness.
+- Accurate results depend on maintainers keeping each article's `- Code:`
+  citations representative of the behavior it explains.

--- a/docs/adr/2026-07-29b-okf-freshness-radar.md
+++ b/docs/adr/2026-07-29b-okf-freshness-radar.md
@@ -51,7 +51,9 @@ a watcher, or learning-state coupling.
    marks only articles that merit review. The reader meta strip labels all
    three states and names the changed paths in the review tooltip. Missing Git
    or incomplete citations degrade to a neutral `unknown` badge and never
-   prevent the panel from opening.
+   prevent the panel from opening. The opening tool returns the catalog and log
+   first; the panel requests the Git-backed audit asynchronously so repository
+   history inspection cannot delay first paint or trip a slow host timeout.
 6. **This remains CLI-layer repository tooling.** No kernel API, database
    migration, background watcher, network call, or dependency is added.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,3 +62,4 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-07-26b](2026-07-26b-central-curriculum-content-service.md) | Central Curriculum Content Service: Content Only, Pulled Forward | Accepted |
 | [2026-07-27](2026-07-27-macos-notarization.md) | macOS Distribution: Developer ID Notarization, Not the Mac App Store | Accepted — verified on a local notarized build |
 | [2026-07-29](2026-07-29-native-host-answering-route.md) | Name and Show the Surrounding Host as an Answering Route | Proposed |
+| [2026-07-29b](2026-07-29b-okf-freshness-radar.md) | OKF Freshness Radar | Implemented |

--- a/docs/okf/bridge-protocol.md
+++ b/docs/okf/bridge-protocol.md
@@ -7,7 +7,7 @@ tags:
   - bridge
   - agents
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/bridge-protocol.md"
-timestamp: 2026-07-22T04:45:00Z
+timestamp: 2026-07-29T21:07:20Z
 ---
 
 `zam bridge <command>` is ZAM's machine-facing CLI transport: an agent
@@ -34,11 +34,13 @@ The hard contract:
 Representative commands: `next` (pull the next queue card), `submit`
 (apply a rating), `add-token` (register a token *and* create the calling
 user's card — see [token-card-model.md](token-card-model.md)),
-`personal-card-update` (partial update by slug), and the destructive pair
-`personal-card-remove` / `personal-card-delete`, each a preview→confirm
-handshake: without `--confirm` they return an impact preview (affected
-cards, review logs, session steps, agent skills); with `--confirm` they
-execute.
+`personal-card-update` (partial update by slug), and
+`personal-card-publish-revision` (publish with an explicit `cosmetic` or
+`material` classification). The destructive pair `personal-card-remove` /
+`personal-card-delete` uses a preview→confirm handshake: without
+`--confirm` it returns an impact preview (affected cards, review logs,
+session steps, agent skills); with `--confirm` it executes. Assignment
+create, withdraw, and list commands use the same JSON-only surface.
 
 The Android companion accepts one `AddTokenRequest`-shaped bridge-token
 object from a selected JSON file or an Android share intent. It also accepts
@@ -49,8 +51,16 @@ prerequisite edges, and existing knowledge-context assignments. Plain shared
 or pasted text and URLs use the same confirmation path as quick-capture
 drafts.
 
+A photo or screenshot from the camera or gallery is downscaled on-device
+and sent through the native Android command to the library's configured
+HTTPS cloud-vision endpoint. The vision model returns one or more
+bridge-token-shaped drafts; each stays editable and requires confirmation
+before the same atomic import runs. The token records `vision:<model>`
+provenance. Image import is online-only and unavailable when cloud vision
+is not configured.
+
 # Citations
 
 - [ADR 2026-07-06a — MCP as the Canonical Agent Transport](../adr/2026-07-06a-mcp-agent-transport-and-surfaces.md)
 - [Android companion plan](../plans/2026-07-21-android-companion-app.md)
-- Code: `src/cli/app.ts`, `src/cli/commands/bridge.ts`, `src/bridge/protocol.ts`, `mobile/src/import.ts`
+- Code: `src/cli/app.ts`, `src/cli/commands/bridge.ts`, `src/bridge/protocol.ts`, `mobile/src/import.ts`, `mobile/src/main.ts`, `mobile/src/vl-import.ts`, `mobile/src/vision-config.ts`, `mobile/src-tauri/src/vision.rs`

--- a/docs/okf/fsrs-scheduling.md
+++ b/docs/okf/fsrs-scheduling.md
@@ -7,7 +7,7 @@ tags:
   - fsrs
   - scheduling
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/fsrs-scheduling.md"
-timestamp: 2026-07-22T05:35:00Z
+timestamp: 2026-07-29T21:08:14Z
 ---
 
 ZAM's spaced repetition uses **FSRS-5** (Free Spaced Repetition Scheduler,
@@ -33,11 +33,24 @@ row references that session and a matching user `session_steps` row is written
 with the rating. A failure in any of those writes rolls back the card update,
 review log, blocking changes, and session step together.
 
+Published learning content has a substance version. A curator classifies
+each revision as `cosmetic` or `material`: cosmetic publication leaves
+scheduling untouched; material publication increments the token's
+`content_version` and makes cards learned against an older version due
+now. Stability, difficulty, repetitions, and lapses are deliberately kept
+so the next real answer re-tests the change instead of resetting history.
+After that answer, `evaluateRating()` synchronizes the card's
+`learned_content_version`; queue items expose the change and publisher
+provenance so the recall surface can explain why the card returned.
+
 # Review queue
 
-`src/kernel/scheduler/queue.ts` builds each session's queue from due cards
-plus new cards: it interleaves cards by domain (so one topic doesn't
-monopolize a session) and inserts new cards at every 5th position.
+`src/kernel/scheduler/queue.ts` builds each session's queue from eligible
+due cards plus new cards. It excludes blocked or learner-detached cards and
+tokens that are deprecated, in maintenance, or not in the `published`
+editorial state; an active knowledge context can narrow the set further.
+The remaining cards are interleaved by domain (so one topic doesn't
+monopolize a session), with a new card inserted at every 5th position.
 
 # Android voice review
 
@@ -73,7 +86,8 @@ await executeReviewAction(db, {
 # Citations
 
 - [ADR 2026-05-30a — Standalone Learning Session](../adr/2026-05-30a-standalone-learning-session.md)
+- [ADR 2026-07-04 — Multi-Learner Shared Knowledge](../adr/2026-07-04-multi-learner-shared-knowledge.md)
 - [ADR 2026-07-21 — Android Companion Tauri Shell](../adr/2026-07-21-android-companion-tauri-shell.md)
-- Tests as source of truth for scheduling semantics: `tests/kernel/fsrs.test.ts`
-- Code: `src/kernel/scheduler/fsrs.ts`, `src/kernel/scheduler/queue.ts`, `src/kernel/recall/evaluator.ts`, `src/kernel/recall/actions.ts`, `mobile/src/voice.ts`, `mobile/src/review-session.ts`, `mobile/src-tauri/gen/android/app/src/main/java/org/zamos/zam/VoicePlugin.kt`
+- Tests as source of truth for scheduling semantics: `tests/kernel/fsrs.test.ts`, `tests/kernel/library-revision.test.ts`, `tests/kernel/card-detach.test.ts`
+- Code: `src/kernel/scheduler/fsrs.ts`, `src/kernel/scheduler/queue.ts`, `src/kernel/recall/evaluator.ts`, `src/kernel/recall/actions.ts`, `src/kernel/library/revision.ts`, `src/kernel/models/card.ts`, `mobile/src/voice.ts`, `mobile/src/review-session.ts`, `mobile/src-tauri/gen/android/app/src/main/java/org/zamos/zam/VoicePlugin.kt`
 - Algorithm reference: <https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm>

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -22,7 +22,7 @@ Current truth only — the *why* behind it lives in [../adr/](../adr/)
 ## data-model
 
 - [Prerequisite Graph and Blocking](prerequisite-blocking.md) — Tokens form a directed prerequisite graph; blocking and unblocking of dependent cards is separate from FSRS math and coordinated atomically by the review-action kernel API.
-- [Token and Card Model](token-card-model.md) — A token is a shared atomic knowledge concept; a card is one user's FSRS state for it — a concept only appears in a user's queue if a card exists.
+- [Token and Card Model](token-card-model.md) — A token is a shared atomic knowledge concept; a card is one user's FSRS and participation state for it — scheduling requires both a card and eligible published content.
 
 ## protocol
 

--- a/docs/okf/kernel-architecture.md
+++ b/docs/okf/kernel-architecture.md
@@ -7,7 +7,7 @@ tags:
   - cli
   - boundaries
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/kernel-architecture.md"
-timestamp: 2026-07-17T00:00:00Z
+timestamp: 2026-07-29T21:04:29Z
 ---
 
 ZAM has exactly two code layers with a hard boundary between them.
@@ -32,17 +32,23 @@ CLI commands; new HTTP goes in the CLI layer, never in the kernel.
 
 # Persistence
 
-The database is SQLite at `~/.zam/zam.db` (WAL mode, foreign keys on). All
-access goes through the async `Database` contract in
+Without cloud credentials the default is local SQLite at `~/.zam/zam.db`
+(WAL mode, foreign keys on). `openDatabase` can instead select Turso through
+the native libSQL driver (a remote URL or an embedded replica) or ZAM's
+binding-free HTTP provider. An explicit PostgreSQL provider implements the
+same contract for server deployments.
+
+All access goes through the async `Database` contract in
 `src/kernel/db/types.ts`; concrete drivers are imported only inside
 `src/kernel/db/`. IDs are ULIDs throughout. Schema changes require both
 `src/kernel/db/schema.ts` and an idempotent numbered migration.
-Machine-local state (config, selections) lives in `~/.zam/config.json`,
-never in the shareable database.
+Machine-local state (config, selections and credentials) stays under
+`~/.zam/`, never in the shareable database.
 
 # Citations
 
 - [ADR 2026-03-23 — Kernel and Shell Observation](../adr/2026-03-23-kernel-and-shell-observation.md)
 - [ADR 2026-06-09 — Async Database Providers](../adr/2026-06-09-async-database-providers.md)
 - [ADR 2026-07-07 — Resilient Self-Update and Dependency-Failure Isolation](../adr/2026-07-07-resilient-self-update-and-dependency-isolation.md)
-- Code: `src/kernel/index.ts`, `src/kernel/db/types.ts`, `src/cli/index.ts`
+- [ADR 2026-07-23 — Online-Only Server Database and Mobile Gating](../adr/2026-07-23-online-only-server-db-and-mobile-gating.md)
+- Code: `src/kernel/index.ts`, `src/kernel/db/types.ts`, `src/kernel/db/connection.ts`, `src/kernel/db/postgres.ts`, `src/cli/index.ts`

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,13 @@
 ## 2026-07-29
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [Prerequisite Graph and Blocking](prerequisite-blocking.md)
+- **Update** — [Token and Card Model](token-card-model.md)
+- **Update** — [FSRS-5 Scheduling](fsrs-scheduling.md)
+- **Update** — [Bridge CLI Protocol](bridge-protocol.md)
+- **Update** — [Kernel and CLI Architecture](kernel-architecture.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 
 ## 2026-07-22

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,7 @@
 ## 2026-07-29
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Update** — [Prerequisite Graph and Blocking](prerequisite-blocking.md)
 - **Update** — [Token and Card Model](token-card-model.md)
 - **Update** — [FSRS-5 Scheduling](fsrs-scheduling.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-07-29T19:30:00Z
+timestamp: 2026-07-29T21:12:00Z
 ---
 
 `zam mcp` starts a stdio **Model Context Protocol** server
@@ -23,8 +23,9 @@ installed harnesses.
 The server exposes ZAM's tool surface (session start/end, queue and
 review actions, token search and registration, prerequisite linking,
 companion context and sampling, and the OKF knowledge-base tools
-`zam_okf_catalog` / `zam_okf_read` / `zam_okf_upsert` /
-`zam_okf_read_citation` / `zam_okf_import` / `zam_okf_focused`). The
+`zam_okf_catalog` / `zam_okf_read` / `zam_okf_audit` /
+`zam_okf_upsert` / `zam_okf_read_citation` / `zam_okf_import` /
+`zam_okf_focused`). The
 authoritative tool list with annotations is pinned by
 `tests/cli/mcp.test.ts`.
 
@@ -42,6 +43,18 @@ to — an ADR, for example — read-only and restricted to `.md` files that
 resolve inside the repository root; the target may be outside the
 bundle (that's its purpose) but never outside the repo
 (`resolveCitationPath` / `findRepoRoot` in `src/cli/okf/io.ts`).
+
+`zam_okf_audit` is the read-only freshness radar. For each article it
+reads repo-contained path-shaped values enclosed in backticks on `- Code:`
+rows under `# Citations`, then compares their Git history with the
+article's latest commit. Code at or before that article commit is
+`current`; a later descendant commit or an uncommitted change is
+`review-recommended`; unavailable or unrelated history is `unknown`.
+A valid frontmatter timestamp is only the fallback for an untracked
+article. A missing path-shaped citation recommends review, while a
+descriptive identifier without path syntax is ignored. The audit reports
+evidence and summary counts but never writes an article or changes tokens,
+cards, or FSRS state.
 
 `zam_okf_import` records an agent's finished decomposition of one
 article as learning tokens plus cards for the importing user, in one
@@ -80,6 +93,13 @@ graph (articles as nodes, inter-article links as edges, citations as
 visually distinct nodes), and the `log.md` history. The panel always
 opens — a missing or invalid bundle surfaces as `problems` in the panel
 instead of a tool error.
+
+The visualizer receives the freshness audit with its opening result and
+can refresh it through `zam_okf_audit` when it loads or retargets a
+bundle. Only `review-recommended` articles get an amber sidebar dot;
+the reader meta strip labels all three states and its tooltip names the
+changed code paths. Audit failure degrades to neutral `unknown` and does
+not block reading, importing, the graph, or the log.
 
 # OKF link graph: overview and focused mode
 
@@ -146,4 +166,5 @@ available directly.
 - [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
 - [ADR 2026-07-18b — Learning Graph Scope Selectors and the Repo Scope](../adr/2026-07-18b-graph-repo-scope.md)
 - [ADR 2026-07-18c — OKF Import Handoff](../adr/2026-07-18c-okf-import-handoff.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/host.ts`, `src/vscode-extension/latest-task-queue.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`
+- [ADR 2026-07-29b — OKF Freshness Radar](../adr/2026-07-29b-okf-freshness-radar.md)
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-panel.html`

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-07-29T21:12:00Z
+timestamp: 2026-07-29T21:58:00Z
 ---
 
 `zam mcp` starts a stdio **Model Context Protocol** server
@@ -25,9 +25,16 @@ review actions, token search and registration, prerequisite linking,
 companion context and sampling, and the OKF knowledge-base tools
 `zam_okf_catalog` / `zam_okf_read` / `zam_okf_audit` /
 `zam_okf_upsert` / `zam_okf_read_citation` / `zam_okf_import` /
-`zam_okf_focused`). The
-authoritative tool list with annotations is pinned by
+`zam_okf_focused`). The authoritative tool list with annotations is pinned by
 `tests/cli/mcp.test.ts`.
+
+The server publishes MCP-wide intent guidance as well as per-tool
+descriptions. “Knowledge graph”, “learning graph”, and “Wissensgraph”
+mean the learning-token surface (`zam_show_graph`). “Knowledge articles”,
+“Wissensartikel”, “OKFs”, and “ADRs” mean the repo-knowledge surface
+(`zam_okf_visualize` with `view: "graph"`). This distinction is also in
+the shipped ZAM skill so hosts with only one inline app choose the right
+tool.
 
 The `zam_okf_*` tools resolve their default bundle directory as
 `docs/okf` under the MCP client's workspace root (MCP `roots/list`),
@@ -85,18 +92,27 @@ flight may finish, then the latest requested panel mounts last and owns
 the final iframe. This makes rapid toolbar or command switches
 deterministic.
 
+Native hosts own MCP App placement. Recall requests the standard `pip`
+display mode only when the negotiated host context advertises it; an
+inline-only host remains inline, and ZAM cannot force a host-specific
+right sidebar. The shared context bar hides the evaluator/model control
+on the two read-only graph surfaces because no model participates in
+rendering stored learning tokens, OKF articles, or citations.
+
 `zam_okf_visualize` opens the OKF panel on any OKF bundle (default
-resolved like the other `zam_okf_*` tools — see above): articles
-grouped by type with search, a markdown reader that expands cited ADRs
-and other citation targets inline via `zam_okf_read_citation`, a link
-graph (articles as nodes, inter-article links as edges, citations as
-visually distinct nodes), and the `log.md` history. The panel always
+resolved like the other `zam_okf_*` tools — see above). Its optional
+`view` argument initializes `reader`, `graph`, or `log`; `graph` shows
+the requested OKF articles and cited ADRs immediately. The argument is
+forwarded through the VS Code UI intent and Copilot canvas adapters.
+The panel groups articles by type with search, expands cited ADRs and
+other citation targets inline via `zam_okf_read_citation`, and always
 opens — a missing or invalid bundle surfaces as `problems` in the panel
 instead of a tool error.
 
-The visualizer receives the freshness audit with its opening result and
-can refresh it through `zam_okf_audit` when it loads or retargets a
-bundle. Only `review-recommended` articles get an amber sidebar dot;
+The visualizer paints its catalog and log first, then requests freshness
+asynchronously through `zam_okf_audit`; retargeting a bundle does the
+same. Git inspection therefore cannot delay opening on a large or slow
+checkout. Only `review-recommended` articles get an amber sidebar dot;
 the reader meta strip labels all three states and its tooltip names the
 changed code paths. Audit failure degrades to neutral `unknown` and does
 not block reading, importing, the graph, or the log.
@@ -146,8 +162,10 @@ to `~/.zam/okf-focus.json`), so a request like "import this okf" or
 `zam_okf_focused` tool. The agent does the thinking either way, then
 records via `zam_okf_import`.
 
-The knowledge-graph card (`zam_show_graph`, `ui://zam/graph`) centers
-on a focus token's direct prerequisites and dependents. Opened without
+The explicitly named learning-token graph (`zam_show_graph`,
+`ui://zam/graph`, displayed as **ZAM Learning Graph**) centers on a focus
+token's direct prerequisites and dependents. It never renders OKF article
+or ADR nodes; those belong to `zam_okf_visualize`'s graph view. Opened without
 a focus it does not dead-end: it shows scope selectors (desktop-app
 style — scope pills, domains with `/`-prefix groups, and a clickable
 token list) and defaults to the tokens anchored in the workspace's OKF
@@ -160,6 +178,7 @@ available directly.
 # Citations
 
 - [ADR 2026-07-06a — MCP as the Canonical Agent Transport](../adr/2026-07-06a-mcp-agent-transport-and-surfaces.md)
+- [ADR 2026-07-11 — Codex and VS Code Companion Surfaces](../adr/2026-07-11-codex-and-vscode-companion-surfaces.md)
 - [ADR 2026-07-16 — Companion Context Bar and Harness Affinity](../adr/2026-07-16-companion-context-and-harness-affinity.md)
 - [ADR 2026-07-17 — OKF Knowledge Base](../adr/2026-07-17-okf-knowledge-base.md)
 - [ADR 2026-07-17b — OKF Visualizer Panel](../adr/2026-07-17b-okf-visualizer-panel.md)
@@ -167,4 +186,4 @@ available directly.
 - [ADR 2026-07-18b — Learning Graph Scope Selectors and the Repo Scope](../adr/2026-07-18b-graph-repo-scope.md)
 - [ADR 2026-07-18c — OKF Import Handoff](../adr/2026-07-18c-okf-import-handoff.md)
 - [ADR 2026-07-29b — OKF Freshness Radar](../adr/2026-07-29b-okf-freshness-radar.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-panel.html`
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/context-bar.ts`, `desktop/src/panel/display-mode.ts`, `desktop/src/panel/recall.ts`, `desktop/src/panel/graph.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-panel.html`

--- a/docs/okf/prerequisite-blocking.md
+++ b/docs/okf/prerequisite-blocking.md
@@ -7,7 +7,7 @@ tags:
   - scheduling
   - prerequisites
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/prerequisite-blocking.md"
-timestamp: 2026-07-22T04:24:00Z
+timestamp: 2026-07-29T21:09:01Z
 ---
 
 Tokens are connected by a **directed prerequisite graph** (table

--- a/docs/okf/token-card-model.md
+++ b/docs/okf/token-card-model.md
@@ -1,14 +1,14 @@
 ---
 type: data-model
 title: Token and Card Model
-description: A token is a shared atomic knowledge concept; a card is one user's FSRS state for it — a concept only appears in a user's queue if a card exists.
+description: A token is a shared atomic knowledge concept; a card is one user's FSRS and participation state for it — scheduling requires both a card and eligible published content.
 tags:
   - kernel
   - data-model
   - tokens
   - cards
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/token-card-model.md"
-timestamp: 2026-07-22T04:45:00Z
+timestamp: 2026-07-29T21:08:52Z
 ---
 
 The central distinction in ZAM's domain model:
@@ -40,34 +40,48 @@ deleted — with its learning state preserved, but its cards leave the
 review queue and due list until the binding is repaired and maintenance
 cleared.
 
-A **card** is one user's FSRS scheduling state for a token: stability,
-difficulty, due date, state, and block status (see
-[fsrs-scheduling.md](fsrs-scheduling.md) and
+Curated tokens also carry an **editorial state**: `draft`, `in_review`,
+`published`, or `deprecated`. Only `published` content enters review
+queues. Publishing records `published_by` / `published_at`; a material
+revision increments `content_version`, while a cosmetic revision keeps
+the version. The version lets ZAM identify cards whose learner last
+answered older substance.
+
+A **card** is one user's FSRS and participation state for a token:
+stability, difficulty, due date, state, block status, the
+`learned_content_version`, optional assignment provenance, and optional
+`detached_at` (see [fsrs-scheduling.md](fsrs-scheduling.md) and
 [prerequisite-blocking.md](prerequisite-blocking.md)).
 
-The practical consequence: **a concept only appears in a user's review
-queue if a card exists for that user.** `zam token register` creates only
-the shared token; `zam bridge add-token` creates the token *and* the
+The practical consequence: **a concept needs a card for that user and must
+remain eligible to enter the review queue.** `zam token register` creates
+only the shared token; `zam bridge add-token` creates the token *and* the
 calling user's card. The Android additive-import and quick-capture flow
 preserves the same invariant: after explicit confirmation it atomically
 creates the token and the paired learner's card, together with requested
-prerequisite and knowledge-context links. Removing a card
-(`personal-card-remove`) clears that user's learning state and history but
-leaves the shared token untouched; deleting a token
+prerequisite and knowledge-context links.
+
+A learner can detach a card as "not for me": the card and review history
+remain, scheduling stops, and reattaching resumes the preserved state.
+An active assignment prevents detaching or deleting until it is withdrawn.
+Removing a card (`personal-card-remove`) clears that user's learning state
+and history but leaves the shared token untouched; deleting a token
 (`personal-card-delete`) removes the concept for everyone.
 
 Supporting tables: `prerequisites` (directed dependency edges between
-tokens), `review_logs` (immutable audit trail of review events),
-`session`/`session_step` (work+learning episodes with per-step ratings),
-and `token_embeddings` (semantic-search vectors, produced by the CLI
-layer, stored by the kernel).
+tokens), `assignments` (curator-to-learner bindings), `review_logs`
+(immutable audit trail of review events), `session`/`session_step`
+(work+learning episodes with per-step ratings), and `token_embeddings`
+(semantic-search vectors, produced by the CLI layer, stored by the kernel).
 
 # Citations
 
 - [ADR 2026-03-26 — Personal Workflow Foundations](../adr/2026-03-26-personal-workflow-foundations.md)
 - [ADR 2026-07-04 — Knowledge Contexts](../adr/2026-07-04-knowledge-contexts.md)
+- [ADR 2026-07-04 — Multi-Learner Shared Knowledge](../adr/2026-07-04-multi-learner-shared-knowledge.md)
+- [ADR 2026-07-25 — Shared Curated Learning Content](../adr/2026-07-25-shared-curated-learning-content.md)
 - [ADR 2026-07-03 — RAG Semantic Token Search](../adr/2026-07-03-rag-semantic-token-search.md)
 - [ADR 2026-07-18 — Knowledge-to-Learning Import](../adr/2026-07-18-okf-learning-import.md)
 - [ADR 2026-07-18b — Learning Graph Scope Selectors and the Repo Scope](../adr/2026-07-18b-graph-repo-scope.md)
 - [Android companion plan](../plans/2026-07-21-android-companion-app.md)
-- Code: `src/kernel/models/token.ts`, `src/kernel/recall/prompter.ts`, `mobile/src/import.ts`
+- Code: `src/kernel/models/token.ts`, `src/kernel/models/card.ts`, `src/kernel/models/assignment.ts`, `src/kernel/library/revision.ts`, `src/kernel/scheduler/queue.ts`, `src/kernel/recall/prompter.ts`, `src/kernel/db/schema.ts`, `mobile/src/import.ts`

--- a/docs/release-notes-0.23.0.md
+++ b/docs/release-notes-0.23.0.md
@@ -11,7 +11,23 @@ cited code is visible immediately.
 The OKF visualizer shows the same signal without turning the article list into
 a dashboard: only a review recommendation gets a small amber dot in the
 sidebar, while the open article carries a labeled status and an explanatory
-tooltip.
+tooltip. Git inspection now follows the first paint asynchronously, so opening
+the app stays responsive even on slower Windows hosts and larger repositories.
+
+## Clear knowledge surfaces in every agent host
+
+ZAM now distinguishes its two graphs explicitly:
+
+- “knowledge graph”, “learning graph”, or “Wissensgraph” opens the renamed
+  **ZAM Learning Graph** with learning tokens and prerequisite relations;
+- “knowledge articles”, “Wissensartikel”, “OKFs”, or “ADRs” opens the OKF
+  visualizer with `view: "graph"`, showing articles and their cited ADRs.
+
+`zam_okf_visualize` accepts `view: "reader" | "graph" | "log"` and forwards it
+through the VS Code and Copilot companions. Read-only graph surfaces no longer
+show an irrelevant evaluator/model selector. Recall asks for the standard MCP
+Apps picture-in-picture mode when a host advertises it; hosts retain control of
+the actual placement, so inline-only clients continue to work unchanged.
 
 ## For developer teams
 

--- a/docs/release-notes-0.23.0.md
+++ b/docs/release-notes-0.23.0.md
@@ -1,0 +1,45 @@
+# ZAM 0.23.0 — OKF freshness radar
+
+Engineering knowledge now tells you when it deserves another look.
+
+`zam_okf_audit` compares each OKF article with the repo-relative code paths it
+declares under `# Citations`. The result is intentionally conservative:
+`current`, `review-recommended`, or `unknown`, with the changed paths included
+as evidence. Git ancestry is the normal baseline, and an uncommitted change to
+cited code is visible immediately.
+
+The OKF visualizer shows the same signal without turning the article list into
+a dashboard: only a review recommendation gets a small amber dot in the
+sidebar, while the open article carries a labeled status and an explanatory
+tooltip.
+
+## For developer teams
+
+- Run `zam_okf_audit` during normal task or release work to find reference
+  articles whose cited implementation moved after the article was reviewed.
+- Read the article and changed code, then update deliberately through
+  `zam_okf_upsert`. The audit never rewrites prose.
+- A green result means that no *declared* code citation is newer. It does not
+  claim that citations are complete or that prose was semantically proved.
+- Bundles without usable Git history, and articles without code citations,
+  remain available with an honest `unknown` status.
+
+The repository's six existing OKF articles were reviewed while building the
+feature. The bridge, scheduling, architecture, MCP-surface, and token/card
+articles now cover behavior that had landed since their previous review; the
+prerequisite article was confirmed unchanged.
+
+## Unchanged
+
+Freshness is repository guidance, not learning state. It never changes an
+article, token, card, imported source binding, or FSRS schedule. If an article
+review reveals that a memorized concept changed, the existing explicit
+`zam_okf_import` re-import classifications remain the place to decide whether
+learning state is kept or reset.
+
+The visualizer also fixes a narrow-window layout issue found during browser
+verification: the article pane now uses the full width below its mobile
+breakpoint.
+
+The design and its limits are recorded in
+[ADR 2026-07-29b](adr/2026-07-29b-okf-freshness-radar.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.22.8",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.22.8",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.22.8",
+  "version": "0.23.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.22.8",
+          "User-Agent": "ZAM-Content-Studio/0.23.0",
         },
       });
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -42,7 +42,6 @@ import {
   writeCompanionContext,
 } from "../companion-context-server.js";
 import type { CatalogEntry } from "../okf/bundle.js";
-import type { OkfFreshnessAudit } from "../okf/freshness.js";
 import { publishUiIntent } from "../ui-intent.js";
 import { executeBridgeCommandJson } from "./bridge.js";
 
@@ -58,6 +57,14 @@ const RECALL_RESOURCE_URI = "ui://zam/recall";
 const GRAPH_RESOURCE_URI = "ui://zam/graph";
 const SETTINGS_RESOURCE_URI = "ui://zam/settings";
 const OKF_RESOURCE_URI = "ui://zam/okf";
+
+const MCP_SERVER_INSTRUCTIONS =
+  "ZAM has two distinct knowledge surfaces. For “Wissensgraph”, “knowledge " +
+  "graph”, or learning-graph requests, call zam_show_graph: it shows learning " +
+  "tokens and prerequisite relations. For “Wissensartikel”, “OKFs”, knowledge " +
+  'articles, or ADRs, call zam_okf_visualize with view: "graph": it shows OKF ' +
+  'articles and cited ADRs. Use view: "reader" to read articles and ' +
+  "zam_open_recall for review sessions. App placement is controlled by the host.";
 
 /**
  * Commands the ZAM Studio panel may run through `zam_studio_bridge`. A
@@ -212,10 +219,13 @@ async function resolveOpeningCompanionContextSafely(
  * Creates and configures the McpServer instance with all tools mapped.
  */
 export function createMcpServer(db: Database): McpServer {
-  const server = new McpServer({
-    name: "zam",
-    version: pkg.version,
-  });
+  const server = new McpServer(
+    {
+      name: "zam",
+      version: pkg.version,
+    },
+    { instructions: MCP_SERVER_INSTRUCTIONS },
+  );
 
   async function getUserId(paramUser: string | undefined) {
     if (paramUser) return paramUser;
@@ -987,7 +997,7 @@ export function createMcpServer(db: Database): McpServer {
     }),
   );
 
-  // zam_show_graph — the 2D knowledge-graph card (MCP Apps). Read-only from
+  // zam_show_graph — the 2D learning-token graph card (MCP Apps). Read-only from
   // the model's side: it opens a panel that fetches its own data through
   // zam_studio_bridge (get-neighborhood). `focus` seeds the initial node;
   // the model usually supplies it from conversation context (e.g. the token
@@ -996,13 +1006,14 @@ export function createMcpServer(db: Database): McpServer {
     server,
     "zam_show_graph",
     {
-      title: "Open ZAM knowledge graph",
+      title: "Open ZAM learning graph",
       description:
-        "Open the ZAM 2D knowledge-graph card, centered on a token's direct " +
-        "prerequisites and dependents. Pass `focus` (a token slug) when the " +
-        "conversation already names one; without it the card offers scope " +
-        "selectors and defaults to tokens anchored in the current repo's " +
-        "OKF knowledge base.",
+        "Open the ZAM learning-token graph for requests such as “knowledge " +
+        "graph” or “Wissensgraph”, centered on a token's direct prerequisites " +
+        "and dependents. This graph shows learning tokens, not OKF articles or " +
+        'ADRs; use `zam_okf_visualize` with `view: "graph"` for those. Pass ' +
+        "`focus` when the conversation names a token; without it the card " +
+        "offers scope selectors.",
       inputSchema: {
         focus: z
           .string()
@@ -1073,7 +1084,7 @@ export function createMcpServer(db: Database): McpServer {
         {
           uri: GRAPH_RESOURCE_URI,
           mimeType: RESOURCE_MIME_TYPE,
-          text: loadPanelHtml("graph-panel.html", "ZAM Graph"),
+          text: loadPanelHtml("graph-panel.html", "ZAM Learning Graph"),
         },
       ],
     }),
@@ -1311,6 +1322,12 @@ export function createMcpServer(db: Database): McpServer {
     .optional()
     .describe(
       "Bundle directory (default: docs/okf under the client's workspace root, falling back to the server cwd)",
+    );
+  const okfViewSchema = z
+    .enum(["reader", "graph", "log"])
+    .optional()
+    .describe(
+      "Initial panel view: graph shows OKF articles and cited ADRs; reader opens articles; log shows bundle history (default: reader)",
     );
 
   /**
@@ -1669,22 +1686,26 @@ export function createMcpServer(db: Database): McpServer {
   // 2026-07-17b). Mirrors zam_show_graph's open-tool pattern, but the
   // catalog and log.md are loaded eagerly (unlike graph's data, which the
   // panel always pulls itself via zam_studio_bridge) so the panel paints its
-  // sidebar and log view without a first round-trip; article bodies, the
-  // link graph, and citation reads stay on-demand through the existing
-  // zam_okf_* tools. A missing or invalid bundle is not an error: the result
-  // carries an empty catalog plus `problems` and still opens the panel.
+  // sidebar and log view without a first round-trip. The Git-backed freshness
+  // audit is deliberately loaded by the panel after first paint so a large
+  // repository cannot delay opening. Article bodies, the link graph, citation
+  // reads, and freshness stay on-demand through the existing zam_okf_* tools.
+  // A missing or invalid bundle is not an error: the result carries an empty
+  // catalog plus `problems` and still opens the panel.
   registerAppTool(
     server,
     "zam_okf_visualize",
     {
       title: "Open ZAM OKF visualizer",
       description:
-        "Open the ZAM OKF knowledge-base visualizer: articles by type with " +
-        "search, a markdown reader with inline-expandable cited ADRs, a " +
-        "link graph, and the log. Pass `bundle_dir` to browse a bundle " +
-        "other than the default (docs/okf under the server cwd).",
+        "Open ZAM's knowledge articles (OKFs and their cited ADRs). Set " +
+        '`view: "graph"` for requests such as “show my knowledge articles”, ' +
+        '“OKFs”, or “ADRs”; use `view: "reader"` to read articles and ' +
+        '`view: "log"` for bundle history. Pass `bundle_dir` to browse a ' +
+        "bundle other than the workspace default.",
       inputSchema: {
         bundle_dir: okfBundleDirSchema,
+        view: okfViewSchema,
       },
       annotations: {
         ...commonAnnotations,
@@ -1694,83 +1715,87 @@ export function createMcpServer(db: Database): McpServer {
         ui: { resourceUri: OKF_RESOURCE_URI },
       },
     },
-    wrapHandler(async ({ bundle_dir }: { bundle_dir?: string }) => {
-      // Mirror zam_open_recall/zam_show_graph/zam_open_settings: never fails
-      // to open the panel — any companion-context resolution failure
-      // degrades to a minimal fallback context instead of rejecting the
-      // call. This tool takes no `user` argument (the bundle is
-      // repo-scoped, not per-learner), so there is no invocation override.
-      const opening = await resolveOpeningCompanionContextSafely(
-        db,
-        "okf",
-        undefined,
-        getNativeClientInfo(),
-        { clientSamplingCapable: getClientSamplingCapable() },
-      );
-      const { loadBundle } = await import("../okf/io.js");
-      const { resolve } = await import("node:path");
-      const requestedDir = await resolveOkfBundleDir(bundle_dir);
-      let resolvedBundleDir = resolve(requestedDir);
-      // Publish the RESOLVED absolute dir, not the raw argument: the VS Code
-      // Companion's own zam server runs with a different cwd, so a relative
-      // (or defaulted) dir would resolve to a different bundle over there
-      // (0.13.0 live finding: the Companion opened an empty bundle).
-      await publishUiIntent("okf", { bundle_dir: resolvedBundleDir });
-      let catalog: CatalogEntry[] = [];
-      let problems: string[] = [];
-      let log = "";
-      let okfVersion: string | null = null;
-      let freshness: OkfFreshnessAudit | null = null;
-      let freshnessProblem: string | null = null;
-      try {
-        const bundle = loadBundle(requestedDir);
-        resolvedBundleDir = bundle.dir;
-        catalog = bundle.catalog;
-        problems = bundle.problems;
+    wrapHandler(
+      async ({
+        bundle_dir,
+        view,
+      }: {
+        bundle_dir?: string;
+        view?: "reader" | "graph" | "log";
+      }) => {
+        // Mirror zam_open_recall/zam_show_graph/zam_open_settings: never fails
+        // to open the panel — any companion-context resolution failure
+        // degrades to a minimal fallback context instead of rejecting the
+        // call. This tool takes no `user` argument (the bundle is
+        // repo-scoped, not per-learner), so there is no invocation override.
+        const opening = await resolveOpeningCompanionContextSafely(
+          db,
+          "okf",
+          undefined,
+          getNativeClientInfo(),
+          { clientSamplingCapable: getClientSamplingCapable() },
+        );
+        const { loadBundle } = await import("../okf/io.js");
+        const { resolve } = await import("node:path");
+        const requestedDir = await resolveOkfBundleDir(bundle_dir);
+        let resolvedBundleDir = resolve(requestedDir);
+        // Publish the RESOLVED absolute dir, not the raw argument: the VS Code
+        // Companion's own zam server runs with a different cwd, so a relative
+        // (or defaulted) dir would resolve to a different bundle over there
+        // (0.13.0 live finding: the Companion opened an empty bundle).
+        const initialView = view ?? "reader";
+        await publishUiIntent("okf", {
+          bundle_dir: resolvedBundleDir,
+          view: initialView,
+        });
+        let catalog: CatalogEntry[] = [];
+        let problems: string[] = [];
+        let log = "";
+        let okfVersion: string | null = null;
         try {
-          const { auditOkfFreshness } = await import("../okf/freshness.js");
-          freshness = auditOkfFreshness(bundle.dir);
+          const bundle = loadBundle(requestedDir);
+          resolvedBundleDir = bundle.dir;
+          catalog = bundle.catalog;
+          problems = bundle.problems;
+          const { readFileSync } = await import("node:fs");
+          try {
+            log = readFileSync(join(bundle.dir, "log.md"), "utf8");
+          } catch {
+            log = "";
+          }
+          try {
+            const { parseFrontmatter } = await import("../okf/bundle.js");
+            const indexRaw = readFileSync(join(bundle.dir, "index.md"), "utf8");
+            const { fields } = parseFrontmatter(indexRaw);
+            okfVersion =
+              typeof fields.okf_version === "string"
+                ? fields.okf_version
+                : null;
+          } catch {
+            okfVersion = null;
+          }
         } catch (error) {
-          freshnessProblem =
-            error instanceof Error ? error.message : String(error);
+          // Missing/invalid bundle directory (loadBundle throws only when the
+          // directory itself cannot be read) — report it as `problems`, not a
+          // tool error, so the panel still opens and shows the empty state.
+          problems = [error instanceof Error ? error.message : String(error)];
         }
-        const { readFileSync } = await import("node:fs");
-        try {
-          log = readFileSync(join(bundle.dir, "log.md"), "utf8");
-        } catch {
-          log = "";
-        }
-        try {
-          const { parseFrontmatter } = await import("../okf/bundle.js");
-          const indexRaw = readFileSync(join(bundle.dir, "index.md"), "utf8");
-          const { fields } = parseFrontmatter(indexRaw);
-          okfVersion =
-            typeof fields.okf_version === "string" ? fields.okf_version : null;
-        } catch {
-          okfVersion = null;
-        }
-      } catch (error) {
-        // Missing/invalid bundle directory (loadBundle throws only when the
-        // directory itself cannot be read) — report it as `problems`, not a
-        // tool error, so the panel still opens and shows the empty state.
-        problems = [error instanceof Error ? error.message : String(error)];
-      }
 
-      return {
-        okf: "zam",
-        version: pkg.version,
-        user: opening.context.user.currentId ?? null,
-        bundleDir: resolvedBundleDir,
-        okfVersion,
-        catalog,
-        problems,
-        log,
-        freshness,
-        ...(freshnessProblem ? { freshnessProblem } : {}),
-        companionContext: opening.context,
-        ...(opening.degraded ? { companionContextDegraded: true } : {}),
-      };
-    }),
+        return {
+          okf: "zam",
+          version: pkg.version,
+          user: opening.context.user.currentId ?? null,
+          bundleDir: resolvedBundleDir,
+          okfVersion,
+          view: initialView,
+          catalog,
+          problems,
+          log,
+          companionContext: opening.context,
+          ...(opening.degraded ? { companionContextDegraded: true } : {}),
+        };
+      },
+    ),
   );
 
   registerAppResource(

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -42,6 +42,7 @@ import {
   writeCompanionContext,
 } from "../companion-context-server.js";
 import type { CatalogEntry } from "../okf/bundle.js";
+import type { OkfFreshnessAudit } from "../okf/freshness.js";
 import { publishUiIntent } from "../ui-intent.js";
 import { executeBridgeCommandJson } from "./bridge.js";
 
@@ -1302,7 +1303,7 @@ export function createMcpServer(db: Database): McpServer {
     ),
   );
 
-  // 19.–22. zam_okf_* — the OKF knowledge-base surface (ADR 2026-07-17).
+  // 19.–23. zam_okf_* — the OKF knowledge-base surface (ADR 2026-07-17).
   // Operates on any OKF bundle directory; docs/okf of the current workspace
   // by default. Upsert is the ONLY sanctioned write path into a bundle.
   const okfBundleDirSchema = z
@@ -1404,6 +1405,25 @@ export function createMcpServer(db: Database): McpServer {
       const markdown = readFileSync(path, "utf8");
       const { fields } = parseFrontmatter(markdown);
       return { file: params.file, frontmatter: fields, markdown };
+    }),
+  );
+
+  server.registerTool(
+    "zam_okf_audit",
+    {
+      description:
+        "Audit OKF article freshness against repo-relative code paths declared under '# Citations'. Returns conservative current, review-recommended, or unknown hints from Git history and working-tree state. Read-only: never changes articles, tokens, cards, or FSRS state.",
+      inputSchema: {
+        bundle_dir: okfBundleDirSchema,
+      },
+      annotations: {
+        ...commonAnnotations,
+        readOnlyHint: true,
+      },
+    },
+    wrapHandler(async (params: { bundle_dir?: string }) => {
+      const { auditOkfFreshness } = await import("../okf/freshness.js");
+      return auditOkfFreshness(await resolveOkfBundleDir(params.bundle_dir));
     }),
   );
 
@@ -1645,7 +1665,7 @@ export function createMcpServer(db: Database): McpServer {
     }),
   );
 
-  // 23. zam_okf_visualize — the OKF visualizer panel (MCP Apps; ADR
+  // 24. zam_okf_visualize — the OKF visualizer panel (MCP Apps; ADR
   // 2026-07-17b). Mirrors zam_show_graph's open-tool pattern, but the
   // catalog and log.md are loaded eagerly (unlike graph's data, which the
   // panel always pulls itself via zam_studio_bridge) so the panel paints its
@@ -1700,11 +1720,20 @@ export function createMcpServer(db: Database): McpServer {
       let problems: string[] = [];
       let log = "";
       let okfVersion: string | null = null;
+      let freshness: OkfFreshnessAudit | null = null;
+      let freshnessProblem: string | null = null;
       try {
         const bundle = loadBundle(requestedDir);
         resolvedBundleDir = bundle.dir;
         catalog = bundle.catalog;
         problems = bundle.problems;
+        try {
+          const { auditOkfFreshness } = await import("../okf/freshness.js");
+          freshness = auditOkfFreshness(bundle.dir);
+        } catch (error) {
+          freshnessProblem =
+            error instanceof Error ? error.message : String(error);
+        }
         const { readFileSync } = await import("node:fs");
         try {
           log = readFileSync(join(bundle.dir, "log.md"), "utf8");
@@ -1736,6 +1765,8 @@ export function createMcpServer(db: Database): McpServer {
         catalog,
         problems,
         log,
+        freshness,
+        ...(freshnessProblem ? { freshnessProblem } : {}),
         companionContext: opening.context,
         ...(opening.degraded ? { companionContextDegraded: true } : {}),
       };

--- a/src/cli/okf/freshness.ts
+++ b/src/cli/okf/freshness.ts
@@ -169,7 +169,7 @@ class GitInspector {
     const result = runGit(this.repoRoot, [
       "log",
       "-1",
-      "--format=%H%x00%cI",
+      "--format=%H%n%cI",
       "--",
       path,
     ]);
@@ -177,7 +177,9 @@ class GitInspector {
       this.commits.set(path, null);
       return null;
     }
-    const [commit, rawChangedAt] = result.stdout.trim().split("\0");
+    // Newline-delimited fields survive Git-for-Windows/Node process pipes
+    // consistently; a NUL separator was observed to truncate on Windows ARM.
+    const [commit, rawChangedAt] = result.stdout.trim().split(/\r?\n/, 2);
     const changedAtMs = Date.parse(rawChangedAt ?? "");
     const value =
       commit && Number.isFinite(changedAtMs)

--- a/src/cli/okf/freshness.ts
+++ b/src/cli/okf/freshness.ts
@@ -169,7 +169,7 @@ class GitInspector {
     const result = runGit(this.repoRoot, [
       "log",
       "-1",
-      "--format=%H%n%cI",
+      "--format=%H%x09%cI",
       "--",
       path,
     ]);
@@ -177,9 +177,9 @@ class GitInspector {
       this.commits.set(path, null);
       return null;
     }
-    // Newline-delimited fields survive Git-for-Windows/Node process pipes
-    // consistently; a NUL separator was observed to truncate on Windows ARM.
-    const [commit, rawChangedAt] = result.stdout.trim().split(/\r?\n/, 2);
+    // A tab survives Git-for-Windows/Node process pipes without the NUL
+    // truncation seen on Windows ARM or platform-specific newline handling.
+    const [commit, rawChangedAt] = result.stdout.trim().split("\t", 2);
     const changedAtMs = Date.parse(rawChangedAt ?? "");
     const value =
       commit && Number.isFinite(changedAtMs)

--- a/src/cli/okf/freshness.ts
+++ b/src/cli/okf/freshness.ts
@@ -1,0 +1,442 @@
+/**
+ * Conservative freshness hints for OKF reference articles.
+ *
+ * The audit is deliberately read-only and lives in the CLI layer because it
+ * inspects Git. It never changes articles, tokens, cards, or FSRS state.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { type CatalogEntry, parseFrontmatter } from "./bundle.js";
+import { findRepoRoot, loadBundle } from "./io.js";
+
+export type OkfFreshnessStatus = "current" | "review-recommended" | "unknown";
+
+export type OkfFreshnessReason =
+  | "no-code-citations"
+  | "git-unavailable"
+  | "article-not-tracked"
+  | "invalid-article-timestamp"
+  | "code-path-missing"
+  | "code-not-tracked"
+  | "unrelated-history"
+  | "working-tree-changed";
+
+export interface OkfFreshnessBaseline {
+  source: "git" | "frontmatter";
+  changedAt: string;
+  commit?: string;
+}
+
+export interface OkfCodeReferenceFreshness {
+  path: string;
+  status: OkfFreshnessStatus;
+  changedAt?: string;
+  commit?: string;
+  workingTreeChanged?: boolean;
+  reason?: OkfFreshnessReason;
+}
+
+export interface OkfArticleFreshness {
+  file: string;
+  title: string;
+  timestamp?: string;
+  status: OkfFreshnessStatus;
+  baseline?: OkfFreshnessBaseline;
+  codeReferences: OkfCodeReferenceFreshness[];
+  reason?: OkfFreshnessReason;
+}
+
+export interface OkfFreshnessAudit {
+  dir: string;
+  repoRoot: string;
+  gitAvailable: boolean;
+  summary: {
+    current: number;
+    reviewRecommended: number;
+    unknown: number;
+  };
+  articles: OkfArticleFreshness[];
+}
+
+interface GitCommit {
+  commit: string;
+  changedAt: string;
+}
+
+interface GitResult {
+  status: number | null;
+  stdout: string;
+}
+
+function runGit(repoRoot: string, args: string[]): GitResult {
+  const result = spawnSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    windowsHide: true,
+    maxBuffer: 1024 * 1024,
+    timeout: 5_000,
+  });
+  return {
+    status: result.status,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+  };
+}
+
+function containedPath(repoRoot: string, candidate: string): boolean {
+  const rel = relative(repoRoot, candidate);
+  return !(rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel));
+}
+
+/**
+ * Read the repo-relative paths enclosed in backticks on `- Code:` rows under
+ * an article's `# Citations` section. Anything that could escape the
+ * repository is ignored. A missing value is retained only when it still looks
+ * path-like, so deleted `src/foo.ts` citations become review signals while
+ * descriptive backticks such as a function name do not become audit targets.
+ */
+export function extractOkfCodeReferences(
+  markdown: string,
+  repoRoot: string,
+): string[] {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const citationsIndex = lines.findIndex((line) =>
+    /^#\s+Citations\s*$/i.test(line.trim()),
+  );
+  if (citationsIndex === -1) return [];
+
+  const references = new Set<string>();
+  const canonicalRoot = existsSync(repoRoot)
+    ? realpathSync(repoRoot)
+    : resolve(repoRoot);
+
+  for (let index = citationsIndex + 1; index < lines.length; index++) {
+    const line = lines[index];
+    if (/^#\s+/.test(line.trim())) break;
+    const codeRow = /^\s*-\s*Code:\s*(.+)$/i.exec(line);
+    if (!codeRow) continue;
+
+    for (const match of codeRow[1].matchAll(/`([^`]+)`/g)) {
+      const raw = match[1].trim();
+      if (
+        raw === "" ||
+        isAbsolute(raw) ||
+        /^[A-Za-z]:[\\/]/.test(raw) ||
+        raw.includes("\\")
+      ) {
+        continue;
+      }
+      const candidate = resolve(canonicalRoot, raw);
+      if (!containedPath(canonicalRoot, candidate)) {
+        continue;
+      }
+      if (!existsSync(candidate)) {
+        if (!raw.includes("/") && !/\.[A-Za-z0-9]+$/.test(raw)) continue;
+        references.add(relative(canonicalRoot, candidate).split(sep).join("/"));
+        continue;
+      }
+      const canonicalCandidate = realpathSync(candidate);
+      if (!containedPath(canonicalRoot, canonicalCandidate)) continue;
+      references.add(
+        relative(canonicalRoot, canonicalCandidate).split(sep).join("/"),
+      );
+    }
+  }
+
+  return [...references];
+}
+
+class GitInspector {
+  readonly repoRoot: string;
+  readonly available: boolean;
+  private readonly commits = new Map<string, GitCommit | null>();
+  private readonly dirty = new Map<string, boolean | null>();
+  private readonly ancestry = new Map<string, boolean | null>();
+
+  constructor(candidateRoot: string) {
+    const probe = runGit(candidateRoot, ["rev-parse", "--show-toplevel"]);
+    this.available = probe.status === 0 && probe.stdout.trim() !== "";
+    this.repoRoot = this.available
+      ? realpathSync(resolve(probe.stdout.trim()))
+      : realpathSync(resolve(candidateRoot));
+  }
+
+  lastCommit(path: string): GitCommit | null {
+    if (!this.available) return null;
+    const cached = this.commits.get(path);
+    if (cached !== undefined) return cached;
+
+    const result = runGit(this.repoRoot, [
+      "log",
+      "-1",
+      "--format=%H%x00%cI",
+      "--",
+      path,
+    ]);
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      this.commits.set(path, null);
+      return null;
+    }
+    const [commit, rawChangedAt] = result.stdout.trim().split("\0");
+    const changedAtMs = Date.parse(rawChangedAt ?? "");
+    const value =
+      commit && Number.isFinite(changedAtMs)
+        ? { commit, changedAt: new Date(changedAtMs).toISOString() }
+        : null;
+    this.commits.set(path, value);
+    return value;
+  }
+
+  hasWorkingTreeChange(path: string): boolean | null {
+    if (!this.available) return null;
+    const cached = this.dirty.get(path);
+    if (cached !== undefined) return cached;
+    const result = runGit(this.repoRoot, [
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+      "--",
+      path,
+    ]);
+    const value = result.status === 0 ? result.stdout.trim() !== "" : null;
+    this.dirty.set(path, value);
+    return value;
+  }
+
+  isAncestor(ancestor: string, descendant: string): boolean | null {
+    if (!this.available) return null;
+    const key = `${ancestor}:${descendant}`;
+    const cached = this.ancestry.get(key);
+    if (cached !== undefined) return cached;
+    const result = runGit(this.repoRoot, [
+      "merge-base",
+      "--is-ancestor",
+      ancestor,
+      descendant,
+    ]);
+    const value =
+      result.status === 0 ? true : result.status === 1 ? false : null;
+    this.ancestry.set(key, value);
+    return value;
+  }
+}
+
+function parseTimestamp(timestamp: string | undefined): string | undefined {
+  if (!timestamp) return undefined;
+  const ms = Date.parse(timestamp);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined;
+}
+
+function articleBaseline(
+  inspector: GitInspector,
+  articlePath: string,
+  timestamp: string | undefined,
+): OkfFreshnessBaseline | undefined {
+  const commit = inspector.lastCommit(articlePath);
+  if (commit) {
+    return {
+      source: "git",
+      changedAt: commit.changedAt,
+      commit: commit.commit,
+    };
+  }
+  const changedAt = parseTimestamp(timestamp);
+  return changedAt ? { source: "frontmatter", changedAt } : undefined;
+}
+
+function referenceFreshness(
+  inspector: GitInspector,
+  path: string,
+  baseline: OkfFreshnessBaseline | undefined,
+): OkfCodeReferenceFreshness {
+  const dirty = inspector.hasWorkingTreeChange(path);
+  if (dirty === true) {
+    return {
+      path,
+      status: "review-recommended",
+      workingTreeChanged: true,
+      reason: "working-tree-changed",
+    };
+  }
+  if (!inspector.available) {
+    return { path, status: "unknown", reason: "git-unavailable" };
+  }
+  if (!existsSync(resolve(inspector.repoRoot, path))) {
+    return {
+      path,
+      status: "review-recommended",
+      reason: "code-path-missing",
+    };
+  }
+  if (!baseline) {
+    return {
+      path,
+      status: "unknown",
+      reason: "article-not-tracked",
+    };
+  }
+
+  const codeCommit = inspector.lastCommit(path);
+  if (!codeCommit) {
+    return { path, status: "unknown", reason: "code-not-tracked" };
+  }
+
+  if (baseline.source === "frontmatter") {
+    return {
+      path,
+      status:
+        Date.parse(codeCommit.changedAt) > Date.parse(baseline.changedAt)
+          ? "review-recommended"
+          : "current",
+      changedAt: codeCommit.changedAt,
+      commit: codeCommit.commit,
+    };
+  }
+
+  if (codeCommit.commit === baseline.commit) {
+    return {
+      path,
+      status: "current",
+      changedAt: codeCommit.changedAt,
+      commit: codeCommit.commit,
+    };
+  }
+
+  const codePredatesArticle = inspector.isAncestor(
+    codeCommit.commit,
+    baseline.commit!,
+  );
+  if (codePredatesArticle === true) {
+    return {
+      path,
+      status: "current",
+      changedAt: codeCommit.changedAt,
+      commit: codeCommit.commit,
+    };
+  }
+  const articlePredatesCode = inspector.isAncestor(
+    baseline.commit!,
+    codeCommit.commit,
+  );
+  if (articlePredatesCode === true) {
+    return {
+      path,
+      status: "review-recommended",
+      changedAt: codeCommit.changedAt,
+      commit: codeCommit.commit,
+    };
+  }
+  return {
+    path,
+    status: "unknown",
+    changedAt: codeCommit.changedAt,
+    commit: codeCommit.commit,
+    reason: "unrelated-history",
+  };
+}
+
+function aggregateStatus(
+  references: OkfCodeReferenceFreshness[],
+): OkfFreshnessStatus {
+  if (
+    references.some((reference) => reference.status === "review-recommended")
+  ) {
+    return "review-recommended";
+  }
+  if (references.some((reference) => reference.status === "unknown")) {
+    return "unknown";
+  }
+  return references.length > 0 ? "current" : "unknown";
+}
+
+function unknownReason(
+  inspector: GitInspector,
+  timestamp: string | undefined,
+  baseline: OkfFreshnessBaseline | undefined,
+  references: OkfCodeReferenceFreshness[],
+): OkfFreshnessReason | undefined {
+  if (references.length === 0) return "no-code-citations";
+  if (!inspector.available) return "git-unavailable";
+  if (!baseline) {
+    return timestamp ? "invalid-article-timestamp" : "article-not-tracked";
+  }
+  return references.find((reference) => reference.reason)?.reason;
+}
+
+function catalogEntryFor(
+  catalog: CatalogEntry[],
+  file: string,
+): CatalogEntry | undefined {
+  return catalog.find((entry) => entry.file === file);
+}
+
+/**
+ * Audit every article in one bundle against its declared code citations.
+ *
+ * An article's own latest Git commit is the preferred baseline: cited code
+ * at or before that commit is current, while a later descendant commit
+ * recommends review. Frontmatter `timestamp` is only a fallback for an
+ * untracked article. Uncommitted cited-code changes also recommend review.
+ * Anything ambiguous is reported as unknown rather than guessed.
+ */
+export function auditOkfFreshness(bundleDir: string): OkfFreshnessAudit {
+  const bundle = loadBundle(bundleDir);
+  const candidateRoot = findRepoRoot(bundle.dir);
+  const inspector = new GitInspector(candidateRoot);
+  const repoRoot = inspector.repoRoot;
+
+  const articles = bundle.articles.map(({ file, markdown }) => {
+    const entry = catalogEntryFor(bundle.catalog, file);
+    let timestamp = entry?.timestamp;
+    if (timestamp === undefined) {
+      try {
+        const { fields } = parseFrontmatter(markdown);
+        timestamp =
+          typeof fields.timestamp === "string" ? fields.timestamp : undefined;
+      } catch {
+        // Bundle conformance problems already describe malformed frontmatter.
+      }
+    }
+    const articlePath = relative(
+      repoRoot,
+      realpathSync(resolve(bundle.dir, file)),
+    )
+      .split(sep)
+      .join("/");
+    const baseline = articleBaseline(inspector, articlePath, timestamp);
+    const codeReferences = extractOkfCodeReferences(markdown, repoRoot).map(
+      (path) => referenceFreshness(inspector, path, baseline),
+    );
+    const status = aggregateStatus(codeReferences);
+    const reason =
+      status === "unknown"
+        ? unknownReason(inspector, timestamp, baseline, codeReferences)
+        : undefined;
+
+    return {
+      file,
+      title: entry?.title ?? file.replace(/\.md$/, ""),
+      ...(timestamp ? { timestamp } : {}),
+      status,
+      ...(baseline ? { baseline } : {}),
+      codeReferences,
+      ...(reason ? { reason } : {}),
+    } satisfies OkfArticleFreshness;
+  });
+
+  return {
+    dir: bundle.dir,
+    repoRoot,
+    gitAvailable: inspector.available,
+    summary: {
+      current: articles.filter((article) => article.status === "current")
+        .length,
+      reviewRecommended: articles.filter(
+        (article) => article.status === "review-recommended",
+      ).length,
+      unknown: articles.filter((article) => article.status === "unknown")
+        .length,
+    },
+    articles,
+  };
+}

--- a/src/cli/okf/freshness.ts
+++ b/src/cli/okf/freshness.ts
@@ -166,24 +166,37 @@ class GitInspector {
     const cached = this.commits.get(path);
     if (cached !== undefined) return cached;
 
-    const result = runGit(this.repoRoot, [
-      "log",
+    const commitResult = runGit(this.repoRoot, [
+      "rev-list",
       "-1",
-      "--format=%H%x09%cI",
+      "HEAD",
       "--",
       path,
     ]);
-    if (result.status !== 0 || result.stdout.trim() === "") {
+    const commit = commitResult.stdout.trim();
+    if (commitResult.status !== 0 || commit === "") {
       this.commits.set(path, null);
       return null;
     }
-    // A tab survives Git-for-Windows/Node process pipes without the NUL
-    // truncation seen on Windows ARM or platform-specific newline handling.
-    const [commit, rawChangedAt] = result.stdout.trim().split("\t", 2);
-    const changedAtMs = Date.parse(rawChangedAt ?? "");
+
+    // Keep each Git response to one plain ASCII field. Combined pretty-format
+    // output proved unreliable through Node process pipes on Windows ARM.
+    const timestampResult = runGit(this.repoRoot, [
+      "show",
+      "-s",
+      "--format=%ct",
+      commit,
+    ]);
+    const rawChangedAtSeconds = timestampResult.stdout.trim();
+    const changedAtSeconds = Number(rawChangedAtSeconds);
     const value =
-      commit && Number.isFinite(changedAtMs)
-        ? { commit, changedAt: new Date(changedAtMs).toISOString() }
+      timestampResult.status === 0 &&
+      rawChangedAtSeconds !== "" &&
+      Number.isFinite(changedAtSeconds)
+        ? {
+            commit,
+            changedAt: new Date(changedAtSeconds * 1_000).toISOString(),
+          }
         : null;
     this.commits.set(path, value);
     return value;

--- a/src/cli/okf/freshness.ts
+++ b/src/cli/okf/freshness.ts
@@ -179,8 +179,8 @@ class GitInspector {
       return null;
     }
 
-    // Keep each Git response to one plain ASCII field. Combined pretty-format
-    // output proved unreliable through Node process pipes on Windows ARM.
+    // Keep each Git response to one plain ASCII field, avoiding
+    // platform-specific field separation and ISO date parsing.
     const timestampResult = runGit(this.repoRoot, [
       "show",
       "-s",
@@ -412,10 +412,7 @@ export function auditOkfFreshness(bundleDir: string): OkfFreshnessAudit {
         // Bundle conformance problems already describe malformed frontmatter.
       }
     }
-    const articlePath = relative(
-      repoRoot,
-      realpathSync(resolve(bundle.dir, file)),
-    )
+    const articlePath = relative(candidateRoot, resolve(bundle.dir, file))
       .split(sep)
       .join("/");
     const baseline = articleBaseline(inspector, articlePath, timestamp);

--- a/src/copilot-extension/extension.mjs
+++ b/src/copilot-extension/extension.mjs
@@ -27,7 +27,7 @@ const APP_CONFIG = {
     allowedTools: new Set(["zam_get_reviews", "zam_submit_review"]),
   },
   graph: {
-    title: "ZAM Graph",
+    title: "ZAM Learning Graph",
     toolName: "zam_show_graph",
     allowedTools: new Set(["zam_studio_bridge"]),
   },
@@ -91,9 +91,12 @@ function compactObject(value) {
 
 function buildToolArguments(kind, input) {
   // `okf` takes no `user`: `zam_okf_visualize` is repo-scoped and its input
-  // schema only knows `bundle_dir`.
+  // schema accepts the bundle plus its requested initial view.
   if (kind === "okf") {
-    return compactObject({ bundle_dir: input?.bundle_dir });
+    return compactObject({
+      bundle_dir: input?.bundle_dir,
+      view: input?.view,
+    });
   }
   const common = { user: input?.user };
   if (kind === "recall") {
@@ -489,9 +492,9 @@ await joinSession({
     }),
     createCanvas({
       id: "zam-graph",
-      displayName: "ZAM Graph",
+      displayName: "ZAM Learning Graph",
       description:
-        "Open the original interactive ZAM knowledge-graph MCP App in a hosted Copilot canvas.",
+        "Open the interactive ZAM learning-token graph MCP App in a hosted Copilot canvas.",
       inputSchema: {
         type: "object",
         properties: {
@@ -519,6 +522,12 @@ await joinSession({
             type: "string",
             description:
               "Bundle directory (default docs/okf under the zam server cwd).",
+          },
+          view: {
+            type: "string",
+            enum: ["reader", "graph", "log"],
+            description:
+              "Initial view: graph for OKFs and cited ADRs, reader for articles, or log for history.",
           },
         },
         additionalProperties: false,

--- a/src/copilot-extension/extension.mjs
+++ b/src/copilot-extension/extension.mjs
@@ -37,6 +37,7 @@ const APP_CONFIG = {
     allowedTools: new Set([
       "zam_okf_catalog",
       "zam_okf_read",
+      "zam_okf_audit",
       "zam_okf_read_citation",
       "zam_okf_focus",
     ]),

--- a/src/vscode-extension/protocol.ts
+++ b/src/vscode-extension/protocol.ts
@@ -58,6 +58,7 @@ export const COMPANION_APPS: Record<CompanionApp, CompanionAppConfig> = {
     allowedTools: new Set([
       "zam_okf_catalog",
       "zam_okf_read",
+      "zam_okf_audit",
       "zam_okf_read_citation",
       "zam_okf_focus",
       "zam_companion_context",

--- a/src/vscode-extension/protocol.ts
+++ b/src/vscode-extension/protocol.ts
@@ -48,7 +48,7 @@ export const COMPANION_APPS: Record<CompanionApp, CompanionAppConfig> = {
     ]),
   },
   graph: {
-    title: "ZAM Graph",
+    title: "ZAM Learning Graph",
     toolName: "zam_show_graph",
     allowedTools: new Set(["zam_studio_bridge", "zam_companion_context"]),
   },
@@ -177,15 +177,15 @@ export function buildOpeningArguments(
   app: CompanionApp,
   input: Record<string, string>,
 ): Record<string, string> {
-  // `okf` deliberately omits `user`: `zam_okf_visualize` is repo-scoped and
-  // its input schema has no user parameter (unlike the learner-scoped apps).
+  // `okf` deliberately omits `user`: `zam_okf_visualize` is repo-scoped
+  // (unlike the learner-scoped apps), but forwards the requested initial view.
   const allowed =
     app === "recall"
       ? ["user", "domain"]
       : app === "graph"
         ? ["user", "focus"]
         : app === "okf"
-          ? ["bundle_dir"]
+          ? ["bundle_dir", "view"]
           : ["user"];
   return Object.fromEntries(
     allowed.flatMap((key) =>

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -96,9 +96,9 @@ describe("MCP stdio server tests", () => {
     });
   });
 
-  it("lists all 27 tools with correct annotations", async () => {
+  it("lists all 28 tools with correct annotations", async () => {
     const response = await client.listTools();
-    expect(response.tools).toHaveLength(27);
+    expect(response.tools).toHaveLength(28);
 
     const toolNames = response.tools.map((t) => t.name).sort();
     const expectedNames = [
@@ -123,6 +123,7 @@ describe("MCP stdio server tests", () => {
       "zam_companion_sample",
       "zam_okf_catalog",
       "zam_okf_read",
+      "zam_okf_audit",
       "zam_okf_upsert",
       "zam_okf_read_citation",
       "zam_okf_visualize",
@@ -1149,6 +1150,36 @@ describe("MCP stdio server tests", () => {
       expect(data.log).toBeUndefined();
     });
 
+    it("exposes zam_okf_audit as a read-only freshness hint", async () => {
+      const tools = await client.listTools();
+      const tool = tools.tools.find((entry) => entry.name === "zam_okf_audit");
+      expect((tool as any).annotations).toEqual({
+        openWorldHint: false,
+        readOnlyHint: true,
+      });
+
+      const res = await client.callTool({
+        name: "zam_okf_audit",
+        arguments: { bundle_dir: bundleDir },
+      });
+      expect(res.isError).toBeUndefined();
+      const data = JSON.parse(res.content[0].text);
+      expect(data.dir).toBe(bundleDir);
+      expect(data.gitAvailable).toBe(false);
+      expect(data.summary).toEqual({
+        current: 0,
+        reviewRecommended: 0,
+        unknown: 1,
+      });
+      expect(data.articles[0]).toEqual(
+        expect.objectContaining({
+          file: "fsrs-scheduling.md",
+          status: "unknown",
+          reason: "no-code-citations",
+        }),
+      );
+    });
+
     it("returns an empty log string when log.md does not exist yet", async () => {
       const emptyBundleDir = join(repoRoot, "docs", "empty-okf");
       mkdirSync(emptyBundleDir, { recursive: true });
@@ -1309,6 +1340,13 @@ describe("MCP stdio server tests", () => {
         catalog?: Array<{ file: string }>;
         log?: string;
         problems?: string[];
+        freshness?: {
+          summary?: {
+            current?: number;
+            reviewRecommended?: number;
+            unknown?: number;
+          };
+        };
         companionContext?: { surface?: string };
       };
       expect(structured.okf).toBe("zam");
@@ -1326,6 +1364,11 @@ describe("MCP stdio server tests", () => {
       // log.md was written by upsertArticle in beforeEach — returned eagerly,
       // with no separate zam_okf_catalog round-trip required.
       expect(structured.log).toContain("FSRS Scheduling");
+      expect(structured.freshness?.summary).toEqual({
+        current: 0,
+        reviewRecommended: 0,
+        unknown: 1,
+      });
       expect(structured.companionContext?.surface).toBe("okf");
     });
 
@@ -1341,11 +1384,13 @@ describe("MCP stdio server tests", () => {
         problems?: string[];
         okfVersion?: string | null;
         bundleDir?: string;
+        freshness?: unknown;
       };
       expect(structured.catalog).toEqual([]);
       expect(structured.problems?.length).toBeGreaterThan(0);
       expect(structured.okfVersion).toBeNull();
       expect(structured.bundleDir).toBe(missingDir);
+      expect(structured.freshness).toBeNull();
     });
   });
 });

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -96,6 +96,13 @@ describe("MCP stdio server tests", () => {
     });
   });
 
+  it("publishes unambiguous routing instructions for both knowledge surfaces", () => {
+    expect(client.getInstructions()).toContain("zam_show_graph");
+    expect(client.getInstructions()).toContain("learning tokens");
+    expect(client.getInstructions()).toContain("zam_okf_visualize");
+    expect(client.getInstructions()).toContain('view: "graph"');
+  });
+
   it("lists all 28 tools with correct annotations", async () => {
     const response = await client.listTools();
     expect(response.tools).toHaveLength(28);
@@ -1306,7 +1313,7 @@ describe("MCP stdio server tests", () => {
       expect(content.text).toContain("zam-okf-panel");
     });
 
-    it("links zam_okf_visualize to the okf panel resource and eagerly returns the bundle catalog/log", async () => {
+    it("links zam_okf_visualize to the okf panel resource and initializes the requested view", async () => {
       const response = await client.listTools();
       const tool = response.tools.find((t) => t.name === "zam_okf_visualize");
       expect(tool).toBeDefined();
@@ -1319,16 +1326,18 @@ describe("MCP stdio server tests", () => {
         readOnlyHint: true,
       });
 
-      // inputSchema accepts only an optional bundle_dir.
+      // Both the bundle and initial reader/graph/log view are optional.
       const schema = tool?.inputSchema as
         | { properties?: Record<string, unknown>; required?: string[] }
         | undefined;
       expect(schema?.properties).toHaveProperty("bundle_dir");
+      expect(schema?.properties).toHaveProperty("view");
       expect(schema?.required ?? []).not.toContain("bundle_dir");
+      expect(schema?.required ?? []).not.toContain("view");
 
       const res = await client.callTool({
         name: "zam_okf_visualize",
-        arguments: { bundle_dir: bundleDir },
+        arguments: { bundle_dir: bundleDir, view: "graph" },
       });
       expect(res.isError).toBeUndefined();
       const structured = (res as any).structuredContent as {
@@ -1337,16 +1346,10 @@ describe("MCP stdio server tests", () => {
         user?: string | null;
         bundleDir?: string;
         okfVersion?: string | null;
+        view?: string;
         catalog?: Array<{ file: string }>;
         log?: string;
         problems?: string[];
-        freshness?: {
-          summary?: {
-            current?: number;
-            reviewRecommended?: number;
-            unknown?: number;
-          };
-        };
         companionContext?: { surface?: string };
       };
       expect(structured.okf).toBe("zam");
@@ -1357,6 +1360,7 @@ describe("MCP stdio server tests", () => {
       // okf_version comes from the bundle's own index.md frontmatter
       // (renderIndex's default), not the zam package version.
       expect(structured.okfVersion).toBe("0.1");
+      expect(structured.view).toBe("graph");
       expect(structured.catalog?.map((e) => e.file)).toEqual([
         "fsrs-scheduling.md",
       ]);
@@ -1364,11 +1368,9 @@ describe("MCP stdio server tests", () => {
       // log.md was written by upsertArticle in beforeEach — returned eagerly,
       // with no separate zam_okf_catalog round-trip required.
       expect(structured.log).toContain("FSRS Scheduling");
-      expect(structured.freshness?.summary).toEqual({
-        current: 0,
-        reviewRecommended: 0,
-        unknown: 1,
-      });
+      // Git inspection is fetched asynchronously by the panel through
+      // zam_okf_audit so opening never waits for repository history.
+      expect(structured).not.toHaveProperty("freshness");
       expect(structured.companionContext?.surface).toBe("okf");
     });
 
@@ -1384,13 +1386,14 @@ describe("MCP stdio server tests", () => {
         problems?: string[];
         okfVersion?: string | null;
         bundleDir?: string;
-        freshness?: unknown;
+        view?: string;
       };
       expect(structured.catalog).toEqual([]);
       expect(structured.problems?.length).toBeGreaterThan(0);
       expect(structured.okfVersion).toBeNull();
       expect(structured.bundleDir).toBe(missingDir);
-      expect(structured.freshness).toBeNull();
+      expect(structured.view).toBe("reader");
+      expect(structured).not.toHaveProperty("freshness");
     });
   });
 });

--- a/tests/cli/okf-freshness.test.ts
+++ b/tests/cli/okf-freshness.test.ts
@@ -1,0 +1,217 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  auditOkfFreshness,
+  extractOkfCodeReferences,
+} from "../../src/cli/okf/freshness.js";
+
+const scratchDirs: string[] = [];
+
+function scratchRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "zam-okf-freshness-"));
+  scratchDirs.push(root);
+  execFileSync("git", ["-C", root, "init"], { stdio: "pipe" });
+  execFileSync("git", ["-C", root, "config", "user.name", "ZAM Test"], {
+    stdio: "pipe",
+  });
+  execFileSync(
+    "git",
+    ["-C", root, "config", "user.email", "zam-test@example.invalid"],
+    { stdio: "pipe" },
+  );
+  return root;
+}
+
+function commit(root: string, message: string, date: string): void {
+  execFileSync("git", ["-C", root, "add", "."], { stdio: "pipe" });
+  execFileSync("git", ["-C", root, "commit", "-m", message], {
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: date,
+      GIT_COMMITTER_DATE: date,
+    },
+  });
+}
+
+function article(options: {
+  title?: string;
+  timestamp?: string;
+  code?: string[];
+}): string {
+  const code =
+    options.code === undefined
+      ? ""
+      : `\n# Citations\n\n- Code: ${options.code.map((path) => `\`${path}\``).join(", ")}\n`;
+  return [
+    "---",
+    "type: reference",
+    `title: ${options.title ?? "Freshness fixture"}`,
+    "description: Test article",
+    ...(options.timestamp ? [`timestamp: ${options.timestamp}`] : []),
+    "---",
+    "",
+    "# Fixture",
+    "",
+    "Current behavior.",
+    code,
+  ].join("\n");
+}
+
+afterEach(() => {
+  for (const root of scratchDirs.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("OKF freshness audit", () => {
+  it("extracts repo-contained code paths and ignores descriptive identifiers", () => {
+    const root = scratchRepo();
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "engine.ts"), "export {};\n");
+    const markdown = [
+      "# Citations",
+      "",
+      "- Code: `src/engine.ts`, `missing.ts`, `renderEngine`",
+      "- Code: `src/engine.ts`, `../outside.ts`, `/absolute.ts`",
+      "",
+      "# Next section",
+      "",
+      "- Code: `src/not-in-citations.ts`",
+    ].join("\n");
+
+    expect(extractOkfCodeReferences(markdown, root)).toEqual([
+      "src/engine.ts",
+      "missing.ts",
+    ]);
+  });
+
+  it("uses commit ancestry and recommends review after cited code changes", () => {
+    const root = scratchRepo();
+    const bundleDir = join(root, "docs", "okf");
+    mkdirSync(join(root, "src"), { recursive: true });
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(join(root, "src", "stable.ts"), "export const stable = 1;\n");
+    writeFileSync(join(root, "src", "changed.ts"), "export const value = 1;\n");
+    commit(root, "add code", "2026-07-01T10:00:00Z");
+
+    writeFileSync(
+      join(bundleDir, "system.md"),
+      article({
+        timestamp: "2026-07-02T10:00:00Z",
+        code: ["src/stable.ts", "src/changed.ts"],
+      }),
+    );
+    commit(root, "document system", "2026-07-02T10:00:00Z");
+
+    const current = auditOkfFreshness(bundleDir);
+    expect(current.gitAvailable).toBe(true);
+    expect(current.summary).toEqual({
+      current: 1,
+      reviewRecommended: 0,
+      unknown: 0,
+    });
+    expect(current.articles[0].baseline?.source).toBe("git");
+    expect(
+      current.articles[0].codeReferences.map((reference) => reference.status),
+    ).toEqual(["current", "current"]);
+
+    writeFileSync(join(root, "src", "changed.ts"), "export const value = 2;\n");
+    commit(root, "change documented behavior", "2026-07-03T10:00:00Z");
+
+    const stale = auditOkfFreshness(bundleDir);
+    expect(stale.summary).toEqual({
+      current: 0,
+      reviewRecommended: 1,
+      unknown: 0,
+    });
+    expect(stale.articles[0].status).toBe("review-recommended");
+    expect(stale.articles[0].codeReferences).toEqual([
+      expect.objectContaining({ path: "src/stable.ts", status: "current" }),
+      expect.objectContaining({
+        path: "src/changed.ts",
+        status: "review-recommended",
+      }),
+    ]);
+  });
+
+  it("falls back to frontmatter for an untracked article and sees dirty code", () => {
+    const root = scratchRepo();
+    const bundleDir = join(root, "docs", "okf");
+    mkdirSync(join(root, "src"), { recursive: true });
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(join(root, "src", "engine.ts"), "export const value = 1;\n");
+    commit(root, "add engine", "2026-07-01T10:00:00Z");
+    writeFileSync(
+      join(bundleDir, "engine.md"),
+      article({
+        timestamp: "2026-07-02T10:00:00Z",
+        code: ["src/engine.ts"],
+      }),
+    );
+
+    const current = auditOkfFreshness(bundleDir);
+    expect(current.articles[0]).toEqual(
+      expect.objectContaining({
+        status: "current",
+        baseline: expect.objectContaining({ source: "frontmatter" }),
+      }),
+    );
+
+    writeFileSync(join(root, "src", "engine.ts"), "export const value = 2;\n");
+    const dirty = auditOkfFreshness(bundleDir);
+    expect(dirty.articles[0].status).toBe("review-recommended");
+    expect(dirty.articles[0].codeReferences[0]).toEqual(
+      expect.objectContaining({
+        workingTreeChanged: true,
+        reason: "working-tree-changed",
+      }),
+    );
+  });
+
+  it("reports unknown when an article declares no auditable code", () => {
+    const root = scratchRepo();
+    const bundleDir = join(root, "docs", "okf");
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(
+      join(bundleDir, "concept.md"),
+      article({ timestamp: "2026-07-02T10:00:00Z" }),
+    );
+    commit(root, "add conceptual article", "2026-07-02T10:00:00Z");
+
+    const audit = auditOkfFreshness(bundleDir);
+    expect(audit.articles[0]).toEqual(
+      expect.objectContaining({
+        status: "unknown",
+        reason: "no-code-citations",
+        codeReferences: [],
+      }),
+    );
+  });
+
+  it("recommends review when a path-shaped citation no longer exists", () => {
+    const root = scratchRepo();
+    const bundleDir = join(root, "docs", "okf");
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(
+      join(bundleDir, "removed-code.md"),
+      article({
+        timestamp: "2026-07-02T10:00:00Z",
+        code: ["src/removed.ts", "renderRemoved"],
+      }),
+    );
+    commit(root, "document removed code", "2026-07-02T10:00:00Z");
+
+    const audit = auditOkfFreshness(bundleDir);
+    expect(audit.articles[0].codeReferences).toEqual([
+      {
+        path: "src/removed.ts",
+        status: "review-recommended",
+        reason: "code-path-missing",
+      },
+    ]);
+  });
+});

--- a/tests/cli/vscode-companion-protocol.test.ts
+++ b/tests/cli/vscode-companion-protocol.test.ts
@@ -99,8 +99,10 @@ describe("VS Code companion protocol", () => {
     ).toEqual({ bundle_dir: "C:/src/dw/Cops.AI/docs/okf" });
     expect(COMPANION_APPS.okf.toolName).toBe("zam_okf_visualize");
     // The reader records its focused article so chat agents can resolve
-    // "import this okf" — the write tool must be reachable from the panel.
+    // "import this okf", while the panel can refresh its read-only freshness
+    // hints without reopening — both tools must be reachable from the panel.
     expect(COMPANION_APPS.okf.allowedTools.has("zam_okf_focus")).toBe(true);
+    expect(COMPANION_APPS.okf.allowedTools.has("zam_okf_audit")).toBe(true);
   });
 
   it("serializes overlapping app mounts so the latest request wins", async () => {

--- a/tests/cli/vscode-companion-protocol.test.ts
+++ b/tests/cli/vscode-companion-protocol.test.ts
@@ -94,9 +94,13 @@ describe("VS Code companion protocol", () => {
       buildOpeningArguments("okf", {
         user: "thomas",
         bundle_dir: "C:/src/dw/Cops.AI/docs/okf",
+        view: "graph",
         focus: "ignore-me",
       }),
-    ).toEqual({ bundle_dir: "C:/src/dw/Cops.AI/docs/okf" });
+    ).toEqual({
+      bundle_dir: "C:/src/dw/Cops.AI/docs/okf",
+      view: "graph",
+    });
     expect(COMPANION_APPS.okf.toolName).toBe("zam_okf_visualize");
     // The reader records its focused article so chat agents can resolve
     // "import this okf", while the panel can refresh its read-only freshness

--- a/tests/desktop/context-bar-build.test.ts
+++ b/tests/desktop/context-bar-build.test.ts
@@ -23,6 +23,7 @@ const PANEL_FILES = [
   "recall-panel.html",
   "graph-panel.html",
   "settings-panel.html",
+  "okf-panel.html",
 ] as const;
 
 const distUi = (file: string) => join(process.cwd(), "dist", "ui", file);
@@ -68,6 +69,10 @@ describeIfBuilt("shared context bar — built MCP Apps panels", () => {
         expect(html()).toContain("User");
       });
 
+      it("keeps conditionally irrelevant pills visually hidden", () => {
+        expect(html()).toContain(".zam-pill[hidden]");
+      });
+
       it("bundles the honest quick-mode fallback label, never a bare host name", () => {
         expect(html()).toContain("Quick mode");
         // ADR 2026-07-16 §Decision 2/5: never a bare "VS Code" or bare
@@ -79,7 +84,7 @@ describeIfBuilt("shared context bar — built MCP Apps panels", () => {
 });
 
 describe("shared context bar build coverage", () => {
-  it("built all four panels for the assertions above (build first if this fails)", () => {
+  it("built all five panels for the assertions above (build first if this fails)", () => {
     expect(builtPanels).toEqual(PANEL_FILES);
   });
 });

--- a/tests/desktop/context-bar.test.ts
+++ b/tests/desktop/context-bar.test.ts
@@ -7,6 +7,7 @@ import {
   fallbackContextBarState,
   formatAgentLabel,
   PendingConfirmGate,
+  surfaceUsesEvaluator,
   userPillTitle,
   userPillValue,
 } from "../../desktop/src/panel/context-bar.js";
@@ -55,6 +56,15 @@ describe("formatAgentLabel", () => {
     // point, and a UI must degrade rather than crash on unexpected data.
     expect(() => formatAgentLabel({ provider: "Claude" })).not.toThrow();
     expect(formatAgentLabel({ provider: "Claude" })).toBe("Claude");
+  });
+});
+
+describe("surfaceUsesEvaluator", () => {
+  it("hides evaluator controls on both read-only graph surfaces", () => {
+    expect(surfaceUsesEvaluator("graph")).toBe(false);
+    expect(surfaceUsesEvaluator("okf")).toBe(false);
+    expect(surfaceUsesEvaluator("recall")).toBe(true);
+    expect(surfaceUsesEvaluator("studio")).toBe(true);
   });
 });
 

--- a/tests/desktop/display-mode.test.ts
+++ b/tests/desktop/display-mode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { preferredRecallDisplayMode } from "../../desktop/src/panel/display-mode.js";
+
+describe("preferredRecallDisplayMode", () => {
+  it("requests picture-in-picture only when the host advertises it", () => {
+    expect(
+      preferredRecallDisplayMode({
+        displayMode: "inline",
+        availableDisplayModes: ["inline", "pip"],
+      }),
+    ).toBe("pip");
+    expect(
+      preferredRecallDisplayMode({
+        displayMode: "inline",
+        availableDisplayModes: ["inline", "fullscreen"],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not request a redundant mode change", () => {
+    expect(
+      preferredRecallDisplayMode({
+        displayMode: "pip",
+        availableDisplayModes: ["inline", "pip"],
+      }),
+    ).toBeUndefined();
+    expect(preferredRecallDisplayMode(undefined)).toBeUndefined();
+  });
+});

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -437,6 +437,15 @@ const PRE_EXISTING_FALLBACK_KEYS = new Set([
   "okf_graph_hint_focused",
   "okf_graph_focus_exit",
   "okf_graph_focus_on",
+  // OKF Freshness Radar (0.23.0) — en/de shipped; es/fr/pt/zh/ja await
+  // native pack review.
+  "okf_freshness_current",
+  "okf_freshness_review",
+  "okf_freshness_unknown",
+  "okf_freshness_current_title",
+  "okf_freshness_review_title",
+  "okf_freshness_review_paths",
+  "okf_freshness_unknown_title",
   // Closed-group library Phase 2 Studio release step strings (en/de shipped)
   "btn_release_revision",
   "lbl_release_modal_title",

--- a/tests/desktop/okf-render.test.ts
+++ b/tests/desktop/okf-render.test.ts
@@ -8,10 +8,12 @@ import {
   type GraphEdge,
   type GraphNode,
   groupCatalog,
+  indexFreshnessByFile,
   layoutFocusGraph,
   layoutGraph,
   neighborIdsOf,
   renderMarkdown,
+  reviewRecommendedPaths,
   stripFrontmatter,
 } from "../../desktop/src/panel/okf-render.js";
 
@@ -68,6 +70,32 @@ const FSRS_BODY = [
   "- Code: `src/kernel/scheduler/fsrs.ts`, `src/kernel/scheduler/queue.ts`, `src/kernel/recall/evaluator.ts`",
   "- Algorithm reference: <https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm>",
 ].join("\n");
+
+describe("freshness audit indexing", () => {
+  it("indexes articles and exposes only review-recommended code paths", () => {
+    const byFile = indexFreshnessByFile({
+      articles: [
+        {
+          file: "mcp-surfaces.md",
+          status: "review-recommended",
+          codeReferences: [
+            {
+              path: "src/cli/commands/mcp.ts",
+              status: "review-recommended",
+            },
+            { path: "src/cli/okf/io.ts", status: "current" },
+          ],
+        },
+      ],
+    });
+
+    expect([...byFile.keys()]).toEqual(["mcp-surfaces.md"]);
+    expect(reviewRecommendedPaths(byFile.get("mcp-surfaces.md"))).toEqual([
+      "src/cli/commands/mcp.ts",
+    ]);
+    expect(indexFreshnessByFile(null).size).toBe(0);
+  });
+});
 
 describe("renderMarkdown", () => {
   it("escapes HTML first so an embedded script can never survive", () => {


### PR DESCRIPTION
## What changed

- add the read-only `zam_okf_audit` MCP tool with conservative `current`, `review-recommended`, and `unknown` results based on declared code citations, Git ancestry, and working-tree changes
- surface freshness in the OKF visualizer with an unobtrusive sidebar marker and an explanatory article badge
- allow the audit through the VS Code and Copilot companion hosts
- review and refresh all six existing OKF reference articles through `zam_okf_upsert`
- document the design in ADR 2026-07-29b and add 0.23.0 release notes
- bump npm, desktop, Tauri, lockfile, and source-reader versions to 0.23.0

## Why

Developer teams need a deterministic way to notice when implementation code has moved after an OKF article was reviewed, without automatically rewriting team knowledge or altering learner scheduling state.

## Impact

The audit is advisory and read-only. It never changes articles, tokens, cards, imported source bindings, or FSRS state. Missing Git history or incomplete citations degrade to `unknown`, and the OKF panel remains usable while the audit loads. After the feature commit, all six repository OKF articles audit as `current`.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 169 files passed, 1 skipped; 1,615 tests passed, 5 skipped
- `npm run build`
- `npm run build` in `desktop/`
- `cargo metadata --locked --format-version 1 --no-deps` in `desktop/src-tauri/`
- targeted freshness/MCP/panel/protocol/conformance/i18n tests — 158 passed
- local browser QA of the exact built OKF MCP panel, including narrow viewport and console checks
