### PR TITLE
docs: correct the Foundry status side-effect claim and record hardware validation

### DIFF
--- a/docs/adr/2026-08-02-foundry-local-and-hardware-classification.md
+++ b/docs/adr/2026-08-02-foundry-local-and-hardware-classification.md
@@ -141,13 +141,35 @@ A registry entry left by the preview-era "Foundry Local Vision" setup has its
 `image` capability cleared when the Ollama path is chosen. An image transport
 known not to work must not survive as a silent fallback.
 
-### 5. Foundry is started lazily, and never downloads implicitly
+### 5. Nothing is downloaded implicitly — but inspection does start the daemon
 
-- `getFoundryLocalStatus` inspects. It never starts the service and never
-  downloads, so Settings polling cannot spin up a service or consume bandwidth.
+- `getFoundryLocalStatus` inspects and **never downloads**, so Settings polling
+  cannot consume bandwidth.
 - `prepareFoundryEndpoint` starts the service and loads an **already-downloaded**
   model, and runs only on a call about to use the model — recall, text, and
   vision resolution, not passive status checks.
+
+This decision originally also claimed that inspection never starts the Foundry
+service. **That claim was wrong, and hardware testing caught it.** Measured
+against Foundry Local 0.10.2 on a Snapdragon X machine:
+
+| Command | Starts the daemon |
+|---|---|
+| `foundry server status` | no |
+| `foundry model list` | **yes** |
+| `foundry cache list` | **yes** |
+
+Every `model` and `cache` subcommand starts `foundrylocald`, so there is no
+daemon-free route to the catalog through Foundry's CLI — and the catalog is what
+the recommendation needs. Opening Settings therefore starts a local background
+service the learner did not ask for.
+
+The separation that survives is the one that costs the learner something real:
+**no implicit downloads.** Starting a local daemon holds memory and a port and
+is reversible with `foundry server stop`; pulling several gigabytes is neither.
+Gating the catalog call on an already-running service was considered and is
+recorded under Alternatives — it would make the stronger property true at the
+cost of hiding the recommended model until the learner acts.
 
 `ensureFoundryModelLoaded` refuses a model that is not cached rather than
 fetching it; a review that silently pulls several gigabytes is not an acceptable
@@ -193,6 +215,15 @@ truthful.
 
 **Include integrated GPUs in the allowlist.** Rejected: an iGPU is a CPU-class
 result for this workload, so including it would restore the failure §1 removes.
+Confirmed concretely on the Snapdragon X test machine, whose Adreno X1-45
+classifies as `unsupported` when the NPU branch is taken out of the picture.
+
+**Read the catalog only when the daemon already runs**, to keep the
+"inspection has no side effects" property of §5 literally true. Not taken for
+now: it would leave the Settings card unable to name the recommended model
+until the learner starts Foundry or runs setup, trading a visible capability
+for a background process that `foundry server stop` undoes. Worth revisiting if
+the daemon turns out to be expensive to leave running.
 
 ## Consequences
 
@@ -236,11 +267,29 @@ result for this workload, so including it would restore the failure §1 removes.
       model is pulled.
 - [x] Settings chrome localization covered by
       `tests/desktop/i18n-completeness.test.ts`.
-- [ ] End-to-end Foundry setup on a Snapdragon X device: winget install, service
-      start, NPU model load, and one real recall answer.
+- [x] Classification verified on a real Snapdragon X (X126100, Oryon CPU,
+      Hexagon NPU, Adreno X1-45 GPU): `getSystemProfile()` returns
+      `snapdragon-x` / `npu` / runner `generic` /
+      `phi-3.5-mini-instruct-qnn-npu`. The same machine's Adreno classifies as
+      `unsupported` once the NPU branch is excluded, so the iGPU exclusion holds
+      against a real device name rather than only a fixture.
+- [x] Recommendation verified against the real catalog on that machine: 43
+      entries, of which **42 are CPU builds and exactly one is NPU**
+      (`phi-3.5-mini`). The recommendation selects it, and a pre-change
+      fallback would have landed on the CPU build `qwen3.5-0.8b` — the concrete
+      case §2 exists to prevent.
+- [x] `foundryHttpModelId` suffix stripping verified against the live service:
+      the catalog id is `phi-3.5-mini-instruct-qnn-npu:2` and `/v1/models`
+      serves `phi-3.5-mini-instruct-qnn-npu`, which is what the registry stores.
+- [x] `local-vision-status` and `embedding-status` report `usable: true` on that
+      machine with Ollama installed and Qwen3-VL 4B present, including the new
+      `accelerated` field.
+- [ ] End-to-end Foundry **setup and one real recall answer** on Snapdragon X:
+      winget install, NPU model download and load, then a review. Inspection and
+      selection are now proven on hardware; the load-and-answer path is not.
 - [ ] Discrete-GPU path exercised end to end on an NVIDIA machine. Detection is
