### PR TITLE
chore: release 0.25.1

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.25.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.25.0"
+version = "0.25.1"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.25.1.md
+++ b/docs/release-notes-0.25.1.md
@@ -1,0 +1,63 @@
+# ZAM 0.25.1 — Voice mode in your own language, and evaluations that finish
+
+Three faults from the first field test of voice review on an iPad, all of them
+things that only running the feature on real hardware could have shown.
+
+## Voice mode speaks the learner's language
+
+Voice mode read the review language from the pairing payload — a snapshot taken
+once, when the device was paired — while the rest of the app follows
+`learnerLocale` live from the synced database. `system.locale` defaults to
+`"en"`, and because `"en"` is a real value rather than an absent one, the
+fallback chain never reached the device's own language either. A device paired
+before the language was set therefore spoke English forever, on an otherwise
+entirely German tablet.
+
+Voice now reads the same live locale the evaluation path already used, so
+changing the review language takes effect without pairing the device again.
+
+## The best voice the device actually has
+
+Both Apple engines were picking the compact voice. iOS took the first match
+from `speechVoices()`; macOS used `voiceWithLanguage`, which returns the system
+default. The natural-sounding `enhanced` and `premium` voices are a one-time
+download, so a learner who had already downloaded one still got the flat,
+decade-old-sounding read-aloud.
+
+Selection now ranks by voice quality — but quality alone turned out to be a
+*regression*, and only measuring against the real installed voices caught it:
+where nothing but default-quality voices exist the tie broke arbitrarily and
+landed on the novelty voices, choosing "Zarvox" over "Samantha" and "Shelley"
+over "Anna" on the development Mac. The system's own choice for that language
+now breaks the tie, with exact region after it, so an unchanged machine keeps
+exactly the voice it had and a machine with a better voice downloaded gets it.
+A regression test pins both halves.
+
+Where only a compact voice is installed, the companion now points at the
+download, because otherwise the flat voice reads as what ZAM sounds like.
+
+## Evaluations that run out of thinking room are retried
+
+Reported from the iPad, with 95% of the prepaid budget still unused, so a quota
+was never involved: *"the model hit its output limit before finishing the
+evaluation."*
+
+MiMo is a reasoning model. It spent the whole 1200-token allowance thinking and
+never emitted a visible character. That allowance had already been raised once
+for the same reason, and raising it again for everyone means every model pays
+for the worst case — while a chain of thought has no ceiling that would make any
+number the right one.
+
+So the first attempt stays cheap and only a truncated one is retried once, with
+real room (4000 tokens). If that also runs out, the mobile app now falls through
+to the next model in the chain instead of ending the session, and the message
+names the actual cause: the model spent its whole output budget before
+answering, which makes a reasoning model a poor fit for card evaluation. Both
+the mobile and desktop evaluation paths got the same retry — the desktop would
+have failed identically against the same model.
+
+## Notes
+
+- The voice fixes apply to iPadOS, iPhone, and macOS. Windows and Android voice
+  selection is unchanged.
+- Voice mode on iPad and iPhone continues to ship through TestFlight.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.25.0",
+          "User-Agent": "ZAM-Content-Studio/0.25.1",
         },
       });
 


### PR DESCRIPTION
Version bump for 0.25.1, carrying the three iPad field-test fixes merged in #267:

- voice mode reads the live learner locale instead of the frozen pairing snapshot
- Apple voice selection ranks by quality, with the system default breaking ties so no machine is downgraded to a novelty voice
- a truncated evaluation is retried once with real output room, and mobile falls through to the next model instead of ending the session

Touches root and desktop `package.json` + lockfiles, the `zam-app` crate and `Cargo.lock`, and the hardcoded `source-reader` User-Agent. Adds `docs/release-notes-0.25.1.md`.

Verified locally: lint clean, `tsc --noEmit` clean, 1719 tests passed / 5 skipped, `cargo metadata --locked` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)