### PR TITLE
fix: speak the learner's language, in the best voice the device has

### DIFF
--- a/desktop/src-tauri/src/voice.rs
+++ b/desktop/src-tauri/src/voice.rs
@@ -123,8 +123,10 @@ mod platform {
     use block2::RcBlock;
     use objc2::runtime::AnyObject;
     use objc2::AllocAnyThread;
+    use objc2::rc::Retained;
     use objc2_avf_audio::{
-        AVAudioRecorder, AVSpeechSynthesisVoice, AVSpeechSynthesizer, AVSpeechUtterance,
+        AVAudioRecorder, AVSpeechSynthesisVoice, AVSpeechSynthesisVoiceQuality,
+        AVSpeechSynthesizer, AVSpeechUtterance,
     };
     use objc2_foundation::{
         NSDate, NSDictionary, NSLocale, NSNumber, NSRunLoop, NSString, NSURL,
@@ -268,10 +270,63 @@ mod platform {
         }
     }
 
+    /// Rank a voice: quality, then the system's own pick, then exact region.
+    ///
+    /// macOS ships a small `Default` (compact) voice per language and
+    /// downloads `Enhanced`/`Premium` ones only on request (System Settings ›
+    /// Accessibility › Spoken Content › System Voice › Manage Voices).
+    /// `voiceWithLanguage` returns the system *default* for the language,
+    /// which is normally the compact one — so read-aloud sounded a decade old
+    /// even where a good voice was installed. An accent difference is far
+    /// smaller than a synthesis-generation difference, so quality outranks
+    /// region.
+    fn voice_rank(
+        voice: &AVSpeechSynthesisVoice,
+        wanted: &str,
+        system_default: Option<&str>,
+    ) -> (i32, i32, i32) {
+        let quality = unsafe { voice.quality() };
+        let tier = if quality == AVSpeechSynthesisVoiceQuality::Premium {
+            3
+        } else if quality == AVSpeechSynthesisVoiceQuality::Enhanced {
+            2
+        } else {
+            1
+        };
+        // Equal quality must not be broken arbitrarily: speechVoices() also
+        // contains novelty voices (Zarvox, Bells, …), and picking the max of an
+        // unordered list happily returned those over Anna and Samantha. The
+        // voice the system itself nominates for the language is the sane peer
+        // among equals.
+        let identifier = unsafe { voice.identifier() }.to_string();
+        let is_system_default =
+            i32::from(system_default.is_some_and(|id| id == identifier));
+        let language = unsafe { voice.language() }.to_string();
+        let exact = i32::from(language.eq_ignore_ascii_case(wanted));
+        (tier, is_system_default, exact)
+    }
+
+    /// Best installed voice for `locale`, or `None` when the language has none.
+    pub fn best_voice(locale: &str) -> Option<Retained<AVSpeechSynthesisVoice>> {
+        let prefix = locale.split('-').next().unwrap_or(locale).to_ascii_lowercase();
+        let system_default = unsafe {
+            AVSpeechSynthesisVoice::voiceWithLanguage(Some(&NSString::from_str(locale)))
+        }
+        .map(|voice| unsafe { voice.identifier() }.to_string());
+        unsafe { AVSpeechSynthesisVoice::speechVoices() }
+            .into_iter()
+            .filter(|voice| {
+                unsafe { voice.language() }
+                    .to_string()
+                    .to_ascii_lowercase()
+                    .starts_with(&prefix)
+            })
+            .max_by_key(|voice| voice_rank(voice, locale, system_default.as_deref()))
+    }
+
     pub fn speak(text: &str, locale: &str) -> Result<(), String> {
         unsafe {
-            let voice =
-                AVSpeechSynthesisVoice::voiceWithLanguage(Some(&NSString::from_str(locale)));
+            let voice = best_voice(locale);
             if voice.is_none() {
                 return Err(format!("no installed macOS system voice for {locale}"));
             }
@@ -1061,6 +1116,39 @@ pub fn voice_discard_capture(path: String) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression guard: ranking by quality alone broke ties arbitrarily and
+    /// picked novelty voices — on this machine it chose "Zarvox" for en-US
+    /// over "Samantha". Where no better-quality voice is installed, the
+    /// selection must land on exactly what the system nominates.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn never_downgrades_to_a_novelty_voice() {
+        for tag in ["de-DE", "en-US"] {
+            let system_default = unsafe {
+                objc2_avf_audio::AVSpeechSynthesisVoice::voiceWithLanguage(Some(
+                    &objc2_foundation::NSString::from_str(tag),
+                ))
+            };
+            let Some(system_default) = system_default else {
+                continue; // no voice for this language on this machine
+            };
+            let chosen = platform::best_voice(tag).expect("a voice was available");
+            let default_tier = unsafe { system_default.quality() };
+            let chosen_tier = unsafe { chosen.quality() };
+            assert!(
+                chosen_tier.0 >= default_tier.0,
+                "{tag}: chose a lower-quality voice than the system default",
+            );
+            if chosen_tier == default_tier {
+                assert_eq!(
+                    unsafe { chosen.identifier() }.to_string(),
+                    unsafe { system_default.identifier() }.to_string(),
+                    "{tag}: equal quality must resolve to the system's own pick",
+                );
+            }
+        }
+    }
 
     #[test]
     fn normalizes_locales_like_the_kernel() {

--- a/desktop/src/panel/recall-evaluation.ts
+++ b/desktop/src/panel/recall-evaluation.ts
@@ -14,6 +14,17 @@ import { languageName } from "../../../src/kernel/system/language-names.js";
  */
 export const RECALL_EVALUATION_MAX_OUTPUT_TOKENS = 1200;
 
+/**
+ * Budget for the single retry after a truncated evaluation.
+ *
+ * A reasoning model's chain of thought is unbounded in principle, so no fixed
+ * first budget is correct for every model: 256 was too small for all of them,
+ * 1200 covers most, and MiMo still spent it thinking before writing a word.
+ * Rather than making every model pay for the worst case, the first attempt
+ * stays cheap and only a truncated one is retried with real room.
+ */
+export const RECALL_EVALUATION_RETRY_OUTPUT_TOKENS = 4000;
+
 export interface RecallEvaluationCard {
   slug: string;
   question?: string;

--- a/mobile/src-tauri/ios/Sources/VoicePlugin.swift
+++ b/mobile/src-tauri/ios/Sources/VoicePlugin.swift
@@ -80,15 +80,65 @@ class VoicePlugin: Plugin, AVSpeechSynthesizerDelegate {
     return recognizer
   }
 
-  /// An installed voice for the language, preferring an exact region match.
+  /// The best installed voice for the language.
+  ///
+  /// Quality is ranked before region. iOS ships every language with a small
+  /// `.default` (compact) voice and downloads `.enhanced` / `.premium` ones
+  /// only when the user asks for them in Settings › Accessibility › Spoken
+  /// Content › Voices. Taking the first match therefore reliably picked the
+  /// *worst* installed voice, which is what made the read-aloud sound a
+  /// decade old even on devices that had a good voice available.
+  ///
+  /// Among voices of equal quality the system's own pick for the language
+  /// wins, then an exact region match — a premium de-AT voice still beats a
+  /// compact de-DE one, because an accent is a far smaller difference than a
+  /// synthesis generation.
   private static func voice(for tag: String) -> AVSpeechSynthesisVoice? {
     let wanted = normalized(tag)
     let language = String(wanted.prefix(2))
+    // The voice the system itself nominates for the language. Equal quality
+    // must not be broken arbitrarily — speechVoices() also carries novelty
+    // voices, and taking an arbitrary maximum picked those over the sensible
+    // default (verified on macOS, where it chose "Zarvox" over "Samantha").
+    let systemDefault = AVSpeechSynthesisVoice(language: wanted)?.identifier
     let installed = AVSpeechSynthesisVoice.speechVoices().filter {
       $0.language.lowercased().hasPrefix(language)
     }
-    return installed.first { $0.language.caseInsensitiveCompare(wanted) == .orderedSame }
-      ?? installed.first
+    return installed.max { left, right in
+      rank(left, wanted, systemDefault) < rank(right, wanted, systemDefault)
+    }
+  }
+
+  private static func rank(
+    _ voice: AVSpeechSynthesisVoice, _ wanted: String, _ systemDefault: String?
+  ) -> (Int, Int, Int) {
+    let tier: Int
+    switch voice.quality {
+    case .premium: tier = 3
+    case .enhanced: tier = 2
+    default: tier = 1
+    }
+    let isSystemDefault = voice.identifier == systemDefault ? 1 : 0
+    let exactRegion = voice.language.caseInsensitiveCompare(wanted) == .orderedSame ? 1 : 0
+    return (tier, isSystemDefault, exactRegion)
+  }
+
+  /// Quality of the voice a session would actually use, for the UI hint.
+  /// `"default"` means only a compact voice is installed and the learner can
+  /// get a much better one with a one-time download.
+  @objc public func voiceQuality(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(VoiceLocaleArgs.self)
+    guard let voice = Self.voice(for: args.locale) else {
+      invoke.resolve(["quality": "none"])
+      return
+    }
+    let quality: String
+    switch voice.quality {
+    case .premium: quality = "premium"
+    case .enhanced: quality = "enhanced"
+    default: quality = "default"
+    }
+    invoke.resolve(["quality": quality, "voice": voice.name])
   }
 
   // MARK: - Permissions

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -74,6 +74,7 @@ pub fn run() {
             voice::voice_stop,
             voice::voice_speak,
             voice::voice_listen,
+            voice::voice_quality,
             voice::voice_install_data,
             voice::voice_open_app_settings,
             reminder::reminder_check_permissions,

--- a/mobile/src-tauri/src/voice.rs
+++ b/mobile/src-tauri/src/voice.rs
@@ -148,6 +148,22 @@ pub async fn voice_listen<R: Runtime>(
         .map_err(|error| error.to_string())
 }
 
+/// Quality of the voice a session would use, so the UI can point the learner
+/// at the one-time download when only a compact voice is installed
+/// (ADR 2026-07-31). iOS-only today; Android picks its own installed voice.
+#[cfg(mobile)]
+#[tauri::command]
+pub async fn voice_quality<R: Runtime>(
+    app: AppHandle<R>,
+    locale: String,
+) -> Result<serde_json::Value, String> {
+    app.state::<Voice<R>>()
+        .0
+        .run_mobile_plugin_async("voiceQuality", VoiceLocalePayload { locale: &locale })
+        .await
+        .map_err(|error| error.to_string())
+}
+
 #[cfg(mobile)]
 #[tauri::command]
 pub fn voice_install_data<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
@@ -204,6 +220,12 @@ pub fn voice_speak(_text: String, _locale: String) -> Result<(), String> {
 #[cfg(not(mobile))]
 #[tauri::command]
 pub fn voice_listen(_locale: String) -> Result<serde_json::Value, String> {
+    Err("voice mode is not available in this build".to_string())
+}
+
+#[cfg(not(mobile))]
+#[tauri::command]
+pub fn voice_quality(_locale: String) -> Result<serde_json::Value, String> {
     Err("voice mode is not available in this build".to_string())
 }
 

--- a/mobile/src/evaluate.ts
+++ b/mobile/src/evaluate.ts
@@ -11,6 +11,7 @@ import {
   buildRecallEvaluationPrompt,
   parseRecallEvaluation,
   RECALL_EVALUATION_MAX_OUTPUT_TOKENS,
+  RECALL_EVALUATION_RETRY_OUTPUT_TOKENS,
   type RecallEvaluation,
   type RecallEvaluationCard,
 } from "../../desktop/src/panel/recall-evaluation.js";
@@ -140,6 +141,18 @@ export function resolveEvaluationBackend(
   return "on-device";
 }
 
+/**
+ * The model ran out of output budget before finishing. Typed so the caller can
+ * retry with more room instead of giving up — for a reasoning model the whole
+ * budget can disappear into thinking before a single visible token.
+ */
+export class EvaluationTruncatedError extends Error {
+  constructor() {
+    super("the model hit its output limit before finishing the evaluation");
+    this.name = "EvaluationTruncatedError";
+  }
+}
+
 async function defaultFetchText(
   url: string,
   init: RequestInit,
@@ -159,9 +172,7 @@ async function defaultFetchText(
   // A truncated answer and an absent one are different failures, and saying
   // "empty content" for both hides the only one the user can act on.
   if (choice?.finish_reason === "length") {
-    throw new Error(
-      "the model hit its output limit before finishing the evaluation",
-    );
+    throw new EvaluationTruncatedError();
   }
   if (!text) throw new Error("evaluation endpoint returned empty content");
   return text;
@@ -171,6 +182,7 @@ async function generateViaHttp(
   endpoint: ZamPairLlmEndpoint,
   prompt: string,
   fetchText: EvaluationPorts["fetchText"],
+  maxTokens: number = RECALL_EVALUATION_MAX_OUTPUT_TOKENS,
 ): Promise<string> {
   if (endpoint.apiFlavor !== "chat-completions") {
     throw new Error(
@@ -193,7 +205,7 @@ async function generateViaHttp(
       model: endpoint.model,
       messages: [{ role: "user", content: prompt }],
       temperature: 0.2,
-      max_tokens: RECALL_EVALUATION_MAX_OUTPUT_TOKENS,
+      max_tokens: maxTokens,
     }),
   });
 }
@@ -236,16 +248,33 @@ export async function evaluateMobileAnswer(
   const cloudEndpoints = selectCloudHttpEndpoints(input.endpoint);
   for (const cloud of cloudEndpoints) {
     try {
-      const text = await generateViaHttp(cloud, prompt, input.ports.fetchText);
+      let text: string;
+      try {
+        text = await generateViaHttp(cloud, prompt, input.ports.fetchText);
+      } catch (error) {
+        if (!(error instanceof EvaluationTruncatedError)) throw error;
+        // One retry with real room. A model that thinks its way past even that
+        // is the wrong model for this job, and the error below says so.
+        text = await generateViaHttp(
+          cloud,
+          prompt,
+          input.ports.fetchText,
+          RECALL_EVALUATION_RETRY_OUTPUT_TOKENS,
+        );
+      }
       return {
         evaluation: parseRecallEvaluation(text),
         backend: "http",
         modelLabel: cloud.label || cloud.model,
       };
     } catch (error) {
-      errors.push(
-        `http (${cloud.label || cloud.model}): ${error instanceof Error ? error.message : String(error)}`,
-      );
+      const detail =
+        error instanceof EvaluationTruncatedError
+          ? `spent its whole output budget before answering, even at ${RECALL_EVALUATION_RETRY_OUTPUT_TOKENS} tokens — a reasoning model may be a poor fit for card evaluation`
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      errors.push(`http (${cloud.label || cloud.model}): ${detail}`);
     }
   }
   if (cloudEndpoints.length === 0 && input.endpoint) {

--- a/mobile/src/i18n.ts
+++ b/mobile/src/i18n.ts
@@ -137,6 +137,8 @@ const DE: Messages = {
   voice_answer_recognized:
     "Antwort erkannt. Erwartete Antwort wird vorgelesen.",
   voice_paused_msg: "Sprachmodus pausiert: {message}",
+  voice_compact_voice_hint:
+    "Tipp: Unter Einstellungen › Bedienungshilfen › Gesprochene Inhalte › Stimmen gibt es natürlicher klingende Stimmen zum Laden.",
   voice_paused_typing: "Sprachmodus pausiert. Tippen bleibt verfügbar.",
   voice_pause_failed: "Sprachmodus konnte nicht pausiert werden: {error}",
   voice_data_opened:
@@ -312,6 +314,8 @@ const EN: Messages = {
   no_domain: "No domain",
   voice_answer_recognized: "Answer recognised. Reading the expected answer.",
   voice_paused_msg: "Voice mode paused: {message}",
+  voice_compact_voice_hint:
+    "Tip: Settings › Accessibility › Spoken Content › Voices offers more natural voices to download.",
   voice_paused_typing: "Voice mode paused. Typing stays available.",
   voice_pause_failed: "Could not pause voice mode: {error}",
   voice_data_opened:

--- a/mobile/src/main.ts
+++ b/mobile/src/main.ts
@@ -822,11 +822,18 @@ async function pauseVoiceMode(): Promise<void> {
 }
 
 function startVoiceMode(): void {
+  // `learnerLocale` first, exactly as the evaluation path does. The pairing
+  // payload's locale is a snapshot taken once, when the device was paired, and
+  // `system.locale` defaults to "en" — so a device paired before the learner's
+  // language was stored keeps speaking English forever, while the UI and the
+  // evaluation have long since followed the database. And because "en" is a
+  // real value, `??` never falls through to the device language either.
   const locale = resolveVoiceLocale(
-    currentPairing?.settings?.locale ?? navigator.language,
+    learnerLocale ?? currentPairing?.settings?.locale ?? navigator.language,
   );
   installVoiceDataButton.hidden = true;
   updateVoiceButton();
+  void hintWhenOnlyCompactVoice(locale);
   void voiceController
     .start(locale)
     .catch((error) => {
@@ -838,6 +845,29 @@ function startVoiceMode(): void {
     })
     .finally(updateVoiceButton);
   updateVoiceButton();
+}
+
+/**
+ * Point at the one-time download when only a compact voice is installed.
+ *
+ * Every iOS language ships a small `default`-quality voice; the natural
+ * sounding ones are downloaded on request. Without this the learner has no way
+ * to know the flat read-aloud is a missing download rather than what ZAM
+ * sounds like.
+ */
+async function hintWhenOnlyCompactVoice(locale: VoiceLocale): Promise<void> {
+  if (!platformFeatures.voice) return;
+  try {
+    const result = await invoke<{ quality?: string }>("voice_quality", {
+      locale,
+    });
+    if (result?.quality === "default") {
+      setReviewStatus(t("voice_compact_voice_hint"));
+    }
+  } catch {
+    // Android has no such command, and a missing hint must never stop a
+    // session from starting.
+  }
 }
 
 function renderCurrentReview(message = ""): void {

--- a/src/cli/llm/client.ts
+++ b/src/cli/llm/client.ts
@@ -51,6 +51,13 @@ const CLOUD_CURRICULUM_IMPORT_HARD_TIMEOUT_MS = 180_000;
 /** Tight output caps for recall — short questions/evaluations, faster round-trips. */
 export const RECALL_QUESTION_MAX_OUTPUT_TOKENS = 400;
 export const RECALL_EVALUATION_MAX_OUTPUT_TOKENS = 1200;
+/**
+ * Budget for the single retry after a truncated evaluation. Kept in sync by
+ * hand with `RECALL_EVALUATION_RETRY_OUTPUT_TOKENS` in
+ * `desktop/src/panel/recall-evaluation.ts`; the CLI must not import from the
+ * desktop layer.
+ */
+export const RECALL_EVALUATION_RETRY_OUTPUT_TOKENS = 4000;
 export const RECALL_DISCUSSION_MAX_OUTPUT_TOKENS = 1200;
 
 const RECALL_ENDPOINT_CACHE_MS = 60_000;
@@ -814,28 +821,40 @@ Evaluation:`;
     };
   }
 
-  const res = await fetchWithInteractiveTimeout(
-    `${endpoint.url}/chat/completions`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${endpoint.apiKey}`,
+  const requestEvaluation = async (maxTokens: number): Promise<string> => {
+    const res = await fetchWithInteractiveTimeout(
+      `${endpoint.url}/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${endpoint.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: endpoint.model,
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ],
+          temperature: 0.2,
+          max_tokens: maxTokens,
+        }),
+        locale: cfg.locale,
       },
-      body: JSON.stringify({
-        model: endpoint.model,
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userPrompt },
-        ],
-        temperature: 0.2,
-        max_tokens: RECALL_EVALUATION_MAX_OUTPUT_TOKENS,
-      }),
-      locale: cfg.locale,
-    },
-  );
+    );
+    return readChatContent(res, "LLM evaluation");
+  };
 
-  const text = await readChatContent(res, "LLM evaluation");
+  // A reasoning model can spend the whole allowance thinking before writing a
+  // visible token, so no single budget is right for every model. The first
+  // attempt stays cheap; only a truncated one is retried with real room.
+  let text: string;
+  try {
+    text = await requestEvaluation(RECALL_EVALUATION_MAX_OUTPUT_TOKENS);
+  } catch (error) {
+    if (!(error instanceof LlmResponseTruncatedError)) throw error;
+    text = await requestEvaluation(RECALL_EVALUATION_RETRY_OUTPUT_TOKENS);
+  }
   return {
     text,
     model: endpoint.model,

--- a/tests/mobile/evaluate.test.ts
+++ b/tests/mobile/evaluate.test.ts
@@ -391,3 +391,95 @@ describe("a dead endpoint does not end the chain", () => {
     ).rejects.toThrow(/Grok \(CLI\).*Cloud recall/s);
   });
 });
+
+// Reported from the iPad: "Automatische Beurteilung nicht möglich (http (Mimo):
+// the model hit its output limit before finishing the evaluation)" — with 95%
+// of the prepaid budget still unused, so a quota was never the issue. MiMo is a
+// reasoning model and spent the whole 1200-token allowance thinking.
+describe("a reasoning model that thinks past its budget", () => {
+  const truncated = {
+    choices: [{ message: { content: "" }, finish_reason: "length" }],
+  };
+
+  function portsFor(fetchText: EvaluationPorts["fetchText"]): EvaluationPorts {
+    return {
+      checkOnDeviceStatus: async () => ({
+        status: "unavailable",
+        available: false,
+        downloadable: false,
+      }),
+      generateOnDevice: async (): Promise<never> => {
+        throw new Error("not on iOS");
+      },
+      fetchText,
+    };
+  }
+
+  it("retries once with real room and keeps the answer", async () => {
+    const budgets: number[] = [];
+    const fetchText = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string);
+      budgets.push(body.max_tokens);
+      if (budgets.length === 1) {
+        // Mirror defaultFetchText's own truncation detection.
+        const choice = truncated.choices[0];
+        if (choice.finish_reason === "length") {
+          const { EvaluationTruncatedError } = await import(
+            "../../mobile/src/evaluate.js"
+          );
+          throw new EvaluationTruncatedError();
+        }
+      }
+      return goodJson;
+    });
+
+    const result = await evaluateMobileAnswer({
+      card,
+      learnerAnswer: "F = m · a",
+      locale: "de",
+      endpoint: cloudEndpoint(),
+      onDeviceAvailable: false,
+      ports: portsFor(fetchText),
+    });
+
+    expect(result?.backend).toBe("http");
+    expect(budgets).toEqual([1200, 4000]);
+  });
+
+  it("does not retry a failure that is not a truncation", async () => {
+    const fetchText = vi.fn(async () => {
+      throw new Error("HTTP 401");
+    });
+    await expect(
+      evaluateMobileAnswer({
+        card,
+        learnerAnswer: "F = m · a",
+        locale: "de",
+        endpoint: cloudEndpoint(),
+        onDeviceAvailable: false,
+        ports: portsFor(fetchText),
+      }),
+    ).rejects.toThrow(/401/);
+    expect(fetchText).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the real cause when even the larger budget is not enough", async () => {
+    const fetchText = vi.fn(async () => {
+      const { EvaluationTruncatedError } = await import(
+        "../../mobile/src/evaluate.js"
+      );
+      throw new EvaluationTruncatedError();
+    });
+    await expect(
+      evaluateMobileAnswer({
+        card,
+        learnerAnswer: "F = m · a",
+        locale: "de",
+        endpoint: cloudEndpoint(),
+        onDeviceAvailable: false,
+        ports: portsFor(fetchText),
+      }),
+    ).rejects.toThrow(/reasoning model may be a poor fit/);
+    expect(fetchText).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/mobile/voice-wiring.test.ts
+++ b/tests/mobile/voice-wiring.test.ts
@@ -103,3 +103,41 @@ describe("iOS voice-mode wiring", () => {
     expect(plugin).toContain("AVAudioSession.sharedInstance().recordPermission");
   });
 });
+
+describe("voice locale and voice quality", () => {
+  const main = read("mobile/src/main.ts");
+
+  it("speaks in the learner's current language, not the pairing snapshot", () => {
+    // system.locale defaults to "en", and the pairing payload freezes whatever
+    // it was at pairing time. A device paired before the language was stored
+    // otherwise keeps speaking English while the UI and evaluation follow the
+    // database (reported on an iPad running entirely in German).
+    expect(main).toContain(
+      "learnerLocale ?? currentPairing?.settings?.locale ?? navigator.language",
+    );
+  });
+
+  it("ranks voices by quality, with the system's own pick breaking ties", () => {
+    const plugin = read("mobile/src-tauri/ios/Sources/VoicePlugin.swift");
+    expect(plugin).toContain("case .premium: tier = 3");
+    expect(plugin).toContain("case .enhanced: tier = 2");
+    // Ranking on quality alone breaks ties arbitrarily and reaches novelty
+    // voices; verified on macOS, where it chose "Zarvox" over "Samantha".
+    expect(plugin).toContain("AVSpeechSynthesisVoice(language: wanted)?.identifier");
+    expect(plugin).toContain("isSystemDefault");
+
+    const desktop = read("desktop/src-tauri/src/voice.rs");
+    expect(desktop).toContain("AVSpeechSynthesisVoiceQuality::Premium");
+    expect(desktop).toContain("is_system_default");
+    // voiceWithLanguage alone returns the compact voice; it is now only the
+    // tie-break, not the selection.
+    expect(desktop).toContain("fn best_voice(");
+  });
+
+  it("tells the learner where better voices come from", () => {
+    expect(main).toContain('invoke<{ quality?: string }>("voice_quality"');
+    expect(main).toContain('t("voice_compact_voice_hint")');
+    const i18n = read("mobile/src/i18n.ts");
+    expect(i18n.match(/voice_compact_voice_hint/g)?.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Reported from an iPad running entirely in German: voice mode spoke English, and
sounded "clearly 10 year old technology".

Both were real, and both were mine.

## Wrong language

Voice mode read the locale from the **pairing payload** — a snapshot taken once
when the device was paired. The UI and the evaluation path both follow
`learnerLocale`, refreshed live from the synced database.

`system.locale` defaults to `"en"`, so a device paired before the learner's
language was stored keeps speaking English indefinitely. And because `"en"` is
a real value, the `?? navigator.language` fallback never ran either — the
device's own German was available the whole time and never consulted.

Voice now uses the same live locale the evaluation already used.

## Worst available voice

Every Apple language ships a small `default` (compact) voice; the natural
sounding `enhanced` / `premium` ones are a one-time download. Both engines
reliably picked the compact one — iOS took the first match from
`speechVoices()`, macOS used `voiceWithLanguage`, which returns the system
default. A learner who had downloaded a good voice still got the flat one.

Selection now ranks by quality.

### What measuring caught

Ranking on quality alone is wrong, and it took running it to see: with only
default-quality voices installed the tie broke arbitrarily and reached the
**novelty** voices. On the development Mac the "fix" chose *Zarvox* over
*Samantha*, and *Shelley* over *Anna* — a clear regression.

The system's own pick for the language now breaks ties, exact region after it.
An unchanged machine keeps exactly the voice it had; a machine with a premium
voice gets it. A Rust regression test pins both halves.

## Also

Mobile points at the download when only a compact voice is installed. Without
it, the flat read-aloud reads as what ZAM sounds like rather than as a missing
download.

## Verification

Lint clean, 1716 tests pass (5 new), `tsc` clean, `cargo check --target
aarch64-apple-ios` builds the Swift package, macOS Rust tests pass including
the novelty-voice guard run against the real system voices.

**Not verified:** how it sounds. That needs the TestFlight build and a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)