### PR TITLE
feat: let the desktop turn off the per-review question rewrite

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -350,6 +350,17 @@
               <span id="lbl-observer-model">Observer model</span>
               <code id="observer-model-status">—</code>
             </div>
+            <!-- Dynamic questions (ADR 2026-06-15). On by default; the toggle
+                 exists because the per-card model round-trip is what makes the
+                 start of a session slow on a modest model. -->
+            <label class="settings-toggle" for="toggle-dynamic-questions">
+              <input type="checkbox" id="toggle-dynamic-questions" checked />
+              <span>
+                <span id="lbl-dynamic-questions">Reword questions each review</span>
+                <span id="lbl-dynamic-questions-help" class="settings-card-help"></span>
+              </span>
+            </label>
+            <p id="dynamic-questions-status" class="sub-label settings-status-row" aria-live="polite"></p>
             <div id="ai-config-editor" class="ai-config-editor hidden" aria-live="polite">
               <p id="ai-config-status" class="sub-label settings-status-row"></p>
               <div id="ai-provider-list" class="ai-provider-list"></div>

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -4902,6 +4902,12 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "Voice mode is not available on this device.",
     voice_unavailable_device_only:
       "Voice mode is set to stay on this device, and this device cannot do it.",
+    lbl_dynamic_questions: "Reword questions each review",
+    lbl_dynamic_questions_help:
+      "ZAM rephrases each card's question every time it comes up, so you learn the concept rather than the wording. It asks the model once per card, which is what makes the first card of a session slow. Turn it off to get your stored question straight away.",
+    dynamic_questions_on: "Questions will be reworded each review.",
+    dynamic_questions_off: "Your stored question is used as written — reviews start faster.",
+    dynamic_questions_error: "The setting could not be saved.",
     wizard_connect_model_link: "Connect an AI model",
   },
   de: {
@@ -5979,6 +5985,12 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "Der Sprachmodus ist auf diesem Gerät nicht verfügbar.",
     voice_unavailable_device_only:
       "Der Sprachmodus soll dieses Gerät nicht verlassen, und dieses Gerät kann es nicht.",
+    lbl_dynamic_questions: "Fragen jedes Mal neu formulieren",
+    lbl_dynamic_questions_help:
+      "ZAM formuliert die Frage einer Karte bei jeder Wiederholung neu, damit du den Inhalt lernst und nicht den Wortlaut. Dafür wird pro Karte einmal das Modell gefragt — genau das macht die erste Karte einer Sitzung langsam. Ausschalten heißt: deine gespeicherte Frage erscheint sofort.",
+    dynamic_questions_on: "Fragen werden bei jeder Wiederholung neu formuliert.",
+    dynamic_questions_off: "Deine gespeicherte Frage wird unverändert genutzt — die Abfrage startet schneller.",
+    dynamic_questions_error: "Die Einstellung konnte nicht gespeichert werden.",
     wizard_connect_model_link: "KI-Modell verbinden",
   },
   // es, fr, pt, zh, ja packs come from TRANSLATION_PACKS above; en/de stay inline here as the reference locales.

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -660,6 +660,10 @@ function initializeTranslations() {
     t("lbl_learning_model");
   document.getElementById("lbl-observer-model")!.textContent =
     t("lbl_observer_model");
+  document.getElementById("lbl-dynamic-questions")!.textContent =
+    t("lbl_dynamic_questions");
+  document.getElementById("lbl-dynamic-questions-help")!.textContent =
+    t("lbl_dynamic_questions_help");
   const aiConfigButton = document.getElementById("btn-toggle-ai-config");
   if (aiConfigButton) {
     aiConfigButton.textContent = aiConfigEditorOpen
@@ -1518,6 +1522,59 @@ async function loadProviderStatus(): Promise<void> {
   } catch {
     recallEl.textContent = t("provider_unknown");
     visionEl.textContent = t("provider_unknown");
+  }
+}
+
+/**
+ * Dynamic questions (ADR 2026-06-15).
+ *
+ * ZAM normally rewrites a card's question for every review so the wording
+ * cannot be memorised. That costs one model round-trip before the card can be
+ * shown, which is exactly what makes the first card of a session feel slow on
+ * a modest or cold model. The setting has existed since 0.x but had no way to
+ * reach it short of writing the database row by hand.
+ */
+async function loadDynamicQuestionSetting(): Promise<void> {
+  const toggle = document.getElementById(
+    "toggle-dynamic-questions",
+  ) as HTMLInputElement | null;
+  if (!toggle) return;
+  try {
+    const settings = await runBridge<{
+      recall?: { dynamicQuestions?: boolean };
+    }>("get-settings");
+    // Absent means on, matching the kernel-side `!== "false"` default.
+    toggle.checked = settings?.recall?.dynamicQuestions !== false;
+  } catch {
+    // Leave the checkbox at its markup default rather than claiming a state
+    // we could not read.
+  }
+}
+
+async function setDynamicQuestions(enabled: boolean): Promise<void> {
+  const status = document.getElementById("dynamic-questions-status");
+  const toggle = document.getElementById(
+    "toggle-dynamic-questions",
+  ) as HTMLInputElement | null;
+  if (status) status.textContent = "";
+  try {
+    await runBridge("setting-set", [
+      "--key",
+      "llm.dynamic_questions",
+      "--value",
+      enabled ? "true" : "false",
+    ]);
+    if (status) {
+      status.textContent = enabled
+        ? t("dynamic_questions_on")
+        : t("dynamic_questions_off");
+    }
+  } catch (error) {
+    console.error("Failed to persist the dynamic-question setting", error);
+    // Put the checkbox back where it was: a toggle that silently did nothing
+    // is worse than one that says it failed.
+    if (toggle) toggle.checked = !enabled;
+    if (status) status.textContent = t("dynamic_questions_error");
   }
 }
 
@@ -3345,6 +3402,7 @@ function refreshSettingsData(): void {
   void loadDatabaseStatus();
   void loadSettingsKnowledgeContext();
   void loadAgentHarnessStatus();
+  void loadDynamicQuestionSetting();
   if (aiConfigEditorOpen) void loadModelRegistry();
 }
 
@@ -6019,6 +6077,12 @@ window.addEventListener("DOMContentLoaded", () => {
     });
 
   // Submit Answer / Reveal Answer Button
+  document
+    .getElementById("toggle-dynamic-questions")
+    ?.addEventListener("change", (event) => {
+      void setDynamicQuestions((event.target as HTMLInputElement).checked);
+    });
+
   document.getElementById("btn-reveal-answer")!.addEventListener("click", () => {
     submitAndReveal();
   });

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -614,6 +614,29 @@ textarea:focus-visible {
   padding: 11px 0;
 }
 
+/* Checkbox row inside a settings card: the label wraps the control so the
+   whole row is clickable, and the help text sits under the label rather than
+   beside it, which keeps long explanations readable at narrow widths. */
+.settings-toggle {
+  align-items: flex-start;
+  border-top: 1px solid var(--border-soft);
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  padding: 11px 0;
+}
+
+.settings-toggle input {
+  /* Nudge the box onto the first line of the label text. */
+  margin-top: 2px;
+}
+
+.settings-toggle > span {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .settings-row:first-of-type {
   border-top: 0;
   padding-top: 0;

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -3258,6 +3258,10 @@ bridgeCommand
 // must go through their dedicated commands, never this escape hatch.
 const UI_WRITABLE_SETTINGS = new Set([
   "llm.enabled",
+  // Default on. Disabling it serves the stored question verbatim and skips one
+  // model round-trip per card (ADR 2026-06-15) — the setting existed from the
+  // start but had no way to reach it short of writing the row by hand.
+  "llm.dynamic_questions",
   "llm.vision.enabled",
   "recall.quick_mode",
   "system.locale",
@@ -3980,6 +3984,9 @@ bridgeCommand
         },
         recall: {
           quickMode: (await getSetting(db, "recall.quick_mode")) === "true",
+          // Absent means on, matching ensureHighQualityQuestion's `!== "false"`.
+          dynamicQuestions:
+            (await getSetting(db, "llm.dynamic_questions")) !== "false",
         },
       });
     });

