### PR TITLE
release: prepare 0.29.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.28.0"
+version = "0.29.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/mobile/node_modules
+++ b/mobile/node_modules
@@ -1,0 +1,1 @@
+/Users/thomas/src/zam/mobile/node_modules

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-mobile",
-  "version": "0.24.1",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-mobile",
-      "version": "0.24.1",
+      "version": "0.29.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-barcode-scanner": "^2.4.5"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zam-mobile",
   "private": true,
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -70,8 +70,8 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         # Stamped from package.json by the release workflow; kept in step here
         # so a local build is not mislabelled either.
-        CFBundleShortVersionString: 0.28.0
-        CFBundleVersion: "0.28.0"
+        CFBundleShortVersionString: 0.29.0
+        CFBundleVersion: "0.29.0"
         # Two uses since the app became standalone (ADR 2026-08-08): scanning
         # a QR code to take over an existing library, and photographing a page
         # to turn it into cards. Neither is the first-run path any more, but

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.28.0",
+          "User-Agent": "ZAM-Content-Studio/0.29.0",
         },
       });
 

--- a/tests/mobile/library.test.ts
+++ b/tests/mobile/library.test.ts
@@ -55,7 +55,20 @@ async function library(): Promise<Database> {
   return db;
 }
 
-describe("listLibrary", () => {
+/**
+ * Slower than the default 5s allows on an emulated runner.
+ *
+ * Every test here provisions one or two complete databases — the schema plus
+ * the whole migration chain, through the IPC stub — and the snapshot tests
+ * then export and re-import a library on top. Locally the file runs in well
+ * under a second; on the emulated windows-arm64 runner it is roughly a
+ * hundred times slower, which put it over the limit intermittently rather
+ * than reliably. A generous ceiling here keeps the 5s default meaningful for
+ * everything that has no business taking that long.
+ */
+const PROVISIONING_TIMEOUT = 60_000;
+
+describe("listLibrary", { timeout: PROVISIONING_TIMEOUT }, () => {
   it("lists the learner's cards with their subjects", async () => {
     const db = await library();
     const entries = await listLibrary(db, LOCAL_USER_ID);
@@ -71,7 +84,7 @@ describe("listLibrary", () => {
   });
 });
 
-describe("searchLibrary", () => {
+describe("searchLibrary", { timeout: PROVISIONING_TIMEOUT }, () => {
   it("falls back to full text when no embedding model is connected", async () => {
     const db = await library();
     const fetchImpl = vi.fn();
@@ -164,7 +177,7 @@ describe("searchLibrary", () => {
   });
 });
 
-describe("saveCardEdit", () => {
+describe("saveCardEdit", { timeout: PROVISIONING_TIMEOUT }, () => {
   it("marks an edited question as human-authored", async () => {
     // Otherwise the dynamic rewriter is free to replace it later — the whole
     // point of the provenance column.
@@ -191,7 +204,7 @@ describe("saveCardEdit", () => {
   });
 });
 
-describe("pause / resume / remove", () => {
+describe("pause / resume / remove", { timeout: PROVISIONING_TIMEOUT }, () => {
   it("takes a paused card out of the queue but keeps it in the library", async () => {
     const db = await library();
     const token = await getTokenBySlug(db, "zam/aktives-erinnern");

--- a/tests/mobile/upgrade.test.ts
+++ b/tests/mobile/upgrade.test.ts
@@ -89,7 +89,20 @@ async function scenario(options: { seedRemote?: boolean } = {}) {
   };
 }
 
-describe("upgradeToServerDatabase", () => {
+/**
+ * Slower than the default 5s allows on an emulated runner.
+ *
+ * Every test here provisions one or two complete databases — the schema plus
+ * the whole migration chain, through the IPC stub — and the snapshot tests
+ * then export and re-import a library on top. Locally the file runs in well
+ * under a second; on the emulated windows-arm64 runner it is roughly a
+ * hundred times slower, which put it over the limit intermittently rather
+ * than reliably. A generous ceiling here keeps the 5s default meaningful for
+ * everything that has no business taking that long.
+ */
+const PROVISIONING_TIMEOUT = 60_000;
+
+describe("upgradeToServerDatabase", { timeout: PROVISIONING_TIMEOUT }, () => {
   it("copies the whole library onto an empty server database", async () => {
     const { io } = await scenario();
     const stages: string[] = [];


### PR DESCRIPTION
Version fields for 0.29.0: root, desktop and mobile `package.json` with their lockfiles, the `zam-app` crate and `Cargo.lock`, the hardcoded User-Agent in the source reader — and, new since the iPadOS app became standalone, the CFBundle placeholders in the generated Xcode project.

Also carries a test fix that `main` needs: `windows-arm64` failed on six timeouts, not assertions. Every test in the upgrade and library suites provisions one or two complete databases through the IPC stub, which takes roughly a hundred times longer on the emulated runner than locally. They passed on #283 by luck and then failed on the merge commit. The ceiling is raised on those describes only.

Release contents: [#283](https://github.com/zam-os/zam/pull/283) — ZAM on iPadOS is a standalone app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
