### PR TITLE
feat: make rejected database credential repairable during startup

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -33,6 +33,7 @@
         <ol id="boot-steps" class="boot-steps"></ol>
         <p id="boot-note" class="boot-note hidden"></p>
         <div id="boot-actions" class="boot-actions hidden">
+          <button id="btn-boot-fix-db" class="btn primary-btn btn-sm hidden" type="button">Fix database credential</button>
           <button id="btn-boot-retry" class="btn primary-btn btn-sm" type="button">Try again</button>
           <button id="btn-boot-continue" class="btn secondary-btn btn-sm" type="button">Continue anyway</button>
         </div>

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -17,6 +17,28 @@
     <div class="blur-glow glow-1"></div>
     <div class="blur-glow glow-2"></div>
 
+    <!-- STARTUP OVERLAY
+         Present in the static markup (not created by main.ts) so it is on
+         screen from the first paint. Everything behind it is placeholder
+         chrome until loadDashboard() answers: the due count, the language
+         badge and the AI pill would otherwise read as facts while the app is
+         still starting. main.ts hides it once the dashboard holds real data. -->
+    <div id="boot-overlay" class="boot-overlay" role="status" aria-live="polite">
+      <div class="boot-box">
+        <div class="boot-heading">
+          <span class="boot-spinner" aria-hidden="true"></span>
+          <h2 id="boot-title">Starting ZAM…</h2>
+        </div>
+        <p id="boot-current" class="boot-current">Loading settings and profile…</p>
+        <ol id="boot-steps" class="boot-steps"></ol>
+        <p id="boot-note" class="boot-note hidden"></p>
+        <div id="boot-actions" class="boot-actions hidden">
+          <button id="btn-boot-retry" class="btn primary-btn btn-sm" type="button">Try again</button>
+          <button id="btn-boot-continue" class="btn secondary-btn btn-sm" type="button">Continue anyway</button>
+        </div>
+      </div>
+    </div>
+
     <main class="container">
       <!-- HEADER BAR -->
       <header class="app-header">
@@ -32,8 +54,10 @@
         </nav>
         <div class="status-area" id="system-status">
           <div class="status-indicator">
-            <span class="pulse-dot gray" role="img" aria-label="Local AI Offline"></span>
-            <span class="status-text" id="ai-status-label">Local AI Offline</span>
+            <!-- "Offline" was a claim the app had not checked yet; start in
+                 the checking state the probe itself uses. -->
+            <span class="pulse-dot amber" role="img" aria-label="Checking AI"></span>
+            <span class="status-text" id="ai-status-label">Checking AI...</span>
           </div>
           <span class="locale-badge" id="locale-badge">EN</span>
         </div>
@@ -69,8 +93,11 @@
         <div class="dashboard-grid">
           <div class="card stat-card frosted">
             <h2 id="lbl-due-reviews">Due Reviews</h2>
-            <div class="large-number" id="due-count">0</div>
-            <p id="lbl-caught-up" class="sub-label" aria-live="polite">You're all caught up!</p>
+            <!-- Placeholder, not a reading: a literal "0" here was
+                 indistinguishable from a real empty queue while the bridge
+                 was still starting. loadDashboard() fills both in. -->
+            <div class="large-number" id="due-count">—</div>
+            <p id="lbl-caught-up" class="sub-label hidden" aria-live="polite">You're all caught up!</p>
           </div>
 
           <div class="card stat-card frosted">
@@ -559,8 +586,11 @@
           <article class="card frosted settings-card" id="secrets-vault-card">
             <div class="settings-card-header">
               <div>
+                <!-- The title text has its own span: applyLabels() writes
+                     textContent per element, and writing it on the <h2> would
+                     delete the Alpha badge nested inside it. -->
                 <h2 id="lbl-settings-secrets-title">
