### PR TITLE
fix: make machine-local state safe for concurrent windows

### DIFF
--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -3,6 +3,7 @@
 ## 2026-08-01
 
 - **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 
 ## 2026-07-31
 

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -130,6 +130,24 @@ window's first workspace folder — and consumes only its own intent file under
   the shared file only while focused, and records every id it sees so it never
   replays another window's request on regaining focus.
 
+## Machine-local settings under concurrency
+
+`~/.zam/config.json` holds every machine-local setting — install mode, model
+registry, workspaces, and the Companion's learner, evaluator, and model
+selections. Each window runs its own `zam mcp`, so several processes write it
+at once.
+
+- `saveInstallConfig` replaces the file through a temp file and a rename, so no
+  reader ever sees a torn file.
+- Every setter goes through `updateInstallConfig`, which loads, mutates, and
+  saves under an exclusive `config.json.lock`. The load happens *inside* the
+  lock: without it two processes interleave and one silently drops the other's
+  change, which the learner sees as a setting reverting by itself.
+- The lock is best-effort by design. A lock held longer than 2 seconds, or left
+  behind by a process that died, is broken once and then taken; a location
+  where no lock can be created falls back to writing unlocked. Failing to lock
+  must never stop ZAM from saving its own settings.
+
 # OKF visualizer
 
 `zam_okf_visualize` accepts an optional initial `view`:
@@ -218,7 +236,8 @@ wrapping so the focused title remains the primary readable label.
 The reader's **import as learning content** action starts an agent-guided flow:
 
 1. The reader records its focused article through the app-only `zam_okf_focus`
-   tool in `~/.zam/okf-focus.json`.
+   tool, in `~/.zam/focus/<hostId>.json` for its own window and in
+   `~/.zam/okf-focus.json` unscoped.
 2. A host advertising MCP Apps `message` receives the decomposition request via
    `ui/message`; the VS Code Companion routes it to the editor Chat view.
 3. A host without chat shows the same instruction as copyable text.
@@ -229,6 +248,15 @@ The reader's **import as learning content** action starts an agent-guided flow:
 A typed request such as “import this OKF” in Claude Code, Copilot, Codex, or
 another connected harness resolves the same machine-local focus through the
 model-visible `zam_okf_focused` tool.
+
+The focus is scoped per window like the UI intents above. The writing panel
+learns its window from `ZAM_COMPANION_HOST_ID`, which the extension injects
+into the `zam mcp` child it spawns; the reader resolves the window from its own
+working directory through the host registry. A window's article wins over the
+unscoped file even when the unscoped one is newer — the agent asking is working
+inside one window, and that window's reader is the one it means. Surfaces
+outside an editor window, such as the desktop app, write and read the unscoped
+file alone.
 
 `zam_okf_import` writes tokens, prerequisite edges, and per-user cards in one
 transaction:
