### PR TITLE
test: compare a due-now write against the database clock, not Node's

### DIFF
--- a/tests/kernel/library-revision.test.ts
+++ b/tests/kernel/library-revision.test.ts
@@ -118,9 +118,34 @@ describe("publishTokenRevision", () => {
     expect(result.cardsRetested).toBe(1);
     expect(result.contentVersion).toBe(2);
 
+    // Compare against the *database's* clock, not Date.now(). due_at is written
+    // as datetime('now'), which truncates to the second — so it is never in the
+    // future by SQLite's own reckoning. Node's clock is a different source and
+    // can read several milliseconds behind SQLite's, which made a Date.now()
+    // comparison fail whenever the write landed just past a second boundary.
     const card = await getCard(db, token.id, "alice");
-    expect(new Date(card!.due_at).getTime()).toBeLessThanOrEqual(Date.now());
+    const dbNow = (await db
+      .prepare("SELECT datetime('now') AS now")
+      .get()) as { now: string };
+    expect(card!.due_at <= dbNow.now).toBe(true);
     expect(await isAwaitingRetest(db, cardId)).toBe(true);
+  });
+
+  it("leaves the retested card immediately selectable by the queue", async () => {
+    const token = await makeToken("due-now-token");
+    await learnedCard(token.id, "alice");
+
+    await publishTokenRevision(db, {
+      tokenId: token.id,
+      materiality: "material",
+      changes: { concept: "Munich — corrected again" },
+    });
+
+    // The property that actually matters, pinned in the terms the scheduler
+    // uses: "due now" means the queue picks the card up on the very next build,
+    // with no wait for a clock to catch up.
+    const queue = await buildReviewQueue(db, { userId: "alice" });
+    expect(queue.items.map((item) => item.tokenId)).toContain(token.id);
   });
 
   it("records revision provenance and surfaces contentChanged in review queue", async () => {


### PR DESCRIPTION
Fixes the intermittent `tests/kernel/library-revision.test.ts > publishTokenRevision > makes the card due now on a material change`, seen on CI in run 30766726201 (windows-arm64): `expected 1785704398000 to be less than or equal to 1785704397986`.

## The suspected cause was wrong

The working theory was that SQLite's `datetime('now')` rounds to the nearest second, so a "due now" card could land up to ~500 ms in the future — a real product bug. Measured on this machine, it is not:

| Question | Result |
|---|---|
| Does `datetime('now')` round? | **No.** 1,272,257 samples, zero disagreements with `floor(strftime('%f','now'))` |
| Would `strftime('%Y-%m-%d %H:%M:%S','now')` help? | **No.** Identical behaviour — 534 vs 534 future readings in the same probe |
| So where does the skew come from? | SQLite's clock and Node's `Date.now()` are **separate sources**. SQLite read ahead in **29.1%** of samples, by up to 10 ms locally and ≥14 ms on the CI runner |

`due_at` is written truncated and is never in the future by the database's own reckoning. When a write lands just past a second boundary on SQLite's clock, the truncated value can still exceed a `Date.now()` read taken moments later, because Node's clock is behind. The assertion was comparing two clocks.

**`revision.ts` is therefore unchanged** — there is nothing wrong with it. Changing the write would have been fixing the wrong thing, and the proposed `strftime` substitution provably changes nothing.

## The fix

The assertion now reads the database's own clock, which is the same source the value came from.

Isolating just the changed comparison over **458,310** write-and-check iterations:

| Assertion | Failures |
|---|---|
| old — `due_at` vs `Date.now()` | 213 (0.046%) |
| new — `due_at` vs db `datetime('now')` | **0** |

0.046% is roughly one in 2,150 runs, which matches how rarely CI saw it.

## Regression test

Added a second test stating the property in the scheduler's own terms: after a material revision the card is selectable by the very next `buildReviewQueue`, with no wait for a clock to catch up. That pins what "due now" is actually for, rather than a timestamp inequality.

## Other `datetime('now')` uses — checked, no action

- `stats.ts:72` compares `due_at <= datetime('now')` entirely inside SQL, so it is same-clock and unaffected.
- All remaining uses are schema column defaults.

**One latent trap found, not fixed here.** `evaluator.ts:105` writes `due_at` as an ISO string (`2026-08-03T04:41:19.000Z`) while `revision.ts` and the schema defaults write SQLite's format (`2026-08-03 04:41:19`). `buildReviewQueue` compares `due_at <= ?` lexicographically against an ISO bound, and `' '` (0x20) sorts before `'T'` (0x54) — so a space-format value with a *later* time on the same day would compare as due. No live bug today, because every space-format writer sets "now" and never a future time. Worth deciding on separately rather than folding into a test fix.

## Verification

- `npx tsc --noEmit` clean
- `biome check src/` clean
- `npx vitest run tests/kernel/` — 458 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
