### PR TITLE
chore: release 0.24.1

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.24.0"
+version = "0.24.1"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.24.1.md
+++ b/docs/release-notes-0.24.1.md
@@ -1,0 +1,65 @@
+# ZAM 0.24.1 — Voice mode says which language it can hear
+
+0.24.0 brought voice review to the desktop. On a machine whose speech pack did
+not match the language ZAM was running in, it reported voice mode unavailable —
+including machines that were perfectly capable of the job in another language.
+This release fixes that, and makes the cloud speech tier reachable at all.
+
+## Availability is a question about a language
+
+Voice mode's availability is not a property of your computer. Windows serves
+recognition from a per-language speech pack and macOS from a per-language
+on-device model, so a machine can be fully equipped for English and have
+nothing at all for German.
+
+0.24.0 asked the wrong question. It checked whether German speech recognition
+could be *named*, not whether it was *installed* — and a language tag always
+parses, whether or not the pack exists. The check passed, the real work then
+failed, and the fallback to English that was supposed to cover exactly this
+case never ran. A machine with working English recognition reported voice mode
+unavailable and offered no way to find out why.
+
+ZAM now asks the operating system which languages it can actually transcribe
+and speak, and answers for the language you are reviewing in. Where it cannot
+help, it says which language is missing and which ones your machine does have:
+
+> Windows has no de-DE speech recognition installed (this machine has en-GB,
+> en-US). Add the language's speech feature in Settings › Time & language ›
+> Language & region, or switch ZAM to a language this machine supports.
+
+Switching ZAM's language re-checks the device, so voice mode can appear or
+disappear when you do — which is the honest answer, not a quirk.
+
+### One language never stands in for another
+
+ZAM will use a close relative: a machine carrying only British English serves an
+American English session, and refusing that would be pedantry. It will not cross
+languages. An English recognizer fed German speech does not fail — it returns
+fluent nonsense, confidently — and the default system voice reads German cards
+aloud in English while reporting success. Both were possible in 0.24.0. Neither
+is now.
+
+## Cloud speech models can actually be chosen
+
+0.24.0 said cloud speech was "an ordinary entry in the model list with the new
+speech-to-text or text-to-speech capability ticked". Those two checkboxes were
+never added to the model editor, and ZAM only stores capabilities you have
+ticked *and* it has detected — so a correctly recognised Whisper endpoint was
+saved with both switched off and could never be selected. The cloud tier could
+not be turned on by anyone.
+
+The checkboxes are there now. They stay hidden for agent-harness entries, which
+cannot carry audio.
+
+## Worth knowing
+
+- **If voice mode was unavailable for you on Windows or macOS, try it again** —
+  particularly if you review in English, where no install is needed. Where a
+  language pack genuinely is missing, ZAM now names it.
+- **To add a language on Windows**, run `Install-Language de-DE` in an elevated
+  PowerShell, or use Settings › Time & language › Language & region and tick the
+  speech and text-to-speech features.
+- **Cloud speech needs an OpenAI-shaped `/audio/*` endpoint.** A chat-only
+  provider cannot serve it, however capable its text models are. A speech server
+  you host yourself counts as local and satisfies "this device only".
+- Nothing else in 0.24.0 changed. This is a fix release for voice mode.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-mobile",
-  "version": "0.23.1",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-mobile",
-      "version": "0.23.1",
+      "version": "0.24.1",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-barcode-scanner": "^2.4.5"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zam-mobile",
   "private": true,
-  "version": "0.23.1",
+  "version": "0.24.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "zam-mobile"
-version = "0.23.1"
+version = "0.24.1"
 dependencies = [
  "base64 0.22.1",
  "hyper-rustls 0.25.0",

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-mobile"
-version = "0.23.1"
+version = "0.24.1"
 description = "ZAM mobile companion app (Android + iOS)"
 edition = "2021"
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.24.0",
+          "User-Agent": "ZAM-Content-Studio/0.24.1",
         },
       });
 

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -5501,7 +5501,7 @@ async function fetchRawHtml(url: string): Promise<string> {
     const res = await fetch(url, {
       signal: controller.signal,
       headers: {
-        "User-Agent": "ZAM-Content-Studio/0.23.1",
+        "User-Agent": "ZAM-Content-Studio/0.24.1",
       },
     });
     if (!res.ok) {


### PR DESCRIPTION
Patch release for the 0.24.0 voice mode, plus the OKF radar fix.

## What ships

- **#260** — voice availability is resolved per language. 0.24.0 checked whether a speech language could be *named* rather than whether it was *installed*, so the en-US fallback never ran and machines fully capable in English reported voice mode unavailable. Unavailable reasons now name the missing language and what the machine does have. Cloud `stt`/`tts` are selectable in Settings for the first time — they were detected but unofferable, so the tier could not be switched on by anyone.
- **#257** — the OKF freshness radar no longer reports version-string churn as drift.

## Version bump

Twelve files. Note that the mobile set and the `bridge.ts` User-Agent had drifted to **0.23.1** again — the same four spots missed at 0.19.0 and 0.23.1 — and are realigned to 0.24.1 here:

| | Was | Now |
| --- | --- | --- |
| root `package.json` + lock | 0.24.0 | 0.24.1 |
| `desktop/package.json` + lock | 0.24.0 | 0.24.1 |
| `desktop/src-tauri` Cargo.toml + lock | 0.24.0 | 0.24.1 |
| `src/cli/adapters/source-reader.ts` UA | 0.24.0 | 0.24.1 |
| `mobile/package.json` + lock | **0.23.1** | 0.24.1 |
| `mobile/src-tauri` Cargo.toml + lock | **0.23.1** | 0.24.1 |
| `src/cli/commands/bridge.ts` UA | **0.23.1** | 0.24.1 |

Both `tauri.conf.json` files read the root `package.json`, so the shipped app version and Android versionCode were correct in 0.24.0 — this is manifest hygiene, not a shipped-version bug.

## Verification

`npm run typecheck`, `npm run lint`, and the full Vitest suite are clean — **1679 passed, 0 failed**. `npm run build` produces `ZAM_Companion_0.24.1.vsix`.

## Known drift, not addressed here

The freshness radar correctly flags two articles against changes that landed in **0.24.0**, not in this release:

- `bridge-protocol.md` — #259 added `voice-preference-get/set`, `voice-availability`, `voice-transcribe`, `voice-synthesize` (119 lines) without documenting them.
- `kernel-architecture.md` — `src/kernel/index.ts` gained the voice exports.

Both are pre-existing documentation debt and are left for a follow-up rather than widened into a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)