@@ -268,4 +296,4 @@ The same operation is available through `zam bridge okf-import`.
 - [ADR 2026-07-18c — OKF Import Handoff](../adr/2026-07-18c-okf-import-handoff.md)
 - [ADR 2026-07-29b — OKF Freshness Radar](../adr/2026-07-29b-okf-freshness-radar.md)
 - [ADR 2026-07-30 — OKF Reader Navigation and Mermaid Rendering](../adr/2026-07-30-okf-reader-navigation-and-mermaid.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/ui-intent.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/extension.ts`, `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/context-bar.ts`, `desktop/src/panel/display-mode.ts`, `desktop/src/panel/recall.ts`, `desktop/src/panel/graph.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-mermaid.ts`, `desktop/src/panel/okf-panel.html`, `vite.config.panel.mts`
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/ui-intent.ts`, `src/kernel/system/install-config.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/extension.ts`, `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/context-bar.ts`, `desktop/src/panel/display-mode.ts`, `desktop/src/panel/recall.ts`, `desktop/src/panel/graph.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-mermaid.ts`, `desktop/src/panel/okf-panel.html`, `vite.config.panel.mts`

--- a/src/cli/okf-focus.ts
+++ b/src/cli/okf-focus.ts
@@ -4,14 +4,30 @@
  * The OKF panel records which article its reader is showing; any agent —
  * Claude Code, Copilot, Codex, whatever else speaks to `zam mcp` — can then
  * resolve "import the currently focused okf article" without the panel
- * needing a conversation surface of its own. Mirrors the ui-intent pattern
- * (src/cli/ui-intent.ts): a last-write-wins snapshot file under `~/.zam`,
- * written atomically via rename; a newer focus supersedes an older one.
+ * needing a conversation surface of its own.
+ *
+ * The focus is scoped per Companion window, using the host registry from
+ * `src/cli/ui-intent.ts`. A single machine-global snapshot meant two editor
+ * windows each browsing the knowledge base overwrote one another, and
+ * `zam_okf_focused` then handed the agent the *other* window's article — the
+ * same class of bug the UI-intent handoff had. The writer learns its window
+ * from `ZAM_COMPANION_HOST_ID`, injected by the extension into the `zam mcp`
+ * child it spawns; the reader resolves the window from its own working
+ * directory through `selectUiHost`.
+ *
+ * `~/.zam/okf-focus.json` stays as the unscoped fallback, for surfaces
+ * outside an editor window (the desktop app) and for readers older than 0.25.
  */
 
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import {
+  getUiHostFocusPath,
+  getUiHostsDirPath,
+  readUiHosts,
+  selectUiHost,
+} from "./ui-intent.js";
 
 export interface OkfFocus {
   version: 1;
@@ -22,59 +38,136 @@ export interface OkfFocus {
   updatedAt: string;
 }
 
+export interface OkfFocusOptions {
+  /** Explicit file to use, bypassing host scoping entirely. */
+  path?: string;
+  /** Home directory the `~/.zam` paths hang off; defaults to `homedir()`. */
+  home?: string;
+  /** Registry directory; defaults to `<home>/.zam/hosts`. */
+  hostsDir?: string;
+  now?: () => Date;
+}
+
+export interface WriteOkfFocusOptions extends OkfFocusOptions {
+  /** Window this panel belongs to; defaults to `ZAM_COMPANION_HOST_ID`. */
+  hostId?: string;
+}
+
+export interface ReadOkfFocusOptions extends OkfFocusOptions {
+  /** Working directory used to resolve the window; defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
 export function getOkfFocusPath(home: string = homedir()): string {
   return join(home, ".zam", "okf-focus.json");
 }
 
-function resolvePath(explicit?: string): string {
-  return explicit ?? process.env.ZAM_OKF_FOCUS_PATH ?? getOkfFocusPath();
+/** The unscoped file, honoring the explicit path and env overrides. */
+function resolveFallbackPath(explicit?: string, home?: string): string {
+  return explicit ?? process.env.ZAM_OKF_FOCUS_PATH ?? getOkfFocusPath(home);
 }
 
+function resolveHostId(explicit?: string): string | undefined {
+  return explicit ?? process.env.ZAM_COMPANION_HOST_ID ?? undefined;
+}
+
+async function writeFocusFile(path: string, focus: OkfFocus): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  // Scope the temp name by pid: two `zam mcp` processes writing at once would
+  // otherwise rename the same `<path>.tmp` out from under each other.
+  const tmp = `${path}.${process.pid}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(focus, null, 2)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+/**
+ * Record the focused article for this window, and in the unscoped file.
+ *
+ * Both are written: the per-host file is what a current reader resolves, and
+ * the unscoped one keeps a non-window surface (or an older reader) working.
+ * With an explicit `path` — the test and `ZAM_OKF_FOCUS_PATH` route — only
+ * that file is touched.
+ */
 export async function writeOkfFocus(
   file: string,
   bundleDir?: string,
-  opts: { path?: string; now?: () => Date } = {},
+  opts: WriteOkfFocusOptions = {},
 ): Promise<OkfFocus> {
   if (file.includes("/") || file.includes("\\") || !file.endsWith(".md")) {
     throw new Error(`invalid article file name: ${file}`);
   }
-  const path = resolvePath(opts.path);
   const focus: OkfFocus = {
     version: 1,
     file,
     ...(bundleDir ? { bundleDir } : {}),
     updatedAt: (opts.now?.() ?? new Date()).toISOString(),
   };
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(focus, null, 2)}\n`, "utf8");
-  await rename(tmp, path);
+
+  const explicitPath = opts.path ?? process.env.ZAM_OKF_FOCUS_PATH;
+  if (explicitPath) {
+    await writeFocusFile(explicitPath, focus);
+    return focus;
+  }
+
+  const hostId = resolveHostId(opts.hostId);
+  if (hostId) {
+    await writeFocusFile(getUiHostFocusPath(hostId, opts.home), focus);
+  }
+  await writeFocusFile(getOkfFocusPath(opts.home), focus);
   return focus;
 }
 
-/** The last recorded focus, or null when absent or unreadable. */
-export async function readOkfFocus(
-  opts: { path?: string } = {},
-): Promise<OkfFocus | null> {
+function parseFocus(raw: string): OkfFocus | null {
+  const parsed = JSON.parse(raw) as Partial<OkfFocus>;
+  if (
+    parsed.version !== 1 ||
+    typeof parsed.file !== "string" ||
+    typeof parsed.updatedAt !== "string"
+  ) {
+    return null;
+  }
+  return {
+    version: 1,
+    file: parsed.file,
+    ...(typeof parsed.bundleDir === "string"
+      ? { bundleDir: parsed.bundleDir }
+      : {}),
+    updatedAt: parsed.updatedAt,
+  };
+}
+
+async function readFocusFile(path: string): Promise<OkfFocus | null> {
   try {
-    const raw = await readFile(resolvePath(opts.path), "utf8");
-    const parsed = JSON.parse(raw) as Partial<OkfFocus>;
-    if (
-      parsed.version !== 1 ||
-      typeof parsed.file !== "string" ||
-      typeof parsed.updatedAt !== "string"
-    ) {
-      return null;
-    }
-    return {
-      version: 1,
-      file: parsed.file,
-      ...(typeof parsed.bundleDir === "string"
-        ? { bundleDir: parsed.bundleDir }
-        : {}),
-      updatedAt: parsed.updatedAt,
-    };
+    return parseFocus(await readFile(path, "utf8"));
   } catch {
     return null;
   }
+}
+
+/**
+ * The focused article of the window this process belongs to, or null.
+ *
+ * Resolution order: an explicit path, then the window whose workspace holds
+ * this process's working directory, then the unscoped file. The per-host file
+ * wins over the unscoped one even when the latter is newer — the agent asking
+ * is working inside one window, and that window's reader is the one it means.
+ */
+export async function readOkfFocus(
+  opts: ReadOkfFocusOptions = {},
+): Promise<OkfFocus | null> {
+  const explicitPath = opts.path ?? process.env.ZAM_OKF_FOCUS_PATH;
+  if (explicitPath) return readFocusFile(explicitPath);
+
+  const hostsDir = opts.hostsDir ?? getUiHostsDirPath(opts.home);
+  const host = selectUiHost(await readUiHosts(hostsDir), {
+    now: (opts.now?.() ?? new Date()).getTime(),
+    cwd: opts.cwd ?? process.cwd(),
+  });
+  if (host) {
+    const scoped = await readFocusFile(
+      getUiHostFocusPath(host.hostId, opts.home),
+    );
+    if (scoped) return scoped;
+  }
+  return readFocusFile(resolveFallbackPath(undefined, opts.home));
 }

--- a/src/cli/ui-intent.ts
+++ b/src/cli/ui-intent.ts
@@ -91,6 +91,20 @@ export function getUiHostIntentPath(
   return join(home, ".zam", "intents", `${hostId}.json`);
 }
 
+/**
+ * The OKF article one window's reader currently shows. Scoped per host for
+ * the same reason intents are: two windows each browsing the knowledge base
+ * would otherwise overwrite one another's "focused article", and
+ * `zam_okf_focused` would resolve "import the open article" to whichever
+ * window last painted (see `src/cli/okf-focus.ts`).
+ */
+export function getUiHostFocusPath(
+  hostId: string,
+  home: string = homedir(),
+): string {
+  return join(home, ".zam", "focus", `${hostId}.json`);
+}
+
 function compactStringInput(
   input: Record<string, string | undefined>,
 ): Record<string, string> {
@@ -197,10 +211,14 @@ export async function pruneUiHosts(
 ): Promise<void> {
   const now = opts.now ?? Date.now();
   const maxAgeMs = opts.maxAgeMs ?? 60_000;
+  // `dir` is `<home>/.zam/hosts`, so the sibling per-host directories hang off
+  // its parent — the same derivation the path helpers above encode.
+  const zamDir = dirname(dir);
   for (const entry of await readUiHosts(dir)) {
     if (heartbeatAge(entry, now) <= maxAgeMs) continue;
     await unlink(join(dir, `${entry.hostId}.json`)).catch(() => {});
     await unlink(entry.intentPath).catch(() => {});
+    await unlink(join(zamDir, "focus", `${entry.hostId}.json`)).catch(() => {});
   }
 }
 

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -542,6 +542,7 @@ export {
   setMachineVoicePreference,
   setOnboardingDone,
   setOnboardingPersona,
+  updateInstallConfig,
   updateMachineCompanionConfig,
   upsertConfiguredWorkspace,
 } from "./system/install-config.js";

--- a/src/kernel/system/install-config.ts
+++ b/src/kernel/system/install-config.ts
@@ -17,6 +17,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -319,6 +320,108 @@ export function saveInstallConfig(
   }
 }
 
+/** How long to wait for another process to finish its read-modify-write. */
+const CONFIG_LOCK_TIMEOUT_MS = 2_000;
+/** A lock older than this belonged to a process that died holding it. */
+const CONFIG_LOCK_STALE_MS = 5_000;
+const CONFIG_LOCK_POLL_MS = 15;
+
+type LockAttempt = "acquired" | "busy" | "unavailable";
+
+/** Block this thread without spinning; the lock is held for microseconds. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function tryAcquireLock(lockPath: string): LockAttempt {
+  try {
+    // "wx" fails when the file exists, which makes creation the atomic
+    // test-and-set every platform agrees on.
+    writeFileSync(lockPath, `${process.pid}\n`, {
+      encoding: "utf-8",
+      flag: "wx",
+    });
+    return "acquired";
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EEXIST"
+      ? "busy"
+      : "unavailable";
+  }
+}
+
+/**
+ * Serialize one read-modify-write cycle against `path` across processes.
+ *
+ * `saveInstallConfig` replaces the file atomically, so a reader never sees a
+ * torn file — but every setter loads, mutates, and saves the *whole* config,
+ * and two processes interleaving those steps silently drop one of the two
+ * changes. With several editor windows each running their own `zam mcp`,
+ * that lost update is a Companion setting that reverts by itself.
+ *
+ * Returns `undefined` when no lock could be taken. Failing to lock must never
+ * stop ZAM from saving its own config, so the caller then proceeds unlocked —
+ * back to the pre-lock behavior rather than an error.
+ */
+function acquireInstallConfigLock(path: string): (() => void) | undefined {
+  const lockPath = `${path}.lock`;
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const release = () => {
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // Already released, or broken by a waiter that timed us out.
+    }
+  };
+
+  const deadline = Date.now() + CONFIG_LOCK_TIMEOUT_MS;
+  for (;;) {
+    const attempt = tryAcquireLock(lockPath);
+    if (attempt === "acquired") return release;
+    if (attempt === "unavailable") return undefined;
+    let heldForMs: number;
+    try {
+      heldForMs = Date.now() - statSync(lockPath).mtimeMs;
+    } catch {
+      // The holder released it between the two calls — retry immediately.
+      continue;
+    }
+    if (heldForMs > CONFIG_LOCK_STALE_MS || Date.now() >= deadline) break;
+    sleepSync(CONFIG_LOCK_POLL_MS);
+  }
+
+  // Break a stale or pathologically slow lock exactly once. Looping here
+  // instead would let two waiters break each other's lock indefinitely.
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // Another waiter broke it first; the acquire below still decides.
+  }
+  return tryAcquireLock(lockPath) === "acquired" ? release : undefined;
+}
+
+/**
+ * Load, mutate, and save the config as one cross-process-atomic step.
+ *
+ * Every setter in this module goes through here: the load happens *inside*
+ * the lock, so a concurrent writer's change is read back rather than
+ * overwritten. Returns whatever `mutate` returns.
+ */
+export function updateInstallConfig<T>(
+  mutate: (config: InstallConfig) => T,
+  path = defaultConfigPath(),
+): T {
+  const release = acquireInstallConfigLock(path);
+  try {
+    const config = loadInstallConfig(path);
+    const result = mutate(config);
+    saveInstallConfig(config, path);
+    return result;
+  } finally {
+    release?.();
+  }
+}
+
 /**
  * This machine's install mode. Defaults to "developer" — the only historical
  * mode — so existing source/CLI installs keep their behavior. A packaged
@@ -332,9 +435,9 @@ export function setInstallMode(
   mode: InstallMode,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  config.mode = mode;
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    config.mode = mode;
+  }, path);
 }
 
 /**
@@ -352,9 +455,9 @@ export function setInstallChannel(
   channel: InstallChannel,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  config.channel = channel;
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    config.channel = channel;
+  }, path);
 }
 
 export function getMachineAiConfig(
@@ -367,9 +470,9 @@ export function saveMachineAiConfig(
   ai: MachineAiConfig,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  config.ai = ai;
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    config.ai = ai;
+  }, path);
 }
 
 const sanitizedMachineRolePaths = new Set<string>();
@@ -381,12 +484,12 @@ export function ensureMachineProviderRolesSanitized(
   if (sanitizedMachineRolePaths.has(path)) return;
   sanitizedMachineRolePaths.add(path);
 
-  const ai = getMachineAiConfig(path);
-  if (!ai.roles?.text) return;
-
-  const roles = { ...ai.roles };
-  delete roles.text;
-  saveMachineAiConfig({ ...ai, roles }, path);
+  updateInstallConfig((config) => {
+    if (!config.ai?.roles?.text) return;
+    const roles = { ...config.ai.roles };
+    delete roles.text;
+    config.ai = { ...config.ai, roles };
+  }, path);
 }
 
 // ── Unified capability-based model registry (ADR 2026-07-12) ─────────────────
@@ -401,8 +504,9 @@ export function saveMachineAiModels(
   models: ModelEntry[],
   path = defaultConfigPath(),
 ): void {
-  const ai = getMachineAiConfig(path);
-  saveMachineAiConfig({ ...ai, models }, path);
+  updateInstallConfig((config) => {
+    config.ai = { ...(config.ai ?? {}), models };
+  }, path);
 }
 
 function isAnthropicUrl(url: string): boolean {
@@ -521,15 +625,19 @@ const migratedModelConfigPaths = new Set<string>();
 export function ensureMachineAiModelsMigrated(
   path = defaultConfigPath(),
 ): ModelEntry[] {
-  const ai = getMachineAiConfig(path);
-  if (ai.models && ai.models.length > 0) return ai.models;
-  if (migratedModelConfigPaths.has(path)) return ai.models ?? [];
+  const existing = getMachineAiConfig(path);
+  if (existing.models && existing.models.length > 0) return existing.models;
+  if (migratedModelConfigPaths.has(path)) return existing.models ?? [];
   migratedModelConfigPaths.add(path);
 
-  const models = migrateMachineRolesToModels(ai);
-  if (!models) return [];
-  saveMachineAiConfig({ ...ai, models }, path);
-  return models;
+  return updateInstallConfig((config) => {
+    const ai = config.ai ?? {};
+    if (ai.models && ai.models.length > 0) return ai.models;
+    const models = migrateMachineRolesToModels(ai);
+    if (!models) return [];
+    config.ai = { ...ai, models };
+    return models;
+  }, path);
 }
 
 /**
@@ -545,13 +653,13 @@ export function setAgentConnectAutoDone(
   done: boolean,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  if (done) {
-    config.agent = { ...(config.agent ?? {}), connectAutoDone: true };
-  } else if (config.agent) {
-    delete config.agent.connectAutoDone;
-  }
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    if (done) {
+      config.agent = { ...(config.agent ?? {}), connectAutoDone: true };
+    } else if (config.agent) {
+      delete config.agent.connectAutoDone;
+    }
+  }, path);
 }
 
 /**
@@ -569,13 +677,13 @@ export function setOnboardingDone(
   done: boolean,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  if (done) {
-    config.onboarding = { ...(config.onboarding ?? {}), done: true };
-  } else if (config.onboarding) {
-    delete config.onboarding.done;
-  }
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    if (done) {
+      config.onboarding = { ...(config.onboarding ?? {}), done: true };
+    } else if (config.onboarding) {
+      delete config.onboarding.done;
+    }
+  }, path);
 }
 
 /**
@@ -593,13 +701,13 @@ export function setOnboardingPersona(
   persona: PersonaId | undefined,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  if (persona) {
-    config.onboarding = { ...(config.onboarding ?? {}), persona };
-  } else if (config.onboarding) {
-    delete config.onboarding.persona;
-  }
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    if (persona) {
+      config.onboarding = { ...(config.onboarding ?? {}), persona };
+    } else if (config.onboarding) {
+      delete config.onboarding.persona;
+    }
+  }, path);
 }
 
 /**
@@ -612,7 +720,12 @@ export function setOnboardingPersona(
 export function getMachineCompanionConfig(
   path = defaultConfigPath(),
 ): MachineCompanionConfig {
-  const raw = loadInstallConfig(path).companion;
+  return normalizeCompanionConfig(loadInstallConfig(path).companion);
+}
+
+function normalizeCompanionConfig(
+  raw: MachineCompanionConfig | undefined,
+): MachineCompanionConfig {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
   const result: MachineCompanionConfig = {};
   if (typeof raw.selectedUserId === "string") {
@@ -652,9 +765,29 @@ export function saveMachineCompanionConfig(
   companion: MachineCompanionConfig,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  config.companion = companion;
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    config.companion = companion;
+  }, path);
+}
+
+/**
+ * Change the Companion section under the config lock, re-reading it inside
+ * the lock. The individual setters below must not `getMachineCompanionConfig`
+ * first and save the result afterwards: with an editor window per workspace,
+ * two `zam mcp` processes doing that concurrently drop one of the two
+ * selections, which the learner sees as a model or evaluator choice reverting
+ * on its own.
+ */
+function updateCompanionConfig(
+  mutate: (companion: MachineCompanionConfig) => void,
+  path = defaultConfigPath(),
+): MachineCompanionConfig {
+  return updateInstallConfig((config) => {
+    const companion = normalizeCompanionConfig(config.companion);
+    mutate(companion);
+    config.companion = companion;
+    return companion;
+  }, path);
 }
 
 /**
@@ -679,15 +812,15 @@ export function setMachineVoicePreference(
   preference: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  const voice: MachineVoiceConfig = { ...(config.voice ?? {}) };
-  if (preference === undefined) {
-    delete voice.enginePreference;
-  } else {
-    voice.enginePreference = preference;
-  }
-  config.voice = voice;
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    const voice: MachineVoiceConfig = { ...(config.voice ?? {}) };
+    if (preference === undefined) {
+      delete voice.enginePreference;
+    } else {
+      voice.enginePreference = preference;
+    }
+    config.voice = voice;
+  }, path);
 }
 
 /**
@@ -721,7 +854,15 @@ export function updateMachineCompanionConfig(
   update: MachineCompanionConfigUpdate,
   path = defaultConfigPath(),
 ): MachineCompanionConfig {
-  const companion = getMachineCompanionConfig(path);
+  return updateCompanionConfig((companion) => {
+    applyCompanionUpdate(companion, update);
+  }, path);
+}
+
+function applyCompanionUpdate(
+  companion: MachineCompanionConfig,
+  update: MachineCompanionConfigUpdate,
+): void {
   if ("selectedUserId" in update) {
     if (update.selectedUserId) {
       companion.selectedUserId = update.selectedUserId;
@@ -771,8 +912,6 @@ export function updateMachineCompanionConfig(
       [update.collapsed.surface]: update.collapsed.value,
     };
   }
-  saveMachineCompanionConfig(companion, path);
-  return companion;
 }
 
 /** The persisted Companion learner, independent of the shared `user.id`. */
