### PR TITLE
fix: let the provider say which models it has

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,10 @@ jobs:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: 'ZAM Desktop ${{ github.ref_name }}'
+          # Not "ZAM Desktop": one release carries the desktop apps, the
+          # Android APK, the editor companion and the npm package. A hand-written
+          # title replaces this before publishing; this is only the draft's name.
+          releaseName: 'ZAM ${{ github.ref_name }}'
           releaseBody: |
             ${{ steps.notes.outputs.body }}
           releaseDraft: true

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -4898,6 +4898,10 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "Everything stays on this device. Nothing is sent anywhere.",
     voice_detail_uses_cloud:
       "Your recordings are sent to the speech model you configured.",
+    voice_cloud_tts_failed:
+      "Cloud speech unavailable ({message}). Continuing with the device voice.",
+    voice_cloud_stt_failed:
+      "Cloud recognition unavailable ({message}). Continuing with the device — please say that again.",
     voice_start: "Start voice mode",
     voice_pause: "Pause voice mode",
     voice_paused_msg: "Voice mode paused: {message}",
@@ -5985,6 +5989,10 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "Alles bleibt auf diesem Gerät. Es wird nichts verschickt.",
     voice_detail_uses_cloud:
       "Deine Aufnahmen gehen an das Sprachmodell, das du eingerichtet hast.",
+    voice_cloud_tts_failed:
+      "Cloud-Sprachausgabe nicht erreichbar ({message}). Weiter mit der Stimme des Geräts.",
+    voice_cloud_stt_failed:
+      "Cloud-Spracherkennung nicht erreichbar ({message}). Weiter mit der Erkennung des Geräts — bitte noch einmal sprechen.",
     voice_start: "Sprachmodus starten",
     voice_pause: "Sprachmodus pausieren",
     voice_paused_msg: "Sprachmodus pausiert: {message}",

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -2211,9 +2211,51 @@ async function showModelForm(id?: string): Promise<void> {
     harnessSelect.appendChild(opt);
   }
 
+  // The endpoint's own list of models, offered as suggestions on the model
+  // field. A datalist rather than a dropdown: an endpoint that serves no
+  // catalog (most local runners) must still accept a typed id, and so must a
+  // model published after this build. Typing stays possible; guessing stops
+  // being necessary.
+  const modelCatalog = document.createElement("datalist");
+  modelCatalog.id = "model-catalog-options";
+  modelInput.setAttribute("list", modelCatalog.id);
+
+  let catalogKey = "";
+  const loadModelCatalog = async (): Promise<void> => {
+    const url = urlInput.value.trim();
+    const key = keyInput.value.trim();
+    const signature = `${url} ${key} ${existing?.apiKeyRef ?? ""}`;
+    if (!url || signature === catalogKey) return;
+    catalogKey = signature;
+    modelCatalog.replaceChildren();
+    try {
+      const args = ["--url", url];
+      if (key) args.push("--key", key);
+      else if (existing?.apiKeyRef) args.push("--key-ref", existing.apiKeyRef);
+      const result = await runBridge<{ models?: string[] }>(
+        "model-catalog",
+        args,
+      );
+      for (const id of result?.models ?? []) {
+        const option = document.createElement("option");
+        option.value = id;
+        modelCatalog.appendChild(option);
+      }
+    } catch {
+      // No catalog is a normal state, not an error — the field still accepts
+      // anything typed, exactly as before.
+      catalogKey = "";
+    }
+  };
+
+  urlInput.addEventListener("change", () => void loadModelCatalog());
+  keyInput.addEventListener("change", () => void loadModelCatalog());
+  modelInput.addEventListener("focus", () => void loadModelCatalog());
+
   const labelField = modelFieldLabel(t("model_field_label"), labelInput);
   const urlField = modelFieldLabel(t("model_field_url"), urlInput);
   const modelField = modelFieldLabel(t("model_field_model"), modelInput);
