### PR TITLE
fix: write the change-signature separator as an escape, not a raw NUL byte

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -2241,7 +2241,7 @@ async function showModelForm(id?: string): Promise<void> {
   const loadModelCatalog = async (): Promise<void> => {
     const url = urlInput.value.trim();
     const key = keyInput.value.trim();
-    const signature = `${url} ${key} ${existing?.apiKeyRef ?? ""}`;
+    const signature = `${url}\0${key}\0${existing?.apiKeyRef ?? ""}`;
     if (!url || signature === catalogKey) return;
     catalogKey = signature;
     modelCatalog.replaceChildren();


### PR DESCRIPTION
`desktop/src/main.ts` carried two literal `0x00` bytes inside a template literal:

```ts
const signature = `${url}<NUL>${key}<NUL>${existing?.apiKeyRef ?? ""}`;
```

That made every tool treat the largest file in the desktop app as **binary**. Plain `grep -n "pattern" desktop/src/main.ts` silently returned nothing, and ripgrep printed `binary file matches (found "\0" byte around offset 85642)` instead of the matching lines — so anyone searching that file, human or agent, was quietly told there were no matches when there were. I hit exactly this while working on another change.

The two bytes are now the two-character escape `\0`. In a template literal that is the same character (it is not followed by a digit here), so the produced string is byte-identical — checked directly for the same inputs:

```
identical: true | codes: 117,0,107,0,114
```

`rg -n "signature" desktop/src/main.ts` now returns normal line output.

### Verification

`lint`, `typecheck` (root + desktop), `test` (182 files / 1811 tests) all green.