### PR TITLE
fix: resolve voice availability per language, and offer stt/tts in Settings

### DIFF
--- a/desktop/src-tauri/src/voice.rs
+++ b/desktop/src-tauri/src/voice.rs
@@ -152,23 +152,33 @@ mod platform {
         NSRunLoop::currentRunLoop().runUntilDate(&deadline);
     }
 
-    pub fn tts_available() -> (bool, Option<String>) {
-        // A macOS install always has at least one system voice; the interesting
-        // failure is a locale with no installed voice, which `speak` reports.
-        {
-            let voices = unsafe { AVSpeechSynthesisVoice::speechVoices() };
-            if voices.count() == 0 {
-                (
+    pub fn tts_available(locale: &str) -> (bool, Option<String>) {
+        unsafe {
+            if AVSpeechSynthesisVoice::speechVoices().count() == 0 {
+                return (
                     false,
                     Some("macOS reports no installed system voices".to_string()),
-                )
-            } else {
-                (true, None)
+                );
             }
+            // Per-locale, because that is what `speak` needs: a Mac with voices
+            // but none for the review language cannot read a card aloud.
+            if AVSpeechSynthesisVoice::voiceWithLanguage(Some(&NSString::from_str(locale)))
+                .is_none()
+            {
+                return (
+                    false,
+                    Some(format!(
+                        "macOS has no {locale} system voice installed \
+                         (System Settings › Accessibility › Spoken Content › \
+                         System Voice › Manage Voices)"
+                    )),
+                );
+            }
+            (true, None)
         }
     }
 
-    pub fn stt_available() -> (bool, Option<String>) {
+    pub fn stt_available(locale: &str) -> (bool, Option<String>) {
         unsafe {
             match SFSpeechRecognizer::authorizationStatus() {
                 SFSpeechRecognizerAuthorizationStatus::Denied => {
@@ -188,24 +198,31 @@ mod platform {
                 }
                 _ => {}
             }
-            for tag in ["de-DE", "en-US"] {
-                let locale = NSLocale::localeWithLocaleIdentifier(&NSString::from_str(tag));
-                if let Some(recognizer) = SFSpeechRecognizer::initWithLocale(
-                    SFSpeechRecognizer::alloc(),
-                    &locale,
-                ) {
-                    if recognizer.supportsOnDeviceRecognition() {
-                        return (true, None);
-                    }
+            // Only the review language: `transcribe_local` asks for that exact
+            // locale, so a recognizer for some *other* language is not an
+            // answer. Reporting one available was the old bug — the session
+            // then failed on the first spoken answer.
+            let nslocale = NSLocale::localeWithLocaleIdentifier(&NSString::from_str(locale));
+            if let Some(recognizer) =
+                SFSpeechRecognizer::initWithLocale(SFSpeechRecognizer::alloc(), &nslocale)
+            {
+                if recognizer.supportsOnDeviceRecognition() {
+                    return (true, None);
                 }
+                return (
+                    false,
+                    Some(format!(
+                        "macOS has no on-device speech model for {locale}; \
+                         download it in System Settings › Keyboard › Dictation"
+                    )),
+                );
             }
             (
                 false,
-                Some(
-                    "no on-device speech model is installed for German or English \
+                Some(format!(
+                    "macOS has no speech recognizer for {locale} \
                      (System Settings › Keyboard › Dictation)"
-                        .to_string(),
-                ),
+                )),
             )
         }
     }
@@ -462,28 +479,134 @@ mod platform {
             .map_err(|error| format!("unsupported speech language {locale}: {error}"))
     }
 
-    pub fn tts_available() -> (bool, Option<String>) {
-        match SpeechSynthesizer::AllVoices() {
-            Ok(voices) => match voices.Size() {
-                Ok(count) if count > 0 => (true, None),
-                _ => (
-                    false,
-                    Some("Windows reports no installed speech voices".to_string()),
-                ),
-            },
-            Err(error) => (false, Some(format!("Windows speech synthesis failed: {error}"))),
+    /// The primary subtag of a BCP-47 tag: `de-DE` → `de`.
+    fn primary_subtag(tag: &str) -> String {
+        tag.split('-').next().unwrap_or(tag).to_ascii_lowercase()
+    }
+
+    /// Pick the installed tag that can serve `locale`: the exact tag when it is
+    /// present, otherwise any tag for the same language.
+    ///
+    /// The same-language fallback is deliberate and narrow. Recognizing German
+    /// speech with an `en-US` engine returns confident nonsense, so we never
+    /// cross languages; but a machine carrying only `en-GB` serves an `en-US`
+    /// session perfectly well, and refusing it would be pedantry.
+    pub(super) fn resolve_tag(locale: &str, installed: &[String]) -> Option<String> {
+        if let Some(exact) = installed
+            .iter()
+            .find(|tag| tag.eq_ignore_ascii_case(locale))
+        {
+            return Some(exact.clone());
+        }
+        let wanted = primary_subtag(locale);
+        installed
+            .iter()
+            .find(|tag| primary_subtag(tag) == wanted)
+            .cloned()
+    }
+
+    fn describe_installed(installed: &[String]) -> String {
+        if installed.is_empty() {
+            "none are installed".to_string()
+        } else {
+            format!("this machine has {}", installed.join(", "))
+        }
+    }
+
+    /// Language tags Windows can synthesize, from the installed voices.
+    fn installed_voice_tags() -> Vec<String> {
+        let Ok(voices) = SpeechSynthesizer::AllVoices() else {
+            return Vec::new();
+        };
+        let mut tags: Vec<String> = Vec::new();
+        for index in 0..voices.Size().unwrap_or(0) {
+            let Ok(voice) = voices.GetAt(index) else {
+                continue;
+            };
+            let Ok(tag) = voice.Language() else { continue };
+            let tag = tag.to_string_lossy();
+            if !tags.iter().any(|seen| seen.eq_ignore_ascii_case(&tag)) {
+                tags.push(tag);
+            }
+        }
+        tags
+    }
+
+    /// Language tags Windows can transcribe free-form speech in.
+    ///
+    /// This — not `Language::CreateLanguage` — is what says whether a speech
+    /// pack is installed. `CreateLanguage` validates the *shape* of a BCP-47
+    /// tag and happily returns `de-DE` on a machine with no German speech
+    /// support at all; the failure only surfaces later, in
+    /// `SpeechRecognizer::Create`, as `0x800455BC`.
+    fn installed_recognizer_tags() -> Vec<String> {
+        let Ok(languages) = SpeechRecognizer::SupportedTopicLanguages() else {
+            return Vec::new();
+        };
+        let mut tags: Vec<String> = Vec::new();
+        for index in 0..languages.Size().unwrap_or(0) {
+            let Ok(language) = languages.GetAt(index) else {
+                continue;
+            };
+            let Ok(tag) = language.LanguageTag() else {
+                continue;
+            };
+            tags.push(tag.to_string_lossy());
+        }
+        tags
+    }
+
+    /// The voice Windows should use for `locale`, or `None` when the machine
+    /// has no voice for that language.
+    ///
+    /// Returning `None` rather than falling through to the default voice is the
+    /// point: the default is whatever the *system* language is, so a silent
+    /// fallback reads German cards aloud in an English voice and reports
+    /// success.
+    pub fn tts_available(locale: &str) -> (bool, Option<String>) {
+        let installed = installed_voice_tags();
+        if installed.is_empty() {
+            return (
+                false,
+                Some("Windows reports no installed speech voices".to_string()),
+            );
+        }
+        match resolve_tag(locale, &installed) {
+            Some(_) => (true, None),
+            None => (
+                false,
+                Some(format!(
+                    "Windows has no {locale} speech voice installed ({}). \
+                     Add the language's text-to-speech feature in Settings › \
+                     Time & language › Language & region.",
+                    describe_installed(&installed)
+                )),
+            ),
         }
     }
 
     /// Windows free-form dictation is served by the installed speech language
-    /// pack. Constructing a recognizer for the locale and compiling its default
-    /// constraints is the only honest availability test — a machine without the
-    /// pack fails at compile time, not at construction.
-    pub fn stt_available() -> (bool, Option<String>) {
-        let Ok(language) = language("de-DE").or_else(|_| language("en-US")) else {
+    /// pack, and availability is **per language**: the answer for `de-DE` says
+    /// nothing about `en-US`. Compiling the recognizer's default constraints is
+    /// the final check — a language can be listed and still fail to compile.
+    pub fn stt_available(locale: &str) -> (bool, Option<String>) {
+        let installed = installed_recognizer_tags();
+        let Some(tag) = resolve_tag(locale, &installed) else {
             return (
                 false,
-                Some("no supported speech recognition language".to_string()),
+                Some(format!(
+                    "Windows has no {locale} speech recognition installed ({}). \
+                     Add the language's speech feature in Settings › Time & \
+                     language › Language & region, or switch ZAM to a language \
+                     this machine supports.",
+                    describe_installed(&installed)
+                )),
+            );
+        };
+        let Ok(language) = language(&tag) else {
+            return (
+                false,
+                Some(format!("Windows rejected the speech language tag {tag}")),
             );
         };
         match SpeechRecognizer::Create(&language) {
@@ -494,8 +617,9 @@ mod platform {
                         Ok(status) => (
                             false,
                             Some(format!(
-                                "Windows speech recognition is not ready ({status:?}); \
-                                 install the speech language pack in Settings › Time & Language"
+                                "Windows speech recognition for {tag} is not ready \
+                                 ({status:?}); reinstall the speech language pack in \
+                                 Settings › Time & language › Language & region"
                             )),
                         ),
                         Err(error) => (false, Some(format!("{error}"))),
@@ -507,7 +631,7 @@ mod platform {
             Err(error) => (
                 false,
                 Some(format!(
-                    "Windows could not create a speech recognizer: {error}"
+                    "Windows could not create a {tag} speech recognizer: {error}"
                 )),
             ),
         }
@@ -515,10 +639,15 @@ mod platform {
 
     /// Windows prompts for microphone access through its own privacy settings
     /// rather than an in-process API, so there is nothing to request here.
+    ///
+    /// Deliberately not locale-aware: microphone consent is a machine-wide
+    /// setting, and reporting "prompt" merely because the learner's language
+    /// pack is missing would send them to the wrong Settings page.
     pub fn authorization_state() -> String {
-        match stt_available() {
-            (true, _) => "granted".to_string(),
-            (false, _) => "prompt".to_string(),
+        if installed_recognizer_tags().is_empty() {
+            "prompt".to_string()
+        } else {
+            "granted".to_string()
         }
     }
 
@@ -529,17 +658,28 @@ mod platform {
     pub fn speak(text: &str, locale: &str) -> Result<(), String> {
         let synthesizer = SpeechSynthesizer::new()
             .map_err(|error| format!("Windows speech synthesis failed: {error}"))?;
-        if let Ok(language) = language(locale) {
-            if let Ok(voices) = SpeechSynthesizer::AllVoices() {
-                let tag = language.LanguageTag().unwrap_or_default();
-                for index in 0..voices.Size().unwrap_or(0) {
-                    let Ok(voice) = voices.GetAt(index) else {
-                        continue;
-                    };
-                    if voice.Language().map(|l| l == tag).unwrap_or(false) {
-                        let _ = synthesizer.SetVoice(&voice);
-                        break;
-                    }
+        // Refuse rather than read the card in the wrong language. `tts_available`
+        // gates this in normal operation; the check here is what makes the
+        // failure legible if anything ever calls past it.
+        let installed = installed_voice_tags();
+        let Some(tag) = resolve_tag(locale, &installed) else {
+            return Err(format!(
+                "Windows has no {locale} speech voice installed ({})",
+                describe_installed(&installed)
+            ));
+        };
+        if let Ok(voices) = SpeechSynthesizer::AllVoices() {
+            for index in 0..voices.Size().unwrap_or(0) {
+                let Ok(voice) = voices.GetAt(index) else {
+                    continue;
+                };
+                let matches = voice
+                    .Language()
+                    .map(|l| l.to_string_lossy().eq_ignore_ascii_case(&tag))
+                    .unwrap_or(false);
+                if matches {
+                    let _ = synthesizer.SetVoice(&voice);
+                    break;
                 }
             }
         }
@@ -596,9 +736,21 @@ mod platform {
     }
 
     pub fn listen(locale: &str) -> Result<String, String> {
-        let language = language(locale)?;
-        let recognizer = SpeechRecognizer::Create(&language)
-            .map_err(|error| format!("Windows could not create a speech recognizer: {error}"))?;
+        // Resolve against what is installed before constructing anything: a
+        // valid tag is not an installed language, and `Create` would otherwise
+        // fail with a bare `0x800455BC` that names neither the language nor the
+        // fix (see `installed_recognizer_tags`).
+        let installed = installed_recognizer_tags();
+        let tag = resolve_tag(locale, &installed).ok_or_else(|| {
+            format!(
+                "Windows has no {locale} speech recognition installed ({})",
+                describe_installed(&installed)
+            )
+        })?;
+        let language = language(&tag)?;
+        let recognizer = SpeechRecognizer::Create(&language).map_err(|error| {
+            format!("Windows could not create a {tag} speech recognizer: {error}")
+        })?;
         recognizer
             .CompileConstraintsAsync()
             .and_then(|operation| operation.join())
@@ -633,7 +785,9 @@ mod platform {
     use std::path::PathBuf;
     use std::process::Command;
 
-    pub fn tts_available() -> (bool, Option<String>) {
+    /// `spd-say` resolves the voice from `--language` at speak time and falls
+    /// back to its default, so availability here is not per-locale.
+    pub fn tts_available(_locale: &str) -> (bool, Option<String>) {
         match Command::new("spd-say").arg("--version").output() {
             Ok(output) if output.status.success() => (true, None),
             _ => (
@@ -646,7 +800,7 @@ mod platform {
     /// No desktop Linux distribution ships a general-purpose offline recognizer
     /// ZAM can rely on. Voice mode on Linux therefore needs either the cloud
     /// tier or a self-hosted transcription endpoint (ADR 2026-07-31).
-    pub fn stt_available() -> (bool, Option<String>) {
+    pub fn stt_available(_locale: &str) -> (bool, Option<String>) {
         (
             false,
             Some(
@@ -695,10 +849,22 @@ mod platform {
 /* Commands                                                                   */
 /* -------------------------------------------------------------------------- */
 
+/// Report what this device can do locally **for one review language**.
+///
+/// Availability is per-locale, not per-machine: Windows serves recognition
+/// from a per-language speech pack and macOS from a per-language on-device
+/// model, so a machine can be fully capable in English and have nothing at all
+/// for German. Answering machine-wide was the 0.24.0 bug — a locale the learner
+/// never uses could report the feature available, and the session then failed
+/// on the first spoken word.
+///
+/// `locale` is optional so the command stays callable from a probe that has no
+/// UI locale yet; it falls back to the same default as `normalize_locale`.
 #[tauri::command]
-pub fn voice_capabilities() -> VoiceCapabilities {
-    let (tts_local, tts_detail) = platform::tts_available();
-    let (stt_local, stt_detail) = platform::stt_available();
+pub fn voice_capabilities(locale: Option<String>) -> VoiceCapabilities {
+    let locale = normalize_locale(locale.as_deref().unwrap_or_default());
+    let (tts_local, tts_detail) = platform::tts_available(locale);
+    let (stt_local, stt_detail) = platform::stt_available(locale);
     VoiceCapabilities {
         stt_local,
         tts_local,
@@ -855,12 +1021,50 @@ mod tests {
     fn reports_capabilities_without_panicking() {
         // Availability differs per machine; the contract is that probing is
         // always safe to call, including with no microphone and no consent.
-        let capabilities = voice_capabilities();
-        assert_eq!(
-            capabilities.stt_local,
-            capabilities.stt_detail.is_none(),
-            "a missing capability must always explain itself"
-        );
-        assert_eq!(capabilities.tts_local, capabilities.tts_detail.is_none());
+        for locale in [None, Some("de".to_string()), Some("en-GB".to_string())] {
+            let capabilities = voice_capabilities(locale);
+            assert_eq!(
+                capabilities.stt_local,
+                capabilities.stt_detail.is_none(),
+                "a missing capability must always explain itself"
+            );
+            assert_eq!(capabilities.tts_local, capabilities.tts_detail.is_none());
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    mod windows_tags {
+        use super::super::platform;
+
+        #[test]
+        fn resolves_the_exact_tag_before_the_language() {
+            let installed = vec!["en-GB".to_string(), "en-US".to_string()];
+            assert_eq!(
+                platform::resolve_tag("en-US", &installed).as_deref(),
+                Some("en-US")
+            );
+        }
+
+        /// A machine carrying only en-GB should still serve an en-US session:
+        /// same language, and refusing it would be pedantry.
+        #[test]
+        fn falls_back_within_the_same_language() {
+            let installed = vec!["en-GB".to_string()];
+            assert_eq!(
+                platform::resolve_tag("en-US", &installed).as_deref(),
+                Some("en-GB")
+            );
+        }
+
+        /// The regression that shipped in 0.24.0: `Language::CreateLanguage`
+        /// accepts `de-DE` on a machine with only English speech, so ZAM
+        /// believed it had a German recognizer and `Create` failed with
+        /// 0x800455BC. Languages must never substitute for one another.
+        #[test]
+        fn never_crosses_languages() {
+            let installed = vec!["en-GB".to_string(), "en-US".to_string()];
+            assert_eq!(platform::resolve_tag("de-DE", &installed), None);
+            assert_eq!(platform::resolve_tag("de-DE", &[]), None);
+        }
     }
 }

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -48,6 +48,7 @@ import {
   unavailableReasonKey,
   type VoiceEnginePlan,
   type VoiceEnginePreference,
+  type VoiceLocale,
 } from "./voice.js";
 import {
   beginTurn,
@@ -1004,6 +1005,9 @@ async function setLocale(locale: Locale): Promise<void> {
   initializeTranslations();
   void loadWorkspaceList();
   void loadProviderStatus();
+  // Device speech availability is per-language: a machine with an English
+  // speech pack and no German one gains or loses voice mode on this switch.
+  void refreshVoiceAvailability();
 }
 
 function isActiveWorkspace(workspace: WorkspaceConfig): boolean {
@@ -1745,9 +1749,19 @@ function capabilityLabel(cap: ModelCapability): string {
   }
 }
 
-// Capabilities exposed in the Settings UI today; the data model also carries
-// video/stt/tts for forward-compatibility (ADR 2026-07-12).
-const UI_CAPABILITIES: ModelCapability[] = ["text", "embedding", "image"];
+// Capabilities exposed in the Settings UI. stt/tts joined the list in 0.24.0:
+// voice mode's cloud tier reads `capabilities.stt`/`.tts`, and `validateModelSave`
+// intersects what the learner ticked with what the probe detected — so a
+// capability the editor never offers can never be stored, and a correctly
+// detected Whisper endpoint would sit there permanently unusable. `video` stays
+// out until something consumes it (ADR 2026-07-12, ADR 2026-07-31).
+const UI_CAPABILITIES: ModelCapability[] = [
+  "text",
+  "embedding",
+  "image",
+  "stt",
+  "tts",
+];
 
 async function loadModelRegistry(): Promise<void> {
   const status = aiConfigStatusEl();
@@ -4967,6 +4981,14 @@ const REVIEW_ACTION_TRIGGER_IDS = [
 /** Machine-local preference; loaded from ~/.zam/config.json on first probe. */
 let voicePreference: VoiceEnginePreference = readStoredPreference(undefined);
 let voiceCapabilities: NativeVoiceCapabilities | null = null;
+/**
+ * The review locale `voiceCapabilities` was probed for.
+ *
+ * Device speech availability is per-language, so the cached answer is only
+ * valid for the language it was asked about; switching the app language must
+ * re-probe rather than reuse a verdict about a different one.
+ */
+let voiceCapabilitiesLocale: VoiceLocale | null = null;
 let voiceCloudAvailability = { stt: false, tts: false };
 let voiceProbePending = false;
 
@@ -5086,24 +5108,27 @@ function updateVoiceButton(): void {
 }
 
 /**
- * Probe the device once per app run and show or explain the control.
+ * Probe the device for the current review language and show or explain the
+ * control.
  *
- * The cloud tier is not wired yet, so cloud availability is reported as false:
- * every preference therefore resolves to the device, which is the honest
- * answer today rather than a promise the build cannot keep.
+ * The probe is cached per locale rather than per app run: device speech
+ * availability differs by language, so switching the app language invalidates
+ * the previous answer and must ask again.
  */
 async function refreshVoiceAvailability(): Promise<void> {
   if (voiceProbePending) return;
   voiceProbePending = true;
   try {
-    if (!voiceCapabilities) {
+    const locale = resolveVoiceLocale(currentLocale);
+    if (!voiceCapabilities || voiceCapabilitiesLocale !== locale) {
       try {
         const stored = await runBridge("voice-preference-get", []);
         voicePreference = readStoredPreference(stored?.preference);
       } catch (error) {
         console.warn("Falling back to the default voice preference", error);
       }
-      voiceCapabilities = await probeNativeCapabilities(voiceInvoke);
+      voiceCapabilities = await probeNativeCapabilities(voiceInvoke, locale);
+      voiceCapabilitiesLocale = locale;
     }
     try {
       const cloud = await runBridge("voice-availability", []);

--- a/desktop/src/voice.ts
+++ b/desktop/src/voice.ts
@@ -108,10 +108,19 @@ export function createVoicePort(invoke: TauriInvoke): VoicePort {
   };
 }
 
+/**
+ * Ask the device what it can do locally **for one review language**.
+ *
+ * The locale is required, not incidental: Windows serves recognition from a
+ * per-language speech pack and macOS from a per-language on-device model, so a
+ * machine can be fully capable in English and have nothing for German. Callers
+ * must re-probe when the app language changes — see `refreshVoiceAvailability`.
+ */
 export function probeNativeCapabilities(
   invoke: TauriInvoke,
+  locale: VoiceLocale,
 ): Promise<NativeVoiceCapabilities> {
-  return invoke<NativeVoiceCapabilities>("voice_capabilities");
+  return invoke<NativeVoiceCapabilities>("voice_capabilities", { locale });
 }
 
 /** What the tiered port needs from the bridge and the page to reach the cloud. */

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -18,7 +18,7 @@ Current truth only — the *why* behind it lives in [../adr/](../adr/)
 
 - [Kernel and CLI Architecture](kernel-architecture.md) — ZAM is split into an AI-agnostic learning kernel and a thin CLI orchestration layer; all learning logic lives in the kernel, all LLM/HTTP code in the CLI.
 - [MCP Transport and Surfaces](mcp-surfaces.md) — zam mcp is the preferred agent transport - a stdio MCP server exposing focused ZAM tools and host-rendered MCP Apps panels.
-- [Hands-Free Voice Mode](voice-mode.md) — Voice review runs one shared kernel loop over a device tier of native OS speech and a cloud tier from the capability registry, resolved per capability from a machine-local user preference.
+- [Hands-Free Voice Mode](voice-mode.md) — Voice review runs one shared kernel loop over a device tier of native OS speech and a cloud tier from the capability registry, resolved per capability and per language from a machine-local user preference.
 
 ## data-model
 

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-31
 
+- **Update** — [Hands-Free Voice Mode](voice-mode.md)
 - **Update** — [FSRS-5 Scheduling](fsrs-scheduling.md)
 - **Creation** — [Hands-Free Voice Mode](voice-mode.md)
 

--- a/docs/okf/voice-mode.md
+++ b/docs/okf/voice-mode.md
@@ -1,14 +1,14 @@
 ---
 type: architecture
 title: Hands-Free Voice Mode
-description: Voice review runs one shared kernel loop over a device tier of native OS speech and a cloud tier from the capability registry, resolved per capability from a machine-local user preference.
+description: Voice review runs one shared kernel loop over a device tier of native OS speech and a cloud tier from the capability registry, resolved per capability and per language from a machine-local user preference.
 tags:
   - voice
   - recall
   - desktop
   - mobile
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/voice-mode.md"
-timestamp: 2026-07-31T08:00:00Z
+timestamp: 2026-07-31T09:40:00Z
 ---
 
 Voice mode reads a due card aloud, listens for the spoken answer, and maps a
@@ -61,6 +61,12 @@ Speech-to-text and text-to-speech resolve **independently**. Linux has local
 synthesis but no local recognizer, so it reads cards aloud locally while
 transcribing through the cloud; a learner with no cloud model configured still
 gets local reading-aloud.
+
+The cloud tier is reachable only through a registry entry whose `stt` or `tts`
+flag is set, and `validateModelSave` stores the *intersection* of what the
+learner ticked and what the probe detected. Both flags are therefore offered as
+checkboxes in Settings (`UI_CAPABILITIES`): a capability the editor does not
+offer can never be stored, however well the probe detects it.
 
 `resolveVoiceEnginePlan(preference, availability)` returns a tier plus a
 *reason* per capability, so a surface can always state why. `isVoiceModeUsable`
@@ -134,12 +140,34 @@ Unlike macOS it exposes no on-device flag, so ZAM treats Windows local
 recognition as available only when the recognizer compiles its constraints on
 that machine, and does not claim it is provably offline.
 
-# Availability is per device
+# Availability is per device *and per language*
 
 Voice mode is the first ZAM feature whose availability legitimately differs per
-machine. `voice_capabilities` reports each local capability plus a human
-readable reason when it is missing, and surfaces render that reason instead of
-a dead button.
+machine. `voice_capabilities(locale)` reports each local capability for **one
+review language**, plus a human readable reason when it is missing, and
+surfaces render that reason instead of a dead button.
+
+The locale is not decoration. Windows serves recognition from a per-language
+speech pack and macOS from a per-language on-device model, so a machine can be
+fully capable in English and have nothing at all for German. Two rules follow:
+
+- **Ask about the language being reviewed.** A recognizer for some *other*
+  language is not an answer — the session would fail on the first spoken word.
+- **Never let one language stand in for another.** Recognizing German speech
+  with an English engine returns confident nonsense, and the default synthesis
+  voice reads German cards aloud in an English one while reporting success.
+  Falling back *within* a language is fine: a machine carrying only `en-GB`
+  serves an `en-US` session, and refusing that would be pedantry.
+
+On Windows the installed set comes from `SupportedTopicLanguages()` and
+`SpeechSynthesizer::AllVoices()`. `Language::CreateLanguage` must not be used
+for this: it validates the *shape* of a BCP-47 tag and accepts `de-DE` on a
+machine with no German speech at all, deferring the failure to
+`SpeechRecognizer::Create` as a bare `0x800455BC`. On macOS the check is
+`initWithLocale` plus `supportsOnDeviceRecognition` for that one locale.
+
+Because the answer is per-language, the desktop caches the probe per locale and
+re-probes when the app language changes.
 
 # Citations
 

--- a/tests/desktop/voice.test.ts
+++ b/tests/desktop/voice.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildAvailability,
@@ -50,9 +52,26 @@ describe("desktop voice port", () => {
 
   it("probes capabilities through voice_capabilities", async () => {
     const invoke = (async <T,>(): Promise<T> => native(true, true) as T) as TauriInvoke;
-    await expect(probeNativeCapabilities(invoke)).resolves.toEqual(
+    await expect(probeNativeCapabilities(invoke, "de-DE")).resolves.toEqual(
       native(true, true),
     );
+  });
+
+  // Device speech availability is per-language — Windows serves recognition
+  // from a per-language speech pack, macOS from a per-language on-device model
+  // — so the probe that omitted the locale could only ever answer about some
+  // other language than the one being reviewed.
+  it("asks about the locale being reviewed", async () => {
+    const calls: unknown[] = [];
+    const invoke = (async <T,>(_command: string, args?: unknown): Promise<T> => {
+      calls.push(args);
+      return native(true, true) as T;
+    }) as TauriInvoke;
+
+    await probeNativeCapabilities(invoke, "de-DE");
+    await probeNativeCapabilities(invoke, "en-US");
+
+    expect(calls).toEqual([{ locale: "de-DE" }, { locale: "en-US" }]);
   });
 });
 
@@ -100,6 +119,35 @@ describe("desktop voice availability", () => {
     expect(readStoredPreference("quality-first")).toBe("quality-first");
     for (const stored of [undefined, null, "", "local", 7, {}]) {
       expect(readStoredPreference(stored)).toBe("device-first");
+    }
+  });
+
+  /**
+   * The cloud tier is reachable only through `capabilities.stt`/`.tts` on a
+   * registry entry, and `validateModelSave` intersects what the learner ticked
+   * with what the probe detected. A capability the Settings editor never offers
+   * can therefore never be stored — 0.24.0 shipped with stt/tts detected but
+   * unofferable, so every cloud speech model was saved with both flags false
+   * and the tier was dead on arrival. Asserted against the source because
+   * main.ts owns the DOM and cannot be imported here.
+   */
+  it("offers every voice capability the cloud tier reads", () => {
+    const source = readFileSync(
+      join(process.cwd(), "desktop", "src", "main.ts"),
+      "utf-8",
+    );
+    const declaration = source.match(
+      /const UI_CAPABILITIES: ModelCapability\[\] = \[([^\]]*)\]/,
+    );
+    expect(declaration, "UI_CAPABILITIES must exist in main.ts").not.toBeNull();
+    const offered = [...declaration![1].matchAll(/"([a-z]+)"/g)].map(
+      (match) => match[1],
+    );
+    for (const capability of ["stt", "tts"]) {
+      expect(
+        offered,
+        `Settings must let a model be marked ${capability}`,
+      ).toContain(capability);
     }
   });
 });


### PR DESCRIPTION
Voice mode shipped in 0.24.0 unusable on Windows machines without a German speech pack — including ones fully capable in English — and its cloud tier could not be switched on at all. Both halves are fixed here.

## Device tier: availability is per language

`stt_available` guarded its en-US fallback with `Language::CreateLanguage`, which validates the *shape* of a BCP-47 tag rather than whether a pack is installed. `de-DE` therefore always parsed, the `.or_else` never ran, and `SpeechRecognizer::Create` was only ever attempted with German — failing `0x800455BC` on a machine whose `en-US` recognizer worked perfectly.

Three more instances of the same class:

- `listen()` had no fallback at all, so a German session failed even where detection succeeded.
- `speak()` silently fell through to the system default voice — reading German cards aloud in English and reporting success.
- macOS `stt_available` looped `["de-DE", "en-US"]` and returned available if *either* worked, while `transcribe_local` then asked for the session locale.

Availability is genuinely per-language, so `voice_capabilities` now takes the review locale and answers for that language alone. Installed languages come from `SupportedTopicLanguages()` / `AllVoices()` on Windows and `initWithLocale` + `supportsOnDeviceRecognition` on macOS. Falling back *within* a language is allowed (a machine carrying only `en-GB` serves an `en-US` session); across languages never is, because an English engine transcribes German as confident nonsense.

The desktop caches the probe per locale and re-probes on a language switch, and unavailable reasons now name the language and what the machine actually has:

```
[de]     stt=false  "Windows has no de-DE speech recognition installed (this machine has
                     en-GB, en-US). Add the language's speech feature in Settings › Time &
                     language › Language & region, or switch ZAM to a language this
                     machine supports."
[en-US]  stt=true   tts=true
```

That second line is the point: on the reporting machine, voice mode works today in English and previously did not.

## Cloud tier: stt/tts were unofferable

`UI_CAPABILITIES` listed only text/embedding/image, and `validateModelSave` stores the *intersection* of what the learner ticked with what the probe detected. A correctly detected Whisper endpoint was therefore always persisted with both flags false and could never be selected — the tier was dead on arrival. Both are now checkboxes, and stay hidden for agent-transport entries, which cannot carry audio.

## Verification

- 7 Rust tests pass, including three new ones pinning `resolve_tag`: exact match, same-language fallback, and never crossing languages.
- 2 new TS tests: the probe forwards the locale, and Settings must offer every capability the cloud tier reads.
- `npm run typecheck`, `npm run lint`, and the desktop `tsc && vite build` are clean.
- Full suite: 9 failures on this branch vs **8 on clean main** — all in `tests/cli/*`, all the known subprocess-timeout flakiness (they pass in isolation), none touching voice or desktop. Baseline measured by checking out main and running it, not assumed.
- Settings editor driven in the running renderer: all five checkboxes render with correct labels, tick, and correctly collapse to text-only on agent transport.
- `docs/okf/voice-mode.md` updated through `zam_okf_upsert`.

`cargo fmt` diffs were left alone — all six are pre-existing, in macOS code this PR does not touch, and CI runs neither fmt nor clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)