### PR TITLE
fix: address the Companion handoff to one editor window

### DIFF
--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-08-01
+
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+
 ## 2026-07-31
 
 - **Update** — [Hands-Free Voice Mode](voice-mode.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -111,6 +111,25 @@ final iframe.
 - The read-only Learning Graph and OKF surfaces hide evaluator/model controls,
   because their stored data is rendered without a model.
 
+## Multi-window handoff
+
+An opening tool cannot render a panel itself, so it publishes a UI intent that
+a local Companion window picks up. Each editor window registers itself under
+`~/.zam/hosts/<hostId>.json` — heartbeat every 5 seconds, focus state, and the
+window's first workspace folder — and consumes only its own intent file under
+`~/.zam/intents/`.
+
+- `publishUiIntent` picks the window whose workspace contains the publishing
+  process's working directory; focus and heartbeat recency only break ties.
+- Registration continues while a window is unfocused, so a request published
+  while the user's focus sits elsewhere still reaches a window.
+- Entries older than 60 seconds are pruned, which cleans up after a window
+  that was killed rather than closed.
+- `~/.zam/vscode-host.json` and the shared `~/.zam/ui-intent.json` remain as a
+  single-slot fallback for a Companion or CLI older than 0.25. A window claims
+  the shared file only while focused, and records every id it sees so it never
+  replays another window's request on regaining focus.
+
 # OKF visualizer
 
 `zam_okf_visualize` accepts an optional initial `view`:
@@ -249,4 +268,4 @@ The same operation is available through `zam bridge okf-import`.
 - [ADR 2026-07-18c — OKF Import Handoff](../adr/2026-07-18c-okf-import-handoff.md)
 - [ADR 2026-07-29b — OKF Freshness Radar](../adr/2026-07-29b-okf-freshness-radar.md)
 - [ADR 2026-07-30 — OKF Reader Navigation and Mermaid Rendering](../adr/2026-07-30-okf-reader-navigation-and-mermaid.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/extension.ts`, `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/context-bar.ts`, `desktop/src/panel/display-mode.ts`, `desktop/src/panel/recall.ts`, `desktop/src/panel/graph.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-mermaid.ts`, `desktop/src/panel/okf-panel.html`, `vite.config.panel.mts`
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/ui-intent.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/extension.ts`, `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/context-bar.ts`, `desktop/src/panel/display-mode.ts`, `desktop/src/panel/recall.ts`, `desktop/src/panel/graph.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-mermaid.ts`, `desktop/src/panel/okf-panel.html`, `vite.config.panel.mts`

--- a/src/cli/ui-intent.ts
+++ b/src/cli/ui-intent.ts
@@ -1,6 +1,13 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { ulid } from "ulid";
 
 export type UiIntentApp = "recall" | "graph" | "settings" | "okf";
@@ -17,14 +24,53 @@ export interface WriteUiIntentOptions {
   path?: string;
   id?: string;
   now?: () => Date;
+  /** Legacy single-slot registration (`~/.zam/vscode-host.json`). */
   hostRegistrationPath?: string;
+  /** Per-window registry directory (`~/.zam/hosts`). */
+  hostsDir?: string;
+  /**
+   * Working directory used to match a host by workspace. Defaults to the
+   * publishing process's cwd, which for an agent's `zam mcp` is the workspace
+   * the user is actually working in.
+   */
+  cwd?: string;
 }
 
-interface UiHostRegistration {
+/** Legacy machine-global registration written by Companion ≤ 0.24.x. */
+interface LegacyUiHostRegistration {
   version: 1;
   intentPath: string;
   updatedAt: string;
 }
+
+/**
+ * One entry per live Companion window (`~/.zam/hosts/<hostId>.json`).
+ *
+ * The pre-0.25 handoff had a single registration slot and a single intent
+ * file for the whole machine, so two open editor windows overwrote each
+ * other's registration and then raced to consume the one shared intent —
+ * whichever window happened to be focused won, and requests published while
+ * no window was focused were dropped entirely. Each window now owns its own
+ * registry entry and its own intent path, so an intent is addressed to
+ * exactly one window.
+ */
+export interface UiHostEntry {
+  version: 2;
+  /** Stable per-window id (the extension host's pid). */
+  hostId: string;
+  /** The intent file this window — and only this window — consumes. */
+  intentPath: string;
+  /** First workspace folder of the window, when it has one. */
+  workspace?: string;
+  /** Whether the window was focused at the last heartbeat. */
+  focused: boolean;
+  /** Last time the window was focused, for tie-breaking. */
+  focusedAt?: string;
+  updatedAt: string;
+}
+
+/** A registration is only considered live for this long after its heartbeat. */
+export const UI_HOST_FRESHNESS_MS = 15_000;
 
 export function getUiIntentPath(home: string = homedir()): string {
   return join(home, ".zam", "ui-intent.json");
@@ -32,6 +78,17 @@ export function getUiIntentPath(home: string = homedir()): string {
 
 export function getUiHostRegistrationPath(home: string = homedir()): string {
   return join(home, ".zam", "vscode-host.json");
+}
+
+export function getUiHostsDirPath(home: string = homedir()): string {
+  return join(home, ".zam", "hosts");
+}
+
+export function getUiHostIntentPath(
+  hostId: string,
+  home: string = homedir(),
+): string {
+  return join(home, ".zam", "intents", `${hostId}.json`);
 }
 
 function compactStringInput(
@@ -44,10 +101,113 @@ function compactStringInput(
   );
 }
 
+function isUiHostEntry(value: unknown): value is UiHostEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<UiHostEntry>;
+  return (
+    entry.version === 2 &&
+    typeof entry.hostId === "string" &&
+    typeof entry.intentPath === "string" &&
+    typeof entry.updatedAt === "string"
+  );
+}
+
+/** True when `cwd` is the workspace directory or lives inside it. */
+function isInsideWorkspace(cwd: string, workspace: string): boolean {
+  const base = resolve(workspace);
+  const target = resolve(cwd);
+  return target === base || target.startsWith(base + sep);
+}
+
+/**
+ * Read every live Companion registration. Unreadable or malformed entries are
+ * skipped rather than failing the read — a half-written file from a window
+ * starting up must never keep a healthy window from receiving its intent.
+ */
+export async function readUiHosts(dir: string): Promise<UiHostEntry[]> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const entries = await Promise.all(
+    names
+      .filter((name) => name.endsWith(".json"))
+      .map(async (name) => {
+        try {
+          const parsed: unknown = JSON.parse(
+            await readFile(join(dir, name), "utf8"),
+          );
+          return isUiHostEntry(parsed) ? parsed : undefined;
+        } catch {
+          return undefined;
+        }
+      }),
+  );
+  return entries.filter((entry): entry is UiHostEntry => entry !== undefined);
+}
+
+function heartbeatAge(entry: UiHostEntry, now: number): number {
+  const updatedAt = Date.parse(entry.updatedAt);
+  return Number.isFinite(updatedAt)
+    ? now - updatedAt
+    : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Pick the window an intent belongs to.
+ *
+ * Workspace affinity comes first: an agent's `zam mcp` runs with the user's
+ * workspace as its cwd, so the window holding that workspace is the one that
+ * asked. Focus only breaks ties — relying on it alone is what made the
+ * pre-0.25 handoff open panels in the wrong window.
+ */
+export function selectUiHost(
+  hosts: UiHostEntry[],
+  opts: { now: number; cwd?: string } = { now: Date.now() },
+): UiHostEntry | undefined {
+  const live = hosts.filter(
+    (entry) => heartbeatAge(entry, opts.now) <= UI_HOST_FRESHNESS_MS,
+  );
+  if (live.length === 0) return undefined;
+
+  const cwd = opts.cwd;
+  const matching = cwd
+    ? live.filter(
+        (entry) => entry.workspace && isInsideWorkspace(cwd, entry.workspace),
+      )
+    : [];
+  const candidates = matching.length > 0 ? matching : live;
+
+  return [...candidates].sort((a, b) => {
+    if (a.focused !== b.focused) return a.focused ? -1 : 1;
+    const focusDelta =
+      (Date.parse(b.focusedAt ?? "") || 0) -
+      (Date.parse(a.focusedAt ?? "") || 0);
+    if (focusDelta !== 0) return focusDelta;
+    return heartbeatAge(a, opts.now) - heartbeatAge(b, opts.now);
+  })[0];
+}
+
+/** Remove registrations whose window is long gone, so the registry stays small. */
+export async function pruneUiHosts(
+  dir: string,
+  opts: { now?: number; maxAgeMs?: number } = {},
+): Promise<void> {
+  const now = opts.now ?? Date.now();
+  const maxAgeMs = opts.maxAgeMs ?? 60_000;
+  for (const entry of await readUiHosts(dir)) {
+    if (heartbeatAge(entry, now) <= maxAgeMs) continue;
+    await unlink(join(dir, `${entry.hostId}.json`)).catch(() => {});
+    await unlink(entry.intentPath).catch(() => {});
+  }
+}
+
 /**
  * Atomically hand one purpose-built MCP App request to a local visual host.
- * The file is deliberately a last-intent snapshot rather than a queue: users
- * operate one harness at a time, and a newer request supersedes an older one.
+ * The file is deliberately a last-intent snapshot rather than a queue: a
+ * newer request for the same window supersedes an older one.
  */
 export async function writeUiIntent(
   app: UiIntentApp,
@@ -72,8 +232,12 @@ export async function writeUiIntent(
 }
 
 /**
- * Opening an MCP App must still succeed in hosts that do not run the VS Code
+ * Opening an MCP App must still succeed in hosts that do not run the
  * companion, or when its optional local handoff cannot be written.
+ *
+ * Resolution order: the per-window registry (Companion ≥ 0.25), then the
+ * legacy single-slot registration so an older Companion still receives
+ * intents from a newer CLI.
  */
 export async function publishUiIntent(
   app: UiIntentApp,
@@ -88,26 +252,52 @@ export async function publishUiIntent(
     }
 
     const now = (opts.now ?? (() => new Date()))();
-    const registrationPath =
-      opts.hostRegistrationPath ?? getUiHostRegistrationPath();
+    const target = await resolveIntentPath(now, opts);
+    if (!target) return undefined;
+
+    return await writeUiIntent(app, input, {
+      ...opts,
+      path: target,
+      now: () => now,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveIntentPath(
+  now: Date,
+  opts: WriteUiIntentOptions,
+): Promise<string | undefined> {
+  const registrationPath =
+    opts.hostRegistrationPath ?? getUiHostRegistrationPath();
+  // The registry always sits beside the legacy registration file (`~/.zam`),
+  // so pointing one at a test home implicitly points the other there too.
+  const hostsDir =
+    opts.hostsDir ??
+    (opts.hostRegistrationPath
+      ? join(dirname(opts.hostRegistrationPath), "hosts")
+      : getUiHostsDirPath());
+  const host = selectUiHost(await readUiHosts(hostsDir), {
+    now: now.getTime(),
+    cwd: opts.cwd ?? process.cwd(),
+  });
+  if (host) return host.intentPath;
+
+  try {
     const registration = JSON.parse(
       await readFile(registrationPath, "utf8"),
-    ) as Partial<UiHostRegistration>;
+    ) as Partial<LegacyUiHostRegistration>;
     const updatedAt = Date.parse(registration.updatedAt ?? "");
     if (
       registration.version !== 1 ||
       typeof registration.intentPath !== "string" ||
       !Number.isFinite(updatedAt) ||
-      now.getTime() - updatedAt > 15_000
+      now.getTime() - updatedAt > UI_HOST_FRESHNESS_MS
     ) {
       return undefined;
     }
-
-    return await writeUiIntent(app, input, {
-      ...opts,
-      path: registration.intentPath,
-      now: () => now,
-    });
+    return registration.intentPath;
   } catch {
     return undefined;
   }

--- a/src/vscode-extension/extension.ts
+++ b/src/vscode-extension/extension.ts
@@ -1,5 +1,12 @@
 import { unwatchFile, watchFile } from "node:fs";
-import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -7,6 +14,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import * as vscode from "vscode";
+import {
+  getUiHostIntentPath,
+  getUiHostsDirPath,
+  pruneUiHosts,
+  type UiHostEntry,
+} from "../cli/ui-intent.js";
 import {
   getCompanionSelectedAntigravityEvaluatorId,
   getCompanionSelectedAntigravityModelId,
@@ -702,39 +715,67 @@ class CompanionViewProvider implements vscode.WebviewViewProvider {
   }
 }
 
-async function writeHostRegistration(
+async function writeJsonAtomically(
+  path: string,
+  value: unknown,
+): Promise<void> {
+  const tempPath = join(dirname(path), `.vscode-host-${process.pid}.tmp`);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(tempPath, path);
+}
+
+/**
+ * Legacy single-slot registration (`~/.zam/vscode-host.json`), still written
+ * so a CLI older than 0.25 keeps finding a host. It points at the shared
+ * intent file, which every window also watches — ambiguous with several
+ * windows open, which is exactly why the per-window registry below exists.
+ */
+async function writeLegacyHostRegistration(
   registrationPath: string,
   intentPath: string,
 ): Promise<void> {
-  const tempPath = join(
-    dirname(registrationPath),
-    `.vscode-host-${process.pid}.tmp`,
-  );
-  await mkdir(dirname(registrationPath), { recursive: true });
-  await writeFile(
-    tempPath,
-    `${JSON.stringify(
-      {
-        version: 1,
-        intentPath,
-        updatedAt: new Date().toISOString(),
-      },
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
-  await rename(tempPath, registrationPath);
+  await writeJsonAtomically(registrationPath, {
+    version: 1,
+    intentPath,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+/**
+ * This window's entry in `~/.zam/hosts`. Written on every heartbeat whether
+ * or not the window is focused: a request published while the user's focus
+ * sits in a terminal (or in the agent's own chat) must still reach a window
+ * instead of being dropped for want of a fresh registration.
+ */
+async function writeHostEntry(
+  entryPath: string,
+  entry: UiHostEntry,
+): Promise<void> {
+  await writeJsonAtomically(entryPath, entry);
 }
 
 let activeMcpHost: ZamMcpHost | undefined;
+let releaseHostRegistration: (() => Promise<void>) | undefined;
 
 export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  const zamDir = join(homedir(), ".zam");
-  const intentPath =
-    process.env.ZAM_UI_INTENT_PATH ?? join(zamDir, "ui-intent.json");
+  const home = homedir();
+  const zamDir = join(home, ".zam");
+  // One id per editor window: VS Code runs a separate extension host process
+  // per window, so its pid identifies the window for as long as it lives.
+  const hostId = `vscode-${process.pid}`;
+  const hostsDir = getUiHostsDirPath(home);
+  const hostEntryPath = join(hostsDir, `${hostId}.json`);
+  // The intent file only this window consumes. ZAM_UI_INTENT_PATH still wins
+  // so tests and single-window setups can pin one explicit path.
+  const ownIntentPath =
+    process.env.ZAM_UI_INTENT_PATH ?? getUiHostIntentPath(hostId, home);
+  // The pre-0.25 shared file, watched only so an older CLI still reaches us.
+  const legacyIntentPath = process.env.ZAM_UI_INTENT_PATH
+    ? undefined
+    : join(zamDir, "ui-intent.json");
   const registrationPath = join(zamDir, "vscode-host.json");
   const launchConfigPath = join(zamDir, "vscode-launch.json");
   const output = vscode.window.createOutputChannel("ZAM Companion", {
@@ -789,42 +830,87 @@ export async function activate(
     }),
   );
 
-  let lastIntentId: string | undefined;
-  const consumeIntent = async () => {
-    if (!vscode.window.state.focused) return;
+  const seenIntentIds = new Map<string, string | undefined>();
+  /**
+   * `requireFocus` separates the two handoff paths. This window's own intent
+   * file was addressed to it by name, so it opens whether or not the window
+   * happens to be focused. The legacy shared file is claimed by whichever
+   * window is focused — but its id is recorded either way, so an unfocused
+   * window never replays another window's request when it later gains focus.
+   */
+  const consumeIntent = async (path: string, requireFocus: boolean) => {
     try {
       const intent = parseCompanionIntent(
-        JSON.parse(await readFile(intentPath, "utf8")),
+        JSON.parse(await readFile(path, "utf8")),
       );
-      if (!intent || intent.id === lastIntentId) return;
-      lastIntentId = intent.id;
+      if (!intent || intent.id === seenIntentIds.get(path)) return;
+      seenIntentIds.set(path, intent.id);
+      if (requireFocus && !vscode.window.state.focused) return;
       await provider.open(intent.app, intent.input);
     } catch {
       // The handoff file is optional and may not exist before the first call.
     }
   };
-  const watchListener = () => void consumeIntent();
-  watchFile(intentPath, { interval: 300 }, watchListener);
-  context.subscriptions.push({
-    dispose: () => unwatchFile(intentPath, watchListener),
-  });
 
+  const watchIntentFile = (path: string, requireFocus: boolean) => {
+    const listener = () => void consumeIntent(path, requireFocus);
+    watchFile(path, { interval: 300 }, listener);
+    context.subscriptions.push({
+      dispose: () => unwatchFile(path, listener),
+    });
+  };
+  watchIntentFile(ownIntentPath, false);
+  if (legacyIntentPath) watchIntentFile(legacyIntentPath, true);
+
+  let focusedAt: string | undefined;
   const heartbeat = () => {
-    if (!vscode.window.state.focused) return;
-    void writeHostRegistration(registrationPath, intentPath).catch((error) => {
+    const focused = vscode.window.state.focused;
+    if (focused) focusedAt = new Date().toISOString();
+    void writeHostEntry(hostEntryPath, {
+      version: 2,
+      hostId,
+      intentPath: ownIntentPath,
+      ...(vscode.workspace.workspaceFolders?.[0]
+        ? { workspace: vscode.workspace.workspaceFolders[0].uri.fsPath }
+        : {}),
+      focused,
+      ...(focusedAt ? { focusedAt } : {}),
+      updatedAt: new Date().toISOString(),
+    }).catch((error) => {
       output.warn(
-        `Could not publish VS Code host registration: ${errorMessage(error)}`,
+        `Could not publish ZAM Companion host entry: ${errorMessage(error)}`,
       );
     });
+    // Entries of windows that were killed rather than deactivated cleanly
+    // would otherwise keep collecting intents nobody reads.
+    void pruneUiHosts(hostsDir).catch(() => {});
+    if (!focused || !legacyIntentPath) return;
+    void writeLegacyHostRegistration(registrationPath, legacyIntentPath).catch(
+      (error) => {
+        output.warn(
+          `Could not publish VS Code host registration: ${errorMessage(error)}`,
+        );
+      },
+    );
   };
   heartbeat();
   const heartbeatTimer = setInterval(heartbeat, 5_000);
+  releaseHostRegistration = async () => {
+    await unlink(hostEntryPath).catch(() => {});
+    await unlink(ownIntentPath).catch(() => {});
+  };
   context.subscriptions.push(
     { dispose: () => clearInterval(heartbeatTimer) },
+    {
+      dispose: () => {
+        void releaseHostRegistration?.();
+      },
+    },
     vscode.window.onDidChangeWindowState((state) => {
       if (state.focused) {
         heartbeat();
-        void consumeIntent();
+        void consumeIntent(ownIntentPath, false);
+        if (legacyIntentPath) void consumeIntent(legacyIntentPath, true);
       }
     }),
   );
@@ -833,4 +919,6 @@ export async function activate(
 export async function deactivate(): Promise<void> {
   await activeMcpHost?.close();
   activeMcpHost = undefined;
+  await releaseHostRegistration?.();
+  releaseHostRegistration = undefined;
 }

--- a/tests/cli/ui-intent.test.ts
+++ b/tests/cli/ui-intent.test.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -9,9 +10,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  getUiHostIntentPath,
+  getUiHostsDirPath,
   getUiIntentPath,
   getUiHostRegistrationPath,
+  type UiHostEntry,
+  pruneUiHosts,
   publishUiIntent,
+  selectUiHost,
   writeUiIntent,
 } from "../../src/cli/ui-intent.js";
 
@@ -27,6 +33,31 @@ function tempHome(): string {
   const dir = mkdtempSync(join(tmpdir(), "zam-ui-intent-"));
   tempDirs.push(dir);
   return dir;
+}
+
+const NOW = "2026-08-01T09:26:24.878Z";
+
+function host(overrides: Partial<UiHostEntry> = {}): UiHostEntry {
+  return {
+    version: 2,
+    hostId: "vscode-1",
+    intentPath: "/home/thomas/.zam/intents/vscode-1.json",
+    focused: false,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+/** Write a host entry into a temp home's registry. */
+function registerHost(home: string, entry: UiHostEntry): string {
+  const dir = getUiHostsDirPath(home);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${entry.hostId}.json`),
+    JSON.stringify(entry),
+    "utf8",
+  );
+  return entry.intentPath;
 }
 
 describe("VS Code UI intent", () => {
@@ -130,5 +161,185 @@ describe("VS Code UI intent", () => {
     );
 
     expect(intent).toBeUndefined();
+  });
+});
+
+describe("Companion host registry (multi-window)", () => {
+  const now = Date.parse(NOW);
+
+  it("gives every window its own intent file", () => {
+    expect(getUiHostIntentPath("vscode-42", "/home/thomas")).toBe(
+      join("/home/thomas", ".zam", "intents", "vscode-42.json"),
+    );
+    expect(getUiHostsDirPath("/home/thomas")).toBe(
+      join("/home/thomas", ".zam", "hosts"),
+    );
+  });
+
+  it("prefers the window whose workspace the publisher runs in", () => {
+    const picked = selectUiHost(
+      [
+        host({ hostId: "a", workspace: "/src/other", focused: true }),
+        host({
+          hostId: "b",
+          workspace: "/src/zam",
+          intentPath: "/intents/b.json",
+        }),
+      ],
+      { now, cwd: "/src/zam/docs/okf" },
+    );
+
+    // Focus must not outrank workspace affinity: opening a panel in the
+    // window that merely has focus is the pre-0.25 bug.
+    expect(picked?.hostId).toBe("b");
+  });
+
+  it("falls back to the focused window when no workspace matches", () => {
+    const picked = selectUiHost(
+      [
+        host({ hostId: "a", workspace: "/src/other" }),
+        host({ hostId: "b", workspace: "/src/another", focused: true }),
+      ],
+      { now, cwd: "/somewhere/else" },
+    );
+
+    expect(picked?.hostId).toBe("b");
+  });
+
+  it("breaks ties on the most recently focused window", () => {
+    const picked = selectUiHost(
+      [
+        host({ hostId: "a", focusedAt: "2026-08-01T09:20:00.000Z" }),
+        host({ hostId: "b", focusedAt: "2026-08-01T09:26:00.000Z" }),
+      ],
+      { now },
+    );
+
+    expect(picked?.hostId).toBe("b");
+  });
+
+  it("ignores windows whose heartbeat stopped", () => {
+    expect(
+      selectUiHost([host({ updatedAt: "2026-08-01T09:26:00.000Z" })], { now }),
+    ).toBeUndefined();
+  });
+
+  it("still reaches an unfocused window", () => {
+    // The pre-0.25 handoff only registered while a window had focus, so a
+    // request published from a terminal-side agent reached nothing at all.
+    const picked = selectUiHost([host({ hostId: "a", focused: false })], {
+      now,
+    });
+
+    expect(picked?.hostId).toBe("a");
+  });
+
+  it("publishes into the registered window's own intent file", async () => {
+    const home = tempHome();
+    const intentPath = registerHost(
+      home,
+      host({
+        hostId: "vscode-7",
+        intentPath: getUiHostIntentPath("vscode-7", home),
+        workspace: "/src/zam",
+        focused: true,
+      }),
+    );
+
+    const intent = await publishUiIntent(
+      "graph",
+      {},
+      {
+        hostRegistrationPath: getUiHostRegistrationPath(home),
+        cwd: "/src/zam",
+        now: () => new Date(NOW),
+      },
+    );
+
+    expect(intent?.app).toBe("graph");
+    expect(JSON.parse(readFileSync(intentPath, "utf8"))).toEqual(intent);
+    // The shared legacy file must stay untouched, or a second window would
+    // pick the request up as well.
+    expect(existsSync(getUiIntentPath(home))).toBe(false);
+  });
+
+  it("falls back to the legacy registration when no window registered", async () => {
+    const home = tempHome();
+    const legacyPath = getUiIntentPath(home);
+    mkdirSync(join(home, ".zam"), { recursive: true });
+    writeFileSync(
+      getUiHostRegistrationPath(home),
+      JSON.stringify({
+        version: 1,
+        intentPath: legacyPath,
+        updatedAt: "2026-08-01T09:26:20.000Z",
+      }),
+      "utf8",
+    );
+
+    const intent = await publishUiIntent(
+      "settings",
+      {},
+      {
+        hostRegistrationPath: getUiHostRegistrationPath(home),
+        now: () => new Date(NOW),
+      },
+    );
+
+    expect(intent?.app).toBe("settings");
+    expect(JSON.parse(readFileSync(legacyPath, "utf8"))).toEqual(intent);
+  });
+
+  it("drops entries and intent files of windows that died", async () => {
+    const home = tempHome();
+    const dead = getUiHostIntentPath("vscode-dead", home);
+    registerHost(
+      home,
+      host({
+        hostId: "vscode-dead",
+        intentPath: dead,
+        updatedAt: "2026-08-01T09:20:00.000Z",
+      }),
+    );
+    const alive = getUiHostIntentPath("vscode-alive", home);
+    registerHost(home, host({ hostId: "vscode-alive", intentPath: alive }));
+    mkdirSync(join(home, ".zam", "intents"), { recursive: true });
+    writeFileSync(dead, "{}", "utf8");
+
+    await pruneUiHosts(getUiHostsDirPath(home), { now });
+
+    expect(existsSync(join(getUiHostsDirPath(home), "vscode-dead.json"))).toBe(
+      false,
+    );
+    expect(existsSync(dead)).toBe(false);
+    expect(existsSync(join(getUiHostsDirPath(home), "vscode-alive.json"))).toBe(
+      true,
+    );
+  });
+
+  it("skips a half-written registry entry instead of failing the publish", async () => {
+    const home = tempHome();
+    const dir = getUiHostsDirPath(home);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "vscode-torn.json"), "{ not json", "utf8");
+    const intentPath = registerHost(
+      home,
+      host({
+        hostId: "vscode-good",
+        intentPath: getUiHostIntentPath("vscode-good", home),
+        focused: true,
+      }),
+    );
+
+    const intent = await publishUiIntent(
+      "recall",
+      {},
+      {
+        hostRegistrationPath: getUiHostRegistrationPath(home),
+        now: () => new Date(NOW),
+      },
+    );
+
+    expect(JSON.parse(readFileSync(intentPath, "utf8"))).toEqual(intent);
   });
 });


### PR DESCRIPTION
## Problem

Using the ZAM Companion in more than one VS Code window at a time breaks. Reported symptoms: the second window's Companion never started, and only closing every VS Code window restored a working one.

The MCP App handoff is machine-global — one registration slot in `~/.zam/vscode-host.json` and one intent file in `~/.zam/ui-intent.json` for every open window. Three defects follow from that:

1. **Requests were dropped entirely.** The registration heartbeat only ran while a window had focus (`if (!vscode.window.state.focused) return`), and `publishUiIntent` discarded a registration older than 15s. Publish while focus sits in a terminal or the agent's own chat, and nothing opens.
2. **The wrong window opened the panel.** Focus alone decided who consumed the shared intent, so with two windows it was a coin flip.
3. **A window replayed another window's request.** An unfocused window returned before recording `lastIntentId`, then opened the stale intent on regaining focus (bounded to 30s by `parseCompanionIntent`'s `maxAgeMs`).

No lock was involved — this database is remote (Turso), so nothing serialises across processes.

## Change

Each window gets its own registration and its own intent file.

- `~/.zam/hosts/<hostId>.json` — heartbeat every 5s **whether or not the window is focused**, carrying focus state and the window's first workspace folder.
- `~/.zam/intents/<hostId>.json` — read by that window only, regardless of focus.
- `selectUiHost()` picks the window whose workspace contains the publishing process's cwd; focus and heartbeat recency only break ties.
- Entries older than 60s are pruned, cleaning up after a window that was killed rather than closed.

`~/.zam/vscode-host.json` and the shared `~/.zam/ui-intent.json` stay as a single-slot fallback for a Companion or CLI older than 0.25. A window claims the shared file only while focused, and now records every id it sees so the replay in (3) cannot happen either way.

## Verification

- 1695 tests pass, Biome clean, `npm run build` and `tsc --noEmit` green.
- 10 new tests in `tests/cli/ui-intent.test.ts` cover workspace affinity beating focus, reaching an unfocused window, tie-breaking on last focus, stale-heartbeat rejection, per-window isolation of the intent file, legacy fallback, pruning, and a half-written registry entry not failing the publish.
- `docs/okf/mcp-surfaces.md` gains a "Multi-window handoff" section, written through `upsertArticle` (index and log regenerated).

## Out of scope

`~/.zam/okf-focus.json` and the `companion` section of `~/.zam/config.json` are global last-write-wins for the same reason — the focused OKF article and the evaluator/model selection still clobber each other across windows. Same class of bug, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)