--- a/tests/cli/bridge-dynamic-questions.test.ts
+++ b/tests/cli/bridge-dynamic-questions.test.ts
@@ -1,0 +1,75 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openDatabase, setSetting } from "../../src/kernel/index.js";
+
+/**
+ * `llm.dynamic_questions` has gated the per-review question rewrite since
+ * ADR 2026-06-15, but nothing could write it: it was missing from the bridge's
+ * allowlist, so the only way to turn it off was editing the database row by
+ * hand. `get-settings` did not report it either, so no surface could show its
+ * state. These tests pin both halves of the round trip.
+ */
+describe("bridge dynamic-question setting", () => {
+  let tempHome: string;
+  let tempCwd: string;
+  let cliPath: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tempHome = mkdtempSync(join(tmpdir(), "zam-dq-home-"));
+    tempCwd = mkdtempSync(join(tmpdir(), "zam-dq-cwd-"));
+    cliPath = join(process.cwd(), "dist", "cli", "index.js");
+    const dataDir = join(tempHome, ".zam");
+    mkdirSync(dataDir, { recursive: true });
+    dbPath = join(dataDir, "zam.db");
+    const db = await openDatabase({
+      dbPath,
+      initialize: true,
+      useConfiguredCloud: false,
+    });
+    await setSetting(db, "user.id", "test-user");
+    await db.close();
+  });
+
+  afterEach(() => {
+    for (const dir of [tempHome, tempCwd]) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function runBridge(args: string[]): { recall?: { dynamicQuestions?: boolean } } {
+    const output = execFileSync("node", [cliPath, "bridge", ...args], {
+      cwd: tempCwd,
+      env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+      encoding: "utf8",
+    });
+    return JSON.parse(output);
+  }
+
+  it("reports the rewrite as on when nothing is stored", () => {
+    // Absent must read as on, matching ensureHighQualityQuestion's `!== "false"`.
+    expect(runBridge(["get-settings"]).recall?.dynamicQuestions).toBe(true);
+  });
+
+  it("turns the rewrite off and reports it back", () => {
+    runBridge(["setting-set", "--key", "llm.dynamic_questions", "--value", "false"]);
+    expect(runBridge(["get-settings"]).recall?.dynamicQuestions).toBe(false);
+  });
+
+  it("turns it back on again", () => {
+    runBridge(["setting-set", "--key", "llm.dynamic_questions", "--value", "false"]);
+    runBridge(["setting-set", "--key", "llm.dynamic_questions", "--value", "true"]);
+    expect(runBridge(["get-settings"]).recall?.dynamicQuestions).toBe(true);
+  });
+
+  it("still refuses settings that are not on the allowlist", () => {
+    // Widening the allowlist must not have turned it into a general escape
+    // hatch — secrets and structured provider config keep their own commands.
+    expect(() =>
+      runBridge(["setting-set", "--key", "llm.api_key", "--value", "sk-leak"]),
+    ).toThrow();
+  });
+});

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -895,7 +895,29 @@ describe("MCP stdio server tests", () => {
         });
         expect(readRes.isError).toBeUndefined();
         const data = JSON.parse(readRes.content[0].text);
