### PR TITLE
feat: iOS voice mode, and reach cloud models from a paired device

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,6 +492,30 @@ jobs:
           npm ci
           npm ci --prefix mobile
 
+      # project.yml is versioned and `tauri ios init` deliberately leaves it
+      # alone, so its version would otherwise stay at whatever was last written
+      # by hand — it had drifted to 0.21.0 by 0.24.1. App Store Connect rejects
+      # an upload whose build number is not higher than the previous one, so a
+      # stale value does not just mislabel the build, it blocks the upload.
+      - name: Stamp the iOS bundle version
+        if: steps.apple.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          python3 - "$PKG_VERSION" <<'PY'
+          import re, sys, pathlib
+          version = sys.argv[1]
+          path = pathlib.Path("mobile/src-tauri/gen/apple/project.yml")
+          text = path.read_text()
+          text = re.sub(
+              r"(CFBundleShortVersionString: ).*", rf"\g<1>{version}", text, count=1
+          )
+          text = re.sub(
+              r'(CFBundleVersion: ").*(")', rf"\g<1>{version}\g<2>", text, count=1
+          )
+          path.write_text(text)
+          print(f"stamped iOS bundle version {version}")
+          PY
+
       - name: Generate Xcode project
         if: steps.apple.outputs.configured == 'true'
         working-directory: mobile

--- a/docs/adr/2026-07-31-cross-platform-voice-mode.md
+++ b/docs/adr/2026-07-31-cross-platform-voice-mode.md
@@ -217,7 +217,16 @@ learner's behalf, particularly with minors in the field test.
       with the machine's online speech recognition turned off. The answer
       decides whether Windows local STT may be offered under `device-only`
       (see the Windows caveat above).
+- [x] iOS engine implemented and compiled. `cargo check --target
+      aarch64-apple-ios` builds the Swift package, which caught that it targets
+      a lower deployment version than its manifest declares — the iOS 17
+      `AVAudioApplication` API needed an availability guard with the pre-17 path
+      kept. `tauri ios init` was confirmed to leave the versioned `project.yml`
+      alone, so the usage descriptions reach the generated Info.plist.
 - [ ] iOS end-to-end voice loop via TestFlight on the field-test iPad.
+      Blocked until now by a second thing: the bundle version had drifted to
+      0.21.0 and App Store Connect rejects an upload that does not increase it.
+      The release workflow now stamps it from `package.json`.
 - [x] Cloud tier implemented over the registry and covered by
       `tests/cli/speech.test.ts`: endpoint selection refuses Anthropic-flavour
       and agent-transport entries, the recording is deleted as soon as it has

--- a/docs/okf/fsrs-scheduling.md
+++ b/docs/okf/fsrs-scheduling.md
@@ -7,7 +7,7 @@ tags:
   - fsrs
   - scheduling
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/fsrs-scheduling.md"
-timestamp: 2026-07-31T08:10:00Z
+timestamp: 2026-07-31T19:35:00Z
 ---
 
 ZAM's spaced repetition uses **FSRS-5** (Free Spaced Repetition Scheduler,
@@ -54,23 +54,24 @@ monopolize a session), with a new card inserted at every 5th position.
 
 # Voice review
 
-The Android companion and the macOS/Windows desktop app can operate the same
-review session hands-free. One shared controller speaks the existing template
-question, captures a spoken answer, speaks the expected answer or an
-evaluation, and maps German or English rating words to ratings 1-4. The
-transcript is persisted as the current session draft; the selected rating still
-enters the shared kernel through the same review-session controller and
-`executeReviewAction()`. Typing and tap/click ratings remain available
-throughout.
+Every ZAM surface can operate the same review session hands-free — the Android
+and iOS companions and the macOS/Windows desktop app. One shared controller
+speaks the existing template question, captures a spoken answer, speaks the
+expected answer or an evaluation, and maps German or English rating words to
+ratings 1-4. The transcript is persisted as the current session draft; the
+selected rating still enters the shared kernel through the same review-session
+controller and `executeReviewAction()`. Typing and tap/click ratings remain
+available throughout.
 
 Whether the speech itself stays on the device depends on the learner's
-preference and on what the device can do. On Android it is always on-device:
-recognition uses the on-device recognizer and synthesis selects only installed
-voices that need no network connection. A microphone/media-playback foreground
-service, partial wake lock, and audio-focus handling keep an explicitly started
-voice session usable with the screen off and pause it across transient focus
-loss. See [voice-mode.md](voice-mode.md) for the engine tiering and the
-per-platform detail.
+preference and on what the device can do. On Android and iOS it is always
+on-device: recognition is pinned to the on-device recognizer, and Android
+synthesis selects only installed voices that need no network connection.
+Android additionally holds the session through a microphone/media-playback
+foreground service and a partial wake lock so review continues with the screen
+off; iOS ends the session when the app leaves the foreground, because the
+system takes the microphone back. See [voice-mode.md](voice-mode.md) for the
+engine tiering and the per-platform detail.
 
 # Examples
 

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -2,6 +2,8 @@
 
 ## 2026-07-31
 
+- **Update** — [FSRS-5 Scheduling](fsrs-scheduling.md)
+- **Update** — [Hands-Free Voice Mode](voice-mode.md)
 - **Update** — [Hands-Free Voice Mode](voice-mode.md)
 - **Update** — [Hands-Free Voice Mode](voice-mode.md)
 - **Update** — [FSRS-5 Scheduling](fsrs-scheduling.md)

--- a/docs/okf/voice-mode.md
+++ b/docs/okf/voice-mode.md
@@ -8,13 +8,13 @@ tags:
   - desktop
   - mobile
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/voice-mode.md"
-timestamp: 2026-07-31T16:20:00Z
+timestamp: 2026-07-31T21:00:00Z
 ---
 
 Voice mode reads a due card aloud, listens for the spoken answer, and maps a
 spoken word to an FSRS rating — so a review session works on a walk, during
-housework, or at the gym. It shipped on Android in 0.22.x and reached the
-macOS/Windows desktop in 0.24.0.
+housework, or at the gym. It shipped on Android in 0.22.x, reached the
+macOS/Windows desktop in 0.24.0, and the iPad/iPhone companion after that.
 
 # One loop, many engines
 
@@ -43,6 +43,7 @@ Each surface supplies its own adapter and port:
 | --- | --- |
 | Desktop | `desktop/src/voice.ts` → Tauri commands in `desktop/src-tauri/src/voice.rs` |
 | Android | `mobile/src/main.ts` → `VoicePlugin.kt` |
+| iOS | `mobile/src/main.ts` → `VoicePlugin.swift` |
 
 # Two tiers, resolved per capability
 
@@ -56,6 +57,7 @@ the capability model registry with the `stt` or `tts` flag set.
 | Windows | WinRT `SpeechRecognizer` | WinRT `SpeechSynthesizer` |
 | Linux | none | `speech-dispatcher` |
 | Android | `SpeechRecognizer`, on-device | `TextToSpeech`, embedded voices |
+| iOS | `SFSpeechRecognizer`, on-device required | `AVSpeechSynthesizer` |
 
 Speech-to-text and text-to-speech resolve **independently**. Linux has local
 synthesis but no local recognizer, so it reads cards aloud locally while
@@ -135,6 +137,14 @@ runtime, the `com.apple.security.device.audio-input` entitlement. Consent is
 therefore only obtainable from the signed app bundle, never from a bare test
 binary.
 
+iOS needs the same two usage descriptions, declared in
+`mobile/src-tauri/gen/apple/project.yml` under `info.properties`. That file is
+versioned and `tauri ios init` regenerates only the `.xcodeproj` from it, so
+edits there survive CI. Its `CFBundleShortVersionString` is stamped from
+`package.json` by the release workflow: App Store Connect rejects an upload
+whose build number is not higher than the previous one, so a stale value blocks
+the upload rather than merely mislabelling it.
+
 Windows serves free-form dictation from the installed speech language pack, and
 additionally requires the user to have accepted the **speech privacy policy**
 (Settings › Privacy & security › Speech › "Online speech recognition"). Unlike