-      unit-covered; that Ollama actually reaches the GPU there is assumed, not
-      shown.
+      unit-covered and the classifier agrees on a synthetic RTX 4070 name; that
+      Ollama actually reaches the GPU there is assumed, not shown.
 - [ ] Qwen3-VL 4B observation quality against a real screenshot, compared with
       the cloud vision path. The transport is proven; the output is not.
 - [ ] The NPU-over-GPU precedence in §3 revisited on a machine with both.

--- a/docs/okf/local-ai-runtimes.md
+++ b/docs/okf/local-ai-runtimes.md
@@ -8,7 +8,7 @@ tags:
   - setup
   - windows
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/local-ai-runtimes.md"
-timestamp: 2026-08-02T20:15:00Z
+timestamp: 2026-08-02T20:55:00Z
 ---
 
 ZAM can serve its `text`, `image`, and `embedding` roles from the learner's own
@@ -83,6 +83,12 @@ list, so a machine that gains an accelerated build picks it up without a code
 change. **A catalog holding only CPU builds yields no recommendation** — that is
 the honest answer, not a defect.
 
+How thin the accelerated slice actually is, measured on a Snapdragon X machine
+against Foundry Local 0.10.2: **43 catalog entries, of which 42 are CPU builds
+and exactly one is NPU** (`phi-3.5-mini`). All three preferred aliases exist
+there, but `qwen3.5-2b-text` and `qwen3.5-0.8b` are CPU builds — so the device
+filter, not the alias order, is what does the work.
+
 There is **no second attempt on a CPU build**. If the accelerated candidate's
 execution provider is unavailable — the common Qualcomm case, where QNN is
 missing or the driver is wrong — Foundry's load failure is reported as-is and
@@ -91,23 +97,42 @@ while producing the experience that stops the learner reviewing.
 
 Catalog ids carry a variant suffix (`phi-3.5-mini-instruct-qnn-npu:2`) that the
 HTTP service does not accept. `foundryHttpModelId` strips the trailing `:<n>`;
-the stripped form is what lands in the registry.
+the stripped form is what lands in the registry, and it matches what the running
+service advertises on `/v1/models`.
 
 Installation is guided on Windows only, through winget
 (`Microsoft.FoundryLocal`). Other platforms say so rather than pretending. A
 freshly installed `foundry` not yet on the process PATH produces an explicit
 "restart ZAM, then retry".
 
-# Starting the service: lazily, and never downloading
+# No implicit downloads — but inspection does start the daemon
 
 Two entry points, separated by who is asking:
 
-- **`getFoundryLocalStatus`** inspects only. It never starts the service and
-  never downloads, so opening a settings page cannot spin up a service or
-  consume bandwidth.
+- **`getFoundryLocalStatus`** inspects. It **never downloads**, so opening a
+  settings page cannot consume bandwidth.
 - **`prepareFoundryEndpoint`** starts the service and loads an
   already-downloaded model. It runs only on a call about to *use* the model —
   recall, text, and vision resolution — never on passive status checks.
