### PR TITLE
fix: detect the Windows speech privacy policy before offering voice mode

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -40,4 +40,7 @@ objc2-avf-audio = { version = "0.3", features = ["AVAudioRecorder", "AVSpeechSyn
 objc2-speech = { version = "0.3", features = ["SFSpeechRecognizer", "SFSpeechRecognitionRequest", "SFSpeechRecognitionResult", "SFSpeechRecognitionTask", "SFTranscription", "block2"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = ["Foundation", "Foundation_Collections", "Globalization", "Media_Core", "Media_Playback", "Media_SpeechRecognition", "Media_SpeechSynthesis", "Storage_Streams"] }
+# Win32_System_Registry is needed to read the speech privacy-policy flag:
+# dictation refuses to run without it and only says so at recognition time, so
+# there is no WinRT API to ask up front (see voice.rs::speech_privacy_accepted).
+windows = { version = "0.62", features = ["Foundation", "Foundation_Collections", "Globalization", "Media_Core", "Media_Playback", "Media_SpeechRecognition", "Media_SpeechSynthesis", "Storage_Streams", "Win32_System_Registry"] }

--- a/desktop/src-tauri/src/voice.rs
+++ b/desktop/src-tauri/src/voice.rs
@@ -465,14 +465,93 @@ mod platform {
 
     use windows::core::HSTRING;
     use windows::Globalization::Language;
-    use windows::Media::Playback::{MediaPlayer, MediaPlaybackState};
+    use windows::Media::Core::MediaSource;
+    use windows::Media::Playback::{MediaPlaybackState, MediaPlayer};
     use windows::Media::SpeechRecognition::{
         SpeechRecognitionResultStatus, SpeechRecognizer, SpeechRecognizerState,
     };
     use windows::Media::SpeechSynthesis::SpeechSynthesizer;
-    use windows::Media::Core::MediaSource;
+    use windows::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_CURRENT_USER, KEY_READ, REG_DWORD,
+    };
 
     use super::MAX_OPERATION_SECS;
+
+    /// `SPERR_SPEECH_PRIVACY_POLICY_NOT_ACCEPTED` — what `RecognizeAsync` raises
+    /// when Windows' speech privacy policy has not been accepted.
+    pub(super) const SPEECH_PRIVACY_NOT_ACCEPTED: i32 = 0x8004_5509_u32 as i32;
+
+    /// Where the Speech privacy setting records consent.
+    const PRIVACY_KEY: &str = "Software\\Microsoft\\Speech_OneCore\\Settings\\OnlineSpeechPrivacy";
+
+    /// Shared so the up-front capability answer and a mid-session failure say the
+    /// same thing, and so neither can drift into a bare HRESULT.
+    const PRIVACY_REASON: &str = "Windows has not been given permission for speech recognition. \
+         Turn on Settings › Privacy & security › Speech › \"Online speech recognition\" — \
+         free-form dictation refuses to run until that policy is accepted.";
+
+    /// Whether the user has accepted Windows' speech privacy policy.
+    ///
+    /// This has to be read from the registry because the recognizer will not
+    /// tell us: `CompileConstraintsAsync` reports success either way, and the
+    /// refusal only surfaces from `RecognizeAsync` — i.e. after the learner has
+    /// already started a session and spoken. There is no WinRT API to ask.
+    ///
+    /// A missing key means never-accepted, which is the state of a machine that
+    /// has not visited the Speech privacy page.
+    pub(super) fn speech_privacy_accepted() -> bool {
+        let mut key = HKEY::default();
+        let path: Vec<u16> = PRIVACY_KEY
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let opened = unsafe {
+            RegOpenKeyExW(
+                HKEY_CURRENT_USER,
+                windows::core::PCWSTR(path.as_ptr()),
+                None,
+                KEY_READ,
+                &mut key,
+            )
+        };
+        if opened.is_err() {
+            return false;
+        }
+        let name: Vec<u16> = "HasAccepted"
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let mut value: u32 = 0;
+        let mut size = std::mem::size_of::<u32>() as u32;
+        let mut kind = REG_DWORD;
+        let read = unsafe {
+            RegQueryValueExW(
+                key,
+                windows::core::PCWSTR(name.as_ptr()),
+                None,
+                Some(&mut kind),
+                Some(&mut value as *mut u32 as *mut u8),
+                Some(&mut size),
+            )
+        };
+        unsafe {
+            let _ = RegCloseKey(key);
+        }
+        read.is_ok() && kind == REG_DWORD && value == 1
+    }
+
+    /// Turn a recognition failure into something the learner can act on.
+    ///
+    /// Pure so the privacy mapping is testable without a microphone: the one
+    /// code that must never reach the UI raw is the privacy refusal, because its
+    /// text (`0x80045509`) names neither the cause nor the setting that fixes it.
+    pub(super) fn recognition_error_message(code: i32, detail: &str) -> String {
+        if code == SPEECH_PRIVACY_NOT_ACCEPTED {
+            PRIVACY_REASON.to_string()
+        } else {
+            format!("Windows speech recognition failed: {detail}")
+        }
+    }
 
     fn language(locale: &str) -> Result<Language, String> {
         Language::CreateLanguage(&HSTRING::from(locale))
@@ -609,6 +688,13 @@ mod platform {
                 Some(format!("Windows rejected the speech language tag {tag}")),
             );
         };
+        // Before exercising the recognizer: a machine that has not accepted the
+        // speech privacy policy compiles constraints happily and then refuses
+        // the first spoken word, which is exactly the dead button this module
+        // exists to avoid.
+        if !speech_privacy_accepted() {
+            return (false, Some(PRIVACY_REASON.to_string()));
+        }
         match SpeechRecognizer::Create(&language) {
             Ok(recognizer) => match recognizer.CompileConstraintsAsync() {
                 Ok(operation) => match operation.join() {
@@ -758,7 +844,7 @@ mod platform {
         let result = recognizer
             .RecognizeAsync()
             .and_then(|operation| operation.join())
-            .map_err(|error| format!("Windows speech recognition failed: {error}"))?;
+            .map_err(|error| recognition_error_message(error.code().0, &error.message()))?;
         match result.Status() {
             Ok(SpeechRecognitionResultStatus::Success) => {}
             Ok(status) => return Err(format!("Windows speech recognition failed ({status:?})")),
@@ -1065,6 +1151,42 @@ mod tests {
             let installed = vec!["en-GB".to_string(), "en-US".to_string()];
             assert_eq!(platform::resolve_tag("de-DE", &installed), None);
             assert_eq!(platform::resolve_tag("de-DE", &[]), None);
+        }
+
+        /// 0.24.1 shipped this dead button: the recognizer compiles fine without
+        /// the speech privacy policy and only refuses at `RecognizeAsync`, so
+        /// the learner met a bare `0x80045509` after speaking. The privacy
+        /// refusal must always be translated into the setting that fixes it.
+        #[test]
+        fn privacy_refusal_names_the_setting_to_change() {
+            let message = platform::recognition_error_message(
+                platform::SPEECH_PRIVACY_NOT_ACCEPTED,
+                "The speech privacy policy was not accepted prior to attempting a speech recognition.",
+            );
+            assert!(
+                message.contains("Online speech recognition"),
+                "should name the setting: {message}"
+            );
+            assert!(
+                !message.contains("0x80045509"),
+                "should not leak the raw code: {message}"
+            );
+        }
+
+        /// Everything else keeps its original text — this mapping exists to
+        /// explain one specific refusal, not to swallow unrelated failures.
+        #[test]
+        fn other_failures_keep_their_detail() {
+            let message =
+                platform::recognition_error_message(0x8000_4005_u32 as i32, "Unspecified error");
+            assert!(message.contains("Unspecified error"), "{message}");
+        }
+
+        /// Probing consent must be safe on any machine, including one that has
+        /// never opened the Speech privacy page (the key is absent there).
+        #[test]
+        fn privacy_probe_is_always_safe_to_call() {
+            let _ = platform::speech_privacy_accepted();
         }
     }
 }

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,7 @@
 ## 2026-07-31
 
 - **Update** — [Hands-Free Voice Mode](voice-mode.md)
+- **Update** — [Hands-Free Voice Mode](voice-mode.md)
 - **Update** — [FSRS-5 Scheduling](fsrs-scheduling.md)
 - **Creation** — [Hands-Free Voice Mode](voice-mode.md)
 

--- a/docs/okf/voice-mode.md
+++ b/docs/okf/voice-mode.md
@@ -8,7 +8,7 @@ tags:
   - desktop
   - mobile
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/voice-mode.md"
-timestamp: 2026-07-31T09:40:00Z
+timestamp: 2026-07-31T16:20:00Z
 ---
 
 Voice mode reads a due card aloud, listens for the spoken answer, and maps a
@@ -135,10 +135,31 @@ runtime, the `com.apple.security.device.audio-input` entitlement. Consent is
 therefore only obtainable from the signed app bundle, never from a bare test
 binary.
 
-Windows serves free-form dictation from the installed speech language pack.
-Unlike macOS it exposes no on-device flag, so ZAM treats Windows local
-recognition as available only when the recognizer compiles its constraints on
-that machine, and does not claim it is provably offline.
+Windows serves free-form dictation from the installed speech language pack, and
+additionally requires the user to have accepted the **speech privacy policy**
+(Settings › Privacy & security › Speech › "Online speech recognition"). Unlike
+macOS it exposes no on-device flag, so ZAM treats Windows local recognition as
+available only when the language is installed, consent is on record, and the
+recognizer compiles its constraints on that machine — and does not claim it is
+provably offline. The setting's name is a standing reason for that caution:
+whether the dictation topic constraint is served locally or by Microsoft has
+not been established, so `device-only` on Windows is the weakest of ZAM's
+on-device claims.
+
+## Consent cannot be probed through the recognizer
+
+`CompileConstraintsAsync` reports success whether or not the privacy policy has
+been accepted; the refusal surfaces only from `RecognizeAsync`, as
+`SPERR_SPEECH_PRIVACY_POLICY_NOT_ACCEPTED` (`0x80045509`) — after the learner
+has opened a session and spoken. There is no WinRT API to ask in advance, so
+`speech_privacy_accepted()` reads `HasAccepted` under
+`HKCU\Software\Microsoft\Speech_OneCore\Settings\OnlineSpeechPrivacy`, treating
+an absent key as never-accepted. `recognition_error_message` additionally maps
+the HRESULT, so the refusal is legible even if that flag ever moves.
+
+This is the one place where the module reads the registry rather than asking an
+API, and it is worth the exception: the alternative is 0.24.1's behaviour, where
+the button appeared, the learner spoke, and the session died on a bare HRESULT.
 
 # Availability is per device *and per language*
 
@@ -165,6 +186,10 @@ for this: it validates the *shape* of a BCP-47 tag and accepts `de-DE` on a
 machine with no German speech at all, deferring the failure to
 `SpeechRecognizer::Create` as a bare `0x800455BC`. On macOS the check is
 `initWithLocale` plus `supportsOnDeviceRecognition` for that one locale.
+
+Reasons are ordered from the most fundamental cause outwards — missing language
+before missing consent — so the learner is told the first thing they have to fix
+rather than the last thing that failed.
 
 Because the answer is per-language, the desktop caches the probe per locale and
 re-probes when the app language changes.


### PR DESCRIPTION
Found on a real machine right after 0.24.1 shipped. Voice mode appeared, text-to-speech worked, and then the first spoken answer died with:

> Voice mode paused: Windows speech recognition failed: The speech privacy policy was not accepted prior to attempting a speech recognition. (0x80045509)

## Why it got through

Windows refuses free-form dictation until the user has accepted the speech privacy policy — and it does not say so up front. `CompileConstraintsAsync` reports **success** either way; the refusal surfaces only from `RecognizeAsync`. So `stt_available()` truthfully reported "the recognizer compiles", ZAM showed the button, and the learner discovered the problem by speaking into it.

That is the same dead-button failure #260 fixed for languages, one layer deeper: the reason existed but arrived too late and as a bare HRESULT.

Verified on the reporting machine — the consent key was absent entirely:

```
HKCU\Software\Microsoft\Speech_OneCore\Settings\OnlineSpeechPrivacy   (missing)
```

## The fix

There is no WinRT API to ask about consent, so `speech_privacy_accepted()` reads `HasAccepted` from that key, treating an absent key as never-accepted. `recognition_error_message` **additionally** maps `0x80045509`, so the refusal stays legible even if the flag ever moves — the registry read answers early, it is not the only line of defence.

Before and after on the reporting machine:

| locale | before | after |
| --- | --- | --- |
| `en-US` | reported **available**, died on first speech | unavailable, *"Turn on Settings › Privacy & security › Speech › Online speech recognition"* |
| `de` | unavailable (language missing) | unchanged — language reason still wins |

Reasons are ordered most-fundamental-first on purpose: a machine missing the review language is told that, rather than about consent it would need afterwards anyway.

## Tests

Three added, ten passing. `recognition_error_message` is a pure function so the mapping is testable without a microphone:

- the privacy refusal names the setting that fixes it, and does **not** leak `0x80045509`
- unrelated failures keep their original detail — this mapping explains one refusal, it does not swallow others
- probing consent is safe on a machine that has never opened the Speech privacy page

## Notes

- Adds the `Win32_System_Registry` feature to the `windows` crate. This is the module's only registry read, and the comment says why the exception is earned.
- The OKF article records that the setting is named "Online **speech** recognition", which is a standing reason for caution about `device-only` on Windows: whether the dictation topic constraint is served locally or by Microsoft is **not established**, and this PR does not settle it. Worth a separate look — if it is cloud-served, `device-only` should stop offering Windows STT.
- Also reorders two pre-existing `windows::Media` imports so the Windows module is `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)