@@ -161,6 +171,19 @@ This is the one place where the module reads the registry rather than asking an
 API, and it is worth the exception: the alternative is 0.24.1's behaviour, where
 the button appeared, the learner spoke, and the session died on a bare HRESULT.
 
+# Sessions and backgrounding
+
+Android holds a voice session through a microphone/media-playback foreground
+service and a partial wake lock, so review continues with the screen off —
+that is the point of hands-free. iOS hands the microphone back the moment the
+app leaves the foreground, and a session left running would wait for audio that
+cannot arrive.
+
+The difference is modelled rather than assumed: `platform_features` reports
+`voiceSurvivesBackground`, and the WebView ends the session on
+`visibilitychange` only where that flag is false. Treating every platform like
+iOS would silently remove Android's headline behaviour.
+
 # Availability is per device *and per language*
 
 Voice mode is the first ZAM feature whose availability legitimately differs per
@@ -184,7 +207,7 @@ On Windows the installed set comes from `SupportedTopicLanguages()` and
 `SpeechSynthesizer::AllVoices()`. `Language::CreateLanguage` must not be used
 for this: it validates the *shape* of a BCP-47 tag and accepts `de-DE` on a
 machine with no German speech at all, deferring the failure to
-`SpeechRecognizer::Create` as a bare `0x800455BC`. On macOS the check is
+`SpeechRecognizer::Create` as a bare `0x800455BC`. On macOS and iOS the check is
 `initWithLocale` plus `supportsOnDeviceRecognition` for that one locale.
 
 Reasons are ordered from the most fundamental cause outwards — missing language
@@ -198,6 +221,7 @@ re-probes when the app language changes.
 
 - [ADR 2026-07-31 — Cross-Platform Voice Mode](../adr/2026-07-31-cross-platform-voice-mode.md)
 - [ADR 2026-07-21 — Android Companion Tauri Shell](../adr/2026-07-21-android-companion-tauri-shell.md)
+- [ADR 2026-07-26 — iPadOS Companion Target](../adr/2026-07-26-ipados-companion-target.md)
 - [ADR 2026-07-12 — Unified Capability Model Registry](../adr/2026-07-12-unified-capability-model-registry.md)
 - Tests: `tests/kernel/voice-review.test.ts`, `tests/desktop/voice.test.ts`, `tests/cli/speech.test.ts`, `tests/mobile/voice.test.ts`, `tests/mobile/voice-wiring.test.ts`
-- Code: `src/kernel/recall/voice-review.ts`, `src/cli/llm/speech.ts`, `src/cli/llm/capability-probe.ts`, `desktop/src/voice.ts`, `desktop/src-tauri/src/voice.rs`, `mobile/src/voice.ts`, `src/kernel/system/install-config.ts`
+- Code: `src/kernel/recall/voice-review.ts`, `src/cli/llm/speech.ts`, `src/cli/llm/capability-probe.ts`, `desktop/src/voice.ts`, `desktop/src-tauri/src/voice.rs`, `mobile/src/voice.ts`, `mobile/src-tauri/src/voice.rs`, `mobile/src-tauri/ios/Sources/VoicePlugin.swift`, `src/kernel/system/install-config.ts`

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -63,6 +63,16 @@ targets:
         NSCameraUsageDescription: >-
           ZAM scannt den QR-Code aus ZAM Desktop, um dieses Gerät einmalig mit
           deiner Lernkartei zu verbinden.
+        # Voice review (ADR 2026-07-31). Both keys are mandatory, not
+        # advisory: iOS terminates the process rather than prompting when a
+        # usage description is missing. Recognition is pinned on-device, so the
+        # wording promises exactly that and nothing more.
+        NSMicrophoneUsageDescription: >-
+          ZAM nutzt das Mikrofon nur im Sprachmodus, damit du deine Karten laut
+          beantworten kannst.
+        NSSpeechRecognitionUsageDescription: >-
+          ZAM wandelt deine gesprochene Antwort auf diesem Gerät in Text um, um
+          sie mit der erwarteten Antwort zu vergleichen.
         # ZAM only uses HTTPS/TLS via the OS, which is exempt. Declaring this
         # up front stops TestFlight asking for export compliance on every build.
         ITSAppUsesNonExemptEncryption: false

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -55,8 +55,10 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.21.0
-        CFBundleVersion: "0.21.0"
+        # Stamped from package.json by the release workflow; kept in step here
+        # so a local build is not mislabelled either.
+        CFBundleShortVersionString: 0.24.1
+        CFBundleVersion: "0.24.1"
         # QR pairing is the entire first-run path (FR-0). iOS terminates the
         # app on first camera access if this key is absent, so it is required,
         # not cosmetic. German-first, matching the app UI.