+
+Inspection is **not** free of side effects, despite reading like it should be.
+Measured against Foundry Local 0.10.2:
+
+| Command | Starts `foundrylocald` |
+| --- | --- |
+| `foundry server status` | no |
+| `foundry model list` | **yes** |
+| `foundry cache list` | **yes** |
+
+Every `model` and `cache` subcommand starts the daemon, and the catalog is what
+the recommendation needs — so there is no daemon-free route to it through
+Foundry's CLI. Opening Settings starts a local background service. Stopping it
+is `foundry server stop`.
+
+A visible artefact of this: `getFoundryLocalStatus` runs `server status` and
+`model list` concurrently, so the *first* call after a cold start typically
+reports `running: false` while itself causing the daemon to come up; a second
+call reports `running: true`.
 
 `ensureFoundryModelLoaded` refuses a model that is not cached rather than
 fetching it, so a review cannot unexpectedly consume several gigabytes.
@@ -147,9 +172,10 @@ and saying so sends the learner somewhere that works.
 **Integrated graphics do not count.** The GPU allowlist matches discrete parts
 only — `nvidia`, `geforce`, `rtx`, `gtx`, `quadro`, `tesla`,
 `radeon rx|pro|vii`, Intel Arc — and deliberately does not match
-`Intel UHD Graphics`, `Iris Xe`, or the bare `AMD Radeon(TM) Graphics` name an
-integrated part reports. An iGPU shares memory and bandwidth with the CPU and
-lands in the same too-slow band.
+`Intel UHD Graphics`, `Iris Xe`, the bare `AMD Radeon(TM) Graphics` name an
+integrated part reports, or the `Qualcomm(R) Adreno(TM) X1-45 GPU` a Snapdragon
+X laptop carries. An iGPU shares memory and bandwidth with the CPU and lands in
+the same too-slow band.
 
 NPU classifications take precedence over a discrete GPU, so a machine with both
 keeps its pre-GPU-detection behaviour. Whether that ordering is right is an open


### PR DESCRIPTION
Follow-up to #279. Running the local-AI probes on a real Snapdragon X machine (X126100, Hexagon NPU, Adreno X1-45 GPU, Foundry Local 0.10.2) confirmed most of the design and caught one claim that was simply wrong.

## The wrong claim

ADR decision 5 and the OKF article both stated that `getFoundryLocalStatus` never starts the Foundry service. Measured:

| Command | Starts `foundrylocald` |
|---|---|
| `foundry server status` | no |
| `foundry model list` | **yes** |
| `foundry cache list` | **yes** |

Every `model` and `cache` subcommand starts the daemon, and the catalog is exactly what the recommendation needs — so there is no daemon-free route to it through Foundry's CLI. Opening Settings starts a local background service the learner did not ask for.

A visible artefact, now documented: `getFoundryLocalStatus` runs `server status` and `model list` concurrently, so the first call after a cold start reports `running: false` while itself bringing the daemon up; a second call reports `running: true`.

The separation that survives is the one that costs the learner something real: **no implicit downloads**, which remains true. Gating the catalog call on an already-running service would make the stronger property true too — it is recorded under Alternatives rather than taken, since it would hide the recommended model until the learner acts, and `foundry server stop` undoes a daemon while a multi-gigabyte pull is not undone.

This PR changes documentation only. No behaviour changes.

## What the same session confirmed

Now checked off in the ADR's Validation section:

- Classification on real hardware returns `snapdragon-x` / `npu` / runner `generic` / `phi-3.5-mini-instruct-qnn-npu`.
- The machine's `Qualcomm(R) Adreno(TM) X1-45 GPU` classifies as `unsupported` once the NPU branch is excluded — the integrated-graphics exclusion holds against a real device name, not just a fixture.
- The real catalog holds **43 entries: 42 CPU builds and exactly one NPU build** (`phi-3.5-mini`), and the recommendation selects it. All three preferred aliases exist there, but `qwen3.5-2b-text` and `qwen3.5-0.8b` are CPU builds — so a pre-#279 fallback would have landed on a CPU model on this very machine. The device filter, not the alias order, is what does the work.
- `foundryHttpModelId` suffix stripping matches reality: catalog id `phi-3.5-mini-instruct-qnn-npu:2`, and `/v1/models` serves `phi-3.5-mini-instruct-qnn-npu`.
- `local-vision-status` and `embedding-status` both report `usable: true`, including the new `accelerated` field.

Still open and unchanged: the end-to-end setup-and-answer path on Snapdragon X, and the discrete-GPU path on an NVIDIA machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