-        expect(data.recall).toEqual({ quickMode: true });
+        // `dynamicQuestions` joined the block when the desktop gained a control
+        // for it; absent storage reads as on. Kept as an exact match so a
+        // further addition to the recall block is a deliberate contract change.
+        expect(data.recall).toEqual({ quickMode: true, dynamicQuestions: true });
+      }, 15_000);
+
+      it("reads and writes the dynamic-question setting", async () => {
+        const writeRes = await studioClient.callTool({
+          name: "zam_studio_bridge",
+          arguments: {
+            cmd: "setting-set",
+            args: ["--key", "llm.dynamic_questions", "--value", "false"],
+          },
+        });
+        expect(writeRes.isError).toBeUndefined();
+
+        const readRes = await studioClient.callTool({
+          name: "zam_studio_bridge",
+          arguments: { cmd: "get-settings", args: [] },
+        });
+        expect(readRes.isError).toBeUndefined();
+        const data = JSON.parse(readRes.content[0].text);
+        expect(data.recall.dynamicQuestions).toBe(false);
       }, 15_000);
 
       it("serializes concurrent calls without corrupting either response", async () => {

--- a/tests/desktop/dynamic-questions-wiring.test.ts
+++ b/tests/desktop/dynamic-questions-wiring.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const desktopFile = (path: string) =>
+  readFileSync(join(process.cwd(), "desktop", path), "utf8");
+
+/**
+ * The per-review question rewrite (ADR 2026-06-15) is one model round-trip
+ * before a card can be shown, and it is what makes the first card of a session
+ * slow. `llm.dynamic_questions` has gated it since then, but the desktop had no
+ * control for it — this wiring is what makes the setting reachable.
+ */
+describe("dynamic-question toggle wiring", () => {
+  const html = desktopFile("index.html");
+  const main = desktopFile("src/main.ts");
+
+  it("puts the control in the AI-models card, where the cost comes from", () => {
+    const aiCard = html.indexOf('id="lbl-settings-ai-title"');
+    const toggle = html.indexOf('id="toggle-dynamic-questions"');
+    const agentsCard = html.indexOf('id="lbl-settings-agents-title"');
+
+    expect(toggle).toBeGreaterThan(aiCard);
+    expect(toggle).toBeLessThan(agentsCard);
+  });
+
+  it("labels the control and its cost through the i18n layer", () => {
+    for (const key of [
+      "lbl_dynamic_questions",
+      "lbl_dynamic_questions_help",
+      "dynamic_questions_on",
+      "dynamic_questions_off",
+      "dynamic_questions_error",
+    ]) {
+      expect(main).toContain(`t("${key}")`);
+    }
+  });
+
+  it("reads the stored state instead of assuming the markup default", () => {
+    expect(main).toMatch(
+      /loadDynamicQuestionSetting[\s\S]*?runBridge<[\s\S]*?>\("get-settings"\)/,
+    );
+    // Absent must read as on, matching the kernel's `!== "false"`.
+    expect(main).toContain("settings?.recall?.dynamicQuestions !== false");
+    expect(main).toContain("void loadDynamicQuestionSetting();");
+  });
+
+  it("writes through the allowlisted setter and reverts a failed write", () => {
+    expect(main).toMatch(
+      /setDynamicQuestions[\s\S]*?"setting-set"[\s\S]*?"llm\.dynamic_questions"/,
+    );
+    // A toggle that silently did nothing is worse than one that says it failed.
+    expect(main).toMatch(
+      /catch[\s\S]*?toggle\.checked = !enabled[\s\S]*?dynamic_questions_error/,
+    );
+  });
+
+  it("keeps the setting writable through the bridge allowlist", () => {
+    const bridge = readFileSync(
+      join(process.cwd(), "src", "cli", "commands", "bridge.ts"),
+      "utf8",
+    );
+    expect(bridge).toMatch(
+      /UI_WRITABLE_SETTINGS = new Set\(\[[\s\S]*?"llm\.dynamic_questions"/,
+    );
+  });
+});

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -276,6 +276,13 @@ const REQUIRED_KEYS = [
 // passed over, so the exhaustive scan below doesn't mask *new* regressions
 // while still not churning unrelated strings.
 const PRE_EXISTING_FALLBACK_KEYS = new Set([
+  // Dynamic-question toggle — en/de shipped; es/fr/pt/zh/ja await native pack
+  // review before translation (see i18n pack backlog).
+  "lbl_dynamic_questions",
+  "lbl_dynamic_questions_help",
+  "dynamic_questions_on",
+  "dynamic_questions_off",
+  "dynamic_questions_error",
   // 0.24.0 desktop voice mode (ADR 2026-07-31) — en/de shipped; es/fr/pt/zh/ja
   // await native pack review before translation (see i18n pack backlog).
   "settings_voice_title",


### PR DESCRIPTION
Reported: starting a review session on the desktop takes too long, and there is
no way to switch the dynamic question off.

## What was actually missing

Less than it looked. `llm.dynamic_questions` has gated the per-review rewrite
since [ADR 2026-06-15](docs/adr/2026-06-15-kernel-polish-and-performance.md),
and `ensureHighQualityQuestion` already skips the model call entirely when it is
off. What was missing was any way to reach it:

- it was not in the bridge's `UI_WRITABLE_SETTINGS`, so `setting-set` refused it;
- `get-settings` did not report it, so no surface could show its state.

The only way to turn it off was writing the database row by hand.

## The change

- Both halves of the round trip through the bridge.
- A control in the **AI models** settings card — where the cost comes from —
  with help text naming the trade rather than the mechanism: you learn the
  concept instead of the wording, at one model call per card.
- A failed write reverts the checkbox and says so. A toggle that silently did
  nothing would be worse than one that reports failure.

en/de ship; the other packs stay on the translation backlog.

## Note on an existing test

`tests/cli/mcp.test.ts` asserts the exact shape of the `recall` block in
`get-settings`, so adding a field failed it. Updated deliberately to the new
shape and kept exact, so a further addition there stays a conscious contract
change rather than silently passing.

## Verification

Lint clean, 1695 tests pass (9 new: bridge round-trip including a guard that
widening the allowlist did not turn `setting-set` into an escape hatch, plus
desktop wiring). `tsc` clean, and the desktop bundle was built and checked to
contain the control and its German strings.

Not verified: how much faster a session actually starts. That depends on the
model, and is the thing to check on your own setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)