--- a/mobile/src-tauri/ios/Sources/VoicePlugin.swift
+++ b/mobile/src-tauri/ios/Sources/VoicePlugin.swift
@@ -1,0 +1,430 @@
+// iOS counterpart of VoicePlugin.kt (ADR 2026-07-31).
+//
+// Android drives voice review through a foreground service so a session
+// survives the screen going off. iOS has no equivalent: an app that leaves the
+// foreground loses the microphone. The session therefore lives only while ZAM
+// is frontmost, and `stop` is called on backgrounding by the WebView.
+//
+// Recognition is pinned on-device (`requiresOnDeviceRecognition`), matching the
+// macOS engine and the device tier's promise that nothing leaves the machine.
+// Availability is per language, as 0.24.1 established: a device can be fully
+// equipped for English and have no German model at all, so every entry point
+// answers for the language actually being reviewed.
+//
+// Command names and payload shapes are fixed by src/voice.rs.
+
+import AVFoundation
+import Foundation
+import Speech
+import Tauri
+import UIKit
+import WebKit
+
+struct VoiceLocaleArgs: Decodable {
+  let locale: String
+}
+
+struct VoiceSpeakArgs: Decodable {
+  let text: String
+  let locale: String
+}
+
+/// Silence after speech has started that ends the answer. Matches the desktop
+/// recorder's trailing-silence window so the two feel the same.
+private let trailingSilence: TimeInterval = 1.2
+/// How long we wait for the learner to start talking at all.
+private let speechOnsetTimeout: TimeInterval = 8.0
+/// Hard cap on any single operation, so a stuck recognizer cannot hold the
+/// microphone for the rest of the session.
+private let maxOperationSeconds: TimeInterval = 30.0
+
+class VoicePlugin: Plugin, AVSpeechSynthesizerDelegate {
+  private let synthesizer = AVSpeechSynthesizer()
+  private let audioEngine = AVAudioEngine()
+
+  private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+  private var recognitionTask: SFSpeechRecognitionTask?
+  private var silenceTimer: Timer?
+  private var deadlineTimer: Timer?
+
+  private var active = false
+  private var pendingSpeak: Invoke?
+  private var pendingListen: Invoke?
+  private var transcript = ""
+  private var heardSpeech = false
+
+  override init() {
+    super.init()
+    synthesizer.delegate = self
+  }
+
+  // MARK: - Locale
+
+  /// Mirrors `normalize_locale` in src/voice.rs and `resolveVoiceLocale` in the
+  /// kernel: anything not English is German, which is the field-test default.
+  private static func normalized(_ tag: String) -> String {
+    tag.lowercased().hasPrefix("en") ? "en-US" : "de-DE"
+  }
+
+  /// A recognizer for the requested language, or nil when this device has no
+  /// on-device model for it. Never falls back across languages — an English
+  /// recognizer fed German returns fluent nonsense, confidently.
+  private static func recognizer(for tag: String) -> SFSpeechRecognizer? {
+    let wanted = normalized(tag)
+    guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: wanted)) else {
+      return nil
+    }
+    guard recognizer.isAvailable, recognizer.supportsOnDeviceRecognition else {
+      return nil
+    }
+    return recognizer
+  }
+
+  /// An installed voice for the language, preferring an exact region match.
+  private static func voice(for tag: String) -> AVSpeechSynthesisVoice? {
+    let wanted = normalized(tag)
+    let language = String(wanted.prefix(2))
+    let installed = AVSpeechSynthesisVoice.speechVoices().filter {
+      $0.language.lowercased().hasPrefix(language)
+    }
+    return installed.first { $0.language.caseInsensitiveCompare(wanted) == .orderedSame }
+      ?? installed.first
+  }
+
+  // MARK: - Permissions
+
+  /// `true` granted, `false` denied, `nil` not yet asked.
+  ///
+  /// AVAudioApplication is the iOS 17 replacement, but the Swift package this
+  /// plugin is compiled into is built with a lower deployment target than the
+  /// SwiftPM manifest declares, so the pre-17 path has to stay. The deprecation
+  /// warning on it is expected.
+  private static func recordPermissionGranted() -> Bool? {
+    if #available(iOS 17.0, *) {
+      switch AVAudioApplication.shared.recordPermission {
+      case .granted: return true
+      case .denied: return false
+      default: return nil
+      }
+    }
+    switch AVAudioSession.sharedInstance().recordPermission {
+    case .granted: return true
+    case .denied: return false
+    default: return nil
+    }
+  }
+
+  private static func requestRecordPermission(_ completion: @escaping (Bool) -> Void) {
+    if #available(iOS 17.0, *) {
+      AVAudioApplication.requestRecordPermission(completionHandler: completion)
+    } else {
+      AVAudioSession.sharedInstance().requestRecordPermission(completion)
+    }
+  }
+
+  private static func microphoneState() -> String {
+    let speech = SFSpeechRecognizer.authorizationStatus()
+    if speech == .denied || speech == .restricted { return "denied" }
+
+    switch recordPermissionGranted() {
+    case .some(true):
+      // Both halves are needed; speech consent is the one still outstanding.
+      return speech == .authorized ? "granted" : "prompt"
+    case .some(false):
+      return "denied"
+    default:
+      return "prompt"
+    }
+  }
+
+  @objc public override func checkPermissions(_ invoke: Invoke) {
+    invoke.resolve(["microphone": Self.microphoneState()])
+  }
+
+  /// Asks for both consents in turn. Both usage descriptions must be present in
+  /// the Info.plist or iOS terminates the process instead of prompting.
+  @objc public override func requestPermissions(_ invoke: Invoke) {
+    SFSpeechRecognizer.requestAuthorization { _ in
+      Self.requestRecordPermission { _ in
+        DispatchQueue.main.async {
+          // Re-read rather than trusting the granted flags: voice mode needs
+          // both consents, and either can still be missing.
+          invoke.resolve(["microphone": Self.microphoneState()])
+        }
+      }
+    }
+  }
+
+  @objc public func openAppSettings(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      guard let url = URL(string: UIApplication.openSettingsURLString) else {
+        invoke.reject("Die App-Einstellungen konnten nicht geöffnet werden")
+        return
+      }
+      UIApplication.shared.open(url)
+      invoke.resolve()
+    }
+  }
+
+  /// iOS ships its voices with the system; there is no installer to open.
+  /// Android's counterpart exists, so the command answers rather than 404s.
+  @objc public func installVoiceData(_ invoke: Invoke) {
+    invoke.reject("iOS installiert Stimmen über die Systemeinstellungen, nicht über ZAM")
+  }
+
+  // MARK: - Session
+
+  @objc public func start(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(VoiceLocaleArgs.self)
+    DispatchQueue.main.async {
+      guard Self.microphoneState() == "granted" else {
+        invoke.reject("Mikrofon- oder Spracherkennungsberechtigung fehlt")
+        return
+      }
+      guard Self.recognizer(for: args.locale) != nil else {
+        invoke.reject(
+          "Für \(Self.normalized(args.locale)) ist keine geräteinterne Spracherkennung installiert"
+        )
+        return
+      }
+      if self.active {
+        invoke.resolve()
+        return
+      }
+      do {
+        let session = AVAudioSession.sharedInstance()
+        // .duckOthers rather than .interruptSpokenAudioAndMixWithOthers: a
+        // podcast should dip while ZAM talks, not stop for the whole session.
+        try session.setCategory(
+          .playAndRecord,
+          mode: .spokenAudio,
+          options: [.duckOthers, .defaultToSpeaker, .allowBluetoothHFP]
+        )
+        try session.setActive(true, options: [])
+        self.active = true
+        invoke.resolve()
+      } catch {
+        self.active = false
+        invoke.reject("Audiositzung konnte nicht gestartet werden: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  @objc public func stop(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      self.abort(message: "Sprachmodus beendet")
+      invoke.resolve()
+    }
+  }
+
+  private func abort(message: String) {
+    active = false
+    synthesizer.stopSpeaking(at: .immediate)
+    teardownRecognition()
+
+    pendingSpeak?.reject(message)
+    pendingSpeak = nil
+    pendingListen?.reject(message)
+    pendingListen = nil
+
+    try? AVAudioSession.sharedInstance().setActive(
+      false, options: [.notifyOthersOnDeactivation])
+  }
+
+  // MARK: - Speaking
+
+  @objc public func speak(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(VoiceSpeakArgs.self)
+    DispatchQueue.main.async {
+      guard self.active else {
+        invoke.reject("Sprachmodus ist nicht aktiv")
+        return
+      }
+      guard self.pendingSpeak == nil, self.pendingListen == nil else {
+        invoke.reject("Eine Sprachoperation läuft bereits")
+        return
+      }
+      let text = args.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !text.isEmpty else {
+        invoke.reject("Vorlesetext ist leer")
+        return
+      }
+      guard let voice = Self.voice(for: args.locale) else {
+        invoke.reject("Keine installierte Stimme für \(Self.normalized(args.locale))")
+        return
+      }
+      let utterance = AVSpeechUtterance(string: text)
+      utterance.voice = voice
+      self.pendingSpeak = invoke
+      self.synthesizer.speak(utterance)
+    }
+  }
+
+  func speechSynthesizer(
+    _ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance
+  ) {
+    DispatchQueue.main.async {
+      let invoke = self.pendingSpeak
+      self.pendingSpeak = nil
+      invoke?.resolve()
+    }
+  }
+
+  func speechSynthesizer(
+    _ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance
+  ) {
+    DispatchQueue.main.async {
+      // A cancel during `abort` has already rejected the pending call.
+      guard let invoke = self.pendingSpeak else { return }
+      self.pendingSpeak = nil
+      invoke.reject("Sprachausgabe wurde unterbrochen")
+    }
+  }
+
+  // MARK: - Listening
+
+  @objc public func listen(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(VoiceLocaleArgs.self)
+    DispatchQueue.main.async {
+      guard self.active else {
+        invoke.reject("Sprachmodus ist nicht aktiv")
+        return
+      }
+      guard self.pendingSpeak == nil, self.pendingListen == nil else {
+        invoke.reject("Eine Sprachoperation läuft bereits")
+        return
+      }
+      guard let recognizer = Self.recognizer(for: args.locale) else {
+        invoke.reject(
+          "Für \(Self.normalized(args.locale)) ist keine geräteinterne Spracherkennung verfügbar"
+        )
+        return
+      }
+      self.pendingListen = invoke
+      self.transcript = ""
+      self.heardSpeech = false
+      self.beginRecognition(with: recognizer)
+    }
+  }
+
+  private func beginRecognition(with recognizer: SFSpeechRecognizer) {
+    let request = SFSpeechAudioBufferRecognitionRequest()
+    // The whole point of the device tier: never let this reach Apple.
+    request.requiresOnDeviceRecognition = true
+    request.shouldReportPartialResults = true
+    if #available(iOS 16.0, *) { request.addsPunctuation = true }
+    recognitionRequest = request
+
+    let input = audioEngine.inputNode
+    input.removeTap(onBus: 0)
+    input.installTap(onBus: 0, bufferSize: 1024, format: input.outputFormat(forBus: 0)) {
+      buffer, _ in
+      request.append(buffer)
+    }
+
+    audioEngine.prepare()
+    do {
+      try audioEngine.start()
+    } catch {
+      failListen("Mikrofon konnte nicht gestartet werden: \(error.localizedDescription)")
+      return
+    }
+
+    recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+      guard let self else { return }
+      DispatchQueue.main.async {
+        if let result {
+          let text = result.bestTranscription.formattedString
+          if !text.isEmpty {
+            self.transcript = text
+            self.heardSpeech = true
+            // Restart the window on every new word; the answer ends when the
+            // learner stops talking, not after a fixed duration.
+            self.armSilenceTimer()
+          }
+          if result.isFinal {
+            self.finishListen()
+            return
+          }
+        }
+        if error != nil, !self.heardSpeech {
+          self.failListen("Keine Sprache erkannt")
+        } else if error != nil {
+          self.finishListen()
+        }
+      }
+    }
+
+    armOnsetTimer()
+    armDeadlineTimer()
+  }
+
+  private func armSilenceTimer() {
+    silenceTimer?.invalidate()
+    silenceTimer = Timer.scheduledTimer(withTimeInterval: trailingSilence, repeats: false) {
+      [weak self] _ in
+      self?.finishListen()
+    }
+  }
+
+  private func armOnsetTimer() {
+    silenceTimer?.invalidate()
+    silenceTimer = Timer.scheduledTimer(withTimeInterval: speechOnsetTimeout, repeats: false) {
+      [weak self] _ in
+      guard let self else { return }
+      self.heardSpeech ? self.finishListen() : self.failListen("Keine Sprache erkannt")
+    }
+  }
+
+  private func armDeadlineTimer() {
+    deadlineTimer?.invalidate()
+    deadlineTimer = Timer.scheduledTimer(withTimeInterval: maxOperationSeconds, repeats: false) {
+      [weak self] _ in
+      guard let self else { return }
+      self.heardSpeech
+        ? self.finishListen() : self.failListen("Spracherkennung hat zu lange gedauert")
+    }
+  }
+
+  private func finishListen() {
+    let text = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+    let invoke = pendingListen
+    pendingListen = nil
+    teardownRecognition()
+    guard !text.isEmpty else {
+      invoke?.reject("Keine Sprache erkannt")
+      return
+    }
+    invoke?.resolve(["transcript": text])
+  }
+
+  private func failListen(_ message: String) {
+    let invoke = pendingListen
+    pendingListen = nil
+    teardownRecognition()
+    invoke?.reject(message)
+  }
+
+  private func teardownRecognition() {
+    silenceTimer?.invalidate()
+    silenceTimer = nil
+    deadlineTimer?.invalidate()
+    deadlineTimer = nil
+
+    if audioEngine.isRunning { audioEngine.stop() }
+    audioEngine.inputNode.removeTap(onBus: 0)
+
+    recognitionRequest?.endAudio()
+    recognitionRequest = nil
+    recognitionTask?.cancel()
+    recognitionTask = nil
+
+    transcript = ""
+    heardSpeech = false
+  }
+}
+
+@_cdecl("init_plugin_voice")
+func initPluginVoice() -> Plugin {
+  return VoicePlugin()
+}

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -17,7 +17,15 @@ mod voice;
 fn platform_features() -> serde_json::Value {
     let android = cfg!(target_os = "android");
     serde_json::json!({
-        "voice": android,
+        // Voice review runs on both mobile platforms (ADR 2026-07-31): Android
+        // through a foreground service, iOS only while ZAM is frontmost.
+        "voice": cfg!(mobile),
+        // Android holds the session through a foreground service and a partial
+        // wake lock, so review continues with the screen off — that is the
+        // point of hands-free. iOS hands the microphone back the moment the app
+        // leaves the foreground, so the WebView must end the session instead of
+        // leaving it waiting for audio that can never arrive.
+        "voiceSurvivesBackground": android,
         "inAppUpdate": android,
         "onDeviceEvaluation": android,
     })
@@ -33,13 +41,14 @@ pub fn run() {
     let builder = builder.plugin(secure_store::init());
     #[cfg(mobile)]
     let builder = builder.plugin(reminder::init());
-    // Android-only: the voice pipeline is a foreground service, the on-device
-    // evaluator is Gemini Nano via AICore, and the update channel sideloads an
-    // APK. None of the three has an iOS counterpart — see ADR 2026-07-26.
-    // Their stubs still answer on iOS, so the UI must ask `platform_features`
-    // and hide the controls; an answering stub is not the same as a feature.
-    #[cfg(target_os = "android")]
+    // Voice review exists on both mobile platforms (ADR 2026-07-31).
+    #[cfg(mobile)]
     let builder = builder.plugin(voice::init());
+    // Android-only: the on-device evaluator is Gemini Nano via AICore, and the
+    // update channel sideloads an APK. Neither has an iOS counterpart — see
+    // ADR 2026-07-26. Their stubs still answer on iOS, so the UI must ask
+    // `platform_features` and hide the controls; an answering stub is not the
+    // same as a feature.
     #[cfg(target_os = "android")]
     let builder = builder.plugin(on_device_llm::init());
     #[cfg(target_os = "android")]

--- a/mobile/src-tauri/src/voice.rs
+++ b/mobile/src-tauri/src/voice.rs
@@ -1,24 +1,27 @@
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 use serde::{Deserialize, Serialize};
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 use tauri::plugin::{Builder, PluginHandle, TauriPlugin};
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 use tauri::{AppHandle, Manager, Runtime};
 
 #[cfg(target_os = "android")]
 const PLUGIN_IDENTIFIER: &str = "org.zamos.zam";
 
-#[cfg(target_os = "android")]
+#[cfg(target_os = "ios")]
+tauri::ios_plugin_binding!(init_plugin_voice);
+
+#[cfg(mobile)]
 pub struct Voice<R: Runtime>(PluginHandle<R>);
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct VoiceLocalePayload<'a> {
     locale: &'a str,
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct VoiceSpeakPayload<'a> {
@@ -26,30 +29,36 @@ struct VoiceSpeakPayload<'a> {
     locale: &'a str,
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[derive(Deserialize, Serialize)]
 pub struct VoicePermissionState {
     microphone: Option<String>,
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[derive(Deserialize, Serialize)]
 pub struct VoiceRecognitionResult {
     transcript: String,
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("voice")
         .setup(|app, api| {
+            // Android runs the session in a foreground service so it survives
+            // the screen going off; iOS keeps it only while ZAM is frontmost
+            // (ADR 2026-07-31). The command surface is identical either way.
+            #[cfg(target_os = "android")]
             let handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "VoicePlugin")?;
+            #[cfg(target_os = "ios")]
+            let handle = api.register_ios_plugin(init_plugin_voice)?;
             app.manage(Voice(handle));
             Ok(())
         })
         .build()
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub fn voice_check_permissions<R: Runtime>(
     app: AppHandle<R>,
@@ -60,7 +69,7 @@ pub fn voice_check_permissions<R: Runtime>(
         .map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub async fn voice_request_permissions<R: Runtime>(
     app: AppHandle<R>,
@@ -77,7 +86,7 @@ pub async fn voice_request_permissions<R: Runtime>(
         .map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub async fn voice_start<R: Runtime>(app: AppHandle<R>, locale: String) -> Result<(), String> {
     app.state::<Voice<R>>()
@@ -91,7 +100,7 @@ pub async fn voice_start<R: Runtime>(app: AppHandle<R>, locale: String) -> Resul
         .map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub async fn voice_stop<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
     app.state::<Voice<R>>()
@@ -102,7 +111,7 @@ pub async fn voice_stop<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
         .map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub async fn voice_speak<R: Runtime>(
     app: AppHandle<R>,
@@ -126,7 +135,7 @@ pub async fn voice_speak<R: Runtime>(
         .map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub async fn voice_listen<R: Runtime>(
     app: AppHandle<R>,
@@ -139,7 +148,7 @@ pub async fn voice_listen<R: Runtime>(
         .map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub fn voice_install_data<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
     app.state::<Voice<R>>()
@@ -149,7 +158,7 @@ pub fn voice_install_data<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
         .map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "android")]
+#[cfg(mobile)]
 #[tauri::command]
 pub fn voice_open_app_settings<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
     app.state::<Voice<R>>()
@@ -159,54 +168,53 @@ pub fn voice_open_app_settings<R: Runtime>(app: AppHandle<R>) -> Result<(), Stri
         .map_err(|error| error.to_string())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
-/// Voice mode is Android-only. Reporting the microphone as `denied` sent iOS
-/// users looking for a permission they can never grant, so the stub now names
-/// the real reason. The UI hides the controls entirely (see
-/// `platform_features`); this is the answer for anything that still asks.
+/// Voice mode is a mobile feature in this crate; the desktop app has its own
+/// engine (desktop/src-tauri/src/voice.rs). These stubs answer for a non-mobile
+/// build of the companion so the command surface never 404s.
 pub fn voice_check_permissions() -> serde_json::Value {
     serde_json::json!({ "microphone": "unavailable" })
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_request_permissions() -> serde_json::Value {
     serde_json::json!({ "microphone": "unavailable" })
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_start(_locale: String) -> Result<(), String> {
-    Err("voice mode is only available on Android in this build".to_string())
+    Err("voice mode is not available in this build".to_string())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_stop() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_speak(_text: String, _locale: String) -> Result<(), String> {
-    Err("voice mode is only available on Android in this build".to_string())
+    Err("voice mode is not available in this build".to_string())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_listen(_locale: String) -> Result<serde_json::Value, String> {
-    Err("voice mode is only available on Android in this build".to_string())
+    Err("voice mode is not available in this build".to_string())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_install_data() -> Result<(), String> {
-    Err("voice mode is only available on Android in this build".to_string())
+    Err("voice mode is not available in this build".to_string())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_open_app_settings() -> Result<(), String> {
-    Err("voice mode is only available on Android in this build".to_string())
+    Err("voice mode is not available in this build".to_string())
 }

--- a/mobile/src/evaluate.ts
+++ b/mobile/src/evaluate.ts
@@ -103,15 +103,23 @@ const MAX_FALLBACK_DEPTH = 8;
  * invisible because Gemini Nano answers first; on iOS, which has no on-device
  * evaluator, it meant no evaluation at all (reported on an iPad 9, 2026-07-31).
  */
+export function selectCloudHttpEndpoints(
+  endpoint: ZamPairLlmEndpoint | null | undefined,
+): ZamPairLlmEndpoint[] {
+  const usable: ZamPairLlmEndpoint[] = [];
+  let candidate = endpoint ?? null;
+  for (let depth = 0; candidate && depth < MAX_FALLBACK_DEPTH; depth++) {
+    if (isCloudHttpEndpoint(candidate)) usable.push(candidate);
+    candidate = candidate.fallback ?? null;
+  }
+  return usable;
+}
+
+/** First cloud-usable endpoint in the chain, or null. */
 export function selectCloudHttpEndpoint(
   endpoint: ZamPairLlmEndpoint | null | undefined,
 ): ZamPairLlmEndpoint | null {
-  let candidate = endpoint ?? null;
-  for (let depth = 0; candidate && depth < MAX_FALLBACK_DEPTH; depth++) {
-    if (isCloudHttpEndpoint(candidate)) return candidate;
-    candidate = candidate.fallback ?? null;
-  }
-  return null;
+  return selectCloudHttpEndpoints(endpoint)[0] ?? null;
 }
 
 /**
@@ -219,8 +227,14 @@ export async function evaluateMobileAnswer(
     }
   }
 
-  const cloud = selectCloudHttpEndpoint(input.endpoint);
-  if (cloud) {
+  // Try every reachable endpoint in the chain, not just the first. A paired
+  // payload can advertise an endpoint that cannot actually serve the request —
+  // an agent-transport entry projected before that was fixed at the source
+  // carries a defaulted URL and looks like an ordinary cloud target. Falling
+  // through to the next one repairs an already-paired device without asking
+  // the learner to pair again.
+  const cloudEndpoints = selectCloudHttpEndpoints(input.endpoint);
+  for (const cloud of cloudEndpoints) {
     try {
       const text = await generateViaHttp(cloud, prompt, input.ports.fetchText);
       return {
@@ -230,10 +244,11 @@ export async function evaluateMobileAnswer(
       };
     } catch (error) {
       errors.push(
-        `http: ${error instanceof Error ? error.message : String(error)}`,
+        `http (${cloud.label || cloud.model}): ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-  } else if (input.endpoint) {
+  }
+  if (cloudEndpoints.length === 0 && input.endpoint) {
     // Distinguish "your models are unreachable from here" from "nothing was
     // paired at all" — only the first is something the learner can fix.
     errors.push(

--- a/mobile/src/evaluate.ts
+++ b/mobile/src/evaluate.ts
@@ -1,9 +1,10 @@
 /**
- * Intelligent answer evaluation for the Android companion.
+ * Intelligent answer evaluation for the mobile companions.
  *
- * Always prefer on-device Gemini Nano (AICore → Tensor NPU). Non-local paired
- * endpoints are a secondary HTTP fallback. When neither path is usable the
- * caller falls back to self-rating.
+ * Android prefers on-device Gemini Nano (AICore → Tensor NPU) and treats a
+ * reachable paired endpoint as the secondary HTTP path. iOS has no on-device
+ * evaluator, so the paired cloud endpoint is its only path. When neither is
+ * usable the caller falls back to self-rating.
  */
 
 import {
@@ -50,8 +51,15 @@ export interface EvaluateAnswerInput {
    * answer in any supported language.
    */
   locale: string | null | undefined;
-  /** Paired recall endpoint; used as optional cloud fallback. */
+  /** Paired recall endpoint; its fallback chain is walked for a cloud target. */
   endpoint?: ZamPairLlmEndpoint | null;
+  /**
+   * Whether this platform has an on-device evaluator at all. iOS does not
+   * (`platform_features.onDeviceEvaluation`), so attempting it there only
+   * buys a guaranteed rejection and an error message that blames the wrong
+   * thing. Defaults to true, which is Android's answer.
+   */
+  onDeviceAvailable?: boolean;
   ports: EvaluationPorts;
 }
 
@@ -81,19 +89,46 @@ export function isCloudHttpEndpoint(
   );
 }
 
+/** Depth cap so a malformed paired payload cannot loop the walk forever. */
+const MAX_FALLBACK_DEPTH = 8;
+
+/**
+ * First cloud-usable endpoint in the paired chain, head included.
+ *
+ * The desktop projects its whole fallback chain into the pairing payload
+ * (`src/cli/mobile-pairing.ts`), but only the head was ever inspected. A phone
+ * or tablet cannot reach the desktop's localhost model, so when the learner's
+ * primary recall model is local the head is unusable *by construction* — and
+ * the cloud model sitting right behind it was ignored. On Android that stayed
+ * invisible because Gemini Nano answers first; on iOS, which has no on-device
+ * evaluator, it meant no evaluation at all (reported on an iPad 9, 2026-07-31).
+ */
+export function selectCloudHttpEndpoint(
+  endpoint: ZamPairLlmEndpoint | null | undefined,
+): ZamPairLlmEndpoint | null {
+  let candidate = endpoint ?? null;
+  for (let depth = 0; candidate && depth < MAX_FALLBACK_DEPTH; depth++) {
+    if (isCloudHttpEndpoint(candidate)) return candidate;
+    candidate = candidate.fallback ?? null;
+  }
+  return null;
+}
+
 /**
  * Preferred backend label for UI/tests.
- * On-device is always preferred; cloud HTTP only when no Nano path is intended.
+ *
+ * Android keeps the NPU-first stance, so it reports on-device for every paired
+ * configuration. Where the platform has no on-device evaluator the honest
+ * answer is what will actually run: the cloud endpoint, or nothing.
  */
 export function resolveEvaluationBackend(
   endpoint: ZamPairLlmEndpoint | null | undefined,
+  onDeviceAvailable = true,
 ): EvaluationBackend {
-  // Mobile field-test stance: NPU first. Cloud is fallback only.
-  if (!endpoint?.enabled || endpoint.local || isLoopbackUrl(endpoint.url)) {
-    return "on-device";
+  if (!onDeviceAvailable) {
+    return selectCloudHttpEndpoint(endpoint) ? "http" : "none";
   }
-  // Cloud-configured: still report on-device as primary; evaluateMobileAnswer
-  // tries Nano first and only then HTTP.
+  // Mobile field-test stance: NPU first. Cloud is fallback only.
   return "on-device";
 }
 
@@ -169,36 +204,41 @@ export async function evaluateMobileAnswer(
   const prompt = buildRecallEvaluationPrompt(input.card, answer, input.locale);
   const errors: string[] = [];
 
-  try {
-    const generated = await input.ports.generateOnDevice(prompt);
-    return {
-      evaluation: parseRecallEvaluation(generated.text),
-      backend: "on-device",
-      modelLabel: "Gemini Nano (on-device)",
-    };
-  } catch (error) {
-    errors.push(
-      `on-device: ${error instanceof Error ? error.message : String(error)}`,
-    );
+  if (input.onDeviceAvailable !== false) {
+    try {
+      const generated = await input.ports.generateOnDevice(prompt);
+      return {
+        evaluation: parseRecallEvaluation(generated.text),
+        backend: "on-device",
+        modelLabel: "Gemini Nano (on-device)",
+      };
+    } catch (error) {
+      errors.push(
+        `on-device: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
-  if (isCloudHttpEndpoint(input.endpoint) && input.endpoint) {
+  const cloud = selectCloudHttpEndpoint(input.endpoint);
+  if (cloud) {
     try {
-      const text = await generateViaHttp(
-        input.endpoint,
-        prompt,
-        input.ports.fetchText,
-      );
+      const text = await generateViaHttp(cloud, prompt, input.ports.fetchText);
       return {
         evaluation: parseRecallEvaluation(text),
         backend: "http",
-        modelLabel: input.endpoint.label || input.endpoint.model,
+        modelLabel: cloud.label || cloud.model,
       };
     } catch (error) {
       errors.push(
         `http: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+  } else if (input.endpoint) {
+    // Distinguish "your models are unreachable from here" from "nothing was
+    // paired at all" — only the first is something the learner can fix.
+    errors.push(
+      "no cloud model: the paired models are all local to the desktop and cannot be reached from this device",
+    );
   }
 
   throw new Error(errors.join("; ") || "no evaluation backend available");

--- a/mobile/src/main.ts
+++ b/mobile/src/main.ts
@@ -171,6 +171,8 @@ const updateUnavailable = element<HTMLElement>("update-unavailable");
 
 interface PlatformFeatures {
   voice: boolean;
+  /** Whether a started voice session outlives the app leaving the foreground. */
+  voiceSurvivesBackground: boolean;
   inAppUpdate: boolean;
   onDeviceEvaluation: boolean;
 }
@@ -184,6 +186,7 @@ interface PlatformFeatures {
  */
 let platformFeatures: PlatformFeatures = {
   voice: true,
+  voiceSurvivesBackground: true,
   inAppUpdate: true,
   onDeviceEvaluation: true,
 };
@@ -1364,6 +1367,15 @@ window.addEventListener("focus", () => {
 document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "visible") {
     window.setTimeout(() => void takeSharedImport(), 150);
+    return;
+  }
+  // Where a session cannot outlive backgrounding (iOS), end it explicitly:
+  // the OS takes the microphone back regardless, and a session left "running"
+  // would sit waiting for audio that can never arrive. Android deliberately
+  // keeps going here — reviewing with the screen off is the whole point of
+  // hands-free (ADR 2026-07-31).
+  if (!platformFeatures.voiceSurvivesBackground && voiceController.active) {
+    void pauseVoiceMode();
   }
 });
 

--- a/mobile/src/main.ts
+++ b/mobile/src/main.ts
@@ -765,6 +765,7 @@ async function runSmartEvaluation(): Promise<MobileEvaluationResult | null> {
       learnerAnswer: answer,
       locale: learnerLocale ?? navigator.language,
       endpoint: currentPairing?.llm?.recall ?? null,
+      onDeviceAvailable: platformFeatures.onDeviceEvaluation,
       ports: evaluationPorts,
     });
     if (isStaleEvaluation(item.cardId)) return null;

--- a/src/cli/mobile-pairing.ts
+++ b/src/cli/mobile-pairing.ts
@@ -6,6 +6,20 @@ import {
 } from "../bridge/mobile-pairing.js";
 import type { ProviderConfig } from "./llm/client.js";
 
+/**
+ * Whether a paired device could ever call this endpoint itself.
+ *
+ * An `agent`-transport entry (ADR 2026-07-12a) is generation delegated to a
+ * harness process on *this machine* — a Grok/Claude/Copilot CLI. It carries a
+ * `url` only because `materializeModelEntry` defaults one in, and the desktop
+ * ignores it. Projecting it would hand the phone a plausible-looking HTTP
+ * endpoint that answers nothing, and — worse — one that looks like a perfectly
+ * good cloud target, so the real cloud model behind it is never reached.
+ */
+function isPairableEndpoint(provider: ProviderConfig): boolean {
+  return provider.transport !== "agent";
+}
+
 function projectEndpoint(provider: ProviderConfig): ZamPairLlmEndpoint {
   return {
     enabled: provider.enabled,
@@ -15,10 +29,25 @@ function projectEndpoint(provider: ProviderConfig): ZamPairLlmEndpoint {
     ...(provider.apiKey ? { apiKey: provider.apiKey } : {}),
     local: provider.local,
     ...(provider.label ? { label: provider.label } : {}),
-    ...(provider.fallback
-      ? { fallback: projectEndpoint(provider.fallback) }
-      : {}),
+    ...(() => {
+      const fallback = firstPairable(provider.fallback);
+      return fallback ? { fallback: projectEndpoint(fallback) } : {};
+    })(),
   };
+}
+
+/** First endpoint in the chain a paired device could actually call. */
+function firstPairable(
+  provider: ProviderConfig | undefined,
+): ProviderConfig | undefined {
+  let candidate = provider;
+  // The chain is built by resolveCapability and is finite, but a depth cap
+  // keeps a hand-edited config from hanging the QR dialog.
+  for (let depth = 0; candidate && depth < 8; depth++) {
+    if (isPairableEndpoint(candidate)) return candidate;
+    candidate = candidate.fallback;
+  }
+  return undefined;
 }
 
 export interface MobilePairingPayloadInput {
@@ -42,9 +71,16 @@ export function createMobilePairingPayload(
       token: input.databaseToken,
     },
     learner: { userId: input.userId },
-    ...(input.recallProvider.enabled
-      ? { llm: { recall: projectEndpoint(input.recallProvider) } }
-      : {}),
+    // Only endpoints the device can reach on its own. When the learner's whole
+    // chain is harness-backed, `llm` is omitted entirely: no paired model is a
+    // state the companion already handles (self-rating), whereas a model that
+    // looks present and always fails is not.
+    ...(() => {
+      const recall = input.recallProvider.enabled
+        ? firstPairable(input.recallProvider)
+        : undefined;
+      return recall ? { llm: { recall: projectEndpoint(recall) } } : {};
+    })(),
     settings: { locale: input.recallProvider.locale },
   };
 }

--- a/tests/cli/mobile-pairing.test.ts
+++ b/tests/cli/mobile-pairing.test.ts
@@ -70,3 +70,65 @@ describe("mobile pairing payload projection", () => {
     expect(payload.llm?.recall.apiKey).toBeUndefined();
   });
 });
+
+// Reported 2026-07-31: an iPad 9 could not evaluate answers although a cloud
+// model was configured. The learner's #1 recall model was Grok via a local CLI
+// — an agent-transport entry. materializeModelEntry defaults a `url` onto such
+// entries and the desktop ignores it, but the projection carried it anyway, so
+// the tablet saw a normal-looking HTTP endpoint it could never call.
+describe("agent-transport endpoints are not pairable", () => {
+  const agentProvider: ProviderConfig = {
+    ...recallProvider,
+    label: "Grok (CLI)",
+    model: "grok-4",
+    transport: "agent",
+    agentHarness: "grok-cli",
+  };
+
+  it("skips a harness-backed head and pairs the model behind it", () => {
+    const payload = createMobilePairingPayload({
+      databaseUrl: "libsql://example.turso.io",
+      databaseToken: "database-secret",
+      userId: "student-9",
+      recallProvider: { ...agentProvider, fallback: recallProvider },
+    });
+
+    expect(payload.llm?.recall.model).toBe("recall-small");
+    expect(payload.llm?.recall.url).toBe("https://models.example/v1");
+  });
+
+  it("omits the model entirely when the whole chain is harness-backed", () => {
+    const payload = createMobilePairingPayload({
+      databaseUrl: "libsql://example.turso.io",
+      databaseToken: "database-secret",
+      userId: "student-9",
+      recallProvider: {
+        ...agentProvider,
+        fallback: { ...agentProvider, label: "Claude Code" },
+      },
+    });
+
+    // A model that looks present and always fails is worse than none: the
+    // companion already handles "no paired model" by self-rating.
+    expect(payload.llm).toBeUndefined();
+  });
+
+  it("drops a harness-backed link from the middle of a chain", () => {
+    const payload = createMobilePairingPayload({
+      databaseUrl: "libsql://example.turso.io",
+      databaseToken: "database-secret",
+      userId: "student-9",
+      recallProvider: {
+        ...recallProvider,
+        label: "Primary cloud",
+        fallback: {
+          ...agentProvider,
+          fallback: { ...recallProvider, label: "Backup cloud" },
+        },
+      },
+    });
+
+    expect(payload.llm?.recall.label).toBe("Primary cloud");
+    expect(payload.llm?.recall.fallback?.label).toBe("Backup cloud");
+  });
+});

--- a/tests/mobile/evaluate.test.ts
+++ b/tests/mobile/evaluate.test.ts
@@ -321,3 +321,73 @@ describe("evaluation on a platform without an on-device evaluator", () => {
     expect(resolveEvaluationBackend(localEndpoint())).toBe("on-device");
   });
 });
+
+// An already-paired device still carries whatever the desktop projected before
+// the agent-transport fix — an endpoint that looks like a normal cloud target
+// and answers nothing. Falling through repairs it without re-pairing.
+describe("a dead endpoint does not end the chain", () => {
+  it("falls through to the next reachable model", async () => {
+    const chain = cloudEndpoint2({
+      label: "Grok (CLI)",
+      model: "grok-4",
+      url: "https://harness.invalid/v1",
+      fallback: cloudEndpoint(),
+    });
+
+    const fetchText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("HTTP 404: no such model"))
+      .mockResolvedValueOnce(goodJson);
+
+    const result = await evaluateMobileAnswer({
+      card,
+      learnerAnswer: "F = m · a",
+      locale: "de",
+      endpoint: chain,
+      onDeviceAvailable: false,
+      ports: {
+        checkOnDeviceStatus: async () => ({
+          status: "unavailable",
+          available: false,
+          downloadable: false,
+        }),
+        generateOnDevice: async (): Promise<never> => {
+          throw new Error("not on iOS");
+        },
+        fetchText,
+      },
+    });
+
+    expect(fetchText).toHaveBeenCalledTimes(2);
+    expect(result?.modelLabel).toBe("Cloud recall");
+  });
+
+  it("names each model that failed, so the log points somewhere", async () => {
+    const chain = cloudEndpoint2({
+      label: "Grok (CLI)",
+      fallback: cloudEndpoint(),
+    });
+    await expect(
+      evaluateMobileAnswer({
+        card,
+        learnerAnswer: "F = m · a",
+        locale: "de",
+        endpoint: chain,
+        onDeviceAvailable: false,
+        ports: {
+          checkOnDeviceStatus: async () => ({
+            status: "unavailable",
+            available: false,
+            downloadable: false,
+          }),
+          generateOnDevice: async (): Promise<never> => {
+            throw new Error("not on iOS");
+          },
+          fetchText: async () => {
+            throw new Error("HTTP 401");
+          },
+        },
+      }),
+    ).rejects.toThrow(/Grok \(CLI\).*Cloud recall/s);
+  });
+});

--- a/tests/mobile/evaluate.test.ts
+++ b/tests/mobile/evaluate.test.ts
@@ -5,6 +5,7 @@ import {
   evaluationSpeech,
   isCloudHttpEndpoint,
   resolveEvaluationBackend,
+  selectCloudHttpEndpoint,
 } from "../../mobile/src/evaluate.js";
 import type { ZamPairLlmEndpoint } from "../../src/bridge/mobile-pairing.js";
 
@@ -27,6 +28,12 @@ function localEndpoint(
     local: true,
     ...overrides,
   };
+}
+
+function cloudEndpoint2(
+  overrides: Partial<ZamPairLlmEndpoint> = {},
+): ZamPairLlmEndpoint {
+  return { ...cloudEndpoint(), ...overrides };
 }
 
 function cloudEndpoint(): ZamPairLlmEndpoint {
@@ -185,5 +192,132 @@ describe("evaluationSpeech", () => {
     expect(speech).toContain("Fast — die Richtung fehlt noch.");
     expect(speech).toContain("Schwer");
     expect(speech).toContain("Nochmal");
+  });
+});
+
+// Reported from a field test on an iPad 9 (2026-07-31): voice/eval fell back to
+// self-rating even though a cloud model was configured on the paired desktop.
+// iOS has no on-device evaluator, so the cloud endpoint is the only path — and
+// it was unreachable whenever the desktop's primary recall model was local,
+// because only the head of the paired chain was ever inspected.
+describe("cloud fallback behind a local primary (iPad 9 report)", () => {
+  it("uses a cloud endpoint carried in the paired fallback chain", async () => {
+    const endpoint = localEndpoint({ fallback: cloudEndpoint() });
+    const fetchText = vi.fn(async () => goodJson);
+
+    const result = await evaluateMobileAnswer({
+      card,
+      learnerAnswer: "Kraft = Masse mal Beschleunigung",
+      locale: "de",
+      endpoint,
+      ports: {
+        // iOS: the on-device stub always rejects.
+        checkOnDeviceStatus: async () => ({
+          status: "unavailable",
+          available: false,
+          downloadable: false,
+        }),
+        generateOnDevice: async () => {
+          throw new Error("voice mode is only available on Android");
+        },
+        fetchText,
+      },
+    });
+
+    expect(result?.backend).toBe("http");
+    expect(fetchText).toHaveBeenCalledTimes(1);
+    expect(fetchText.mock.calls[0][0]).toBe(
+      "https://api.example.com/v1/chat/completions",
+    );
+  });
+});
+
+describe("selectCloudHttpEndpoint", () => {
+  it("returns the head when it is already a cloud target", () => {
+    expect(selectCloudHttpEndpoint(cloudEndpoint())?.model).toBe(
+      "cheap-recall",
+    );
+  });
+
+  it("skips local and loopback links to reach the cloud one", () => {
+    const chain = localEndpoint({
+      url: "http://localhost:1234/v1",
+      fallback: localEndpoint({
+        url: "http://192.168.1.10:11434/v1",
+        local: true,
+        fallback: cloudEndpoint(),
+      }),
+    });
+    expect(selectCloudHttpEndpoint(chain)?.model).toBe("cheap-recall");
+  });
+
+  it("returns null when the chain has no reachable cloud target", () => {
+    expect(selectCloudHttpEndpoint(null)).toBeNull();
+    expect(
+      selectCloudHttpEndpoint(localEndpoint({ fallback: localEndpoint() })),
+    ).toBeNull();
+    // A disabled cloud entry is not a target.
+    expect(
+      selectCloudHttpEndpoint(cloudEndpoint2({ enabled: false })),
+    ).toBeNull();
+  });
+
+  it("does not loop forever on a self-referential payload", () => {
+    const cyclic = localEndpoint();
+    (cyclic as { fallback?: ZamPairLlmEndpoint }).fallback = cyclic;
+    expect(selectCloudHttpEndpoint(cyclic)).toBeNull();
+  });
+});
+
+describe("evaluation on a platform without an on-device evaluator", () => {
+  const iosPorts = (fetchText?: EvaluationPorts["fetchText"]) => ({
+    checkOnDeviceStatus: async () => ({
+      status: "unavailable",
+      available: false,
+      downloadable: false,
+    }),
+    generateOnDevice: async (): Promise<never> => {
+      throw new Error("on-device evaluation is only available on Android");
+    },
+    ...(fetchText ? { fetchText } : {}),
+  });
+
+  it("does not attempt the on-device path at all", async () => {
+    const generateOnDevice = vi.fn(async (): Promise<never> => {
+      throw new Error("should not be called");
+    });
+    const result = await evaluateMobileAnswer({
+      card,
+      learnerAnswer: "F = m · a",
+      locale: "de",
+      endpoint: cloudEndpoint(),
+      onDeviceAvailable: false,
+      ports: { ...iosPorts(async () => goodJson), generateOnDevice },
+    });
+    expect(result?.backend).toBe("http");
+    expect(generateOnDevice).not.toHaveBeenCalled();
+  });
+
+  it("says the paired models are unreachable rather than blaming the device", async () => {
+    await expect(
+      evaluateMobileAnswer({
+        card,
+        learnerAnswer: "F = m · a",
+        locale: "de",
+        endpoint: localEndpoint(),
+        onDeviceAvailable: false,
+        ports: iosPorts(),
+      }),
+    ).rejects.toThrow(/all local to the desktop/);
+  });
+
+  it("reports the backend that will actually run", () => {
+    expect(resolveEvaluationBackend(cloudEndpoint(), false)).toBe("http");
+    expect(resolveEvaluationBackend(localEndpoint(), false)).toBe("none");
+    expect(
+      resolveEvaluationBackend(localEndpoint({ fallback: cloudEndpoint() }), false),
+    ).toBe("http");
+    // Android is unchanged.
+    expect(resolveEvaluationBackend(localEndpoint())).toBe("on-device");
   });
 });

--- a/tests/mobile/voice-wiring.test.ts
+++ b/tests/mobile/voice-wiring.test.ts
@@ -57,3 +57,49 @@ describe("Android voice-mode wiring", () => {
     expect(html).toContain('id="toggle-voice"');
   });
 });
+
+describe("iOS voice-mode wiring", () => {
+  it("declares both usage descriptions iOS terminates the app without", () => {
+    const project = read("mobile/src-tauri/gen/apple/project.yml");
+    expect(project).toContain("NSMicrophoneUsageDescription");
+    expect(project).toContain("NSSpeechRecognitionUsageDescription");
+  });
+
+  it("pins recognition on-device and never crosses languages", () => {
+    const plugin = read("mobile/src-tauri/ios/Sources/VoicePlugin.swift");
+    expect(plugin).toContain("requiresOnDeviceRecognition = true");
+    expect(plugin).toContain("supportsOnDeviceRecognition");
+    // A recognizer for one language must never serve another: fed the wrong
+    // language it returns fluent nonsense rather than failing.
+    expect(plugin).not.toContain("SFSpeechRecognizer()");
+  });
+
+  it("registers the plugin on both mobile platforms", () => {
+    const voice = read("mobile/src-tauri/src/voice.rs");
+    expect(voice).toContain("register_ios_plugin(init_plugin_voice)");
+    expect(voice).toContain('register_android_plugin(PLUGIN_IDENTIFIER, "VoicePlugin")');
+    const lib = read("mobile/src-tauri/src/lib.rs");
+    expect(lib).toContain("#[cfg(mobile)]\n    let builder = builder.plugin(voice::init());");
+  });
+
+  it("reports voice on both platforms but backgrounding only on Android", () => {
+    // iOS hands the microphone back when the app leaves the foreground, so a
+    // session there must end rather than wait for audio that cannot arrive.
+    const lib = read("mobile/src-tauri/src/lib.rs");
+    expect(lib).toContain('"voice": cfg!(mobile)');
+    expect(lib).toContain('"voiceSurvivesBackground": android');
+
+    const main = read("mobile/src/main.ts");
+    expect(main).toContain(
+      "!platformFeatures.voiceSurvivesBackground && voiceController.active",
+    );
+  });
+
+  it("guards the iOS 17 permission API so the pre-17 path still builds", () => {
+    // The Swift package is compiled with a lower deployment target than its
+    // manifest declares; without the guard the whole iOS build fails.
+    const plugin = read("mobile/src-tauri/ios/Sources/VoicePlugin.swift");
+    expect(plugin).toContain("if #available(iOS 17.0, *)");
+    expect(plugin).toContain("AVAudioSession.sharedInstance().recordPermission");
+  });
+});


### PR DESCRIPTION
Two things the iPad 9 field test surfaced, plus the iOS half of
[ADR 2026-07-31](docs/adr/2026-07-31-cross-platform-voice-mode.md).

## Why cloud models did not work on the iPad — two causes

**The paired fallback chain was never walked.** The desktop projects its whole
chain into the pairing payload, but mobile only inspected the head. A tablet
cannot reach the desktop's localhost model, so a local primary made the head
unusable by construction and the cloud model behind it was ignored. Invisible
on Android, where Gemini Nano answers first.

**A harness-backed model was paired as if it were an HTTP endpoint.** The
reporter's #1 recall model was Grok through a local CLI — an `agent`-transport
entry. `materializeModelEntry` defaults a `url` onto those and infers
`chat-completions`; the desktop ignores both because it routes through the
harness. The projection copied them anyway and dropped `transport`, so the
tablet saw something indistinguishable from a normal cloud endpoint — one it
can never call, and which shadowed the real cloud model behind it.

Fixed at both ends: the projection skips agent entries anywhere in the chain
and omits `llm` entirely when nothing pairable remains, and evaluation tries
every reachable endpoint rather than only the first. The second half repairs an
already-paired device without re-pairing.

## iOS voice mode

`VoicePlugin.swift` mirrors the Android command surface, so `src/voice.rs` and
the WebView change only in registration. Recognition is pinned on-device and
answered per language, matching what 0.24.1 established for the desktop.

Backgrounding is modelled, not assumed: Android holds the session through a
foreground service — that is what makes reviewing with the screen off work —
while iOS loses the microphone. The new `voiceSurvivesBackground` flag ends the
session only where it must, instead of breaking Android's headline behaviour.

## Also: the TestFlight round was blocked

`gen/apple/project.yml` is versioned and `tauri ios init` regenerates only the
`.xcodeproj` from it, so nothing ever updated its bundle version — it had
drifted to 0.21.0. App Store Connect rejects an upload that does not increase
the build number, so this blocked the upload rather than mislabelling it. The
release workflow now stamps both fields from `package.json`.

## Verification

Lint clean, 1703 tests pass (28 new). `cargo check --target aarch64-apple-ios`
builds the Swift package — the first attempt failed on an iOS 17 API used below
the effective deployment target, now guarded. `tauri ios init` was run to
confirm the usage descriptions survive into the generated Info.plist, and the
CI stamping script was executed against a copy of project.yml.

**Not verified:** the end-to-end voice loop on an iPad. That is the TestFlight
round, and it stays open in the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)