+  modelField.appendChild(modelCatalog);
   const keyField = modelFieldLabel(t("model_field_key"), keyInput);
   const harnessField = modelFieldLabel(
     t("model_field_harness"),
@@ -5144,6 +5186,18 @@ const voiceController = createVoiceController(
       };
     },
     play: playVoiceAudio,
+  },
+  (capability, message) => {
+    // Say it plainly and keep going. A misconfigured endpoint — a model the
+    // provider does not actually serve — otherwise ends the session with a raw
+    // gateway error, which is the worst possible moment to learn about it.
+    setVoiceStatus(
+      tf(
+        capability === "tts" ? "voice_cloud_tts_failed" : "voice_cloud_stt_failed",
+        { message },
+      ),
+      true,
+    );
   }),
 );
 

--- a/desktop/src/voice.ts
+++ b/desktop/src/voice.ts
@@ -153,18 +153,46 @@ export function createTieredVoicePort(
   plan: () => VoiceEnginePlan,
   invoke: TauriInvoke,
   cloud: CloudSpeechDeps,
+  onDegraded: (capability: "stt" | "tts", message: string) => void = () => {},
 ): VoicePort {
   const native = createVoicePort(invoke);
+  // Capabilities whose cloud endpoint failed in this session. A misconfigured
+  // endpoint fails identically on every utterance, so retrying it each time
+  // would only add a delay before the same message.
+  const degraded = new Set<"stt" | "tts">();
+  const useCloud = (capability: "stt" | "tts"): boolean =>
+    plan()[capability].tier === "cloud" && !degraded.has(capability);
+
+  /**
+   * A cloud speech call failed. Continue on the device rather than ending the
+   * session: the whole point of voice mode is that the review happens, and
+   * falling back *to the device* is the direction that costs the learner
+   * nothing — it is the same `fell-back-to-local` outcome the plan already
+   * allows, just decided at call time instead of at resolution time.
+   */
+  const degrade = (capability: "stt" | "tts", error: unknown): void => {
+    degraded.add(capability);
+    onDegraded(
+      capability,
+      error instanceof Error ? error.message : String(error),
+    );
+  };
+
   return {
     start: native.start,
     stop: native.stop,
     async speak(text: string, locale: VoiceLocale): Promise<void> {
-      if (plan().tts.tier === "local") return native.speak(text, locale);
-      const audio = await cloud.synthesize(text, locale);
-      await cloud.play(audio.audioBase64, audio.mime);
+      if (!useCloud("tts")) return native.speak(text, locale);
+      try {
+        const audio = await cloud.synthesize(text, locale);
+        await cloud.play(audio.audioBase64, audio.mime);
+      } catch (error) {
+        degrade("tts", error);
+        await native.speak(text, locale);
+      }
     },
     async listen(locale: VoiceLocale): Promise<string> {
-      if (plan().stt.tier === "local") return native.listen(locale);
+      if (!useCloud("stt")) return native.listen(locale);
       const capture = await invoke<{ path: string; mime: string }>(
         "voice_capture",
         { locale },
@@ -177,7 +205,10 @@ export function createTieredVoicePort(
         await invoke("voice_discard_capture", { path: capture.path }).catch(
           () => undefined,
         );
-        throw error;
+        degrade("stt", error);
+        // The recording is gone with the failed call, so the learner is asked
+        // once more — better than losing the session over a bad endpoint.
+        return native.listen(locale);
       }
     },
   };

--- a/mobile/src/i18n.ts
+++ b/mobile/src/i18n.ts
@@ -159,6 +159,10 @@ const DE: Messages = {
     "Kein Cloud-Sprachmodell eingerichtet. Aktiviere auf dem Desktop bei einem Cloud-Modell die Fähigkeit stt oder tts — es erscheint hier nach der nächsten Synchronisierung. Bis dahin bleibt der Sprachmodus auf dem Gerät.",
   voice_cloud_notice:
     "Sprachmodus nutzt ein Cloud-Modell. Das Gesprochene verlässt dieses Gerät.",
+  voice_cloud_tts_failed:
+    "Cloud-Sprachausgabe nicht erreichbar ({message}). Weiter mit der Stimme des Geräts.",
+  voice_cloud_stt_failed:
+    "Cloud-Spracherkennung nicht erreichbar ({message}). Weiter mit der Erkennung des Geräts — bitte noch einmal sprechen.",
   voice_no_cloud_stt:
     "Kein Cloud-Modell für Spracherkennung eingerichtet. Aktiviere auf dem Desktop die Fähigkeit stt bei einem Cloud-Modell.",
   voice_no_cloud_tts:
@@ -359,6 +363,10 @@ const EN: Messages = {
     "No cloud speech model is set up. Enable the stt or tts capability on a cloud model on the desktop — it appears here after the next sync. Until then voice mode stays on the device.",
   voice_cloud_notice:
     "Voice mode is using a cloud model. What you say leaves this device.",
+  voice_cloud_tts_failed:
+    "Cloud speech unavailable ({message}). Continuing with the device voice.",
+  voice_cloud_stt_failed:
+    "Cloud recognition unavailable ({message}). Continuing with the device — please say that again.",
   voice_no_cloud_stt:
     "No cloud speech-to-text model is set up. Enable the stt capability on a cloud model on the desktop.",
   voice_no_cloud_tts:

--- a/mobile/src/main.ts
+++ b/mobile/src/main.ts
@@ -352,6 +352,17 @@ const voicePort: VoicePort = createMobileTieredVoicePort(
       return synthesizeViaCloud(endpoint, { text, locale });
     },
   },
+  (capability, message) => {
+    setReviewStatus(
+      tf(
+        capability === "tts"
+          ? "voice_cloud_tts_failed"
+          : "voice_cloud_stt_failed",
+        { message },
+      ),
+      true,
+    );
+  },
 );
 
 const voiceController = new HandsFreeReviewController(voicePort, {

--- a/mobile/src/voice.ts
+++ b/mobile/src/voice.ts
@@ -144,19 +144,53 @@ export function createMobileTieredVoicePort(
   plan: () => VoiceEnginePlan,
   native: MobileVoiceNative,
   cloud: MobileCloudSpeech,
+  onDegraded: (capability: "stt" | "tts", message: string) => void = () => {},
 ): VoicePort {
+  // Capabilities whose cloud endpoint failed in this session. A misconfigured
+  // endpoint fails identically on every utterance, so retrying it per sentence
+  // would only add a delay before the same message.
+  const degraded = new Set<"stt" | "tts">();
+  const useCloud = (capability: "stt" | "tts"): boolean =>
+    plan()[capability].tier === "cloud" && !degraded.has(capability);
+
+  /**
+   * Continue on the device rather than ending the session. The point of voice
+   * mode is that the review happens, and falling back *to the device* costs
+   * the learner nothing — it is the `fell-back-to-local` outcome the plan
+   * already allows, decided at call time instead of at resolution time.
+   */
+  const degrade = (capability: "stt" | "tts", error: unknown): void => {
+    degraded.add(capability);
+    onDegraded(
+      capability,
+      error instanceof Error ? error.message : String(error),
+    );
+  };
+
   return {
     start: (locale) => native.start(locale),
     stop: () => native.stop(),
     async speak(text: string, locale: VoiceLocale): Promise<void> {
-      if (plan().tts.tier !== "cloud") return native.speak(text, locale);
-      const audio = await cloud.synthesize(text, locale);
-      await native.play(audio.audioBase64, audio.mime);
+      if (!useCloud("tts")) return native.speak(text, locale);
+      try {
+        const audio = await cloud.synthesize(text, locale);
+        await native.play(audio.audioBase64, audio.mime);
+      } catch (error) {
+        degrade("tts", error);
+        await native.speak(text, locale);
+      }
     },
     async listen(locale: VoiceLocale): Promise<string> {
-      if (plan().stt.tier !== "cloud") return native.listen(locale);
+      if (!useCloud("stt")) return native.listen(locale);
       const capture = await native.capture(locale);
-      return cloud.transcribe(capture.audioBase64, capture.mime, locale);
+      try {
+        return await cloud.transcribe(capture.audioBase64, capture.mime, locale);
+      } catch (error) {
+        degrade("stt", error);
+        // The recording went with the failed call, so the learner is asked once
+        // more — better than losing the session over a bad endpoint.
+        return native.listen(locale);
+      }
     },
   };
 }

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -2720,6 +2720,24 @@ bridgeCommand
     jsonOut({ ok: true, ref: opts.ref, masked: maskSecret(key) });
   });
 
+// The endpoint's own answer to "which models do you have" — better than any
+// name heuristic, and the only thing that catches a typo before it becomes a
+// 404 in the middle of a review (reported 2026-08-01 for `mimo-v2.5-tts`).
+bridgeCommand
+  .command("model-catalog")
+  .description("List the models an endpoint advertises (JSON)")
+  .requiredOption("--url <url>", "Endpoint base URL")
+  .option("--key-ref <ref>", "Stored credential reference")
+  .option("--key <value>", "API key for an endpoint not yet saved")
+  .action(async (opts) => {
+    const apiKey =
+      (opts.key as string | undefined)?.trim() ||
+      (opts.keyRef ? (getProviderApiKey(opts.keyRef) ?? undefined) : undefined);
+    // An endpoint that serves no catalog is a normal state, not an error: many
+    // local runners have none, and the caller falls back to free typing.
+    jsonOut({ models: await getAvailableModels(opts.url, apiKey) });
+  });
+
 bridgeCommand
   .command("provider-clear-key")
   .description("Remove a stored provider API key (JSON)")

--- a/src/cli/llm/capability-probe.ts
+++ b/src/cli/llm/capability-probe.ts
@@ -134,8 +134,14 @@ export function classifyCapabilities(
 
   detected.embedding = looksEmbedding || dimProbeEmbedding;
   detected.image = looksVision;
-  detected.stt = looksStt;
-  detected.tts = looksTts;
+  // Speech is claimed from the model *name*, so it must be checked against the
+  // provider's own catalog exactly as text is. Without that gate a name that
+  // merely looks like a speech model — `mimo-v2.5-tts`, which Xiaomi does not
+  // serve — was accepted, and the misconfiguration only surfaced mid-review as
+  // a 404 from the gateway (reported 2026-08-01). An endpoint that publishes no
+  // catalog is trusted, as everywhere else.
+  detected.stt = looksStt && (inCatalog || !catalogKnown);
+  detected.tts = looksTts && (inCatalog || !catalogKnown);
   // A chat-completions endpoint serves text unless it is a single-purpose
   // embedding or audio model. Audio models answer on /audio/*, not /chat, so
   // offering them for text would break recall coaching.
@@ -248,6 +254,28 @@ export function validateModelSave(
       ok: false,
       error:
         "Endpoint is unreachable — cannot verify capabilities. Bring it online and retry.",
+    };
+  }
+  // The provider published a catalog and this id is not in it. Saving anyway
+  // stores a row that can only fail later, at the worst moment: a mistyped
+  // `mimo-v2.5-tts` looked like a speech model, passed every check, and ended
+  // a review session with a 404 from the gateway. When the endpoint says which
+  // models it has, that answer beats any name heuristic.
+  //
+  // Hosted endpoints only. A local runner's catalog is a moving target the
+  // learner controls — `enableLocalEmbedding` pulls a model and saves it in one
+  // step, and the catalog it read beforehand cannot list what it just fetched.
+  if (
+    !entry.local &&
+    probe.catalog.length > 0 &&
+    !catalogHasModel(probe.catalog, entry.model)
+  ) {
+    const shown = probe.catalog.slice(0, 8).join(", ");
+    const more =
+      probe.catalog.length > 8 ? ` (+${probe.catalog.length - 8} more)` : "";
+    return {
+      ok: false,
+      error: `The endpoint does not offer a model called "${entry.model}". It lists: ${shown}${more}.`,
     };
   }
   return {

--- a/tests/cli/capability-probe.test.ts
+++ b/tests/cli/capability-probe.test.ts
@@ -146,3 +146,120 @@ describe("validateModelSave", () => {
     expect(result.entry?.probedAt).toBe("2026-07-12T00:00:00Z");
   });
 });
+
+// Reported 2026-08-01: `mimo-v2.5-tts` was configured against Xiaomi's
+// endpoint, which serves no such model and no /audio/speech route at all. The
+// name matched a TTS hint, the capability was stored, and the misconfiguration
+// only surfaced mid-review as a 404 from the gateway.
+describe("speech capabilities are checked against the provider's catalog", () => {
+  const catalog = ["mimo-v2.5", "mimo-v2.5-vl"];
+
+  it("does not claim speech for a model the endpoint does not list", () => {
+    const detected = classifyCapabilities(
+      { model: "mimo-v2.5-tts", apiFlavor: "chat-completions" },
+      catalog,
+      true,
+    );
+
+    expect(detected.tts).toBe(false);
+  });
+
+  it("still claims speech for a listed speech model", () => {
+    const detected = classifyCapabilities(
+      { model: "tts-1-hd", apiFlavor: "chat-completions" },
+      ["tts-1-hd", "whisper-1"],
+      true,
+    );
+
+    expect(detected.tts).toBe(true);
+    expect(
+      classifyCapabilities(
+        { model: "whisper-1", apiFlavor: "chat-completions" },
+        ["tts-1-hd", "whisper-1"],
+        true,
+      ).stt,
+    ).toBe(true);
+  });
+
+  it("trusts an endpoint that publishes no catalog", () => {
+    // Most single-model local runners serve no /v1/models; refusing them would
+    // break the self-hosted path the ADR keeps for `device-only`.
+    const detected = classifyCapabilities(
+      { model: "kokoro", apiFlavor: "chat-completions" },
+      [],
+      false,
+    );
+
+    expect(detected.tts).toBe(true);
+  });
+
+  it("refuses to save a model the endpoint does not offer, and says what it has", () => {
+    const result = validateModelSave(
+      {
+        id: "x",
+        label: "Mimo TTS",
+        url: "https://token-plan.example/v1",
+        model: "mimo-v2.5-tts",
+        local: false,
+        apiFlavor: "chat-completions",
+        order: 0,
+        capabilities: { ...emptyCapabilityFlags(), tts: true },
+        detectedCapabilities: emptyCapabilityFlags(),
+      },
+      { reachable: true, catalog, detected: emptyCapabilityFlags() },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("mimo-v2.5-tts");
+    expect(result.error).toContain("mimo-v2.5");
+  });
+
+  it("leaves a local runner alone, whose catalog lags what it just pulled", () => {
+    // enableLocalEmbedding pulls a model and saves it in one step; the catalog
+    // it read beforehand cannot list what it has just fetched.
+    const result = validateModelSave(
+      {
+        id: "x",
+        label: "Ollama - Embedding",
+        url: "http://localhost:11434/v1",
+        model: "embeddinggemma:300m",
+        local: true,
+        apiFlavor: "chat-completions",
+        order: 0,
+        capabilities: { ...emptyCapabilityFlags(), embedding: true },
+        detectedCapabilities: emptyCapabilityFlags(),
+      },
+      {
+        reachable: true,
+        catalog: ["qwen3.5:4b"],
+        detected: { ...emptyCapabilityFlags(), embedding: true },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("saves a listed model unchanged", () => {
+    const result = validateModelSave(
+      {
+        id: "x",
+        label: "Mimo",
+        url: "https://token-plan.example/v1",
+        model: "mimo-v2.5",
+        local: false,
+        apiFlavor: "chat-completions",
+        order: 0,
+        capabilities: { ...emptyCapabilityFlags(), text: true },
+        detectedCapabilities: emptyCapabilityFlags(),
+      },
+      {
+        reachable: true,
+        catalog,
+        detected: { ...emptyCapabilityFlags(), text: true },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.entry?.capabilities.text).toBe(true);
+  });
+});

--- a/tests/desktop/voice.test.ts
+++ b/tests/desktop/voice.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildAvailability,
+  type CloudSpeechDeps,
+  createTieredVoicePort,
   createVoiceController,
   createVoicePort,
   type DesktopVoiceHost,
@@ -13,7 +15,11 @@ import {
   type TauriInvoke,
   unavailableReasonKey,
 } from "../../desktop/src/voice.js";
-import type { VoiceLocale, VoicePort } from "../../src/kernel/index.js";
+import type {
+  VoiceEnginePlan,
+  VoiceLocale,
+  VoicePort,
+} from "../../src/kernel/index.js";
 
 const native = (
   sttLocal: boolean,
@@ -259,5 +265,91 @@ describe("desktop voice controller", () => {
 
     await createVoiceController(host, port).start("de-DE");
     expect(rate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Reported 2026-08-01: cloud TTS 404'd mid-session and voice mode stopped.
+// A misconfigured endpoint must cost the utterance, not the review.
+describe("a failing cloud endpoint degrades to the device", () => {
+  const cloudPlan: VoiceEnginePlan = {
+    stt: { tier: "cloud", reason: "preferred" },
+    tts: { tier: "cloud", reason: "preferred" },
+  };
+
+  function harness(cloud: Partial<CloudSpeechDeps>) {
+    const calls: string[] = [];
+    const degraded: Array<[string, string]> = [];
+    const invoke = (async (command: string) => {
+      calls.push(command);
+      if (command === "voice_listen") return { transcript: "device transcript" };
+      if (command === "voice_capture") return { path: "/tmp/a.wav", mime: "audio/wav" };
+      return undefined;
+    }) as TauriInvoke;
+    const port = createTieredVoicePort(
+      () => cloudPlan,
+      invoke,
+      {
+        transcribe: async () => "cloud transcript",
+        synthesize: async () => ({ audioBase64: "AAA", mime: "audio/wav" }),
+        play: async () => {},
+        ...cloud,
+      },
+      (capability, message) => degraded.push([capability, message]),
+    );
+    return { calls, degraded, port };
+  }
+
+  it("reads the card with the device voice when synthesis fails", async () => {
+    const { calls, degraded, port } = harness({
+      synthesize: async () => {
+        throw new Error("Speech synthesis failed (404 Not Found)");
+      },
+    });
+
+    await port.speak("Frage", "de-DE");
+
+    expect(calls).toContain("voice_speak");
+    expect(degraded[0][0]).toBe("tts");
+    expect(degraded[0][1]).toContain("404");
+  });
+
+  it("stops retrying the broken endpoint for the rest of the session", async () => {
+    // The same misconfiguration fails identically every time; retrying it per
+    // sentence would only add a delay before the same message.
+    let attempts = 0;
+    const { degraded, port } = harness({
+      synthesize: async () => {
+        attempts++;
+        throw new Error("404");
+      },
+    });
+
+    await port.speak("eins", "de-DE");
+    await port.speak("zwei", "de-DE");
+
+    expect(attempts).toBe(1);
+    expect(degraded).toHaveLength(1);
+  });
+
+  it("falls back to device recognition and discards the recording", async () => {
+    const { calls, degraded, port } = harness({
+      transcribe: async () => {
+        throw new Error("Transcription failed (404 Not Found)");
+      },
+    });
+
+    expect(await port.listen("de-DE")).toBe("device transcript");
+    // The spoken answer must not be left lying in the temp directory.
+    expect(calls).toContain("voice_discard_capture");
+    expect(degraded[0][0]).toBe("stt");
+  });
+
+  it("leaves a working cloud endpoint alone", async () => {
+    const { calls, degraded, port } = harness({});
+
+    await port.speak("Frage", "de-DE");
+
+    expect(calls).not.toContain("voice_speak");
+    expect(degraded).toHaveLength(0);
   });
 });

--- a/tests/mobile/voice.test.ts
+++ b/tests/mobile/voice.test.ts
@@ -364,3 +364,52 @@ describe("mobile voice availability", () => {
     expect(planLeavesDevice(plan)).toBe(true);
   });
 });
+
+describe("mobile cloud failures degrade to the device", () => {
+  const cloudPlan: VoiceEnginePlan = {
+    stt: { tier: "cloud", reason: "preferred" },
+    tts: { tier: "cloud", reason: "preferred" },
+  };
+
+  it("keeps the session alive on a failing cloud voice", async () => {
+    const calls: string[] = [];
+    const degraded: string[] = [];
+    const native: MobileVoiceNative = {
+      start: async () => {},
+      stop: async () => {},
+      speak: async (text) => {
+        calls.push(`native:speak:${text}`);
+      },
+      listen: async () => {
+        calls.push("native:listen");
+        return "device transcript";
+      },
+      capture: async () => ({ audioBase64: "AQID", mime: "audio/wav" }),
+      play: async () => {
+        calls.push("native:play");
+      },
+    };
+    const port = createMobileTieredVoicePort(
+      () => cloudPlan,
+      native,
+      {
+        transcribe: async () => {
+          throw new Error("Transcription failed (404 Not Found)");
+        },
+        synthesize: async () => {
+          throw new Error("Speech synthesis failed (404 Not Found)");
+        },
+      },
+      (capability) => degraded.push(capability),
+    );
+
+    await port.speak("Frage", "de-DE");
+    expect(await port.listen("de-DE")).toBe("device transcript");
+
+    expect(calls).toEqual([
+      "native:speak:Frage",
+      "native:listen",
+    ]);
+    expect(degraded).toEqual(["tts", "stt"]);
+  });
+});


### PR DESCRIPTION
Voice mode died mid-review with `Speech synthesis failed (404 Not Found)` from an openresty gateway. The configured model was `mimo-v2.5-tts` — which Xiaomi does not serve.

Three things had to be wrong at once for a typo to reach a review session.

## The name was trusted over the catalog

`classifyCapabilities` gated `text` on the endpoint's `/v1/models` list but claimed `stt`/`tts` from the model **name** alone. Anything ending in `-tts` was a speech model, listed or not.

The comment above those hints even predicted this failure — *"a false positive here would offer the learner a cloud transcription path that 400s on the first spoken answer"* — while the code below skipped the check that prevents it. Speech is now gated on the catalog exactly as text is. An endpoint publishing no catalog is still trusted, since most local runners have none.

## The save was silent

`validateModelSave` shrinks capabilities to what was detected, so a mistyped id saved cleanly. A **hosted** endpoint that publishes a catalog and does not list the id is now a refused save that names the models it does have.

Local runners are exempt on purpose: `enableLocalEmbedding` pulls a model and saves it in one step, and the catalog it read beforehand cannot list what it has just fetched.

## The learner had to type the id

This is the actual fix, and what was asked for. The catalog was already fetched on every probe and displayed nowhere. The model field now offers the endpoint's own list, through a new `model-catalog` bridge command.

A `<datalist>`, not a dropdown — an endpoint with no catalog and a model newer than this build both have to stay typable. Guessing just stops being necessary.

## And a failing endpoint no longer ends the session

Voice mode continues with the device voice and says why, on desktop and both companions. Falling back *to the device* costs the learner nothing — it is the `fell-back-to-local` outcome the plan already allows, decided at call time rather than at resolution time — and a review that stops is the one outcome voice mode exists to prevent. The broken endpoint is not retried for the rest of the session.

## Also

The release draft is no longer titled "ZAM Desktop". One release carries the desktop apps, the Android APK, the editor companion, and the npm package.

## Verification

1785 tests pass; lint and both typechecks clean; mobile frontend builds. New regression tests cover the exact reported configuration.

Not verified: whether Xiaomi's endpoint has an `/audio/speech` route at all. The 404 says it does not for that model, and the catalog gate makes the distinction moot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)