-                  Multi-machine secrets
+                  <span id="lbl-settings-secrets-title-text">Multi-machine secrets</span>
                   <span id="lbl-settings-secrets-alpha" class="settings-badge-alpha">Alpha</span>
                 </h2>
                 <p id="lbl-settings-secrets-help" class="settings-card-help">

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.27.0",
+  "version": "0.27.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.27.0"
+version = "0.27.1"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/desktop/src/boot-progress.ts
+++ b/desktop/src/boot-progress.ts
@@ -41,6 +41,7 @@ export const BOOT_SLOW_AFTER_MS = 6_000;
 export interface BootFailure {
   step: BootStepId;
   message: string;
+  isDbError?: boolean;
 }
 
 export interface BootState {
@@ -100,10 +101,11 @@ export function failStep(
   state: BootState,
   step: BootStepId,
   message: string,
+  isDbError?: boolean,
 ): BootState {
   return {
     ...withStatus(state, step, "failed"),
-    failure: { step, message },
+    failure: { step, message, isDbError },
     finished: false,
   };
 }

--- a/desktop/src/boot-progress.ts
+++ b/desktop/src/boot-progress.ts
@@ -1,0 +1,174 @@
+/**
+ * Startup progress state for the desktop app.
+ *
+ * The Studio paints its full chrome from static HTML long before the bridge
+ * has answered anything: until `loadDashboard` completes, the numbers, the
+ * language badge, and the AI pill are placeholders, not facts. A slow or
+ * wedged start therefore looked like a *finished* dashboard claiming "0 due —
+ * you're all caught up" in English, with nothing saying the app was still
+ * working. This module tracks which startup step is running so the overlay can
+ * say what ZAM is doing and, when it hangs, where it stopped.
+ *
+ * Framework-free and DOM-free on purpose: main.ts owns the rendering, so the
+ * state machine stays unit-testable without a WebView.
+ */
+
+/** The startup steps a learner can actually wait on, in the order they run. */
+export type BootStepId = "settings" | "vault" | "cards";
+
+export type BootStepStatus = "pending" | "running" | "done" | "failed";
+
+export const BOOT_STEP_IDS: readonly BootStepId[] = [
+  "settings",
+  "vault",
+  "cards",
+];
+
+/** i18n keys describing each step in the learner's own words. */
+export const BOOT_STEP_LABEL_KEYS: Record<BootStepId, string> = {
+  settings: "boot_step_settings",
+  vault: "boot_step_vault",
+  cards: "boot_step_cards",
+};
+
+/**
+ * How long a start may take before the overlay says so. Below this a healthy
+ * start just flickers; above it the learner deserves to know it is still
+ * working rather than wondering whether the app is dead.
+ */
+export const BOOT_SLOW_AFTER_MS = 6_000;
+
+export interface BootFailure {
+  step: BootStepId;
+  message: string;
+}
+
+export interface BootState {
+  /** Wall-clock start, used only for the elapsed/slow readout. */
+  readonly startedAt: number;
+  readonly statuses: Readonly<Record<BootStepId, BootStepStatus>>;
+  readonly failure?: BootFailure;
+  /** True once the dashboard holds real data and the overlay may close. */
+  readonly finished: boolean;
+}
+
+export function createBootState(now: number): BootState {
+  return {
+    startedAt: now,
+    statuses: { settings: "pending", vault: "pending", cards: "pending" },
+    finished: false,
+  };
+}
+
+function withStatus(
+  state: BootState,
+  step: BootStepId,
+  status: BootStepStatus,
+): BootState {
+  return {
+    ...state,
+    statuses: { ...state.statuses, [step]: status },
+  };
+}
+
+/**
+ * Mark a step as running. Steps run in order, so anything before it that is
+ * still pending has been skipped over (a retry entering mid-sequence) and is
+ * recorded as done rather than left looking stuck.
+ */
+export function startStep(state: BootState, step: BootStepId): BootState {
+  const index = BOOT_STEP_IDS.indexOf(step);
+  let next = state;
+  for (const earlier of BOOT_STEP_IDS.slice(0, index)) {
+    if (next.statuses[earlier] === "pending") {
+      next = withStatus(next, earlier, "done");
+    }
+  }
+  return withStatus(next, step, "running");
+}
+
+export function completeStep(state: BootState, step: BootStepId): BootState {
+  return withStatus(state, step, "done");
+}
+
+/**
+ * Record the step that failed and why. The overlay stays open on failure —
+ * this is the one moment where the learner must not be handed a dashboard
+ * full of placeholder numbers that look like real ones.
+ */
+export function failStep(
+  state: BootState,
+  step: BootStepId,
+  message: string,
+): BootState {
+  return {
+    ...withStatus(state, step, "failed"),
+    failure: { step, message },
+    finished: false,
+  };
+}
+
+/** The dashboard now holds real data; the overlay may go away. */
+export function finishBoot(state: BootState): BootState {
+  let next: BootState = { ...state, finished: true, failure: undefined };
+  for (const step of BOOT_STEP_IDS) {
+    if (next.statuses[step] !== "failed") next = withStatus(next, step, "done");
+  }
+  return next;
+}
+
+/** Start over for a retry, keeping the original clock so elapsed stays honest. */
+export function restartBoot(state: BootState): BootState {
+  return { ...createBootState(state.startedAt) };
+}
+
+/** The step currently running, if any. */
+export function currentStep(state: BootState): BootStepId | undefined {
+  return BOOT_STEP_IDS.find((step) => state.statuses[step] === "running");
+}
+
+/**
+ * The step to name when a start fails. Usually the one that was running; a
+ * failure raised between steps is attributed to the first one not yet done,
+ * so the overlay never reports a step the learner already saw succeed.
+ */
+export function stepToBlame(state: BootState): BootStepId {
+  return (
+    currentStep(state) ??
+    BOOT_STEP_IDS.find((step) => state.statuses[step] !== "done") ??
+    BOOT_STEP_IDS[BOOT_STEP_IDS.length - 1]
+  );
+}
+
+/** i18n key naming what ZAM is doing right now, for the overlay's status line. */
+export function currentStepLabelKey(state: BootState): string | undefined {
+  const step = currentStep(state) ?? state.failure?.step;
+  return step ? BOOT_STEP_LABEL_KEYS[step] : undefined;
+}
+
+export function elapsedMs(state: BootState, now: number): number {
+  return Math.max(0, now - state.startedAt);
+}
+
+/** Whole seconds elapsed — what the overlay shows once a start looks slow. */
+export function elapsedSeconds(state: BootState, now: number): number {
+  return Math.floor(elapsedMs(state, now) / 1000);
+}
+
+/**
+ * Whether to tell the learner this is taking unusually long. A failed start
+ * has its own, more specific message, so it never also counts as "slow".
+ */
+export function isSlow(
+  state: BootState,
+  now: number,
+  thresholdMs: number = BOOT_SLOW_AFTER_MS,
+): boolean {
+  if (state.finished || state.failure) return false;
+  return elapsedMs(state, now) >= thresholdMs;
+}
+
+/** The overlay is up until the dashboard is real, and stays up on failure. */
+export function isOverlayVisible(state: BootState): boolean {
+  return !state.finished;
+}

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -3968,6 +3968,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "This is taking longer than usual ({seconds}s). ZAM is still working — the step above is the one it is waiting on.",
     boot_failed_at: "Startup stopped at “{step}”.",
     boot_retry: "Try again",
+    boot_fix_db: "Fix database credential",
     boot_continue: "Continue anyway",
     boot_continue_note:
       "The dashboard may show incomplete numbers until this succeeds.",
@@ -5146,6 +5147,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
       "Das dauert länger als üblich ({seconds}s). ZAM arbeitet noch — der Schritt oben ist der, auf den gewartet wird.",
     boot_failed_at: "Der Start ist bei „{step}“ stehen geblieben.",
     boot_retry: "Erneut versuchen",
+    boot_fix_db: "Zugangsdaten korrigieren",
     boot_continue: "Trotzdem fortfahren",
     boot_continue_note:
       "Bis das klappt, können die Zahlen im Dashboard unvollständig sein.",

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -3960,6 +3960,19 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     lbl_due_reviews: "Due Reviews",
     lbl_caught_up: "You're all caught up!",
     dashboard_error: "Could not load your data",
+    boot_title: "Starting ZAM…",
+    boot_step_settings: "Loading settings and profile",
+    boot_step_vault: "Unlocking stored credentials",
+    boot_step_cards: "Checking your due cards",
+    boot_slow_note:
+      "This is taking longer than usual ({seconds}s). ZAM is still working — the step above is the one it is waiting on.",
+    boot_failed_at: "Startup stopped at “{step}”.",
+    boot_retry: "Try again",
+    boot_continue: "Continue anyway",
+    boot_continue_note:
+      "The dashboard may show incomplete numbers until this succeeds.",
+    boot_panel_failed:
+      "Some settings cards could not be set up ({panels}). The rest of ZAM works; see the log for details.",
     lbl_domains: "Active Domains",
     btn_start_session: "Start Learning Session",
     lbl_translating: "Translating dynamically...",
@@ -5125,6 +5138,19 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     lbl_due_reviews: "Anstehende Wiederholungen",
     lbl_caught_up: "Du bist voll auf dem Laufenden!",
     dashboard_error: "Deine Daten konnten nicht geladen werden",
+    boot_title: "ZAM wird gestartet…",
+    boot_step_settings: "Einstellungen und Profil werden geladen",
+    boot_step_vault: "Gespeicherte Zugangsdaten werden entsperrt",
+    boot_step_cards: "Fällige Karten werden geprüft",
+    boot_slow_note:
+      "Das dauert länger als üblich ({seconds}s). ZAM arbeitet noch — der Schritt oben ist der, auf den gewartet wird.",
+    boot_failed_at: "Der Start ist bei „{step}“ stehen geblieben.",
+    boot_retry: "Erneut versuchen",
+    boot_continue: "Trotzdem fortfahren",
+    boot_continue_note:
+      "Bis das klappt, können die Zahlen im Dashboard unvollständig sein.",
+    boot_panel_failed:
+      "Einige Einstellungs-Karten konnten nicht eingerichtet werden ({panels}). Der Rest von ZAM funktioniert; Details stehen im Log.",
     lbl_domains: "Aktive Wissensbereiche",
     btn_start_session: "Lernsitzung starten",
     lbl_translating: "Übersetze dynamisch...",

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -4888,6 +4888,10 @@ function renderBootOverlay(): void {
     if (bootState.failure?.isDbError) {
       fixDbBtn.classList.remove("hidden");
       fixDbBtn.onclick = () => {
+        // The credential form is behind this modal overlay. Dismiss it before
+        // moving focus or the learner lands on Settings but cannot edit the
+        // token field that repairs the failed start.
+        dismissBootOverlay();
         switchView("settings-view");
         const tokenInput = document.getElementById("server-db-token");
         if (tokenInput) {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -20,6 +20,23 @@ import {
   tf,
 } from "./i18n.js";
 import {
+  BOOT_STEP_IDS,
+  BOOT_STEP_LABEL_KEYS,
+  type BootState,
+  type BootStepId,
+  completeStep,
+  createBootState,
+  currentStepLabelKey,
+  elapsedSeconds,
+  failStep,
+  finishBoot,
+  isOverlayVisible,
+  isSlow,
+  restartBoot,
+  startStep,
+  stepToBlame,
+} from "./boot-progress.js";
+import {
   initCurriculumWizard,
   setCurriculumWizardModelSetup,
 } from "./curriculum-wizard.js";
@@ -501,6 +518,31 @@ function loadThemePreference(): ThemePreference {
     return localStorage.getItem("zam:theme") === "dark" ? "dark" : "light";
   } catch {
     return "light";
+  }
+}
+
+/**
+ * Last locale the bridge reported, cached like the theme preference.
+ *
+ * The bridge owns the real setting, but it cannot answer before the window
+ * paints — and `currentLocale` starts at "en". Without this the first seconds
+ * of every start were in English regardless of the learner's language, which
+ * is most visible exactly when a start is slow enough to be worth reading.
+ */
+function loadRememberedLocale(): string | undefined {
+  try {
+    return localStorage.getItem("zam:locale") ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rememberLocale(locale: string | undefined): void {
+  if (!locale) return;
+  try {
+    localStorage.setItem("zam:locale", locale);
+  } catch {
+    // A cached hint is optional; the bridge value still applies this session.
   }
 }
 
@@ -1033,6 +1075,7 @@ function setupLocaleSwitcher(): void {
 async function setLocale(locale: Locale): Promise<void> {
   if (locale === currentLocale) return;
   setCurrentLocale(locale);
+  rememberLocale(locale);
 
   // Persist as an OS-default override; read back by desktop-bootstrap on launch.
   try {
@@ -4643,6 +4686,7 @@ async function loadDashboard() {
   try {
     clearDashboardError();
     // 1. Initialize first-run state, then apply settings and translations.
+    beginBootStep("settings");
     const settings = await runBridge<{
       userId: string;
       locale: string;
@@ -4674,8 +4718,14 @@ async function loadDashboard() {
     onboardingWorkspaceStructure =
       settings.workspaceStructure ?? onboardingWorkspaceStructure;
     dashboardSignalsLoaded = true;
+    completeBootStep("settings");
 
+    // Remember the locale for the *next* start: the overlay paints before the
+    // bridge can answer, and defaulting it to English made the first seconds
+    // of every start lie about the language.
+    rememberLocale(settings.locale);
     initializeTranslations();
+    renderBootOverlay();
 
     // First-run gate (ADR 2026-07-24): a machine that has not completed the
     // guided flow lands there instead of the empty dashboard. The rest of
@@ -4692,13 +4742,15 @@ async function loadDashboard() {
     // 2. Vault-backed secrets (e.g. Turso token in Bitwarden) must resolve
     // before any DB read — otherwise we silently hit an empty local file.
     clearDashboardError();
+    beginBootStep("vault");
     const vaultOk = await assureBitwardenAccess();
     if (!vaultOk) {
-      showDashboardError(
-        new Error(t("bw_assure_cancelled")),
-      );
+      const cancelled = new Error(t("bw_assure_cancelled"));
+      failBootStep("vault", cancelled);
+      showDashboardError(cancelled);
       return;
     }
+    completeBootStep("vault");
 
     // 3. Check due cards count and active domains
     let dueInfo: {
@@ -4706,6 +4758,7 @@ async function loadDashboard() {
       domains: string[];
       stats?: { cardsInDeck?: number };
     };
+    beginBootStep("cards");
     try {
       dueInfo = await runBridge<{
         dueCount: number;
@@ -4723,6 +4776,7 @@ async function loadDashboard() {
     }
     totalDue = dueInfo.dueCount;
     deckCardCount = dueInfo.stats?.cardsInDeck ?? null;
+    completeBootStep("cards");
 
     const dueCountEl = document.getElementById("due-count")!;
     dueCountEl.textContent = String(totalDue);
@@ -4766,6 +4820,11 @@ async function loadDashboard() {
       domainsContainer.appendChild(span);
     }
 
+    // The dashboard now shows measured values rather than markup defaults, so
+    // the startup overlay has nothing left to explain.
+    finishBootOverlay();
+    reportFailedPanels();
+
     // 4. Bring the local LLM online (auto-starts the server like `zam learn`)
     //    and reflect status. Don't block the dashboard on model load.
     refreshAiStatus();
@@ -4778,12 +4837,205 @@ async function loadDashboard() {
         await loadDashboard();
         return;
       } catch (err2) {
+        failBootStep(currentBootStep(), err2);
         showDashboardError(err2);
         return;
       }
     }
+    // Leave the overlay up naming the step that broke: behind it the dashboard
+    // still shows placeholders, which is exactly what must not read as data.
+    failBootStep(currentBootStep(), err);
     showDashboardError(err);
   }
+}
+
+// ── STARTUP OVERLAY ───────────────────────────────────────────────────────
+// The dashboard's markup is placeholder chrome until loadDashboard() answers.
+// This overlay covers it, names the step in progress, and — when a start hangs
+// or fails — says which step it stopped on instead of leaving a plausible but
+// invented dashboard on screen. State machine: desktop/src/boot-progress.ts.
+
+let bootState: BootState = createBootState(Date.now());
+let bootTicker: ReturnType<typeof setInterval> | undefined;
+
+function renderBootOverlay(): void {
+  const overlay = document.getElementById("boot-overlay");
+  if (!overlay) return;
+
+  if (!isOverlayVisible(bootState)) {
+    overlay.classList.add("hidden");
+    if (bootTicker) {
+      clearInterval(bootTicker);
+      bootTicker = undefined;
+    }
+    return;
+  }
+  overlay.classList.remove("hidden");
+
+  const title = document.getElementById("boot-title");
+  if (title) title.textContent = t("boot_title");
+  const retryBtn = document.getElementById("btn-boot-retry");
+  if (retryBtn) retryBtn.textContent = t("boot_retry");
+  const continueBtn = document.getElementById("btn-boot-continue");
+  if (continueBtn) continueBtn.textContent = t("boot_continue");
+
+  const stepKey = currentStepLabelKey(bootState);
+  const current = document.getElementById("boot-current");
+  if (current) current.textContent = stepKey ? t(stepKey) : "";
+
+  const list = document.getElementById("boot-steps");
+  if (list) {
+    list.replaceChildren();
+    for (const step of BOOT_STEP_IDS) {
+      const status = bootState.statuses[step];
+      const item = document.createElement("li");
+      item.className = "boot-step";
+      item.dataset.status = status;
+      const marker = document.createElement("span");
+      marker.className = "boot-step-marker";
+      marker.setAttribute("aria-hidden", "true");
+      marker.textContent =
+        status === "done"
+          ? "✓"
+          : status === "failed"
+            ? "✕"
+            : status === "running"
+              ? "›"
+              : "·";
+      const label = document.createElement("span");
+      label.textContent = t(BOOT_STEP_LABEL_KEYS[step]);
+      item.append(marker, label);
+      list.appendChild(item);
+    }
+  }
+
+  const note = document.getElementById("boot-note");
+  const actions = document.getElementById("boot-actions");
+  if (bootState.failure) {
+    if (note) {
+      const stepLabel = t(BOOT_STEP_LABEL_KEYS[bootState.failure.step]);
+      note.textContent = `${tf("boot_failed_at", { step: stepLabel })} ${
+        bootState.failure.message
+      }`;
+      note.classList.remove("hidden");
+      note.classList.add("boot-note-error");
+    }
+    actions?.classList.remove("hidden");
+  } else if (isSlow(bootState, Date.now())) {
+    if (note) {
+      note.textContent = tf("boot_slow_note", {
+        seconds: String(elapsedSeconds(bootState, Date.now())),
+      });
+      note.classList.remove("hidden");
+      note.classList.remove("boot-note-error");
+    }
+    // A slow start is still a start: offer the escape hatch, not a retry that
+    // would abandon work already in flight.
+    actions?.classList.add("hidden");
+  } else {
+    note?.classList.add("hidden");
+    actions?.classList.add("hidden");
+  }
+}
+
+/** Keep the elapsed readout moving while a start is still running. */
+function startBootTicker(): void {
+  if (bootTicker) return;
+  bootTicker = setInterval(() => {
+    if (!isOverlayVisible(bootState)) return;
+    renderBootOverlay();
+  }, 1_000);
+}
+
+function beginBootStep(step: BootStepId): void {
+  bootState = startStep(bootState, step);
+  renderBootOverlay();
+}
+
+function completeBootStep(step: BootStepId): void {
+  bootState = completeStep(bootState, step);
+  renderBootOverlay();
+}
+
+function currentBootStep(): BootStepId {
+  return stepToBlame(bootState);
+}
+
+function failBootStep(step: BootStepId, err: unknown): void {
+  bootState = failStep(
+    bootState,
+    step,
+    err instanceof Error ? err.message : String(err),
+  );
+  renderBootOverlay();
+}
+
+function finishBootOverlay(): void {
+  bootState = finishBoot(bootState);
+  renderBootOverlay();
+}
+
+/** Dismiss the overlay without a retry — the dashboard may be incomplete. */
+function dismissBootOverlay(): void {
+  bootState = { ...bootState, finished: true };
+  renderBootOverlay();
+}
+
+/**
+ * Names of settings widgets whose startup wiring threw, shown once the
+ * dashboard is up.
+ */
+const failedPanels: string[] = [];
+
+/**
+ * Wire one optional settings widget without letting it take the app down.
+ *
+ * These are all initialized from the single DOMContentLoaded handler that also
+ * kicks off `loadDashboard()`, so an exception in any one of them used to
+ * abort the whole handler — the dashboard never loaded, and because its markup
+ * is a fully rendered placeholder, that looked like a finished app stuck on
+ * "0 due" rather than a crash. (`initSecretsVault` did exactly this: it
+ * deleted the Alpha badge it then required.) The learner may lose a settings
+ * card; they must not lose the dashboard.
+ */
+function initPanel(name: string, init: () => void): void {
+  try {
+    init();
+  } catch (err) {
+    console.error(`Startup: ${name} failed to initialize`, err);
+    failedPanels.push(name);
+  }
+}
+
+/** Show a non-blocking notice naming any widget that failed to wire up. */
+function reportFailedPanels(): void {
+  if (failedPanels.length === 0) return;
+  const view = document.getElementById("dashboard-view");
+  if (!view) return;
+  let banner = document.getElementById("dashboard-panel-warning");
+  if (!banner) {
+    banner = document.createElement("div");
+    banner.id = "dashboard-panel-warning";
+    banner.className = "error-banner";
+    view.prepend(banner);
+  }
+  banner.textContent = `⚠ ${tf("boot_panel_failed", {
+    panels: failedPanels.join(", "),
+  })}`;
+  banner.classList.remove("hidden");
+}
+
+function initBootOverlay(): void {
+  document.getElementById("btn-boot-retry")?.addEventListener("click", () => {
+    bootState = restartBoot(bootState);
+    renderBootOverlay();
+    void loadDashboard();
+  });
+  document
+    .getElementById("btn-boot-continue")
+    ?.addEventListener("click", () => dismissBootOverlay());
+  renderBootOverlay();
+  startBootTicker();
 }
 
 /**
@@ -6032,25 +6284,40 @@ function devObserverEnabled(): boolean {
 
 window.addEventListener("DOMContentLoaded", () => {
   applyTheme(loadThemePreference());
+  // Apply the remembered locale before the first render, so the startup
+  // overlay and the chrome behind it speak the learner's language from the
+  // outset rather than switching once the bridge answers.
+  const remembered = loadRememberedLocale();
+  if (remembered) setCurrentLocale(remembered);
+  initBootOverlay();
   initializeTranslations();
   setupLocaleSwitcher();
-  initLearningContentStudio();
-  initCurriculumWizard();
-  // Text-LLM-offline in the wizard links back to the onboarding model page
-  // instead of dead-ending in an error (ADR 2026-07-24 §7, plan Phase 9).
-  setCurriculumWizardModelSetup(() => showOnboardingAt("model"));
-  initServerDbWizard(
-    () => void loadDatabaseStatus(),
-    { openExternal: (url: string) => void openUrl(url) },
+  initPanel("learning-content", () => initLearningContentStudio());
+  initPanel("curriculum-wizard", () => {
+    initCurriculumWizard();
+    // Text-LLM-offline in the wizard links back to the onboarding model page
+    // instead of dead-ending in an error (ADR 2026-07-24 §7, plan Phase 9).
+    setCurriculumWizardModelSetup(() => showOnboardingAt("model"));
+  });
+  initPanel("server-db", () =>
+    initServerDbWizard(
+      () => void loadDatabaseStatus(),
+      { openExternal: (url: string) => void openUrl(url) },
+    ),
   );
-  initSecretsVault({ openExternal: (url: string) => void openUrl(url) });
-  initMobilePairing(() => void loadDatabaseStatus());
+  initPanel("secrets-vault", () =>
+    initSecretsVault({ openExternal: (url: string) => void openUrl(url) }),
+  );
+  initPanel("mobile-pairing", () =>
+    initMobilePairing(() => void loadDatabaseStatus()),
+  );
   // Goal-driven import stays reachable outside first run (plan Phase 8):
   // Learning Content's "Goal import" reopens the flow at the goal page.
   document
     .getElementById("btn-content-goal-import")
     ?.addEventListener("click", () => showOnboardingAt("goal"));
-  onboardingController = initOnboarding({
+  initPanel("onboarding", () => {
+    onboardingController = initOnboarding({
     getStepContext: () => ({
       personas: onboardingPersonas,
       selectedPersonaId: onboardingPersonaId,
@@ -6082,6 +6349,7 @@ window.addEventListener("DOMContentLoaded", () => {
       if (reason === "later") onboardingDeferredThisSession = true;
       void loadDashboard();
     },
+    });
   });
 
   // Load initial dashboard state

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -56,7 +56,11 @@ import {
   assureBitwardenAccessAfterError,
 } from "./bitwarden-assure.js";
 import { initSecretsVault } from "./secrets-vault.js";
-import { initServerDbWizard } from "./server-db.js";
+import {
+  classifyServerDbError,
+  initServerDbWizard,
+  isServerDbError,
+} from "./server-db.js";
 import {
   buildAvailability,
   createTieredVoicePort,
@@ -4878,6 +4882,23 @@ function renderBootOverlay(): void {
   if (retryBtn) retryBtn.textContent = t("boot_retry");
   const continueBtn = document.getElementById("btn-boot-continue");
   if (continueBtn) continueBtn.textContent = t("boot_continue");
+  const fixDbBtn = document.getElementById("btn-boot-fix-db");
+  if (fixDbBtn) {
+    fixDbBtn.textContent = t("boot_fix_db");
+    if (bootState.failure?.isDbError) {
+      fixDbBtn.classList.remove("hidden");
+      fixDbBtn.onclick = () => {
+        switchView("settings-view");
+        const tokenInput = document.getElementById("server-db-token");
+        if (tokenInput) {
+          tokenInput.focus();
+          tokenInput.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      };
+    } else {
+      fixDbBtn.classList.add("hidden");
+    }
+  }
 
   const stepKey = currentStepLabelKey(bootState);
   const current = document.getElementById("boot-current");
@@ -4962,11 +4983,10 @@ function currentBootStep(): BootStepId {
 }
 
 function failBootStep(step: BootStepId, err: unknown): void {
-  bootState = failStep(
-    bootState,
-    step,
-    err instanceof Error ? err.message : String(err),
-  );
+  const rawMsg = err instanceof Error ? err.message : String(err);
+  const isDbErr = isServerDbError(rawMsg);
+  const msg = classifyServerDbError(rawMsg);
+  bootState = failStep(bootState, step, msg, isDbErr);
   renderBootOverlay();
 }
 
@@ -6301,7 +6321,12 @@ window.addEventListener("DOMContentLoaded", () => {
   });
   initPanel("server-db", () =>
     initServerDbWizard(
-      () => void loadDatabaseStatus(),
+      () => {
+        void loadDatabaseStatus();
+        bootState = restartBoot(bootState);
+        renderBootOverlay();
+        void loadDashboard();
+      },
       { openExternal: (url: string) => void openUrl(url) },
     ),
   );

--- a/desktop/src/secrets-vault.ts
+++ b/desktop/src/secrets-vault.ts
@@ -75,7 +75,13 @@ export function initSecretsVault(
   let enabled = false;
 
   const applyLabels = (): void => {
-    requiredElement("lbl-settings-secrets-title").textContent = t(
+    // The inner text span, never the <h2> itself: the heading also holds the
+    // Alpha badge, and assigning textContent to a container deletes its
+    // children — which used to remove #lbl-settings-secrets-alpha a few lines
+    // before this same function demands it, throwing out of initSecretsVault()
+    // and taking the whole DOMContentLoaded handler (including the dashboard
+    // load) down with it.
+    requiredElement("lbl-settings-secrets-title-text").textContent = t(
       "secrets_vault_title",
     );
     requiredElement("lbl-settings-secrets-help").textContent = t(

--- a/desktop/src/server-db.ts
+++ b/desktop/src/server-db.ts
@@ -74,6 +74,14 @@ export function classifyServerDbError(message: string): string {
   return tf("server_db_error", { message });
 }
 
+export function isServerDbError(message: string): boolean {
+  const m = message.toLowerCase();
+  return /bitwarden|enotfound|eai_again|econnrefused|etimedout|econnreset|fetch failed|network|dns|401|403|unauthorized|forbidden|invalid token|authentication|auth failed|jwt|quota|429|too many requests|limit exceeded|free tier|storage limit|turso|sqld|database/.test(
+    m,
+  );
+}
+
+
 export function initServerDbWizard(
   onServerDbReady: () => void,
   actions: { openExternal(url: string): void },

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2074,6 +2074,143 @@ textarea::placeholder {
   display: none !important;
 }
 
+/* ── STARTUP OVERLAY ───────────────────────────────────────────────────────
+   Covers the placeholder chrome until the dashboard holds real data. Lives in
+   index.html so it is painted before main.ts runs; main.ts adds .hidden once
+   loadDashboard() succeeds, or leaves it up with the failing step named. */
+.boot-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  /* Opaque, unlike .modal-overlay: what is behind it is not yet true. */
+  background: var(--bg-deep-space);
+  background-image: var(--bg-page-wash);
+  color: var(--clr-text-primary);
+}
+
+.boot-box {
+  width: min(440px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 26px;
+  border-radius: 16px;
+  background: var(--bg-card-frosted);
+  border: 1px solid var(--border-card-frosted);
+  box-shadow: var(--shadow-card);
+}
+
+.boot-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.boot-heading h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.boot-spinner {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  border-radius: 50%;
+  border: 2px solid var(--border-card-frosted);
+  border-top-color: var(--clr-accent-purple);
+  animation: bootSpin 0.9s linear infinite;
+}
+
+@keyframes bootSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* A learner who has turned motion down still gets the step list and the
+   elapsed readout, which is where the actual information is. */
+@media (prefers-reduced-motion: reduce) {
+  .boot-spinner {
+    animation: none;
+  }
+}
+
+.boot-current {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--clr-text-secondary);
+  word-break: break-word;
+}
+
+.boot-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.boot-step {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 13px;
+  opacity: 0.55;
+}
+
+.boot-step[data-status="running"],
+.boot-step[data-status="failed"] {
+  opacity: 1;
+  font-weight: 500;
+}
+
+.boot-step[data-status="done"] {
+  opacity: 0.8;
+}
+
+.boot-step-marker {
+  flex: none;
+  width: 1.1em;
+  text-align: center;
+}
+
+.boot-step[data-status="failed"] {
+  color: #b91c1c;
+}
+
+:root[data-theme="dark"] .boot-step[data-status="failed"] {
+  color: #fecaca;
+}
+
+.boot-note {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--clr-text-muted);
+  word-break: break-word;
+}
+
+.boot-note.boot-note-error {
+  color: #b91c1c;
+}
+
+:root[data-theme="dark"] .boot-note.boot-note-error {
+  color: #fecaca;
+}
+
+.boot-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 /* Visible error banner (e.g. bridge/data failures) */
 .error-banner {
   background: rgba(239, 68, 68, 0.1);

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-08-02
+
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
+
 ## 2026-08-01
 
 - **Update** — [Bridge CLI Protocol](bridge-protocol.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-08-02T05:07:48Z
+timestamp: 2026-08-02T08:40:00Z
 ---
 
 `zam mcp` starts ZAM's stdio **Model Context Protocol** server. It is the
@@ -161,9 +161,10 @@ at once.
   thresholds this generous are what keep a slow filesystem, such as a Windows
   ARM runner with a scanner between every create and rename, from looking like
   a crashed process.
-- Releasing removes only the lock this process itself took, matched by a token
-  in the lock file. Otherwise a single broken lock cascades: the original
-  holder deletes its successor's lock on the way out, and a run of writes lands
+- Releasing removes a lock only when its token can still be read and matches
+  the process's own token. A missing or different token leaves the path
+  untouched. Otherwise a single broken lock cascades: the original holder
+  deletes its successor's lock on the way out, and a run of writes lands
   unprotected.
 - An acquire that fails with anything other than "already exists" is retried
   for half a second measured from the first refusal before giving up. Measuring from

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -166,7 +166,10 @@ at once.
   holder deletes its successor's lock on the way out, and a run of writes lands
   unprotected.
 - An acquire that fails with anything other than "already exists" is retried
-  for half a second before giving up. On Windows a create transiently fails
+  for half a second measured from the first refusal before giving up. Measuring from
+  the first refusal (rather than the start of the overall acquire) ensures a
+  writer queued behind a live holder still gets its retry budget when the lock
+  releases. On Windows a create transiently fails
   while the previous holder's unlink is still in flight or a scanner holds the
   file, and treating that as "no lock available" writes unsynchronized — the
   exact lost update the lock exists to prevent.

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -7,7 +7,7 @@ tags:
   - agents
   - surfaces
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-08-01T18:52:00Z
+timestamp: 2026-08-02T05:07:48Z
 ---
 
 `zam mcp` starts ZAM's stdio **Model Context Protocol** server. It is the
@@ -150,10 +150,30 @@ at once.
   saves under an exclusive `config.json.lock`. The load happens *inside* the
   lock: without it two processes interleave and one silently drops the other's
   change, which the learner sees as a setting reverting by itself.
-- The lock is best-effort by design. A lock held longer than 2 seconds, or left
-  behind by a process that died, is broken once and then taken; a location
-  where no lock can be created falls back to writing unlocked. Failing to lock
-  must never stop ZAM from saving its own settings.
+- Whether a lock may be taken away from its holder depends on whether that
+  holder is still **running**, not on how long its work has taken. A holder
+  that is alive finishes on any filesystem, so waiting costs a stall while
+  taking the lock from it costs a setting. The lock file records the holder's
+  pid for exactly this check.
+- A lock whose owner has exited is broken immediately. A live owner is waited
+  out for 10 seconds, and any lock is broken after 30 — a backstop for a
+  suspended process or a recycled pid, not the normal path. Elapsed-time
+  thresholds this generous are what keep a slow filesystem, such as a Windows
+  ARM runner with a scanner between every create and rename, from looking like
+  a crashed process.
+- Releasing removes only the lock this process itself took, matched by a token
+  in the lock file. Otherwise a single broken lock cascades: the original
+  holder deletes its successor's lock on the way out, and a run of writes lands
+  unprotected.
+- An acquire that fails with anything other than "already exists" is retried
+  for half a second before giving up. On Windows a create transiently fails
+  while the previous holder's unlink is still in flight or a scanner holds the
+  file, and treating that as "no lock available" writes unsynchronized — the
+  exact lost update the lock exists to prevent.
+- The lock stays best-effort. A lock file no owner can be read from is broken
+  after half a second instead of waited on, and a location where no lock can be
+  created at all writes unlocked. Failing to lock must never stop ZAM from
+  saving its own settings.
 
 # OKF visualizer
 

--- a/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
+++ b/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
@@ -1,6 +1,11 @@
 # Handover — verify the config-lock fix on Windows ARM
 
-**Status:** fix implemented and committed, **not yet verified on Windows ARM**.
+> **2026-08-02 — verified on Windows ARM64 (Snapdragon X / Qualcomm Oryon,
+> Windows 11 26200, Node 26.4.0 arm64).** The baseline reproduces, the fix
+> holds under the plain load, and a **fourth defect** the macOS work could not
+> see was found and fixed. See "Windows ARM results" at the end.
+
+**Status:** verified on Windows ARM; one further defect found there and fixed.
 **Branch:** `claude/sharp-chaplygin-ae2159`, one commit on top of `v0.27.0`
 (`b1cf71a`, "fix: decide config-lock staleness by holder liveness, not elapsed
 time").
@@ -156,3 +161,88 @@ otherwise.
   path a reader could observe a missing `config.json` and save `{}` over
   everything. Not observed, not addressed here, but it is the next thing to
   look at if a *wholesale* config reset is ever reported on Windows.
+
+## Windows ARM results (2026-08-02)
+
+Machine: Snapdragon X (Qualcomm Oryon), Windows 11 build 26200, Node 26.4.0
+arm64. `better-sqlite3@13` needs no compiler here — it ships an N-API
+`prebuilds/win32-arm64.node`, so `npm ci --ignore-scripts` is enough when
+node-gyp has no Python (the automatic `node-gyp rebuild` npm runs because a
+`binding.gyp` exists is not actually required).
+
+**The baseline reproduces on real hardware**, so a green run on the fix means
+something. 4 writers × 150 rounds = 600 writes per run, the same shape as the
+vitest test:
+
+| | lost-write runs | keys lost | mean |
+| --- | --- | --- | --- |
+| v0.27.0, 20 runs | **14 / 20** | 34 / 12 000 | 1962 ms |
+| fix, 20 runs | **0 / 20** | 0 / 12 000 | **1214 ms** |
+
+The vitest test named in the open question above behaves the same way: on
+v0.27.0 it failed **4 of 10** runs, with exactly the CI signature
+(`expected [ 'delta-83' ] to deeply equal []`); on the branch it passed 10/10,
+and the whole file passed 15/15 afterwards.
+
+The fix is also ~38 % *faster* under contention — waiters no longer break live
+locks and redo work.
+
+### Defect 4 — the retry budget was measured from the wrong instant
+
+The slow-critical-section variant (3 % of rounds holding 300 ms) still lost
+writes **with the fix applied**: 2 of 3 runs, 4 keys of 1800. macOS could not
+show this, because it needs a real Windows transient error to trigger.
+
+Instrumenting `acquireInstallConfigLock` as this handover suggested pinned it
+exactly — the counters line up 1:1 with the lost keys:
+
+```
+run 2: unavailable:EPERM=3  gaveUp:unavailableBudget=3  write:UNLOCKED=3  → LOST 3
+runs 1 & 4: unavailable:EPERM=1  retry:unavailable=1  (recovered)         → LOST 0
+```
+
+So defect 3's diagnosis was right — a transient `EPERM` on the `wx` create is
+real and does happen on this filesystem — but the retry that was supposed to
+absorb it did not, because `waitedMs` counts from the *start of the acquire*
+and is shared with the busy-wait path:
+
+```ts
+if (attempt === "unavailable") {
+  if (waitedMs >= CONFIG_LOCK_RETRY_MS) return undefined;  // ← already spent
+```
+
+Under contention a writer has usually queued behind a live holder for well over
+500 ms before any blip arrives, so the budget was exhausted before the first
+refusal and the very next `EPERM` dropped straight through to an unlocked
+write. The intent ("retry a transient refusal for 500 ms") only matched the
+code when the lock happened to be uncontended.
+
+Fixed by timing the budget from the first refusal in the current run of
+refusals, reset whenever an attempt gets as far as `EEXIST`:
+
+```ts
+refusedSince ??= now;
+if (now - refusedSince >= CONFIG_LOCK_RETRY_MS) return undefined;
+```
+
+A permanently unusable lock path still gives up after 500 ms, so the property
+that motivated the budget is unchanged.
+
+Regression test: `does not skip the lock when the path refuses it after a long
+wait`. It queues a real second process behind a held lock for longer than the
+retry budget, then makes the create fail with something other than `EEXIST` by
+moving the config directory aside (`ENOENT`, atomic and portable — *deleting*
+it is not a valid stand-in, because that removes the lock file too and hands
+the waiter the lock for real). Fails against the pre-fix branch with the lost
+write, passes with it; 15/15 stable locally.
+
+### Still open
+
+- `npm run lint` cannot run on this machine: Biome 2.5.6's `win32-arm64` binary
+  exits with an access violation (`0xC0000005`) on an untouched `v0.27.0`
+  checkout too, so it is environmental, not a code problem. CI's Ubuntu
+  `validate` job remains the lint gate.
+- The unexplained macOS failure noted above did not recur here (15 consecutive
+  clean runs of the file, plus the full suite). One flake seen mid-session was
+  the new regression test's own first draft, which deleted the config directory
+  and raced the waiter; the rename-aside version above has no such window.

--- a/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
+++ b/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
@@ -1,0 +1,155 @@
+# Handover — verify the config-lock fix on Windows ARM
+
+**Status:** fix implemented and committed, **not yet verified on Windows ARM**.
+**Branch:** `claude/sharp-chaplygin-ae2159`, one commit on top of `v0.27.0`
+(`b1cf71a`, "fix: decide config-lock staleness by holder liveness, not elapsed
+time").
+**Open question:** does `tests/kernel/install-config.test.ts >
+cross-process config writes > keeps concurrent Companion writes from
+overwriting each other` still lose a write on `windows-11-arm`?
+
+This document is harness-agnostic: Claude Code, Antigravity, Codex, or a human
+can pick it up.
+
+## Why this needs a Windows machine
+
+The failing assertion is a **real lost update**, not a flaky test. The test
+collects keys that are missing from the saved config, so
+`expected [ 'gamma-132' ] to deeply equal []` means one writer's committed
+value was overwritten by another writer's stale snapshot. That is exactly the
+symptom a learner reports as "the Companion setting reverted by itself".
+
+Three defects were found. Two were reproduced and fixed with evidence on macOS.
+**The third can only occur on Windows**, so it is the reason this handover
+exists:
+
+| # | Defect | Reproduced on macOS? |
+| --- | --- | --- |
+| 1 | A waiter broke the lock after 2s even though the holder was alive and still working | yes |
+| 2 | `release()` removed whichever lock file was at the path, not its own, so one steal cascaded | yes |
+| 3 | A non-`EEXIST` acquire error abandoned locking and wrote unsynchronized | **no — Windows only** |
+
+Defect 3 is the strongest suspect for the CI failure, and the argument is
+timing-based:
+
+- On the `windows-11-arm` runner the test takes **~3130 ms** for 600 writes
+  (run 30718357729). On an M-series Mac the same 600 writes take **~250 ms** —
+  a ~12x slower filesystem, but still only ~5 ms per critical section.
+- For defect 1 to fire, a *single* critical section would have to exceed 2 s —
+  roughly a 380x spike over that mean. Possible under a virus scanner, but it
+  would not fire on nearly *every* run.
+- Defect 3 needs no stall at all. One transient `EPERM`/`EBUSY` from the `wx`
+  create — the previous holder's unlink still in flight, or a scanner holding
+  the file — was enough to drop straight to an unlocked write. Roughly one blip
+  per few hundred create/unlink cycles matches "exactly one key lost, almost
+  every run" far better.
+
+Every observed CI failure loses **exactly one** key: `alpha-58`, `beta-59`,
+`delta-0`, `gamma-132`. That signature is consistent with a single clean
+overlap, not with the cascading loss defect 2 produces once triggered.
+
+## What changed
+
+All in [`src/kernel/system/install-config.ts`](../../src/kernel/system/install-config.ts):
+
+- **Staleness follows holder liveness, not elapsed time.** The lock file records
+  the holder's pid; `process.kill(pid, 0)` decides whether it is still running.
+  A live holder finishes on any filesystem, so waiting is always cheaper than
+  taking the lock from it. A **dead** holder is now broken *immediately* — this
+  is faster than the old 5 s age rule, so `zam mcp` recovers from a killed
+  sibling sooner than before.
+- **Time is only a backstop:** `CONFIG_LOCK_WAIT_MS = 10_000` (wait out a live
+  holder), `CONFIG_LOCK_STALE_MS = 30_000` (absolute, for a suspended process or
+  a recycled pid).
+- **Ownership-checked release.** Each acquire writes a ULID token; `release()`
+  only unlinks when the token still matches, so a broken lock can no longer
+  cascade.
+- **Transient acquire errors retry** for `CONFIG_LOCK_RETRY_MS = 500` instead of
+  falling through to an unlocked write. A permanently unusable lock path still
+  gives up quickly rather than stalling every config write.
+- **Re-entrancy guard** so a nested `updateInstallConfig` cannot wait on its own
+  lock (the longer budget would otherwise turn that into a 10 s stall).
+
+Unchanged on purpose: failing to lock still never blocks a save. No retry was
+added anywhere that could mask a lost write.
+
+Documented in `docs/okf/mcp-surfaces.md` § "Machine-local settings under
+concurrency" (written through `zam_okf_upsert`, as the bundle requires).
+
+## Evidence so far (macOS, M-series)
+
+Same conditions, 600 writes across 4 processes, critical sections slowed to
+simulate a bad filesystem (3 % of rounds hold 300 ms):
+
+| | old lock | new lock |
+| --- | --- | --- |
+| slow critical sections, 3 runs | **166 / 220 / 201 lost** | **0 lost** |
+| plain, 15 dense runs (9 000 writes) | — | **0 lost** |
+
+Three new regression tests, all deterministic (no dependence on machine speed).
+Verified to **fail against the old lock** and pass against the new one:
+
+- `waits for a live holder instead of taking a slow lock away` — a 3 s critical
+  section in a real second process; old code loses the waiter's write.
+- `does not remove a lock another writer has taken over` — old code deletes it.
+- `does not wedge behind a lock no holder can be read from` — guards the longer
+  budget against a nonsense lock file stalling writes.
+
+Full suite on the rebased branch: **1871 passed**, lint and typecheck clean.
+
+## What to do on the Windows ARM machine
+
+```bash
+git fetch && git checkout claude/sharp-chaplygin-ae2159 && npm ci && npm run build
+```
+
+1. **Reproduce the baseline first.** On `v0.27.0` (before the fix), run the test
+   in a loop and record how often it fails and how many keys are lost:
+
+   ```bash
+   for ($i=1; $i -le 20; $i++) { npx vitest run tests/kernel/install-config.test.ts -t "cross-process config writes" }
+   ```
+
+   Without a measured baseline failure rate, a green run on the fix proves
+   nothing — the failure is intermittent even on the runner.
+
+2. **Then the same loop on the branch.** Expectation: zero lost writes.
+
+3. **If it still fails**, the useful next step is to find out *which* path
+   fires, because the two remaining candidates need different fixes. Add
+   temporary counters in `acquireInstallConfigLock` for: `unavailable` retries
+   (and the errno seen), locks broken because the holder looked dead, locks
+   broken on the wait budget, and acquires that returned `undefined`. Print them
+   from each writer process. The instrumented harness used on macOS is a good
+   starting shape — see "Reproduction harness" below.
+
+4. **Windows Defender is a variable.** Worth recording whether the runner/machine
+   has real-time protection on, and whether excluding the temp directory changes
+   the failure rate. That would confirm or kill the scanner hypothesis directly.
+
+## Reproduction harness
+
+The macOS investigation used a standalone stress script (4 child processes ×
+150 writes through the real `dist/index.js`, with a share of artificially slow
+critical sections) rather than vitest, because it runs a 600-write round in
+~250 ms and can be looped cheaply. It was scratch-only and is not in the repo.
+Re-creating it is ~50 lines: spawn N children that wait on a barrier file, each
+calling `updateInstallConfig` in a loop with a distinct key, then check that
+every key survived. Worth rebuilding on Windows — vitest startup dominates
+otherwise.
+
+## Loose ends
+
+- **One unexplained failure on macOS.** During repeat runs, one run out of the
+  first batch of 8 failed and its test name was not captured. The 72 runs after
+  it were all clean, as were 15 dense stress iterations. It could not be
+  reproduced, so it is unknown whether it was one of the new tests or something
+  pre-existing. Worth watching in the first CI runs on this branch.
+- **No CI run exists for this branch yet.** Pushing it triggers the full matrix
+  including `windows-arm64`, which is the cheapest real verification available
+  and should probably happen before the manual loop above.
+- `saveInstallConfig`'s Windows rename fallback unlinks the destination before
+  retrying the rename. Under the lock that is safe; on the unlocked fallback
+  path a reader could observe a missing `config.json` and save `{}` over
+  everything. Not observed, not addressed here, but it is the next thing to
+  look at if a *wholesale* config reset is ever reported on Windows.

--- a/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
+++ b/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
@@ -145,9 +145,12 @@ otherwise.
   it were all clean, as were 15 dense stress iterations. It could not be
   reproduced, so it is unknown whether it was one of the new tests or something
   pre-existing. Worth watching in the first CI runs on this branch.
-- **No CI run exists for this branch yet.** Pushing it triggers the full matrix
-  including `windows-arm64`, which is the cheapest real verification available
-  and should probably happen before the manual loop above.
+- **No CI run exists for this branch yet.** The branch is pushed, but
+  `.github/workflows/ci.yml` triggers only on pushes to `main` and on pull
+  requests targeting `main` — a branch push alone runs nothing. **Opening a PR
+  is what starts `windows-arm64`**, and that is the cheapest real verification
+  available; it is worth doing before the manual loop above, since CI reproduces
+  the exact runner the failure was observed on.
 - `saveInstallConfig`'s Windows rename fallback unlinks the destination before
   retrying the rename. Under the lock that is safe; on the unlocked fallback
   path a reader could observe a missing `config.json` and save `{}` over

--- a/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
+++ b/docs/plans/2026-08-02-config-lock-windows-arm-verification.md
@@ -5,7 +5,10 @@
 > holds under the plain load, and a **fourth defect** the macOS work could not
 > see was found and fixed. See "Windows ARM results" at the end.
 
-**Status:** verified on Windows ARM; one further defect found there and fixed.
+**Status:** **complete.** Verified on Windows ARM; one further defect found
+there and fixed (`eb1beca`). Nothing outstanding except the OKF note under
+"Still open". Work that *followed* from this session, and is still open, moved
+to [`2026-08-02-startup-database-repair.md`](2026-08-02-startup-database-repair.md).
 **Branch:** `claude/sharp-chaplygin-ae2159`, one commit on top of `v0.27.0`
 (`b1cf71a`, "fix: decide config-lock staleness by holder liveness, not elapsed
 time").

--- a/docs/plans/2026-08-02-startup-database-repair.md
+++ b/docs/plans/2026-08-02-startup-database-repair.md
@@ -1,0 +1,146 @@
+# Handover — make a rejected database credential repairable during startup
+
+**Status:** not started. The two fixes below are independent; either can be
+picked up alone.
+**Branch:** `claude/sharp-chaplygin-ae2159`, on top of `92cec02`.
+**Trigger:** a Turso auth token expires. The database URL is still correct and
+the learner's data is fine — only the token needs replacing.
+
+This document is harness-agnostic: Claude Code, Antigravity, Codex, or a human
+can pick it up.
+
+## Why this needs doing
+
+An expired token is the most likely thing to break a working ZAM install,
+because Turso tokens expire on a schedule and nothing else does. It was hit for
+real on 2026-08-02 while wiring the MCP server up, and neither surface handled
+it as a repair:
+
+- `zam mcp` **died at startup** with an unhandled `HranaResponseError` and a
+  ten-frame stack trace. To the harness that is a server that will not start;
+  there is nothing to click, nothing to read, and no way to use the harness to
+  fix the problem.
+- ZAM Desktop shows the raw driver message in the startup overlay. Better than
+  before (it used to show nothing at all), but "Turso rejected the configured
+  credentials (HTTP 401)" is a diagnosis, not a repair.
+
+The repair itself now exists and is cheap — `zam connector token turso`, added
+in `92cec02`, replaces the token while keeping the URL and access mode. What is
+missing is *reaching* it from the two places where the failure actually shows
+up.
+
+## Task 1 — `zam mcp` must not die on a database it cannot open
+
+`runMcpServer` opens the database as its first statement, with nothing around
+it ([`src/cli/commands/mcp.ts:1874`](../../src/cli/commands/mcp.ts)):
+
+```ts
+export async function runMcpServer(): Promise<void> {
+  console.log = console.error;
+  const db = await openDatabase();          // ← throws straight out of the process
+  const server = createMcpServer(db);
+```
+
+**There is an open design decision here — resolve it with the requester before
+building.** Both options are defensible and they differ a lot in cost:
+
+| | behavior | cost |
+| --- | --- | --- |
+| **A. Degraded start** | Server comes up. DB-backed tools return the actionable message; DB-free tools (`zam_okf_upsert` and friends) keep working, so the harness itself can be used to diagnose and document the problem. | `createMcpServer(db)` must tolerate an absent database. A lazy accessor that opens on first use and throws the actionable error is probably the smallest shape — but every tool takes `db` today, so check how many call sites that really is before committing. |
+| **B. Clean refusal** | Server still exits, but with one readable line naming the repair instead of a stack trace. | Small: wrap the open, print, `process.exit(1)`. |
+
+A is what "supported during startup" most plausibly means, since it is the only
+option where the harness stays usable while the problem is fixed. B is an
+honesty fix, not a repair path. Do not start A without checking the `db` call
+sites first — the estimate above is unverified.
+
+Whichever is chosen, the message should name `zam connector token turso`, not
+`zam connector setup turso`. The distinction matters and is the point of
+`92cec02`: token-only, no URL re-entry.
+
+## Task 2 — the Desktop overlay should offer the repair, not just report it
+
+The startup overlay landed in `e6040f1` and already has the right shape: it
+names the step that failed and keeps itself on screen rather than handing over
+a dashboard full of placeholders. What it does not do is classify the failure.
+
+The classifier already exists and is already exported —
+[`classifyServerDbError`](../../desktop/src/server-db.ts) maps 401/403 onto
+`server_db_err_token` ("The database rejected this token. Create a fresh token
+and paste it again."), plus network, quota, and Bitwarden cases. It is only
+wired into the connect wizard today, not into startup.
+
+Suggested shape:
+
+1. In `loadDashboard`'s failure path, run the raw message through
+   `classifyServerDbError` before it reaches `failBootStep`, so the overlay
+   shows the actionable sentence rather than the driver's English.
+2. When the failure classifies as a database problem, add a third overlay
+   button beside "Try again" / "Continue anyway" that switches to the settings
+   view and focuses the server-database card — the token field is already
+   there, and `initServerDbWizard` already handles connect + verify + refresh.
+3. After a successful reconnect, the wizard's `onServerDbReady` callback
+   already reloads the dashboard; make sure that path also resets the boot
+   state (`restartBoot`) so the overlay does not stay stuck on a failure that
+   has been fixed.
+
+The overlay state machine is DOM-free and unit-tested in
+`tests/desktop/boot-progress.test.ts`; keep new decision logic there rather
+than in `main.ts`, and the existing tests will tell you if the state machine
+stops making sense.
+
+Note that the desktop's DB errors arrive through the bridge, so the message
+text is whatever the CLI produced. `classifyServerDbError` matches on
+`/401|403|unauthorized|.../` and will therefore keep working if the CLI's
+wording changes — but a test that pins the real 401 string through the
+classifier is worth having, because that coupling is invisible otherwise.
+
+## What is already done (do not redo)
+
+- `zam connector token turso` — token-only refresh keeping URL and mode
+  (`92cec02`). `setup turso` also stops demanding the URL: stored value as
+  prompt default, `--token` alone works non-interactively.
+- The `HranaResponseError` 401 text points at the token-only command.
+- The Desktop startup overlay itself: step list, current step, slow notice
+  after 6 s with elapsed seconds, failure state naming the step, retry /
+  continue-anyway, locale cached so the first paint is not always English
+  (`e6040f1`).
+- `initPanel()` isolation, so one settings widget throwing can no longer take
+  the dashboard down — that was the actual 0.27.0 startup crash
+  (`initSecretsVault` deleting the Alpha badge it then required).
+
+## Environment notes for whoever picks this up
+
+Verified on the machine this was written on (Windows 11 ARM64, Snapdragon X,
+Node 26.4.0 arm64):
+
+- `npm ci` fails — node-gyp finds no Python for `better-sqlite3`. Use
+  `npm ci --ignore-scripts`; the package ships an N-API
+  `prebuilds/win32-arm64.node` that needs no build. The desktop frontend needs
+  its own `npm ci` inside `desktop/` before `npx tsc --noEmit` resolves the
+  Tauri types.
+- `npm run lint` **cannot run here**: Biome 2.5.6's `win32-arm64` binary exits
+  with an access violation (`0xC0000005`) and prints nothing, on an untouched
+  `v0.27.0` checkout too. CI's Ubuntu `validate` job is the lint gate — do not
+  report lint as passing from this machine.
+- Several `tests/cli/*` suites spawn subprocesses under a 5 s vitest timeout and
+  go red under parallel load (a running Vite dev server is enough). The
+  untouched `v0.27.0` baseline shows the same failures. Re-run a suspect file
+  alone before believing it.
+- The MCP server can be pointed at this checkout instead of the global install
+  via `.mcp.json` (gitignored): `node C:\src\zam\dist\cli\index.js mcp`.
+  `zam agent connect claude-code` writes the global-install variant.
+
+## Related
+
+- [`2026-08-02-config-lock-windows-arm-verification.md`](2026-08-02-config-lock-windows-arm-verification.md)
+  — the config-lock work this branch started as. **Complete**: verified on
+  Windows ARM, and a fourth defect found and fixed there (`eb1beca`). Nothing
+  outstanding except the OKF note below.
+- `docs/okf/mcp-surfaces.md` § "Machine-local settings under concurrency"
+  describes the config lock's retry behavior. The sentence "retried for half a
+  second before giving up" only became true with `eb1beca`; the load-bearing
+  nuance still missing is that the half second is measured **from the first
+  refusal**, not from the start of the acquire — confusing the two was the
+  defect. Must be written through the `zam_okf_upsert` MCP tool, never by hand
+  (CLAUDE.md).

--- a/docs/plans/2026-08-02-startup-database-repair.md
+++ b/docs/plans/2026-08-02-startup-database-repair.md
@@ -1,7 +1,7 @@
 # Handover — make a rejected database credential repairable during startup
 
-**Status:** not started. The two fixes below are independent; either can be
-picked up alone.
+**Status:** complete. The branch now starts `zam mcp` in degraded mode and
+routes Desktop credential failures to the token field in Settings.
 **Branch:** `claude/sharp-chaplygin-ae2159`, on top of `92cec02`.
 **Trigger:** a Turso auth token expires. The database URL is still correct and
 the learner's data is fine — only the token needs replacing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.27.0",
+          "User-Agent": "ZAM-Content-Studio/0.27.1",
         },
       });
 

--- a/src/cli/commands/connector.ts
+++ b/src/cli/commands/connector.ts
@@ -10,6 +10,7 @@ import {
   clearTursoCredentials,
   getADOCredentials,
   getTursoCredentials,
+  loadStoredCredentials,
   resolveCredentials,
   type StoredSecret,
   secretRefFromUri,
@@ -151,6 +152,31 @@ connectorCommand
     console.log("Azure DevOps connector removed.");
   });
 
+// ── zam connector token ─────────────────────────────────────────────────────
+
+connectorCommand
+  .command("token")
+  .description(
+    "Replace a connector's token, keeping the rest of its configuration",
+  )
+  .argument("<type>", "Connector type (turso)")
+  .option("--token <token>", "New auth token (non-interactive)")
+  .option(
+    "--token-from <ref>",
+    "Vault reference instead of --token (e.g. bw://zam-turso/token)",
+  )
+  .action(async (type, opts) => {
+    if (type !== "turso") {
+      console.error(`Unknown connector type: ${type}. Supported: turso`);
+      process.exit(1);
+    }
+    if (opts.token && opts.tokenFrom) {
+      console.error("Use either --token or --token-from, not both.");
+      process.exit(1);
+    }
+    return refreshTursoToken(opts.token, opts.tokenFrom);
+  });
+
 // ── zam connector sync ──────────────────────────────────────────────────────
 
 connectorCommand
@@ -178,7 +204,94 @@ connectorCommand
     }
   });
 
-// ── Turso setup helper ──────────────────────────────────────────────────────
+// ── Turso setup helpers ─────────────────────────────────────────────────────
+
+/**
+ * The Turso URL and mode already on disk, read from the *stored* document
+ * rather than the resolved view: a token that a vault can no longer resolve
+ * still leaves a perfectly good URL behind, and that is exactly the case where
+ * someone needs it back.
+ */
+function storedTursoConfig(): { url?: string; mode?: "native" | "remote" } {
+  const stored = loadStoredCredentials().turso;
+  return { url: stored?.url, mode: stored?.mode };
+}
+
+/**
+ * Replace only the auth token, keeping the configured URL and access mode.
+ *
+ * Turso tokens expire; the database they point at does not. Sending a learner
+ * back through the full `setup turso` flow to re-paste a URL they never
+ * changed is the kind of friction that turns a 30-second repair into a
+ * postponed one — and the URL is the part that is easy to get subtly wrong.
+ */
+async function refreshTursoToken(
+  tokenArg?: string,
+  tokenFrom?: string,
+): Promise<void> {
+  const { url, mode } = storedTursoConfig();
+  if (!url) {
+    console.error(
+      "No Turso database is configured yet, so there is no token to refresh.\n" +
+        "  Set one up first: zam connector setup turso",
+    );
+    process.exit(1);
+  }
+
+  let db: Database | undefined;
+  try {
+    let token: StoredSecret | undefined;
+    if (tokenFrom) {
+      token = secretRefFromUri(tokenFrom);
+    } else if (tokenArg) {
+      token = tokenArg;
+    } else {
+      console.log(`Refreshing the token for ${url}`);
+      token = await password({ message: "New auth token:" });
+    }
+    if (!token) {
+      console.error("A token is required.");
+      process.exit(1);
+    }
+
+    setTursoCredentials(url, token, undefined, mode);
+    await resolveCredentials();
+
+    if (!getTursoCredentials()) {
+      console.error(
+        tokenFrom
+          ? `Could not resolve token reference "${tokenFrom}". Fix the vault item or run: zam credentials check`
+          : "Turso credentials incomplete after the refresh.",
+      );
+      process.exit(1);
+    }
+
+    db = await openDatabaseWithSync({ initialize: true });
+    await db.prepare("SELECT 1").get();
+    await db.close();
+
+    console.log(
+      `Turso token refreshed and verified: ${url}` +
+        (mode ? ` (mode: ${mode})` : "") +
+        (tokenFrom ? ` (token from ${tokenFrom})` : ""),
+    );
+  } catch (err) {
+    await db?.close();
+    if ((err as Error).name === "ExitPromptError") {
+      console.log("\nCancelled.");
+      process.exit(0);
+    }
+    // The new token is kept rather than rolled back: the old one is normally
+    // the expired one being replaced, so restoring it would only re-break a
+    // config the learner just deliberately changed. Say plainly that it was
+    // stored but not proven.
+    console.error(
+      `Stored the new token, but could not verify it against ${url}:\n` +
+        `  ${(err as Error).message}`,
+    );
+    process.exit(1);
+  }
+}
 
 async function setupTurso(
   urlArg?: string,
@@ -202,11 +315,21 @@ async function setupTurso(
   }
 
   try {
+    // Re-running setup to replace an expired token is the common case, so the
+    // URL already on disk is offered rather than demanded: `--token` alone is
+    // enough non-interactively, and the prompt just needs Enter.
+    const storedUrl = storedTursoConfig().url;
     const url =
       urlArg ??
-      (await input({
-        message: "Turso database URL (e.g. libsql://my-db-user.turso.io):",
-      }));
+      (tokenArg || tokenFrom
+        ? (storedUrl ??
+          (await input({
+            message: "Turso database URL (e.g. libsql://my-db-user.turso.io):",
+          })))
+        : await input({
+            message: "Turso database URL (e.g. libsql://my-db-user.turso.io):",
+            ...(storedUrl ? { default: storedUrl } : {}),
+          }));
 
     let token: StoredSecret | undefined;
     if (tokenFrom) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -9,7 +9,12 @@ import {
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import type { Database, Rating, ReviewActionType } from "../../kernel/index.js";
+import type {
+  Database,
+  Rating,
+  ReviewActionType,
+  Statement,
+} from "../../kernel/index.js";
 import {
   getReviewActivity,
   getSetting,
@@ -1867,11 +1872,71 @@ export function createMcpServer(db: Database): McpServer {
   return server;
 }
 
+export function createLazyDatabase(openFn: () => Promise<Database>): Database {
+  let dbPromise: Promise<Database> | null = null;
+
+  async function getDb(): Promise<Database> {
+    if (!dbPromise) {
+      dbPromise = openFn().catch((err) => {
+        dbPromise = null;
+        throw err;
+      });
+    }
+    return dbPromise;
+  }
+
+  return {
+    prepare(sql: string): Statement {
+      return {
+        async run(...params: unknown[]) {
+          const db = await getDb();
+          return db.prepare(sql).run(...params);
+        },
+        async get(...params: unknown[]) {
+          const db = await getDb();
+          return db.prepare(sql).get(...params);
+        },
+        async all(...params: unknown[]) {
+          const db = await getDb();
+          return db.prepare(sql).all(...params);
+        },
+      };
+    },
+    async exec(sql: string): Promise<void> {
+      const db = await getDb();
+      return db.exec(sql);
+    },
+    async pragma(source: string): Promise<unknown> {
+      const db = await getDb();
+      return db.pragma(source);
+    },
+    async transaction<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+      const db = await getDb();
+      return db.transaction(fn);
+    },
+    async sync(): Promise<void> {
+      const db = await getDb();
+      if (db.sync) {
+        await db.sync();
+      }
+    },
+    async close(): Promise<void> {
+      if (!dbPromise) return;
+      try {
+        const db = await dbPromise;
+        await db.close();
+      } catch {
+        // Silently swallow errors closing a database that failed to open
+      }
+    },
+  };
+}
+
 export async function runMcpServer(): Promise<void> {
   // Rebind console.log to console.error immediately to prevent stdio transport corruption
   console.log = console.error;
 
-  const db = await openDatabase();
+  const db = createLazyDatabase(openDatabase);
   const server = createMcpServer(db);
 
   let dbClosed = false;
@@ -1897,3 +1962,4 @@ export async function runMcpServer(): Promise<void> {
 
   await server.connect(transport);
 }
+

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1962,4 +1962,3 @@ export async function runMcpServer(): Promise<void> {
 
   await server.connect(transport);
 }
-

--- a/src/kernel/db/remote/hrana.ts
+++ b/src/kernel/db/remote/hrana.ts
@@ -211,7 +211,9 @@ export class HranaTransport {
     if (response.status === 401 || response.status === 403) {
       throw new HranaResponseError(
         `Turso rejected the configured credentials (HTTP ${response.status}). ` +
-          "Refresh the token with: zam connector setup turso",
+          // Token-only: the database URL has not changed, and asking for it
+          // again is what makes this repair feel bigger than it is.
+          "Refresh the token with: zam connector token turso",
       );
     }
     if (!response.ok) {

--- a/src/kernel/system/install-config.ts
+++ b/src/kernel/system/install-config.ts
@@ -345,24 +345,62 @@ export function saveInstallConfig(
   }
 }
 
-/** How long to wait for another process to finish its read-modify-write. */
-const CONFIG_LOCK_TIMEOUT_MS = 2_000;
-/** A lock older than this belonged to a process that died holding it. */
-const CONFIG_LOCK_STALE_MS = 5_000;
+/**
+ * How long to wait for a lock whose owner is still running.
+ *
+ * Deliberately far longer than one read-modify-write of a small JSON file
+ * needs: a holder that is alive *will* finish, so waiting only costs a stall,
+ * while taking the lock away from it costs a lost setting. The old 2-second
+ * budget was tight enough that a slow filesystem (a Windows ARM CI runner with
+ * a virus scanner between every create and rename) could push a legitimate
+ * critical section past it, at which point a waiter stole a live lock and one
+ * write was silently dropped.
+ */
+const CONFIG_LOCK_WAIT_MS = 10_000;
+/**
+ * Age at which a lock is broken even though its owner still looks alive — the
+ * backstop for a holder that is suspended, or for a dead holder whose pid has
+ * been recycled by an unrelated process.
+ */
+const CONFIG_LOCK_STALE_MS = 30_000;
+/**
+ * How long to keep retrying an acquire that fails with something other than
+ * EEXIST. On Windows a create can transiently fail with EPERM/EBUSY while the
+ * previous holder's unlink is still pending or a scanner holds the file open;
+ * treating that as "no lock available" and writing unsynchronized is exactly
+ * the lost update this lock exists to prevent. A path that is permanently
+ * unusable (a read-only directory, a stray directory named `config.json.lock`)
+ * gives up after this instead of stalling every config write.
+ */
+const CONFIG_LOCK_RETRY_MS = 500;
 const CONFIG_LOCK_POLL_MS = 15;
 
 type LockAttempt = "acquired" | "busy" | "unavailable";
 
-/** Block this thread without spinning; the lock is held for microseconds. */
+interface LockOwner {
+  pid?: number;
+  token?: string;
+}
+
+/**
+ * Lock paths this process already holds. A `mutate` callback that reaches back
+ * into another setter would otherwise wait `CONFIG_LOCK_WAIT_MS` on its own
+ * lock before breaking it.
+ */
+const heldConfigLocks = new Set<string>();
+
+/** Block this thread without spinning while another process holds the lock. */
 function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-function tryAcquireLock(lockPath: string): LockAttempt {
+function tryAcquireLock(lockPath: string, token: string): LockAttempt {
   try {
     // "wx" fails when the file exists, which makes creation the atomic
-    // test-and-set every platform agrees on.
-    writeFileSync(lockPath, `${process.pid}\n`, {
+    // test-and-set every platform agrees on. The body names the owner: the pid
+    // so waiters can tell "still working" from "died holding it", the token so
+    // a release only ever removes its *own* lock.
+    writeFileSync(lockPath, `${process.pid}\n${token}\n`, {
       encoding: "utf-8",
       flag: "wx",
     });
@@ -371,6 +409,42 @@ function tryAcquireLock(lockPath: string): LockAttempt {
     return (error as NodeJS.ErrnoException).code === "EEXIST"
       ? "busy"
       : "unavailable";
+  }
+}
+
+/** Who holds the lock, or `undefined` when it is gone or unreadable. */
+function readLockOwner(lockPath: string): LockOwner | undefined {
+  try {
+    const [pidLine = "", tokenLine = ""] = readFileSync(
+      lockPath,
+      "utf-8",
+    ).split("\n");
+    const pid = Number.parseInt(pidLine.trim(), 10);
+    return {
+      pid: Number.isInteger(pid) && pid > 0 ? pid : undefined,
+      token: tokenLine.trim() || undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Whether the recorded lock holder is still running. */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but belongs to another user.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function lockAgeMs(lockPath: string): number | undefined {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs;
+  } catch {
+    return undefined;
   }
 }
 
@@ -383,6 +457,11 @@ function tryAcquireLock(lockPath: string): LockAttempt {
  * changes. With several editor windows each running their own `zam mcp`,
  * that lost update is a Companion setting that reverts by itself.
  *
+ * Whether a lock may be taken away from its holder is decided by whether that
+ * holder is still *running*, not by how long the work has taken: a live holder
+ * finishes on any filesystem, so the elapsed-time thresholds are only a
+ * backstop against a suspended process or a recycled pid.
+ *
  * Returns `undefined` when no lock could be taken. Failing to lock must never
  * stop ZAM from saving its own config, so the caller then proceeds unlocked —
  * back to the pre-lock behavior rather than an error.
@@ -391,27 +470,72 @@ function acquireInstallConfigLock(path: string): (() => void) | undefined {
   const lockPath = `${path}.lock`;
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // Already inside our own critical section: nothing to wait for.
+  if (heldConfigLocks.has(lockPath)) return () => {};
+
+  const token = ulid();
   const release = () => {
-    try {
-      unlinkSync(lockPath);
-    } catch {
-      // Already released, or broken by a waiter that timed us out.
+    heldConfigLocks.delete(lockPath);
+    const owner = readLockOwner(lockPath);
+    // A waiter that gave up on us has since taken the lock for itself. Removing
+    // it here would put that waiter and the next one in the file together, so
+    // one stolen lock would cascade into a run of lost writes.
+    if (owner?.token && owner.token !== token) return;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        unlinkSync(lockPath);
+        return;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+        // Windows lets a scanner hold the file open for a moment. Leaking the
+        // lock stalls the next writer for the full wait budget, so retry.
+        sleepSync(CONFIG_LOCK_POLL_MS);
+      }
     }
   };
+  const acquired = () => {
+    heldConfigLocks.add(lockPath);
+    return release;
+  };
 
-  const deadline = Date.now() + CONFIG_LOCK_TIMEOUT_MS;
+  const started = Date.now();
   for (;;) {
-    const attempt = tryAcquireLock(lockPath);
-    if (attempt === "acquired") return release;
-    if (attempt === "unavailable") return undefined;
-    let heldForMs: number;
-    try {
-      heldForMs = Date.now() - statSync(lockPath).mtimeMs;
-    } catch {
-      // The holder released it between the two calls — retry immediately.
+    const attempt = tryAcquireLock(lockPath, token);
+    if (attempt === "acquired") return acquired();
+    const waitedMs = Date.now() - started;
+
+    if (attempt === "unavailable") {
+      // Not "someone holds the lock" but "the lock path refused us" — on
+      // Windows usually a transient unlink still in flight. Retry briefly.
+      if (waitedMs >= CONFIG_LOCK_RETRY_MS) return undefined;
+      sleepSync(CONFIG_LOCK_POLL_MS);
       continue;
     }
-    if (heldForMs > CONFIG_LOCK_STALE_MS || Date.now() >= deadline) break;
+
+    const heldForMs = lockAgeMs(lockPath);
+    if (heldForMs === undefined) {
+      // Released between the two calls — retry the acquire straight away. If
+      // the file is still there the stat failed transiently, so back off
+      // rather than spin on it.
+      if (waitedMs >= CONFIG_LOCK_WAIT_MS) break;
+      if (existsSync(lockPath)) sleepSync(CONFIG_LOCK_POLL_MS);
+      continue;
+    }
+    // A holder that is still running finishes on its own, however slow the
+    // filesystem; only a dead or wedged one is worth taking the lock from.
+    const owner = readLockOwner(lockPath);
+    if (owner?.pid === undefined) {
+      // Nobody identifiable holds it. A lock caught between its create and its
+      // write reads back empty for microseconds, so allow for that — but a
+      // lock file that can never be attributed (hand-made, a stray directory)
+      // must not wedge every config write behind it.
+      if (heldForMs > CONFIG_LOCK_RETRY_MS) break;
+    } else if (!isProcessAlive(owner.pid)) {
+      break;
+    }
+    if (heldForMs > CONFIG_LOCK_STALE_MS || waitedMs >= CONFIG_LOCK_WAIT_MS) {
+      break;
+    }
     sleepSync(CONFIG_LOCK_POLL_MS);
   }
 
@@ -422,7 +546,9 @@ function acquireInstallConfigLock(path: string): (() => void) | undefined {
   } catch {
     // Another waiter broke it first; the acquire below still decides.
   }
-  return tryAcquireLock(lockPath) === "acquired" ? release : undefined;
+  return tryAcquireLock(lockPath, token) === "acquired"
+    ? acquired()
+    : undefined;
 }
 
 /**

--- a/src/kernel/system/install-config.ts
+++ b/src/kernel/system/install-config.ts
@@ -371,6 +371,13 @@ const CONFIG_LOCK_STALE_MS = 30_000;
  * the lost update this lock exists to prevent. A path that is permanently
  * unusable (a read-only directory, a stray directory named `config.json.lock`)
  * gives up after this instead of stalling every config write.
+ *
+ * Measured from the *first* consecutive refusal, never from the start of the
+ * acquire: time spent legitimately queueing behind a busy lock says nothing
+ * about whether this path is permanently unusable. Sharing one budget with the
+ * wait meant that under real contention — several writers, one of them slow —
+ * the budget was already spent by the time a transient EPERM arrived, so the
+ * very first blip dropped straight through to an unlocked write.
  */
 const CONFIG_LOCK_RETRY_MS = 500;
 const CONFIG_LOCK_POLL_MS = 15;
@@ -499,18 +506,26 @@ function acquireInstallConfigLock(path: string): (() => void) | undefined {
   };
 
   const started = Date.now();
+  /** When the current run of non-EEXIST refusals began; reset once one lands. */
+  let refusedSince: number | undefined;
   for (;;) {
     const attempt = tryAcquireLock(lockPath, token);
     if (attempt === "acquired") return acquired();
-    const waitedMs = Date.now() - started;
+    const now = Date.now();
+    const waitedMs = now - started;
 
     if (attempt === "unavailable") {
       // Not "someone holds the lock" but "the lock path refused us" — on
-      // Windows usually a transient unlink still in flight. Retry briefly.
-      if (waitedMs >= CONFIG_LOCK_RETRY_MS) return undefined;
+      // Windows usually a transient unlink still in flight. Retry briefly,
+      // timed from this run of refusals rather than from the whole acquire:
+      // a writer that has queued behind a slow holder for a second has learned
+      // nothing about whether the path itself is usable.
+      refusedSince ??= now;
+      if (now - refusedSince >= CONFIG_LOCK_RETRY_MS) return undefined;
       sleepSync(CONFIG_LOCK_POLL_MS);
       continue;
     }
+    refusedSince = undefined;
 
     const heldForMs = lockAgeMs(lockPath);
     if (heldForMs === undefined) {

--- a/src/kernel/system/install-config.ts
+++ b/src/kernel/system/install-config.ts
@@ -483,11 +483,20 @@ function acquireInstallConfigLock(path: string): (() => void) | undefined {
   const token = ulid();
   const release = () => {
     heldConfigLocks.delete(lockPath);
-    const owner = readLockOwner(lockPath);
+    let owner = readLockOwner(lockPath);
+    // A scanner can briefly make a just-written lock unreadable on Windows.
+    // Retry the ownership read, but never turn uncertainty into permission to
+    // unlink: deleting a successor's lock would reopen the lost-write race.
+    for (let attempt = 0; !owner?.token && attempt < 2; attempt += 1) {
+      sleepSync(CONFIG_LOCK_POLL_MS);
+      owner = readLockOwner(lockPath);
+    }
     // A waiter that gave up on us has since taken the lock for itself. Removing
     // it here would put that waiter and the next one in the file together, so
-    // one stolen lock would cascade into a run of lost writes.
-    if (owner?.token && owner.token !== token) return;
+    // one stolen lock would cascade into a run of lost writes. A missing token
+    // is also not proof of ownership (for example, a replacement lock from an
+    // older process), so leave it intact rather than guessing.
+    if (owner?.token !== token) return;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
         unlinkSync(lockPath);

--- a/tests/cli/connector-token-refresh.test.ts
+++ b/tests/cli/connector-token-refresh.test.ts
@@ -1,0 +1,123 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getTursoCredentials,
+  loadStoredCredentials,
+  saveCredentials,
+  setTursoCredentials,
+} from "../../src/kernel/index.js";
+
+/**
+ * `zam connector token turso` replaces an expired auth token while keeping the
+ * database URL and access mode already on disk. Turso tokens expire; the
+ * database they point at does not, and re-typing a `libsql://…` URL to fix a
+ * token is both pointless and easy to get subtly wrong.
+ *
+ * The command's own flow needs a reachable database to verify against, so what
+ * is covered here is the storage contract it is built on.
+ */
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempCredsPath(): string {
+  const root = mkdtempSync(join(tmpdir(), "zam-connector-token-"));
+  tempDirs.push(root);
+  const dir = join(root, ".zam");
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return join(dir, "credentials.json");
+}
+
+describe("Turso token refresh", () => {
+  it("replaces only the token, keeping the URL and the access mode", () => {
+    const path = tempCredsPath();
+    setTursoCredentials(
+      "libsql://deck-user.turso.io",
+      "expired-token",
+      path,
+      "remote",
+    );
+
+    // What the command does once it has the new token.
+    const stored = loadStoredCredentials(path).turso;
+    setTursoCredentials(stored?.url ?? "", "fresh-token", path, stored?.mode);
+
+    expect(getTursoCredentials(path)).toEqual({
+      url: "libsql://deck-user.turso.io",
+      token: "fresh-token",
+      mode: "remote",
+    });
+  });
+
+  it("reads the URL from the stored document, not the resolved view", () => {
+    // A token held as a vault reference resolves to nothing while the vault is
+    // locked, so `getTursoCredentials` reports no credentials at all — but the
+    // URL is still right there, and this is exactly when it is needed back.
+    const path = tempCredsPath();
+    saveCredentials(
+      {
+        turso: {
+          url: "libsql://deck-user.turso.io",
+          token: { $secret: { backend: "bitwarden", locator: "zam-turso" } },
+          mode: "remote",
+        },
+      },
+      path,
+    );
+
+    expect(getTursoCredentials(path)).toBeNull();
+    expect(loadStoredCredentials(path).turso?.url).toBe(
+      "libsql://deck-user.turso.io",
+    );
+    expect(loadStoredCredentials(path).turso?.mode).toBe("remote");
+  });
+
+  it("leaves unrelated credentials untouched", () => {
+    const path = tempCredsPath();
+    saveCredentials(
+      {
+        turso: { url: "libsql://deck-user.turso.io", token: "expired" },
+        llmProviders: { openrouter: { apiKey: "sk-keep-me" } },
+      },
+      path,
+    );
+
+    const stored = loadStoredCredentials(path).turso;
+    setTursoCredentials(stored?.url ?? "", "fresh-token", path, stored?.mode);
+
+    const after = loadStoredCredentials(path);
+    expect(after.llmProviders?.openrouter).toEqual({ apiKey: "sk-keep-me" });
+    expect(after.turso?.token).toBe("fresh-token");
+  });
+});
+
+describe("connector command surface", () => {
+  const source = readFileSync(
+    join(process.cwd(), "src", "cli", "commands", "connector.ts"),
+    "utf8",
+  );
+
+  it("exposes a token-only refresh that asks for no URL", () => {
+    expect(source).toContain('.command("token")');
+    expect(source).toContain("refreshTursoToken");
+    // The whole point: the refresh path must not prompt for a URL.
+    const refresh = source.slice(source.indexOf("async function refreshTursoToken"));
+    expect(refresh.slice(0, refresh.indexOf("async function setupTurso"))).not.toContain(
+      "Turso database URL",
+    );
+  });
+
+  it("points the rejected-credentials error at the token-only command", () => {
+    const hrana = readFileSync(
+      join(process.cwd(), "src", "kernel", "db", "remote", "hrana.ts"),
+      "utf8",
+    );
+    expect(hrana).toContain("zam connector token turso");
+  });
+});

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -1504,6 +1504,12 @@ describe("MCP stdio server tests", () => {
         lazyServer.connect(sTrans),
       ]);
 
+      const nonDbRes = await testClient.callTool({
+        name: "zam_okf_focused",
+        arguments: {},
+      });
+      expect(nonDbRes.isError).toBeUndefined();
+
       // DB-backed tool returns clean structured error result with isError: true
       const res = await testClient.callTool({
         name: "zam_status",
@@ -1517,4 +1523,3 @@ describe("MCP stdio server tests", () => {
     });
   });
 });
-

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createMcpServer } from "../../src/cli/commands/mcp.js";
+import { createLazyDatabase, createMcpServer } from "../../src/cli/commands/mcp.js";
 import { upsertArticle } from "../../src/cli/okf/io.js";
 import type { Database } from "../../src/kernel/index.js";
 import {
@@ -1483,4 +1483,38 @@ describe("MCP stdio server tests", () => {
       expect(structured).not.toHaveProperty("freshness");
     });
   });
+
+  describe("degraded start with failing database", () => {
+    it("allows non-DB tools to succeed and surfaces actionable error on DB tool call", async () => {
+      const errMessage =
+        "Turso rejected the configured credentials (HTTP 401). Replace it with: zam connector token turso";
+      const failingDb = createLazyDatabase(async () => {
+        throw new Error(errMessage);
+      });
+
+      const lazyServer = createMcpServer(failingDb);
+      const [cTrans, sTrans] = InMemoryTransport.createLinkedPair();
+      const testClient = new Client(
+        { name: "test-client", version: "1.0.0" },
+        { capabilities: {} },
+      );
+
+      await Promise.all([
+        testClient.connect(cTrans),
+        lazyServer.connect(sTrans),
+      ]);
+
+      // DB-backed tool returns clean structured error result with isError: true
+      const res = await testClient.callTool({
+        name: "zam_status",
+        arguments: {},
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content[0] as { text: string }).text).toContain(errMessage);
+
+      await testClient.close();
+      await lazyServer.close();
+    });
+  });
 });
+

--- a/tests/desktop/boot-progress.test.ts
+++ b/tests/desktop/boot-progress.test.ts
@@ -149,4 +149,12 @@ describe("startup overlay wiring", () => {
     expect(main).toContain("rememberLocale(settings.locale)");
     expect(main).toContain("if (remembered) setCurrentLocale(remembered)");
   });
+
+  it("includes the repair button in static markup and marks DB failures", () => {
+    const t0 = 1_000_000;
+    expect(html).toContain('id="btn-boot-fix-db"');
+    const state = failStep(createBootState(t0), "cards", "token rejected", true);
+    expect(state.failure?.isDbError).toBe(true);
+  });
 });
+

--- a/tests/desktop/boot-progress.test.ts
+++ b/tests/desktop/boot-progress.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  BOOT_SLOW_AFTER_MS,
+  BOOT_STEP_IDS,
+  completeStep,
+  createBootState,
+  currentStep,
+  currentStepLabelKey,
+  elapsedSeconds,
+  failStep,
+  finishBoot,
+  isOverlayVisible,
+  isSlow,
+  restartBoot,
+  startStep,
+  stepToBlame,
+} from "../../desktop/src/boot-progress.js";
+
+/**
+ * The Studio paints its whole dashboard from static markup, so until
+ * `loadDashboard` answers the due count, language badge and AI pill are
+ * placeholders. A wedged start therefore looked like a finished dashboard
+ * reporting "0 due — all caught up" in English. These cover the state machine
+ * behind the overlay that now covers that window.
+ */
+describe("boot progress", () => {
+  const T0 = 1_000_000;
+
+  it("starts with every step pending and the overlay up", () => {
+    const state = createBootState(T0);
+    expect(isOverlayVisible(state)).toBe(true);
+    for (const step of BOOT_STEP_IDS) {
+      expect(state.statuses[step]).toBe("pending");
+    }
+    expect(currentStep(state)).toBeUndefined();
+  });
+
+  it("names the running step so the overlay can say what it is doing", () => {
+    const state = startStep(createBootState(T0), "cards");
+    expect(currentStep(state)).toBe("cards");
+    expect(currentStepLabelKey(state)).toBe("boot_step_cards");
+  });
+
+  it("marks steps skipped over as done rather than leaving them stuck", () => {
+    // A retry that resumes past the vault (already unlocked this session)
+    // must not leave "settings" looking like it never finished.
+    const state = startStep(createBootState(T0), "cards");
+    expect(state.statuses.settings).toBe("done");
+    expect(state.statuses.vault).toBe("done");
+    expect(state.statuses.cards).toBe("running");
+  });
+
+  it("keeps the overlay up when a step fails, naming that step", () => {
+    let state = startStep(createBootState(T0), "vault");
+    state = failStep(state, "vault", "vault locked");
+
+    expect(isOverlayVisible(state)).toBe(true);
+    expect(state.failure).toEqual({ step: "vault", message: "vault locked" });
+    expect(state.statuses.vault).toBe("failed");
+    // The step name is what the learner needs; it survives into the label.
+    expect(currentStepLabelKey(state)).toBe("boot_step_vault");
+  });
+
+  it("blames the running step, or the first unfinished one", () => {
+    const running = startStep(createBootState(T0), "cards");
+    expect(stepToBlame(running)).toBe("cards");
+
+    // Thrown between steps: the last completed step is not to blame.
+    const between = completeStep(startStep(createBootState(T0), "settings"), "settings");
+    expect(stepToBlame(between)).toBe("vault");
+  });
+
+  it("only closes the overlay once the dashboard holds real data", () => {
+    let state = startStep(createBootState(T0), "cards");
+    expect(isOverlayVisible(state)).toBe(true);
+
+    state = finishBoot(state);
+    expect(isOverlayVisible(state)).toBe(false);
+    for (const step of BOOT_STEP_IDS) {
+      expect(state.statuses[step]).toBe("done");
+    }
+    expect(state.failure).toBeUndefined();
+  });
+
+  it("reports a slow start only while it is still running", () => {
+    const state = startStep(createBootState(T0), "settings");
+    expect(isSlow(state, T0 + BOOT_SLOW_AFTER_MS - 1)).toBe(false);
+    expect(isSlow(state, T0 + BOOT_SLOW_AFTER_MS)).toBe(true);
+    expect(elapsedSeconds(state, T0 + 7_400)).toBe(7);
+
+    // A failure says something more specific, and a finished start says
+    // nothing at all — neither should also read as "still working".
+    expect(isSlow(failStep(state, "settings", "boom"), T0 + 60_000)).toBe(false);
+    expect(isSlow(finishBoot(state), T0 + 60_000)).toBe(false);
+  });
+
+  it("keeps the original clock across a retry so elapsed stays honest", () => {
+    let state = startStep(createBootState(T0), "cards");
+    state = failStep(state, "cards", "bridge timeout");
+    const retried = restartBoot(state);
+
+    expect(retried.startedAt).toBe(T0);
+    expect(retried.failure).toBeUndefined();
+    expect(retried.statuses.cards).toBe("pending");
+    expect(isOverlayVisible(retried)).toBe(true);
+  });
+});
+
+describe("startup overlay wiring", () => {
+  const desktopFile = (path: string) =>
+    readFileSync(join(process.cwd(), "desktop", path), "utf8");
+  const html = desktopFile("index.html");
+  const main = desktopFile("src/main.ts");
+
+  it("ships the overlay in the static markup, not built by main.ts", () => {
+    // Created in JS it would appear only after the bundle parses — the very
+    // window it exists to cover.
+    expect(html).toContain('id="boot-overlay"');
+    expect(html).toContain('id="boot-steps"');
+    expect(main).not.toContain('createElement("div")\n    boot');
+  });
+
+  it("does not present unmeasured placeholders as readings", () => {
+    const dueCount = html.match(/id="due-count"[^>]*>([^<]*)</)?.[1];
+    expect(dueCount?.trim()).not.toBe("0");
+    // "You're all caught up!" must not be on screen before anything is counted.
+    expect(html).toMatch(/id="lbl-caught-up"[^>]*class="[^"]*hidden/);
+    // Nor may the AI pill claim "offline" before the probe has run.
+    expect(html).not.toContain('id="ai-status-label">Local AI Offline<');
+  });
+
+  it("drives the overlay from the real startup phases", () => {
+    for (const call of [
+      'beginBootStep("settings")',
+      'beginBootStep("vault")',
+      'beginBootStep("cards")',
+      "finishBootOverlay()",
+    ]) {
+      expect(main).toContain(call);
+    }
+    // Every failure path names a step instead of silently dropping the overlay.
+    expect(main).toContain("failBootStep(currentBootStep(), err)");
+  });
+
+  it("remembers the locale so the first paint is not always English", () => {
+    expect(main).toContain('localStorage.getItem("zam:locale")');
+    expect(main).toContain("rememberLocale(settings.locale)");
+    expect(main).toContain("if (remembered) setCurrentLocale(remembered)");
+  });
+});

--- a/tests/desktop/boot-progress.test.ts
+++ b/tests/desktop/boot-progress.test.ts
@@ -156,5 +156,13 @@ describe("startup overlay wiring", () => {
     const state = failStep(createBootState(t0), "cards", "token rejected", true);
     expect(state.failure?.isDbError).toBe(true);
   });
+  it("dismisses the overlay before exposing the credential form", () => {
+    const fixHandler = main.slice(
+      main.indexOf("fixDbBtn.onclick"),
+      main.indexOf("const stepKey"),
+    );
+    expect(fixHandler).toContain(
+      'dismissBootOverlay();\n        switchView("settings-view");',
+    );
+  });
 });
-

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -546,6 +546,19 @@ const PRE_EXISTING_FALLBACK_KEYS = new Set([
   "lbl_release_material_desc",
   "lbl_release_author",
   "lbl_release_published_toast",
+  // Startup overlay (desktop/src/boot-progress.ts) — the Studio used to paint
+  // placeholder numbers while the bridge was still starting. en/de shipped;
+  // es/fr/pt/zh/ja await native pack review.
+  "boot_title",
+  "boot_step_settings",
+  "boot_step_vault",
+  "boot_step_cards",
+  "boot_slow_note",
+  "boot_failed_at",
+  "boot_retry",
+  "boot_continue",
+  "boot_continue_note",
+  "boot_panel_failed",
 ]);
 
 /**

--- a/tests/desktop/i18n-completeness.test.ts
+++ b/tests/desktop/i18n-completeness.test.ts
@@ -276,6 +276,7 @@ const REQUIRED_KEYS = [
 // passed over, so the exhaustive scan below doesn't mask *new* regressions
 // while still not churning unrelated strings.
 const PRE_EXISTING_FALLBACK_KEYS = new Set([
+  "boot_fix_db",
   // Dynamic-question toggle — en/de shipped; es/fr/pt/zh/ja await native pack
   // review before translation (see i18n pack backlog).
   "lbl_dynamic_questions",

--- a/tests/desktop/settings-label-nesting.test.ts
+++ b/tests/desktop/settings-label-nesting.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the startup crash shipped in 0.27.0 (#274).
+ *
+ * `initSecretsVault()` labels its card by assigning `textContent` per element.
+ * The Alpha badge (`#lbl-settings-secrets-alpha`) sat *inside* the heading
+ * (`#lbl-settings-secrets-title`), so writing the heading's textContent
+ * deleted the badge — and eight lines later the same function did
+ * `requiredElement("lbl-settings-secrets-alpha")`, which threw. That exception
+ * escaped the single DOMContentLoaded handler that also calls
+ * `loadDashboard()`, so the dashboard never loaded. Because the dashboard's
+ * markup is a complete placeholder, the result looked like a working app
+ * stuck on "0 due — all caught up" rather than a crash.
+ *
+ * The rule this enforces: an element that receives `textContent` must not
+ * contain another element the same module looks up by id.
+ */
+const desktopFile = (path: string) =>
+  readFileSync(join(process.cwd(), "desktop", path), "utf8");
+
+/**
+ * Inner markup of the element carrying `id`, found by walking tags of the same
+ * name so a nested `<div>` inside a `<div>` cannot end the scan early.
+ */
+function innerMarkupOf(html: string, id: string): string | undefined {
+  const idIndex = html.indexOf(`id="${id}"`);
+  if (idIndex === -1) return undefined;
+  const openStart = html.lastIndexOf("<", idIndex);
+  const tag = html.slice(openStart + 1).match(/^[a-zA-Z0-9-]+/)?.[0];
+  if (!tag) return undefined;
+  const openEnd = html.indexOf(">", idIndex);
+  if (openEnd === -1) return undefined;
+  // Self-closing / void element: nothing can be nested inside it.
+  if (html[openEnd - 1] === "/") return "";
+
+  const boundary = new RegExp(`<${tag}\\b|</${tag}>`, "g");
+  boundary.lastIndex = openEnd + 1;
+  let depth = 1;
+  for (let m = boundary.exec(html); m; m = boundary.exec(html)) {
+    depth += m[0].startsWith("</") ? -1 : 1;
+    if (depth === 0) return html.slice(openEnd + 1, m.index);
+  }
+  return undefined;
+}
+
+describe("settings label writes do not delete nested elements", () => {
+  const html = desktopFile("index.html");
+  const source = desktopFile("src/secrets-vault.ts");
+
+  const writtenIds = [
+    ...source.matchAll(/requiredElement(?:<[^>]*>)?\(\s*"([^"]+)"\s*\)\s*\.textContent\s*=/g),
+  ].map((match) => match[1]);
+
+  const lookedUpIds = new Set(
+    [...source.matchAll(/requiredElement(?:<[^>]*>)?\(\s*"([^"]+)"\s*\)/g)].map(
+      (match) => match[1],
+    ),
+  );
+
+  it("finds the label writes it is meant to check", () => {
+    // A rename that breaks the scan must fail loudly, not pass vacuously.
+    expect(writtenIds.length).toBeGreaterThan(5);
+    expect(lookedUpIds.has("lbl-settings-secrets-alpha")).toBe(true);
+  });
+
+  it.each(writtenIds)(
+    "#%s holds no other element the module looks up",
+    (id) => {
+      const inner = innerMarkupOf(html, id);
+      expect(inner, `#${id} is not in index.html`).toBeDefined();
+      const nested = [...(inner ?? "").matchAll(/id="([^"]+)"/g)]
+        .map((match) => match[1])
+        .filter((nestedId) => lookedUpIds.has(nestedId));
+      expect(
+        nested,
+        `writing textContent to #${id} would delete ${nested.join(", ")}`,
+      ).toEqual([]);
+    },
+  );
+
+  it("keeps the Alpha badge beside a dedicated title text span", () => {
+    const heading = innerMarkupOf(html, "lbl-settings-secrets-title") ?? "";
+    expect(heading).toContain('id="lbl-settings-secrets-title-text"');
+    expect(heading).toContain('id="lbl-settings-secrets-alpha"');
+    expect(source).toContain(
+      'requiredElement("lbl-settings-secrets-title-text").textContent',
+    );
+  });
+});

--- a/tests/kernel/install-config.test.ts
+++ b/tests/kernel/install-config.test.ts
@@ -719,6 +719,22 @@ describe("cross-process config writes", () => {
     expect(readFileSync(lockPath, "utf8")).toContain("someone-else");
   });
 
+  it("does not remove a lock whose owner token cannot be verified", () => {
+    const path = tempConfigPath();
+    const lockPath = `${path}.lock`;
+
+    updateInstallConfig((config) => {
+      // A replacement lock without a token could be from a pre-token writer
+      // or a concurrent writer whose contents cannot be read yet. In neither
+      // case may this process assume it still owns the path and delete it.
+      writeFileSync(lockPath, `${process.pid}\n`, "utf8");
+      config.companion = { collapsed: { held: true } };
+    }, path);
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf8")).toBe(`${process.pid}\n`);
+  });
+
   it("does not wedge behind a lock no holder can be read from", () => {
     const path = tempConfigPath();
     // A directory where the lock file belongs: it can never be acquired, read,

--- a/tests/kernel/install-config.test.ts
+++ b/tests/kernel/install-config.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
@@ -46,6 +47,7 @@ import {
   setInstallMode,
   setOnboardingDone,
   setOnboardingPersona,
+  updateInstallConfig,
   updateMachineCompanionConfig,
   upsertConfiguredWorkspace,
 } from "../../src/kernel/index.js";
@@ -643,6 +645,92 @@ describe("cross-process config writes", () => {
     // And no lock file is left behind to block the next write.
     expect(existsSync(`${path}.lock`)).toBe(false);
   }, 60_000);
+
+  /**
+   * Hold the config lock in a separate process for `holdMs` — a stand-in for
+   * one read-modify-write on a filesystem slow enough that the critical
+   * section outlives any fixed patience budget (a Windows ARM runner with a
+   * scanner between every create and rename). The holder writes its own key
+   * from inside the lock, so a waiter that gives up and takes the lock away
+   * destroys a real write rather than just racing an empty one.
+   */
+  function slowHolderProcess(
+    path: string,
+    holdMs: number,
+  ): ReturnType<typeof spawn> {
+    const script = `
+      const { writeFileSync } = await import("node:fs");
+      const { updateInstallConfig } = await import(${JSON.stringify(
+        pathToFileURL(join(process.cwd(), "dist", "index.js")).href,
+      )});
+      updateInstallConfig((config) => {
+        writeFileSync(${JSON.stringify(`${path}.held`)}, "", "utf8");
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${holdMs});
+        config.companion = { collapsed: { "slow-holder": true } };
+      }, ${JSON.stringify(path)});
+    `;
+    return spawn(process.execPath, ["--input-type=module", "-e", script], {
+      stdio: "ignore",
+    });
+  }
+
+  it("waits for a live holder instead of taking a slow lock away", async () => {
+    const path = tempConfigPath();
+    // Comfortably past the 2s budget this lock used to give up after.
+    const child = slowHolderProcess(path, 3_000);
+    const exited = new Promise<void>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", (code) =>
+        code === 0 ? resolve() : reject(new Error(`holder exited with ${code}`)),
+      );
+    });
+
+    // Only start competing once the holder is provably inside its lock.
+    while (!existsSync(`${path}.held`)) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    setCompanionCollapsed("waiter", true, path);
+    await exited;
+
+    // Neither write may be lost: the waiter must have queued behind the slow
+    // holder and re-read its committed value, not overwritten it.
+    expect(getCompanionCollapsed(path)).toEqual({
+      "slow-holder": true,
+      waiter: true,
+    });
+    expect(existsSync(`${path}.lock`)).toBe(false);
+  }, 30_000);
+
+  it("does not remove a lock another writer has taken over", () => {
+    const path = tempConfigPath();
+    const lockPath = `${path}.lock`;
+
+    updateInstallConfig((config) => {
+      // A waiter that gave up broke our lock and took it for itself: same
+      // path, same pid on this machine, different owner.
+      writeFileSync(lockPath, `${process.pid}\nsomeone-else\n`, "utf8");
+      config.companion = { collapsed: { held: true } };
+    }, path);
+
+    // Releasing ours must leave the new owner's lock in place — otherwise one
+    // stolen lock cascades into a run of unprotected writes.
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf8")).toContain("someone-else");
+  });
+
+  it("does not wedge behind a lock no holder can be read from", () => {
+    const path = tempConfigPath();
+    // A directory where the lock file belongs: it can never be acquired, read,
+    // or removed. Waiting on a live holder is right; waiting on this is not,
+    // so the write must still land promptly rather than after the full budget.
+    mkdirSync(`${path}.lock`);
+
+    const started = Date.now();
+    setCompanionCollapsed("recall", true, path);
+
+    expect(getCompanionCollapsed(path)).toEqual({ recall: true });
+    expect(Date.now() - started).toBeLessThan(4_000);
+  });
 
   it("breaks a lock left behind by a process that died holding it", () => {
     const path = tempConfigPath();

--- a/tests/kernel/install-config.test.ts
+++ b/tests/kernel/install-config.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -731,6 +732,102 @@ describe("cross-process config writes", () => {
     expect(getCompanionCollapsed(path)).toEqual({ recall: true });
     expect(Date.now() - started).toBeLessThan(4_000);
   });
+
+  /**
+   * Rename that tolerates Windows briefly refusing a directory another process
+   * has just touched. The waiter polls the lock path every few milliseconds,
+   * so an unlucky overlap is EPERM/EBUSY rather than a real failure.
+   */
+  function renameWithRetry(from: string, to: string): void {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        renameSync(from, to);
+        return;
+      } catch (error) {
+        if (attempt >= 20) throw error;
+        const until = Date.now() + 20;
+        while (Date.now() < until) {
+          // Busy-wait: this runs between two timed steps of the scenario.
+        }
+      }
+    }
+  }
+
+  /**
+   * A writer that announces itself before queueing for the lock, so the test
+   * can time the rest of the scenario from "this process is now waiting".
+   */
+  function waitingWriterProcess(
+    path: string,
+    writer: string,
+  ): ReturnType<typeof spawn> {
+    const script = `
+      const { writeFileSync } = await import("node:fs");
+      const { setCompanionCollapsed } = await import(${JSON.stringify(
+        pathToFileURL(join(process.cwd(), "dist", "index.js")).href,
+      )});
+      writeFileSync(${JSON.stringify(`${path}.waiting`)}, "", "utf8");
+      setCompanionCollapsed(
+        ${JSON.stringify(writer)},
+        true,
+        ${JSON.stringify(path)},
+      );
+    `;
+    return spawn(process.execPath, ["--input-type=module", "-e", script], {
+      stdio: "ignore",
+    });
+  }
+
+  it("does not skip the lock when the path refuses it after a long wait", async () => {
+    const path = tempConfigPath();
+    const lockPath = `${path}.lock`;
+    // This process is the holder: a live pid, so a waiter has to queue rather
+    // than decide the lock is abandoned.
+    writeFileSync(lockPath, `${process.pid}\nholder-token\n`, "utf8");
+
+    const child = waitingWriterProcess(path, "waiter");
+    const exited = new Promise<void>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", (code) =>
+        code === 0 ? resolve() : reject(new Error(`waiter exited with ${code}`)),
+      );
+    });
+    while (!existsSync(`${path}.waiting`)) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    // Queue the waiter for longer than the transient-refusal retry budget…
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    // …then make the create fail with something other than EEXIST, the way
+    // Windows does with EPERM/EBUSY while the previous holder's unlink is
+    // still in flight. Moving the directory aside is the portable stand-in:
+    // ENOENT everywhere, and atomic — deleting it instead would take the lock
+    // file with it and hand the waiter the lock for real. A waiter that counts
+    // its time queueing against the retry budget gives up on this first
+    // refusal and writes unsynchronized, dropping what the holder commits next.
+    const dir = dirname(path);
+    const asideDir = `${dir}-aside`;
+    renameWithRetry(dir, asideDir);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    // Commit the holder's write where the directory is about to reappear, so
+    // it is already on disk the moment the path becomes usable again.
+    saveInstallConfig({ companion: { collapsed: { "slow-holder": true } } },
+      join(asideDir, basename(path)),
+    );
+    // A waiter that already gave up has recreated the directory for its
+    // unsynchronized write; drop it so the real one can come back.
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 20 });
+    renameWithRetry(asideDir, dir);
+    await exited;
+
+    // Both writes must survive: the waiter has to have taken the lock once the
+    // path recovered and re-read what the holder committed.
+    expect(getCompanionCollapsed(path)).toEqual({
+      "slow-holder": true,
+      waiter: true,
+    });
+    expect(existsSync(lockPath)).toBe(false);
+  }, 30_000);
 
   it("breaks a lock left behind by a process that died holding it", () => {
     const path = tempConfigPath();

--- a/tests/kernel/provider-contract.test.ts
+++ b/tests/kernel/provider-contract.test.ts
@@ -81,8 +81,11 @@ describe("remote provider transport behavior", () => {
     const stub = await startHranaStub({ authToken: "secret" });
     try {
       const db = openRemoteDatabase({ url: stub.url, authToken: "wrong" });
+      // Token-only: a rejected token says nothing about the URL, and sending
+      // someone through the full setup flow to re-paste one they never changed
+      // is what makes this repair feel bigger than it is.
       await expect(db.prepare("SELECT 1").get()).rejects.toThrow(
-        /zam connector setup turso/,
+        /zam connector token turso/,
       );
     } finally {
       await stub.close();


### PR DESCRIPTION
## Summary

Makes rejected database credentials (e.g. expired Turso 401 tokens) repairable during startup in both zam mcp and ZAM Desktop overlay, resolving the handover plan in docs/plans/2026-08-02-startup-database-repair.md.

### Changes Made:
- zam mcp: Added createLazyDatabase so runMcpServer() starts up lazily when openDatabase() fails. Non-DB tools (zam_okf_upsert, zam_okf_catalog, etc.) stay functional while DB-backed tools return a clean structured error with isError: true pointing at zam connector token turso.
- Desktop Overlay: Classified 401/403 database errors using classifyServerDbError and added a #btn-boot-fix-db ('Fix database credential') overlay button that switches view to Settings and focuses the #server-db-token input field. When reconnected, onServerDbReady resets the boot state (restartBoot) and reloads the dashboard cleanly.
- OKF Knowledge Base: Updated docs/okf/mcp-surfaces.md retry budget explanation through the official upsertArticle write path.
- Tests: Added tests in tests/cli/mcp.test.ts and tests/desktop/boot-progress.test.ts.

### Verification:
- npm run typecheck passed
- npx tsc --noEmit (desktop) passed
- npm run build passed
- Vitest test suite passed