@@ -786,13 +925,13 @@ export function setCompanionSelectedUserId(
   userId: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const companion = getMachineCompanionConfig(path);
-  if (userId) {
-    companion.selectedUserId = userId;
-  } else {
-    delete companion.selectedUserId;
-  }
-  saveMachineCompanionConfig(companion, path);
+  updateCompanionConfig((companion) => {
+    if (userId) {
+      companion.selectedUserId = userId;
+    } else {
+      delete companion.selectedUserId;
+    }
+  }, path);
 }
 
 /** The persisted Companion evaluator id (validated against `EvaluatorId` by callers). */
@@ -806,13 +945,13 @@ export function setCompanionSelectedEvaluatorId(
   evaluatorId: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const companion = getMachineCompanionConfig(path);
-  if (evaluatorId) {
-    companion.selectedEvaluatorId = evaluatorId;
-  } else {
-    delete companion.selectedEvaluatorId;
-  }
-  saveMachineCompanionConfig(companion, path);
+  updateCompanionConfig((companion) => {
+    if (evaluatorId) {
+      companion.selectedEvaluatorId = evaluatorId;
+    } else {
+      delete companion.selectedEvaluatorId;
+    }
+  }, path);
 }
 
 export function getCompanionSelectedVscodeEvaluatorId(
@@ -825,13 +964,13 @@ export function setCompanionSelectedVscodeEvaluatorId(
   evaluatorId: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const companion = getMachineCompanionConfig(path);
-  if (evaluatorId) {
-    companion.selectedVscodeEvaluatorId = evaluatorId;
-  } else {
-    delete companion.selectedVscodeEvaluatorId;
-  }
-  saveMachineCompanionConfig(companion, path);
+  updateCompanionConfig((companion) => {
+    if (evaluatorId) {
+      companion.selectedVscodeEvaluatorId = evaluatorId;
+    } else {
+      delete companion.selectedVscodeEvaluatorId;
+    }
+  }, path);
 }
 
 export function getCompanionSelectedAntigravityEvaluatorId(
@@ -844,13 +983,13 @@ export function setCompanionSelectedAntigravityEvaluatorId(
   evaluatorId: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const companion = getMachineCompanionConfig(path);
-  if (evaluatorId) {
-    companion.selectedAntigravityEvaluatorId = evaluatorId;
-  } else {
-    delete companion.selectedAntigravityEvaluatorId;
-  }
-  saveMachineCompanionConfig(companion, path);
+  updateCompanionConfig((companion) => {
+    if (evaluatorId) {
+      companion.selectedAntigravityEvaluatorId = evaluatorId;
+    } else {
+      delete companion.selectedAntigravityEvaluatorId;
+    }
+  }, path);
 }
 
 /** The persisted explicit VS Code model choice for the `vscode-lm` adapter. */
@@ -864,13 +1003,13 @@ export function setCompanionSelectedVscodeModelId(
   modelId: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const companion = getMachineCompanionConfig(path);
-  if (modelId) {
-    companion.selectedVscodeModelId = modelId;
-  } else {
-    delete companion.selectedVscodeModelId;
-  }
-  saveMachineCompanionConfig(companion, path);
+  updateCompanionConfig((companion) => {
+    if (modelId) {
+      companion.selectedVscodeModelId = modelId;
+    } else {
+      delete companion.selectedVscodeModelId;
+    }
+  }, path);
 }
 
 /** The persisted explicit Antigravity model choice for the `vscode-lm` adapter. */
@@ -884,13 +1023,13 @@ export function setCompanionSelectedAntigravityModelId(
   modelId: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const companion = getMachineCompanionConfig(path);
-  if (modelId) {
-    companion.selectedAntigravityModelId = modelId;
-  } else {
-    delete companion.selectedAntigravityModelId;
-  }
-  saveMachineCompanionConfig(companion, path);
+  updateCompanionConfig((companion) => {
+    if (modelId) {
+      companion.selectedAntigravityModelId = modelId;
+    } else {
+      delete companion.selectedAntigravityModelId;
+    }
+  }, path);
 }
 
 /** Collapsed state for every surface that has been explicitly set. */
@@ -905,12 +1044,12 @@ export function setCompanionCollapsed(
   collapsed: boolean,
   path = defaultConfigPath(),
 ): void {
-  const companion = getMachineCompanionConfig(path);
-  companion.collapsed = {
-    ...(companion.collapsed ?? {}),
-    [surface]: collapsed,
-  };
-  saveMachineCompanionConfig(companion, path);
+  updateCompanionConfig((companion) => {
+    companion.collapsed = {
+      ...(companion.collapsed ?? {}),
+      [surface]: collapsed,
+    };
+  }, path);
 }
 
 /**
@@ -928,9 +1067,9 @@ export function setLastRepairedVersion(
   version: string,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  config.lastRepairedVersion = version;
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    config.lastRepairedVersion = version;
+  }, path);
 }
 
 export function getConfiguredWorkspaces(
@@ -943,15 +1082,15 @@ export function saveConfiguredWorkspaces(
   workspaces: WorkspaceConfig[],
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  config.workspaces = workspaces;
-  if (
-    config.activeWorkspaceId &&
-    !workspaces.some((workspace) => workspace.id === config.activeWorkspaceId)
-  ) {
-    config.activeWorkspaceId = workspaces[0]?.id;
-  }
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    config.workspaces = workspaces;
+    if (
+      config.activeWorkspaceId &&
+      !workspaces.some((workspace) => workspace.id === config.activeWorkspaceId)
+    ) {
+      config.activeWorkspaceId = workspaces[0]?.id;
+    }
+  }, path);
 }
 
 export function getActiveWorkspaceId(
@@ -964,13 +1103,13 @@ export function setActiveWorkspaceId(
   id: string | undefined,
   path = defaultConfigPath(),
 ): void {
-  const config = loadInstallConfig(path);
-  if (id) {
-    config.activeWorkspaceId = id;
-  } else {
-    delete config.activeWorkspaceId;
-  }
-  saveInstallConfig(config, path);
+  updateInstallConfig((config) => {
+    if (id) {
+      config.activeWorkspaceId = id;
+    } else {
+      delete config.activeWorkspaceId;
+    }
+  }, path);
 }
 
 export function getActiveWorkspace(
@@ -987,31 +1126,32 @@ export function upsertConfiguredWorkspace(
   workspace: WorkspaceConfig,
   path = defaultConfigPath(),
 ): WorkspaceConfig[] {
-  const config = loadInstallConfig(path);
-  const current = config.workspaces ?? [];
-  const next = [
-    ...current.filter((candidate) => candidate.id !== workspace.id),
-    workspace,
-  ];
-  config.workspaces = next;
-  saveInstallConfig(config, path);
-  return next;
+  return updateInstallConfig((config) => {
+    const next = [
+      ...(config.workspaces ?? []).filter(
+        (candidate) => candidate.id !== workspace.id,
+      ),
+      workspace,
+    ];
+    config.workspaces = next;
+    return next;
+  }, path);
 }
 
 export function removeConfiguredWorkspace(
   id: string,
   path = defaultConfigPath(),
 ): WorkspaceConfig[] {
-  const config = loadInstallConfig(path);
-  const next = (config.workspaces ?? []).filter(
-    (workspace) => workspace.id !== id,
-  );
-  config.workspaces = next;
-  if (config.activeWorkspaceId === id) {
-    config.activeWorkspaceId = next[0]?.id;
-  }
-  saveInstallConfig(config, path);
-  return next;
+  return updateInstallConfig((config) => {
+    const next = (config.workspaces ?? []).filter(
+      (workspace) => workspace.id !== id,
+    );
+    config.workspaces = next;
+    if (config.activeWorkspaceId === id) {
+      config.activeWorkspaceId = next[0]?.id;
+    }
+    return next;
+  }, path);
 }
 
 /**
@@ -1047,19 +1187,17 @@ export function setActiveWorkspaceContext(
   contextName: string | undefined,
   path = defaultConfigPath(),
 ): boolean {
-  const config = loadInstallConfig(path);
-  const activeId = config.activeWorkspaceId;
-  if (activeId && config.workspaces) {
-    const workspace = config.workspaces.find((w) => w.id === activeId);
-    if (workspace) {
-      if (contextName) {
-        workspace.activeKnowledgeContext = contextName;
-      } else {
-        delete workspace.activeKnowledgeContext;
-      }
-      saveInstallConfig(config, path);
-      return true;
+  return updateInstallConfig((config) => {
+    const activeId = config.activeWorkspaceId;
+    const workspace = activeId
+      ? config.workspaces?.find((w) => w.id === activeId)
+      : undefined;
+    if (!workspace) return false;
+    if (contextName) {
+      workspace.activeKnowledgeContext = contextName;
+    } else {
+      delete workspace.activeKnowledgeContext;
     }
-  }
-  return false;
+    return true;
+  }, path);
 }

--- a/src/vscode-extension/extension.ts
+++ b/src/vscode-extension/extension.ts
@@ -15,6 +15,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import * as vscode from "vscode";
 import {
+  getUiHostFocusPath,
   getUiHostIntentPath,
   getUiHostsDirPath,
   pruneUiHosts,
@@ -150,7 +151,7 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function childEnvironment(): Record<string, string> {
+function childEnvironment(hostId: string): Record<string, string> {
   return {
     ...Object.fromEntries(
       Object.entries(process.env).filter(
@@ -158,6 +159,10 @@ function childEnvironment(): Record<string, string> {
       ),
     ),
     ZAM_DISABLE_UI_INTENT: "1",
+    // Lets the panel's own `zam mcp` record the focused OKF article against
+    // this window rather than into the machine-wide snapshot every window
+    // shares (src/cli/okf-focus.ts).
+    ZAM_COMPANION_HOST_ID: hostId,
   };
 }
 
@@ -188,6 +193,7 @@ class ZamMcpHost {
   public constructor(
     private readonly launchConfigPath: string,
     private readonly output: vscode.OutputChannel,
+    private readonly hostId: string,
   ) {}
 
   /**
@@ -233,7 +239,7 @@ class ZamMcpHost {
         const transport = new StdioClientTransport({
           command: launch.command,
           args: launch.args,
-          env: childEnvironment(),
+          env: childEnvironment(this.hostId),
           stderr: "pipe",
           ...(workspace ? { cwd: workspace } : {}),
         });
@@ -781,7 +787,7 @@ export async function activate(
   const output = vscode.window.createOutputChannel("ZAM Companion", {
     log: true,
   });
-  const mcp = new ZamMcpHost(launchConfigPath, output);
+  const mcp = new ZamMcpHost(launchConfigPath, output, hostId);
   activeMcpHost = mcp;
   const provider = new CompanionViewProvider(context.extensionUri, mcp, output);
 
@@ -898,6 +904,7 @@ export async function activate(
   releaseHostRegistration = async () => {
     await unlink(hostEntryPath).catch(() => {});
     await unlink(ownIntentPath).catch(() => {});
+    await unlink(getUiHostFocusPath(hostId, home)).catch(() => {});
   };
   context.subscriptions.push(
     { dispose: () => clearInterval(heartbeatTimer) },

--- a/tests/cli/okf-focus.test.ts
+++ b/tests/cli/okf-focus.test.ts
@@ -1,11 +1,17 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getOkfFocusPath,
   readOkfFocus,
   writeOkfFocus,
 } from "../../src/cli/okf-focus.js";
+import {
+  getUiHostFocusPath,
+  getUiHostsDirPath,
+  type UiHostEntry,
+} from "../../src/cli/ui-intent.js";
 
 describe("okf-focus state file", () => {
   let dir: string;
@@ -46,15 +52,15 @@ describe("okf-focus state file", () => {
   });
 
   it("rejects path separators and non-md names", async () => {
-    await expect(writeOkfFocus("../evil.md", undefined, { path })).rejects.toThrow(
-      /invalid/,
-    );
-    await expect(writeOkfFocus("sub\\evil.md", undefined, { path })).rejects.toThrow(
-      /invalid/,
-    );
-    await expect(writeOkfFocus("notes.txt", undefined, { path })).rejects.toThrow(
-      /invalid/,
-    );
+    await expect(
+      writeOkfFocus("../evil.md", undefined, { path }),
+    ).rejects.toThrow(/invalid/);
+    await expect(
+      writeOkfFocus("sub\\evil.md", undefined, { path }),
+    ).rejects.toThrow(/invalid/);
+    await expect(
+      writeOkfFocus("notes.txt", undefined, { path }),
+    ).rejects.toThrow(/invalid/);
   });
 
   it("returns null for a missing or malformed file", async () => {
@@ -80,5 +86,107 @@ describe("okf-focus state file", () => {
         process.env.ZAM_OKF_FOCUS_PATH = previous;
       }
     }
+  });
+});
+
+describe("okf-focus is scoped per Companion window", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "zam-okf-focus-home-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function registerWindow(hostId: string, workspace: string): void {
+    const dir = getUiHostsDirPath(home);
+    mkdirSync(dir, { recursive: true });
+    const entry: UiHostEntry = {
+      version: 2,
+      hostId,
+      intentPath: join(home, ".zam", "intents", `${hostId}.json`),
+      workspace,
+      focused: false,
+      updatedAt: new Date().toISOString(),
+    };
+    writeFileSync(join(dir, `${hostId}.json`), JSON.stringify(entry), "utf8");
+  }
+
+  it("resolves the article of the window the reader works in", async () => {
+    registerWindow("vscode-a", "/src/alpha");
+    registerWindow("vscode-b", "/src/beta");
+    await writeOkfFocus("alpha.md", "/src/alpha/docs/okf", {
+      home,
+      hostId: "vscode-a",
+    });
+    await writeOkfFocus("beta.md", "/src/beta/docs/okf", {
+      home,
+      hostId: "vscode-b",
+    });
+
+    // Two windows browsing the knowledge base used to overwrite one shared
+    // snapshot, so the agent got whichever window painted last.
+    expect((await readOkfFocus({ home, cwd: "/src/alpha" }))?.file).toBe(
+      "alpha.md",
+    );
+    expect((await readOkfFocus({ home, cwd: "/src/beta" }))?.file).toBe(
+      "beta.md",
+    );
+  });
+
+  it("also writes the unscoped file for surfaces outside a window", async () => {
+    await writeOkfFocus("shared.md", undefined, { home, hostId: "vscode-a" });
+
+    expect((await readOkfFocus({ path: getOkfFocusPath(home) }))?.file).toBe(
+      "shared.md",
+    );
+  });
+
+  it("falls back to the unscoped file when no window matches", async () => {
+    await writeOkfFocus("desktop.md", undefined, { home });
+
+    // A writer without a host id — the desktop app — reaches a reader that
+    // resolves no window.
+    expect((await readOkfFocus({ home, cwd: "/src/elsewhere" }))?.file).toBe(
+      "desktop.md",
+    );
+  });
+
+  it("falls back when the matched window has no focus recorded yet", async () => {
+    registerWindow("vscode-a", "/src/alpha");
+    await writeOkfFocus("desktop.md", undefined, { home });
+
+    expect((await readOkfFocus({ home, cwd: "/src/alpha" }))?.file).toBe(
+      "desktop.md",
+    );
+  });
+
+  it("prefers the window's article over a newer unscoped one", async () => {
+    registerWindow("vscode-a", "/src/alpha");
+    await writeOkfFocus("windowed.md", undefined, {
+      home,
+      hostId: "vscode-a",
+      now: () => new Date("2026-08-01T09:00:00.000Z"),
+    });
+    writeFileSync(
+      getOkfFocusPath(home),
+      JSON.stringify({
+        version: 1,
+        file: "newer-elsewhere.md",
+        updatedAt: "2026-08-01T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    // The agent is working inside one window; that window's reader is the
+    // one it means, however recently another surface painted.
+    expect((await readOkfFocus({ home, cwd: "/src/alpha" }))?.file).toBe(
+      "windowed.md",
+    );
+    expect(getUiHostFocusPath("vscode-a", home)).toBe(
+      join(home, ".zam", "focus", "vscode-a.json"),
+    );
   });
 });

--- a/tests/kernel/install-config.test.ts
+++ b/tests/kernel/install-config.test.ts
@@ -1,12 +1,16 @@
+import { spawn } from "node:child_process";
 import {
+  existsSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   detectSyncProvider,
@@ -15,11 +19,11 @@ import {
   getActiveWorkspaceId,
   getAgentConnectAutoDone,
   getCompanionCollapsed,
-  getCompanionSelectedAntigravityModelId,
   getCompanionSelectedAntigravityEvaluatorId,
-  getCompanionSelectedVscodeEvaluatorId,
+  getCompanionSelectedAntigravityModelId,
   getCompanionSelectedEvaluatorId,
   getCompanionSelectedUserId,
+  getCompanionSelectedVscodeEvaluatorId,
   getCompanionSelectedVscodeModelId,
   getConfiguredWorkspaces,
   getInstallMode,
@@ -33,11 +37,11 @@ import {
   setActiveWorkspaceId,
   setAgentConnectAutoDone,
   setCompanionCollapsed,
-  setCompanionSelectedAntigravityModelId,
   setCompanionSelectedAntigravityEvaluatorId,
-  setCompanionSelectedVscodeEvaluatorId,
+  setCompanionSelectedAntigravityModelId,
   setCompanionSelectedEvaluatorId,
   setCompanionSelectedUserId,
+  setCompanionSelectedVscodeEvaluatorId,
   setCompanionSelectedVscodeModelId,
   setInstallMode,
   setOnboardingDone,
@@ -150,10 +154,7 @@ describe("install config", () => {
 
   it("falls back to the default persona for an unknown on-disk value", () => {
     const path = tempConfigPath();
-    saveInstallConfig(
-      { onboarding: { persona: "astronaut" } } as never,
-      path,
-    );
+    saveInstallConfig({ onboarding: { persona: "astronaut" } } as never, path);
     expect(getOnboardingPersona(path)).toBe("private");
   });
 
@@ -357,8 +358,12 @@ describe("install config", () => {
 
     setCompanionSelectedAntigravityModelId("google:gemini-3.5-flash", path);
 
-    expect(getCompanionSelectedAntigravityModelId(path)).toBe("google:gemini-3.5-flash");
-    expect(loadInstallConfig(path).companion?.selectedAntigravityModelId).toBe("google:gemini-3.5-flash");
+    expect(getCompanionSelectedAntigravityModelId(path)).toBe(
+      "google:gemini-3.5-flash",
+    );
+    expect(loadInstallConfig(path).companion?.selectedAntigravityModelId).toBe(
+      "google:gemini-3.5-flash",
+    );
 
     setCompanionSelectedAntigravityModelId(undefined, path);
     expect(getCompanionSelectedAntigravityModelId(path)).toBeUndefined();
@@ -374,8 +379,12 @@ describe("install config", () => {
 
     expect(getCompanionSelectedVscodeEvaluatorId(path)).toBe("vscode-lm");
     expect(getCompanionSelectedAntigravityEvaluatorId(path)).toBe("quick-mode");
-    expect(loadInstallConfig(path).companion?.selectedVscodeEvaluatorId).toBe("vscode-lm");
-    expect(loadInstallConfig(path).companion?.selectedAntigravityEvaluatorId).toBe("quick-mode");
+    expect(loadInstallConfig(path).companion?.selectedVscodeEvaluatorId).toBe(
+      "vscode-lm",
+    );
+    expect(
+      loadInstallConfig(path).companion?.selectedAntigravityEvaluatorId,
+    ).toBe("quick-mode");
 
     setCompanionSelectedVscodeEvaluatorId(undefined, path);
     expect(getCompanionSelectedVscodeEvaluatorId(path)).toBeUndefined();
@@ -544,5 +553,107 @@ describe("install config", () => {
       ),
     ).toBe("iCloud Drive");
     expect(detectSyncProvider("/Users/x/Documents/zam")).toBeNull();
+  });
+});
+
+describe("cross-process config writes", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempConfigPath(): string {
+    const dir = mkdtempSync(join(tmpdir(), "zam-config-lock-"));
+    tempDirs.push(dir);
+    return join(dir, "config.json");
+  }
+
+  /**
+   * Append `rounds` distinct keys to the Companion section from a separate OS
+   * process, so several writers' load-mutate-save cycles really interleave.
+   * `saveInstallConfig` replaces the file atomically, so a torn read is not
+   * what this exercises — the question is whether one writer's snapshot of the
+   * *whole* config silently drops another writer's concurrent change.
+   */
+  function writerProcess(
+    path: string,
+    writer: string,
+    rounds: number,
+  ): ReturnType<typeof spawn> {
+    // The writers wait on a barrier file before starting: without it, Node's
+    // startup cost staggers them so far apart that their read-modify-write
+    // windows never overlap and the race under test cannot occur.
+    const script = `
+      const { existsSync } = await import("node:fs");
+      const { setCompanionCollapsed } = await import(${JSON.stringify(
+        pathToFileURL(join(process.cwd(), "dist", "index.js")).href,
+      )});
+      const idle = new Int32Array(new SharedArrayBuffer(4));
+      while (!existsSync(${JSON.stringify(`${path}.start`)})) {
+        Atomics.wait(idle, 0, 0, 5);
+      }
+      for (let i = 0; i < ${rounds}; i += 1) {
+        setCompanionCollapsed(
+          ${JSON.stringify(writer)} + "-" + i,
+          true,
+          ${JSON.stringify(path)},
+        );
+      }
+    `;
+    return spawn(process.execPath, ["--input-type=module", "-e", script], {
+      stdio: "ignore",
+    });
+  }
+
+  it("keeps concurrent Companion writes from overwriting each other", async () => {
+    const path = tempConfigPath();
+    const writers = ["alpha", "beta", "gamma", "delta"];
+    const rounds = 150;
+
+    const running = writers.map(
+      (writer) =>
+        new Promise<void>((resolve, reject) => {
+          const child = writerProcess(path, writer, rounds);
+          child.on("error", reject);
+          child.on("exit", (code) =>
+            code === 0
+              ? resolve()
+              : reject(new Error(`writer exited with ${code}`)),
+          );
+        }),
+    );
+    // Give every writer time to boot, then release them at once.
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    writeFileSync(`${path}.start`, "", "utf8");
+    await Promise.all(running);
+
+    // Every single write must have survived. With the load and the save
+    // unsynchronized, a writer's snapshot drops whatever another writer
+    // committed in between — the Companion setting that reverts by itself.
+    const stored = getCompanionCollapsed(path);
+    const missing = writers.flatMap((writer) =>
+      Array.from({ length: rounds }, (_, i) => `${writer}-${i}`).filter(
+        (key) => stored[key] !== true,
+      ),
+    );
+    expect(missing).toEqual([]);
+    // And no lock file is left behind to block the next write.
+    expect(existsSync(`${path}.lock`)).toBe(false);
+  }, 60_000);
+
+  it("breaks a lock left behind by a process that died holding it", () => {
+    const path = tempConfigPath();
+    const lockPath = `${path}.lock`;
+    writeFileSync(lockPath, "999999\n", "utf8");
+    const stale = Date.now() - 60_000;
+    utimesSync(lockPath, new Date(stale), new Date(stale));
+
+    setCompanionCollapsed("recall", true, path);
+
+    expect(getCompanionCollapsed(path)).toEqual({ recall: true });
+    expect(existsSync(lockPath)).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to [#269](https://github.com/zam-os/zam/pull/269), now rebased onto `main` after it merged.

Two more `~/.zam` files were machine-global last-write-wins, the same class of bug as the UI-intent handoff.

## 1. The focused OKF article

The reader recorded its article in one shared `~/.zam/okf-focus.json`. Two windows each browsing the knowledge base overwrote one another, so `zam_okf_focused` — the tool behind "import the open article" — handed the agent the *other* window's article.

The focus is now scoped per window:

- The writing panel learns its window from `ZAM_COMPANION_HOST_ID`, which the extension injects into the `zam mcp` child it spawns, and writes `~/.zam/focus/<hostId>.json`.
- The reader resolves the window from its own working directory through `selectUiHost`, the same workspace-affinity rule intents use.
- A window's article wins over the unscoped file **even when the unscoped one is newer** — the agent asking is working inside one window, and that window's reader is the one it means.
- `~/.zam/okf-focus.json` is still written and still read as a fallback, for surfaces outside an editor window (the desktop app) and for readers older than 0.25. The per-host file is pruned along with its window's registration.

Also fixed in passing: `writeOkfFocus` staged through a fixed `<path>.tmp`, so two `zam mcp` processes could rename the same temp file out from under each other. It is pid-scoped now.

## 2. Lost updates in `config.json`

`saveInstallConfig` replaces the file through a temp file and a rename, so a reader never sees a torn file — but every setter did load → mutate → save on the *whole* config, and two processes interleaving those steps silently drop one of the two changes. With an editor window per workspace, that is a Companion evaluator or model selection reverting on its own.

- New `updateInstallConfig(mutate, path)` loads, mutates, and saves under an exclusive `config.json.lock`. The load happens **inside** the lock, which is the entire point.
- Every setter in the module goes through it, including the Companion section: `normalizeCompanionConfig` was factored out so the section is re-read inside the lock rather than passed in from a read taken before it.
- `saveMachineAiModels` and `ensureMachineAiModelsMigrated` had the same pattern one level up and were converted too.
- The lock is best-effort by design: one held longer than 2s, or left behind by a process that died, is broken once and then taken; a location where no lock can be created falls back to writing unlocked. Failing to lock must never stop ZAM from saving its own settings. No mutator calls another locked setter, so the lock is never taken re-entrantly.

## Verification

- 1736 tests pass, Biome clean, `npm run build` and `tsc --noEmit` green — re-run after the rebase onto `main`.
- 5 new tests for per-window focus: workspace-based resolution across two windows, the unscoped write, fallback when no window matches, fallback when the matched window has recorded nothing yet, and per-host winning over a newer unscoped file.
- 2 new tests for the config lock. The concurrency one spawns four writer processes that wait on a barrier file, then each append 150 distinct keys. **Without the lock 433 of the 600 writes are lost; with it, none are.** The other test proves a lock left by a dead process is broken rather than blocking forever.
- `docs/okf/mcp-surfaces.md` documents both, written through `upsertArticle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)