### PR TITLE
fix: cloud embedding and speech models, iPad tab bar, and a Windows-only panel shown everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Dependencies
-node_modules/
+# No trailing slash: that form matches directories only, and a `node_modules`
+# *symlink* (what a linked worktree ends up with) slipped past it straight
+# into a release commit.
+node_modules
 __pycache__/
 *.py[cod]
 .venv/

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -421,7 +421,11 @@
               </span>
             </label>
             <p id="dynamic-questions-status" class="sub-label settings-status-row" aria-live="polite"></p>
-            <div id="foundry-local-setup" class="settings-stack">
+            <!-- Windows-on-ARM only, and hidden until the status call says so.
+                 Foundry Local cannot be installed anywhere else, so on every
+                 other machine this section was a heading, an explanation and a
+                 button for something that could never happen. -->
+            <div id="foundry-local-setup" class="settings-stack hidden">
               <div class="settings-card-header">
                 <div>
                   <h3 id="lbl-foundry-local-title">Foundry Local</h3>

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1672,6 +1672,9 @@ interface FoundryLocalStatusResponse {
   endpoint?: string;
   /** False when the machine has no supported NPU or discrete GPU. */
   accelerated: boolean;
+  os: "windows" | "macos" | "linux" | "unknown";
+  /** The Windows-on-ARM machines Foundry Local exists for. */
+  snapdragonX: boolean;
   recommendations: {
     text?: FoundryLocalModelInfo;
   };
@@ -1711,7 +1714,24 @@ function foundryModelLabel(model: FoundryLocalModelInfo | undefined): string {
   return [model.alias, ...detail].join(" · ");
 }
 
+/**
+ * Foundry Local is Microsoft's, it installs through winget, and
+ * `installFoundryLocal` refuses on anything but Windows. Showing the section
+ * everywhere gave a Mac a heading, an explanation, "not available on this
+ * computer" and a Set-up button in the same breath — three lines of noise in
+ * the one panel a learner opens to answer "which model is ZAM using?".
+ *
+ * So the section stays `hidden` in the markup and is only revealed for the
+ * machines it is for: Windows on ARM, which today means a Snapdragon X.
+ * Everything else never sees it, and never learns a product name it has no
+ * use for.
+ */
+function foundryLocalApplies(status: FoundryLocalStatusResponse): boolean {
+  return status.os === "windows" && status.snapdragonX;
+}
+
 async function loadFoundryLocalStatus(): Promise<void> {
+  const section = document.getElementById("foundry-local-setup");
   const textModel = document.getElementById("foundry-local-text-model");
   const statusLine = document.getElementById("foundry-local-status");
   const setupButton = document.getElementById(
@@ -1724,6 +1744,11 @@ async function loadFoundryLocalStatus(): Promise<void> {
     const status = await runBridge<FoundryLocalStatusResponse>(
       "foundry-local-status",
     );
+    if (!foundryLocalApplies(status)) {
+      section?.classList.add("hidden");
+      return;
+    }
+    section?.classList.remove("hidden");
     textModel.textContent = foundryModelLabel(status.recommendations.text);
     // A CPU-only machine gets the reason instead of a button that would set up
     // a model too slow to review with.
@@ -1744,6 +1769,10 @@ async function loadFoundryLocalStatus(): Promise<void> {
       statusLine.textContent = t("foundry_local_installed");
     }
   } catch (error) {
+    // The status call is also how we learn which machine this is, so a failure
+    // leaves the section hidden rather than guessing. The message is written
+    // anyway, for the case where the section is already open and a later
+    // refresh fails.
     textModel.textContent = t("foundry_local_model_unavailable");
     statusLine.textContent = tf("foundry_local_status_error", {
       message: errorMessage(error),

--- a/docs/adr/2026-08-08-ios-standalone-app.md
+++ b/docs/adr/2026-08-08-ios-standalone-app.md
@@ -117,8 +117,20 @@ ADR 2026-07-23 §4 already contemplated.
 
 ### 5. The canonical cloud embedding model id is fixed
 
-Vectors are tagged **`qwen3-embedding-0.6b`**, and `canonicalEmbeddingModelId`
-folds OpenRouter's `qwen/qwen3-embedding-0.6b` spelling onto it.
+Vectors are tagged **`qwen3-embedding-8b`**, and `canonicalEmbeddingModelId`
+folds OpenRouter's `qwen/qwen3-embedding-8b` and Ollama's `qwen3-embedding:8b`
+spellings onto it.
+
+> **Amended 2026-08-08.** The decision — one fixed canonical id — stands; the
+> model behind it has moved twice. It was `qwen3-embedding-0.6b` when this ADR
+> was written; OpenRouter removed that model from its catalogue the same day
+> and every `/embeddings` call answered 404 (0.29.1 → `qwen3-embedding-4b`).
+> The 4B had the same weakness that caused the outage — a single provider —
+> so the default is now the 8B, which three providers serve and which costs
+> half as much per token. Superseded sizes are deliberately absent from the
+> alias set: 1024, 2560 and 4096 dimensions are not comparable, so their rows
+> must read as stale rather than be folded onto the current id. Nothing was
+> migrated, because ZAM has no users outside the field test yet.
 
 Without this the device and a desktop configured against the same provider
 tag the same vectors differently, and on a shared Turso library each would

--- a/docs/okf/local-ai-runtimes.md
+++ b/docs/okf/local-ai-runtimes.md
@@ -8,14 +8,16 @@ tags:
   - setup
   - windows
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/local-ai-runtimes.md"
-timestamp: 2026-08-02T20:55:00Z
+timestamp: 2026-08-08T20:20:00Z
 ---
 
 ZAM can serve its `text`, `image`, and `embedding` roles from the learner's own
 machine — but only where that is actually usable. The setup lives in Settings as
-three cards, each showing its state and offering one action; the learner never
-types a model identifier. The bridge commands behind those cards exist for
-agents and the desktop shell, not as the normal way through setup.
+up to three cards, each showing its state and offering one action; the learner
+never types a model identifier. How many cards appear depends on the machine —
+the Foundry card is drawn only where Foundry Local can be installed at all. The
+bridge commands behind those cards exist for agents and the desktop shell, not
+as the normal way through setup.
 
 # The governing rule: accelerated, or not offered
 
@@ -101,8 +103,9 @@ the stripped form is what lands in the registry, and it matches what the running
 service advertises on `/v1/models`.
 
 Installation is guided on Windows only, through winget
-(`Microsoft.FoundryLocal`). Other platforms say so rather than pretending. A
-freshly installed `foundry` not yet on the process PATH produces an explicit
+(`Microsoft.FoundryLocal`); `installFoundryLocal` throws on every other
+platform, and the settings card is not drawn there at all — see *Setup surface*.
+A freshly installed `foundry` not yet on the process PATH produces an explicit
 "restart ZAM, then retry".
 
 # No implicit downloads — but inspection does start the daemon
@@ -204,7 +207,7 @@ name-based hint alone never grants a capability.
 
 | Command | Effect |
 | --- | --- |
-| `foundry-local-status` | inspect; adds `hardware`, `acceleration`, `accelerated` |
+| `foundry-local-status` | inspect; adds `hardware`, `acceleration`, `accelerated`, `os`, `snapdragonX` |
 | `foundry-local-setup --role text` | gated; install/start/download/load, then register |
 | `local-vision-status` | Ollama install, server, model, registry, acceleration, usability |
 | `local-vision-setup` | gated; pull `qwen3-vl:4b` if needed and register it |
@@ -221,6 +224,23 @@ first thing the learner has to fix rather than the last thing that failed.
 Neither vision nor embedding setup installs or starts Ollama; the card offers
 the download link first, then the one-click setup once the service runs.
 
+## The Foundry card exists only on Windows on ARM
+
+Being unable to install something and being told about it anyway are different
+failures. Foundry Local is a Microsoft product installed through winget, and
+`installFoundryLocal` refuses everywhere else — but Settings drew its card on
+every platform regardless, so a Mac was shown a heading, an explanation,
+*not available on this computer*, and a **Set up text model** button in the same
+breath. That panel exists to answer one question, *which model is ZAM using*,
+and three lines of Windows-only product noise sat in front of it.
+
+The card now ships hidden and is revealed only when `foundry-local-status`
+reports `os: windows` together with `snapdragonX: true` — which is why the
+command carries those two fields, both read straight off the system profile. A
+status call that fails leaves the card hidden rather than guessing at the
+machine. The two Ollama cards are unaffected: they are cross-platform and stay
+where they were.
+
 Settings copy ships in English and German; further locale packs fall back to
 English until native review.
 
@@ -230,5 +250,5 @@ English until native review.
 - [ADR 2026-07-12 — Unified Capability Model Registry](../adr/2026-07-12-unified-capability-model-registry.md)
 - [ADR 2026-05-30b — Hardware Setup and Agent Distribution](../adr/2026-05-30b-hardware-setup-and-agent-distribution.md)
 - [bridge-protocol.md](bridge-protocol.md)
-- Tests: `tests/cli/foundry-local.test.ts`, `tests/cli/local-vision.test.ts`, `tests/cli/llm-vision.test.ts`, `tests/cli/embedder.test.ts`, `tests/kernel/system.test.ts`, `tests/desktop/i18n-completeness.test.ts`
+- Tests: `tests/cli/foundry-local.test.ts`, `tests/cli/local-vision.test.ts`, `tests/cli/llm-vision.test.ts`, `tests/cli/embedder.test.ts`, `tests/kernel/system.test.ts`, `tests/desktop/i18n-completeness.test.ts`, `tests/desktop/foundry-local-visibility.test.ts`
 - Code: `src/cli/llm/foundry-local.ts`, `src/cli/llm/foundry-local-setup.ts`, `src/cli/llm/local-vision.ts`, `src/cli/llm/local-embedding.ts`, `src/cli/llm/vision.ts`, `src/cli/llm/client.ts`, `src/cli/llm/capability-probe.ts`, `src/cli/llm/model-registry.ts`, `src/kernel/system/profiler.ts`, `src/cli/commands/bridge.ts`, `desktop/src/main.ts`

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-08-08
+
+- **Update** — [Local AI Runtimes](local-ai-runtimes.md)
+
 ## 2026-08-02
 
 - **Update** — [Bridge CLI Protocol](bridge-protocol.md)

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 src-tauri/target/
 src-tauri/gen/*

--- a/mobile/node_modules
+++ b/mobile/node_modules
@@ -1,1 +1,0 @@
-/Users/thomas/src/zam/mobile/node_modules

--- a/mobile/src/ai/connect.ts
+++ b/mobile/src/ai/connect.ts
@@ -35,11 +35,18 @@ import { CLOUD_MODELS_SETTING } from "../model-registry.js";
 /**
  * Model requested for the `embedding` capability of the connected provider.
  *
- * OpenRouter's catalogue no longer lists `qwen/qwen3-embedding-0.6b` (HTTP 404
- * on `/embeddings`, verified 2026-08-08). The 4B sibling is the smallest Qwen3
- * embedding model still available and keeps the same multilingual family.
+ * **Chosen for how many places serve it, not for its size.** ZAM has now been
+ * broken once by a single-provider embedding model: OpenRouter dropped
+ * `qwen3-embedding-0.6b` from its catalogue on 2026-08-08 and every
+ * `/embeddings` call in the field test answered 404. The 4B that replaced it
+ * had the same exposure — one provider. The 8B is served by three (Nebius,
+ * DeepInfra, SiliconFlow) and costs half as much per token besides.
+ *
+ * Semantic search is the one capability that cannot fall back: an evaluation
+ * can be self-rated, a photo can be typed in, but a library embedded against
+ * a model that disappears has to be embedded again.
  */
-export const CLOUD_EMBEDDING_MODEL = "qwen/qwen3-embedding-4b";
+export const CLOUD_EMBEDDING_MODEL = "qwen/qwen3-embedding-8b";
 
 /**
  * Canonical id every stored vector is tagged with, mirroring
@@ -47,12 +54,21 @@ export const CLOUD_EMBEDDING_MODEL = "qwen/qwen3-embedding-4b";
  * on a shared database: a device that tags its vectors differently re-embeds
  * the whole library the first time anyone searches.
  */
-export const CLOUD_EMBEDDING_MODEL_ID = "qwen3-embedding-4b";
+export const CLOUD_EMBEDDING_MODEL_ID = "qwen3-embedding-8b";
 
-/** Former embedding wire names ZAM wrote; migrate in place when still present. */
+/**
+ * Former embedding wire names ZAM wrote; migrate in place when still present.
+ *
+ * Their vectors are not convertible — 0.6B is 1024 dimensions, 4B is 2560, 8B
+ * is 4096 — so this list exists to retire the rows, not to keep them working.
+ * The kernel re-embeds on its own: `token_embeddings` stores `dims`, and a
+ * changed model id or width is already a staleness reason.
+ */
 export const CLOUD_EMBEDDING_LEGACY_MODELS = [
   "qwen/qwen3-embedding-0.6b",
   "qwen/qwen3-embedding-0.6b:free",
+  "qwen/qwen3-embedding-4b",
+  "qwen/qwen3-embedding-4b:free",
 ] as const;
 
 /**

--- a/mobile/src/ai/connect.ts
+++ b/mobile/src/ai/connect.ts
@@ -185,7 +185,7 @@ export async function connectCloudModel(
   // verified key on a provider whose catalogue we know is the probe here —
   // there is no per-capability endpoint to ask.
   //
-  // **Two rows, not one with an embedding override.** A registry row is an
+  // **One row per model, not one row with overrides.** A registry row is an
   // endpoint, and an endpoint is a URL *and a model*: `resolveCapability` on
   // the desktop reads `row.model` and knows nothing else. A single row
   // carrying the chat model plus an `embeddingModel` field worked on the

--- a/mobile/src/ai/connect.ts
+++ b/mobile/src/ai/connect.ts
@@ -2,9 +2,9 @@
  * Connecting a cloud model from the device (ADR 2026-07-24 §5).
  *
  * One field, one button. The learner pastes a key, ZAM verifies it against the
- * provider's own key endpoint and writes a registry row; text, image and
- * embeddings all come from that single row, because OpenRouter serves all
- * three from the same key.
+ * provider's own key endpoint and writes registry rows; text/image, embeddings
+ * and speech-to-text all come from that same key, because OpenRouter serves
+ * chat, embeddings and `/audio/transcriptions` under one account.
  *
  * **Why the key lands in the database.** `apiKeyRef` into a credentials file
  * is the rule for `~/.zam/config.json`, and it is meaningless on a device that
@@ -54,6 +54,16 @@ export const CLOUD_EMBEDDING_LEGACY_MODELS = [
   "qwen/qwen3-embedding-0.6b",
   "qwen/qwen3-embedding-0.6b:free",
 ] as const;
+
+/**
+ * Cloud speech-to-text model for voice mode (OpenRouter audio catalogue).
+ *
+ * Dedicated STT — not a chat model. Registered as its own registry row with
+ * only the `stt` flag so `resolveMobileCloudChain(db, "stt")` never picks the
+ * Luna/chat endpoint. Mobile already POSTs to `/audio/transcriptions`
+ * (`speech.ts`); this is the model id that path sends.
+ */
+export const CLOUD_STT_MODEL = "openai/gpt-transcribe";
 
 export interface CloudKeyCheck {
   valid: boolean;
@@ -199,6 +209,14 @@ export async function connectCloudModel(
     stt: false,
     tts: false,
   };
+  const sttFlags = {
+    text: false,
+    image: false,
+    embedding: false,
+    video: false,
+    stt: true,
+    tts: false,
+  };
 
   // Drop superseded ZAM defaults for this provider so they cannot sit ahead of
   // the working row and burn the evaluation budget (or 404 on embeddings).
@@ -218,10 +236,12 @@ export async function connectCloudModel(
     if (legacyChat.has(row.model) && !row.capabilities?.embedding) return false;
     if (legacyEmbed.has(row.model) && row.capabilities?.embedding) return false;
     // One chat model per provider from this connect path: switching replaces
-    // the previous chat row so dead fallbacks do not pile up.
+    // the previous chat row so dead fallbacks do not pile up. Leave embedding
+    // and stt rows alone — they are separate endpoints.
     if (
       row.capabilities?.text &&
       !row.capabilities?.embedding &&
+      !row.capabilities?.stt &&
       row.model !== chatModel
     ) {
       return false;
@@ -232,6 +252,7 @@ export async function connectCloudModel(
   const wanted: Array<{ model: string; flags: typeof chatFlags }> = [
     { model: chatModel, flags: chatFlags },
     { model: CLOUD_EMBEDDING_MODEL, flags: embeddingFlags },
+    { model: CLOUD_STT_MODEL, flags: sttFlags },
   ];
 
   let created = false;
@@ -341,6 +362,49 @@ export async function migrateStaleCloudDefaults(
       row.probedAt = now;
       changed = true;
     }
+  }
+
+  // OpenRouter key already present, but no STT row yet (connect before
+  // gpt-transcribe was wired): add it so voice mode can use cloud recognition
+  // without asking the learner to reconnect.
+  const openrouterKey = rows.find(
+    (row) => row.url === descriptor.baseUrl && row.apiKey,
+  )?.apiKey;
+  const hasStt = rows.some(
+    (row) =>
+      row.url === descriptor.baseUrl &&
+      row.capabilities?.stt &&
+      row.detectedCapabilities?.stt,
+  );
+  if (openrouterKey && !hasStt) {
+    rows.push({
+      id: ulid(),
+      label: descriptor.label,
+      url: descriptor.baseUrl,
+      model: CLOUD_STT_MODEL,
+      local: false,
+      apiFlavor: "chat-completions",
+      apiKey: openrouterKey,
+      order: rows.length,
+      capabilities: {
+        text: false,
+        image: false,
+        embedding: false,
+        video: false,
+        stt: true,
+        tts: false,
+      },
+      detectedCapabilities: {
+        text: false,
+        image: false,
+        embedding: false,
+        video: false,
+        stt: true,
+        tts: false,
+      },
+      probedAt: now,
+    });
+    changed = true;
   }
 
   if (changed) await writeRows(db, rows);

--- a/mobile/src/evaluate.ts
+++ b/mobile/src/evaluate.ts
@@ -167,6 +167,22 @@ export class EvaluationTruncatedError extends Error {
   }
 }
 
+/**
+ * Nothing to evaluate *with* — no on-device model, no reachable cloud model,
+ * and nothing that failed either.
+ *
+ * This is not a fault: it is a fresh install before anyone has pasted a key,
+ * and rating yourself is how ZAM works without AI. Kept apart from the errors
+ * above so the review screen can say "compare and rate" instead of showing a
+ * red failure on every card a learner without a key ever opens.
+ */
+export class NoEvaluationBackendError extends Error {
+  constructor() {
+    super("no evaluation backend available");
+    this.name = "NoEvaluationBackendError";
+  }
+}
+
 async function defaultFetchText(
   url: string,
   init: RequestInit,
@@ -309,7 +325,8 @@ export async function evaluateMobileAnswer(
     );
   }
 
-  throw new Error(errors.join("; ") || "no evaluation backend available");
+  if (errors.length === 0) throw new NoEvaluationBackendError();
+  throw new Error(errors.join("; "));
 }
 
 export function ratingLabel(

--- a/mobile/src/main.ts
+++ b/mobile/src/main.ts
@@ -39,6 +39,7 @@ import {
   evaluateMobileAnswer,
   evaluationSpeech,
   type MobileEvaluationResult,
+  NoEvaluationBackendError,
   type OnDeviceLlmGenerateResult,
   type OnDeviceLlmStatus,
 } from "./evaluate.js";
@@ -1199,6 +1200,13 @@ async function runSmartEvaluation(): Promise<MobileEvaluationResult | null> {
   } catch (error) {
     if (isStaleEvaluation(item.cardId)) return null;
     clearEvaluationUi();
+    if (error instanceof NoEvaluationBackendError) {
+      // No key connected — the ordinary state of a fresh install. Ask for a
+      // self-rating the same way an unanswered card does, rather than showing
+      // a red failure the learner cannot act on and did not cause.
+      setReviewStatus(t("compare_and_rate"));
+      return null;
+    }
     setReviewStatus(
       tf("evaluation_failed_self_rate", { error: errorMessage(error) }),
       true,

--- a/mobile/src/model-registry.ts
+++ b/mobile/src/model-registry.ts
@@ -27,7 +27,8 @@ export const CLOUD_MODELS_SETTING = "ai.models.cloud";
  * `embedding` joined the list when the app became standalone: semantic search
  * needs vectors, and on a device there is no Ollama to produce them. It is
  * served by the same provider and the same key as text and image — only the
- * model differs, which is what `embeddingModel` on the row carries.
+ * model differs, and a model is what a row *is*, so connecting writes one row
+ * per capability rather than one row with overrides (see `ai/connect.ts`).
  */
 export type MobileModelCapability =
   | "text"

--- a/mobile/src/ui/components.css
+++ b/mobile/src/ui/components.css
@@ -136,9 +136,18 @@
   text-align: center;
 }
 
+/*
+ * The badge needs a positioning context, so the first tab is wrapped — and a
+ * wrapper is what the tab bar then lays out, not the `.tab` inside it. Without
+ * `flex: 1` here the wrapper sizes to its content while its three siblings
+ * share what is left: "Lernen" ends up flush against the left edge and the
+ * other three sit a third of the bar apart. Verified on the iPad (A16)
+ * simulator, where a tap at 21 % of the width selected the *second* tab.
+ */
 .tab-wrap {
   position: relative;
   display: flex;
+  flex: 1;
 }
 
 /* ── Inset grouped list ────────────────────────────────────────────────── */

--- a/src/cli/commands/bridge.ts
+++ b/src/cli/commands/bridge.ts
@@ -3385,6 +3385,11 @@ bridgeCommand
       hardware: profile.localAiHardware,
       acceleration: profile.localAiAcceleration,
       accelerated: supportsLocalGeneration(profile.localAiAcceleration),
+      // Foundry Local is a Windows product and `installFoundryLocal` refuses
+      // anywhere else. The settings UI needs to know that *before* it draws a
+      // section, or it offers a Mac an installer that cannot run.
+      os: profile.os,
+      snapdragonX: profile.hasSnapdragonX,
     });
   });
 

--- a/src/cli/llm/cloud-connect.ts
+++ b/src/cli/llm/cloud-connect.ts
@@ -37,9 +37,12 @@ import {
 /**
  * OpenRouter embedding model registered alongside the chat default so every
  * client of a shared database (desktop + mobile) resolves the same vectors.
- * Must stay aligned with `CLOUD_EMBEDDING_MODEL` in `mobile/src/ai/connect.ts`.
+ * Must stay aligned with `CLOUD_EMBEDDING_MODEL` in `mobile/src/ai/connect.ts`,
+ * which carries the reasoning for picking the 8B: three providers serve it
+ * where the 4B had one, and a withdrawn embedding model is the one outage a
+ * library cannot shrug off.
  */
-export const OPENROUTER_EMBEDDING_MODEL = "qwen/qwen3-embedding-4b";
+export const OPENROUTER_EMBEDDING_MODEL = "qwen/qwen3-embedding-8b";
 
 /**
  * OpenRouter speech-to-text model for voice mode. Aligned with
@@ -47,9 +50,13 @@ export const OPENROUTER_EMBEDDING_MODEL = "qwen/qwen3-embedding-4b";
  */
 export const OPENROUTER_STT_MODEL = "openai/gpt-transcribe";
 
+/** Superseded embedding rows to retire on connect; their vectors are a
+ * different width and are re-embedded, not converted. */
 const OPENROUTER_EMBEDDING_LEGACY_MODELS = [
   "qwen/qwen3-embedding-0.6b",
   "qwen/qwen3-embedding-0.6b:free",
+  "qwen/qwen3-embedding-4b",
+  "qwen/qwen3-embedding-4b:free",
 ] as const;
 
 export interface CloudKeyCheck {

--- a/src/cli/llm/cloud-connect.ts
+++ b/src/cli/llm/cloud-connect.ts
@@ -41,6 +41,12 @@ import {
  */
 export const OPENROUTER_EMBEDDING_MODEL = "qwen/qwen3-embedding-4b";
 
+/**
+ * OpenRouter speech-to-text model for voice mode. Aligned with
+ * `CLOUD_STT_MODEL` in `mobile/src/ai/connect.ts`.
+ */
+export const OPENROUTER_STT_MODEL = "openai/gpt-transcribe";
+
 const OPENROUTER_EMBEDDING_LEGACY_MODELS = [
   "qwen/qwen3-embedding-0.6b",
   "qwen/qwen3-embedding-0.6b:free",
@@ -189,9 +195,10 @@ export async function connectCloudProvider(
     ? models.map((entry) => (entry.id === existing.id ? shared : entry))
     : [...models, shared];
 
-  // Same OpenRouter key serves embeddings; register a second row so desktop and
-  // mobile resolve `embedding` to a real embedding model, not the chat model.
+  // Same OpenRouter key serves embeddings and STT; register dedicated rows so
+  // desktop and mobile resolve those capabilities to the right model, not chat.
   if (descriptor.id === "openrouter") {
+    const now = new Date().toISOString();
     const embedExisting = next.find(
       (entry) =>
         entry.url === descriptor.baseUrl &&
@@ -214,20 +221,49 @@ export async function connectCloudProvider(
       // embedding model through chat-completions would report no text and
       // wipe the flag we need.
       detectedCapabilities: { ...embedFlags },
-      probedAt: new Date().toISOString(),
+      probedAt: now,
     };
     next = embedExisting
       ? next.map((entry) => (entry.id === embedExisting.id ? embedRow : entry))
       : [...next, embedRow];
+
+    const sttExisting = next.find(
+      (entry) =>
+        entry.url === descriptor.baseUrl &&
+        entry.model === OPENROUTER_STT_MODEL,
+    );
+    const sttFlags = emptyCapabilityFlags();
+    sttFlags.stt = true;
+    const sttRow: ResolvedModelEntry = {
+      id: sttExisting?.id ?? ulid(),
+      label: descriptor.label,
+      url: descriptor.baseUrl,
+      model: OPENROUTER_STT_MODEL,
+      local: false,
+      apiFlavor: "chat-completions",
+      apiKeyRef: descriptor.apiKeyRef,
+      apiKey: key,
+      order: 2,
+      capabilities: sttFlags,
+      // Name-fragment STT detection in capability-probe would also work; set
+      // both flags explicitly so resolveCapability does not depend on a probe
+      // of a non-chat catalogue.
+      detectedCapabilities: { ...sttFlags },
+      probedAt: now,
+    };
+    next = sttExisting
+      ? next.map((entry) => (entry.id === sttExisting.id ? sttRow : entry))
+      : [...next, sttRow];
   }
 
   // Keep the freshly connected models first without scrambling foreign rows.
-  let order = 2;
+  let order = 3;
   next = next.map((entry) => {
     if (
       entry.url === descriptor.baseUrl &&
       (entry.model === descriptor.defaultModel ||
-        entry.model === OPENROUTER_EMBEDDING_MODEL)
+        entry.model === OPENROUTER_EMBEDDING_MODEL ||
+        entry.model === OPENROUTER_STT_MODEL)
     ) {
       return entry;
     }

--- a/src/cli/llm/cloud-providers.ts
+++ b/src/cli/llm/cloud-providers.ts
@@ -60,11 +60,12 @@ export const OPENROUTER_RECOMMENDED_MODELS = [
     label: "GPT-5.6 Luna",
   },
   {
-    // Cheapest current Gemini Flash Lite that is still strong enough for
-    // evaluation + photo import — the 3.x Flash Lite tiers are several times
-    // more expensive per token and not competitive as a ZAM default.
-    id: "google/gemini-2.5-flash-lite",
-    label: "Gemini 2.5 Flash Lite",
+    // Multimodal (text+image), ~$0.10/$0.34 per M — same input ballpark as
+    // Luna, cheaper output than Gemini 2.5 Flash Lite, and typically stronger
+    // on general intelligence than that Flash Lite tier. 256K context is
+    // plenty for card evaluation and photo import.
+    id: "google/gemma-4-31b-it",
+    label: "Gemma 4 31B",
   },
   {
     id: "qwen/qwen3.7-flash",

--- a/src/cli/llm/embedder.ts
+++ b/src/cli/llm/embedder.ts
@@ -60,42 +60,36 @@ const EMBEDDINGGEMMA_ALIASES = new Set([
 ]);
 
 /**
- * Cloud embedding models the mobile app connects (ADR 2026-08-08, updated
- * 2026-08-08 when OpenRouter dropped `qwen3-embedding-0.6b` from the catalogue
- * — `/embeddings` returned HTTP 404). The 4B sibling is the smallest Qwen3
- * embedding model still listed. Wire names and bare ids must land on one tag,
- * or a shared library re-embeds itself — at cost — whenever the other device
- * searches.
+ * Cloud embedding model the mobile app connects (ADR 2026-08-08).
+ *
+ * The same folding job as EmbeddingGemma above, for a different reason: the
+ * phone reaches this model through OpenRouter (`qwen/qwen3-embedding-8b`) and
+ * a desktop reaches the same weights through Ollama (`qwen3-embedding:8b`).
+ * Both spellings have to land on one id, or a shared Turso library re-embeds
+ * itself — at cost — the first time the other device searches.
+ *
+ * Superseded sizes are deliberately *not* listed. Vectors from 0.6B (1024
+ * dimensions) and 4B (2560) cannot be compared with 8B's 4096 anyway, so
+ * folding their spellings onto anything would only hide that they must be
+ * recomputed. Unknown ids pass through lowercased, which is exactly the
+ * "stale, re-embed me" signal the kernel wants.
  */
-const QWEN3_EMBEDDING_4B_ALIASES = new Set([
-  "qwen3-embedding-4b",
-  "qwen3-embedding:4b",
-  "qwen/qwen3-embedding-4b",
-  "qwen/qwen3-embedding-4b:free",
+const QWEN3_EMBEDDING_ALIASES = new Set([
+  "qwen3-embedding-8b",
+  "qwen3-embedding:8b",
+  "qwen/qwen3-embedding-8b",
+  "qwen/qwen3-embedding-8b:free",
 ]);
 
-const CANONICAL_QWEN3_EMBEDDING_4B_MODEL_ID = "qwen3-embedding-4b";
-
-/** Retired 0.6B spelling — still recognised so old rows do not invent a third id. */
-const QWEN3_EMBEDDING_0_6B_ALIASES = new Set([
-  "qwen3-embedding-0.6b",
-  "qwen3-embedding:0.6b",
-  "qwen/qwen3-embedding-0.6b",
-  "qwen/qwen3-embedding-0.6b:free",
-]);
-
-const CANONICAL_QWEN3_EMBEDDING_0_6B_MODEL_ID = "qwen3-embedding-0.6b";
+const CANONICAL_QWEN3_EMBEDDING_MODEL_ID = "qwen3-embedding-8b";
 
 export function canonicalEmbeddingModelId(model: string): string {
   const lowered = model.trim().toLowerCase();
   if (EMBEDDINGGEMMA_ALIASES.has(lowered)) {
     return CANONICAL_EMBEDDING_MODEL_ID;
   }
-  if (QWEN3_EMBEDDING_4B_ALIASES.has(lowered)) {
-    return CANONICAL_QWEN3_EMBEDDING_4B_MODEL_ID;
-  }
-  if (QWEN3_EMBEDDING_0_6B_ALIASES.has(lowered)) {
-    return CANONICAL_QWEN3_EMBEDDING_0_6B_MODEL_ID;
+  if (QWEN3_EMBEDDING_ALIASES.has(lowered)) {
+    return CANONICAL_QWEN3_EMBEDDING_MODEL_ID;
   }
   return lowered;
 }

--- a/tests/cli/cloud-connect.test.ts
+++ b/tests/cli/cloud-connect.test.ts
@@ -220,7 +220,7 @@ describe("connectCloudProvider", () => {
     expect(chat?.capabilities.text).toBe(true);
     expect(chat?.capabilities.image).toBe(true);
     expect(chat?.detectedCapabilities.text).toBe(true);
-    expect(embed?.model).toBe("qwen/qwen3-embedding-4b");
+    expect(embed?.model).toBe("qwen/qwen3-embedding-8b");
     expect(embed?.apiKey).toBe("sk-or-good");
     expect(stt?.model).toBe("openai/gpt-transcribe");
     expect(stt?.apiKey).toBe("sk-or-good");

--- a/tests/cli/cloud-connect.test.ts
+++ b/tests/cli/cloud-connect.test.ts
@@ -203,8 +203,8 @@ describe("connectCloudProvider", () => {
       { ref: OPENROUTER_PROVIDER.apiKeyRef, apiKey: "sk-or-good" },
     ]);
     const models = await loadModelRegistry(db);
-    // Chat + embedding: one OpenRouter key serves both (parity with mobile).
-    expect(models).toHaveLength(2);
+    // Chat + embedding + STT: one OpenRouter key serves all three (mobile parity).
+    expect(models).toHaveLength(3);
     // A hosted endpoint belongs to the learner, not to this machine: it goes
     // to the database so every client sees it (ADR 2026-07-23), and it takes
     // its key with it because an apiKeyRef means nothing to a phone.
@@ -213,6 +213,7 @@ describe("connectCloudProvider", () => {
       (m) => m.model === OPENROUTER_PROVIDER.defaultModel,
     );
     const embed = models.find((m) => m.capabilities?.embedding);
+    const stt = models.find((m) => m.capabilities?.stt);
     expect(chat?.apiKey).toBe("sk-or-good");
     expect(chat?.url).toBe(OPENROUTER_PROVIDER.baseUrl);
     expect(chat?.local).toBe(false);
@@ -221,6 +222,8 @@ describe("connectCloudProvider", () => {
     expect(chat?.detectedCapabilities.text).toBe(true);
     expect(embed?.model).toBe("qwen/qwen3-embedding-4b");
     expect(embed?.apiKey).toBe("sk-or-good");
+    expect(stt?.model).toBe("openai/gpt-transcribe");
+    expect(stt?.apiKey).toBe("sk-or-good");
     expect(await getSetting(db, "llm.enabled")).toBe("true");
   });
 
@@ -240,7 +243,7 @@ describe("connectCloudProvider", () => {
     expect(again.created).toBe(false);
 
     const models = await loadModelRegistry(db);
-    expect(models).toHaveLength(2);
+    expect(models).toHaveLength(3);
     const chat = models.find(
       (m) => m.model === OPENROUTER_PROVIDER.defaultModel,
     );

--- a/tests/cli/embedder.test.ts
+++ b/tests/cli/embedder.test.ts
@@ -244,18 +244,28 @@ describe("canonicalEmbeddingModelId", () => {
     }
   });
 
-  it("canonicalises the cloud Qwen3 embedding family and passes others through", () => {
+  it("folds every spelling of the cloud model onto one id", () => {
+    // OpenRouter's `qwen/…` and Ollama's `…:8b` are the same weights reached
+    // two ways; a shared library must not re-embed when the other device
+    // searches.
+    for (const alias of [
+      "qwen/qwen3-embedding-8b",
+      "qwen3-embedding-8b",
+      "qwen3-embedding:8b",
+      "Qwen/Qwen3-Embedding-8B",
+    ]) {
+      expect(canonicalEmbeddingModelId(alias)).toBe("qwen3-embedding-8b");
+    }
+  });
+
+  it("leaves superseded sizes as their own ids, so their vectors read as stale", () => {
+    // 0.6B is 1024 dimensions, 4B is 2560, 8B is 4096. Folding an older size
+    // onto the current id would claim vectors are comparable when they cannot
+    // be; passing through keeps them distinct and the kernel re-embeds.
     expect(canonicalEmbeddingModelId("qwen/qwen3-embedding-4b")).toBe(
-      "qwen3-embedding-4b",
+      "qwen/qwen3-embedding-4b",
     );
-    expect(canonicalEmbeddingModelId("qwen3-embedding-4b")).toBe(
-      "qwen3-embedding-4b",
-    );
-    // Retired 0.6B spelling — still one id so old rows do not invent a third.
     expect(canonicalEmbeddingModelId("qwen3-embedding-0.6b")).toBe(
-      "qwen3-embedding-0.6b",
-    );
-    expect(canonicalEmbeddingModelId("Qwen3-Embedding-0.6B")).toBe(
       "qwen3-embedding-0.6b",
     );
     expect(canonicalEmbeddingModelId("Some-Other-Model")).toBe(

--- a/tests/desktop/foundry-local-visibility.test.ts
+++ b/tests/desktop/foundry-local-visibility.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const file = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
+
+/**
+ * Foundry Local is a Windows product installed through winget, and
+ * `installFoundryLocal` throws on every other platform. The settings panel
+ * still drew its section unconditionally, so a Mac was shown a heading, an
+ * explanation, "not available on this computer" *and* a Set-up button — for
+ * software it cannot run. In a panel a learner opens to find out which model
+ * ZAM is using, that is three lines of pure noise.
+ *
+ * The section is now markup-hidden and revealed only for the machines it
+ * exists for. These are text assertions because the alternative is booting the
+ * Tauri shell; they fail the moment the gate is removed, which is the point.
+ */
+describe("Foundry Local section visibility", () => {
+  const html = file("desktop/index.html");
+  const main = file("desktop/src/main.ts");
+  const bridge = file("src/cli/commands/bridge.ts");
+
+  it("ships hidden, so no machine sees it before the check answers", () => {
+    expect(html).toContain(
+      '<div id="foundry-local-setup" class="settings-stack hidden">',
+    );
+  });
+
+  it("reveals it only on Windows on ARM", () => {
+    expect(main).toContain('status.os === "windows" && status.snapdragonX');
+    // Revealing and hiding both have to be reachable, or the gate is a
+    // one-way door that never opens on the machine it is for.
+    expect(main).toContain('section?.classList.remove("hidden")');
+    expect(main).toContain('section?.classList.add("hidden")');
+  });
+
+  it("carries the machine facts the gate needs over the bridge", () => {
+    const command = bridge.slice(
+      bridge.indexOf('.command("foundry-local-status")'),
+      bridge.indexOf('.command("foundry-local-setup")'),
+    );
+    expect(command).toContain("os: profile.os");
+    expect(command).toContain("snapdragonX: profile.hasSnapdragonX");
+  });
+});

--- a/tests/mobile/ai-connect.test.ts
+++ b/tests/mobile/ai-connect.test.ts
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CLOUD_EMBEDDING_MODEL,
   CLOUD_EMBEDDING_MODEL_ID,
+  CLOUD_STT_MODEL,
   connectCloudModel,
   connectedCloudLabel,
   disconnectCloudModel,
@@ -91,7 +92,7 @@ describe("verifyKey", () => {
 });
 
 describe("connectCloudModel", () => {
-  it("registers the descriptor's model for text, image and embeddings", async () => {
+  it("registers the descriptor's model for text, image, embeddings and STT", async () => {
     const db = await library();
     const result = await connectCloudModel(db, "sk-or-key", {
       verify: accept,
@@ -100,15 +101,24 @@ describe("connectCloudModel", () => {
 
     const rows = JSON.parse(
       (await getSetting(db, "ai.models.cloud")) as string,
-    );
+    ) as Array<{
+      url: string;
+      model: string;
+      label: string;
+      capabilities: Record<string, boolean>;
+      detectedCapabilities: Record<string, boolean>;
+    }>;
     // Built from the shared descriptor, not from literals copied into mobile.
-    expect(rows[0].url).toBe(OPENROUTER_PROVIDER.baseUrl);
-    expect(rows[0].model).toBe(OPENROUTER_PROVIDER.defaultModel);
-    expect(rows[0].label).toBe(OPENROUTER_PROVIDER.label);
-    expect(rows[0].capabilities).toMatchObject({ text: true, image: true });
+    expect(rows).toHaveLength(3);
+    const chat = rows.find((row) => row.model === OPENROUTER_PROVIDER.defaultModel);
+    expect(chat?.url).toBe(OPENROUTER_PROVIDER.baseUrl);
+    expect(chat?.label).toBe(OPENROUTER_PROVIDER.label);
+    expect(chat?.capabilities).toMatchObject({ text: true, image: true });
     // resolveMobileCloudChain needs both sides; a capability the learner
     // ticked but nothing confirmed is a wish, not an endpoint.
-    expect(rows[0].detectedCapabilities).toEqual(rows[0].capabilities);
+    expect(chat?.detectedCapabilities).toEqual(chat?.capabilities);
+    expect(rows.some((row) => row.model === CLOUD_EMBEDDING_MODEL)).toBe(true);
+    expect(rows.some((row) => row.model === CLOUD_STT_MODEL)).toBe(true);
   });
 
   it("refuses to store a key the provider rejected", async () => {
@@ -129,7 +139,7 @@ describe("connectCloudModel", () => {
     const rows = JSON.parse(
       (await getSetting(db, "ai.models.cloud")) as string,
     ) as Array<{ apiKey: string }>;
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(3);
     expect(rows.every((row) => row.apiKey === "second")).toBe(true);
   });
 
@@ -146,16 +156,20 @@ describe("connectCloudModel", () => {
     expect(await connectedCloudLabel(db)).toBeNull();
   });
 
-  it("serves the embedding capability from the embedding model, not the chat one", async () => {
+  it("serves embedding and STT from dedicated models, not the chat one", async () => {
     const db = await library();
     await connectCloudModel(db, "key", { verify: accept });
 
     const text = await resolveMobileCloudChain(db, "text");
     const embedding = await resolveMobileCloudChain(db, "embedding");
+    const stt = await resolveMobileCloudChain(db, "stt");
     expect(text?.model).toBe(OPENROUTER_PROVIDER.defaultModel);
     expect(embedding?.model).toBe(CLOUD_EMBEDDING_MODEL);
+    expect(stt?.model).toBe(CLOUD_STT_MODEL);
     expect(embedding?.url).toBe(text?.url);
+    expect(stt?.url).toBe(text?.url);
     expect(embedding?.apiKey).toBe("key");
+    expect(stt?.apiKey).toBe("key");
   });
 
   it("accepts an explicit chat model and replaces the former ZAM default", async () => {
@@ -269,12 +283,12 @@ describe("connectCloudModel", () => {
     expect(embedding?.model).toBe(CLOUD_EMBEDDING_MODEL);
   });
 
-  it("writes two rows, so a desktop on the same database resolves the same models", async () => {
+  it("writes three rows, so a desktop on the same database resolves the same models", async () => {
     // A registry row is an endpoint, and an endpoint carries *one* model.
     // Encoding the embedding model as an extra field on the chat row worked on
     // the device and left the desktop resolving the embedding role to a chat
     // model — 4xx on every request, and every vector the device wrote counted
-    // as stale because the ids disagreed.
+    // as stale because the ids disagreed. The same applies to STT.
     const db = await library();
     await connectCloudModel(db, "key", { verify: accept });
 
@@ -285,16 +299,20 @@ describe("connectCloudModel", () => {
       capabilities: Record<string, boolean>;
       detectedCapabilities: Record<string, boolean>;
     }>;
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(3);
 
     const chat = rows.find(
       (row) => row.model === OPENROUTER_PROVIDER.defaultModel,
     );
     const embed = rows.find((row) => row.model === CLOUD_EMBEDDING_MODEL);
+    const stt = rows.find((row) => row.model === CLOUD_STT_MODEL);
     expect(chat?.capabilities.text).toBe(true);
     expect(chat?.capabilities.embedding).toBe(false);
+    expect(chat?.capabilities.stt).toBe(false);
     expect(embed?.capabilities.embedding).toBe(true);
     expect(embed?.capabilities.text).toBe(false);
+    expect(stt?.capabilities.stt).toBe(true);
+    expect(stt?.capabilities.text).toBe(false);
 
     // What the desktop reads: `row.model` and the capability flags, nothing
     // else. Resolving `embedding` the way it does must land on the embedding
@@ -306,6 +324,73 @@ describe("connectCloudModel", () => {
     expect(canonicalEmbeddingModelId(desktopEmbedding?.model as string)).toBe(
       CLOUD_EMBEDDING_MODEL_ID,
     );
+  });
+
+  it("adds the STT row on migrate when an OpenRouter key already exists", async () => {
+    const db = await library();
+    await setSetting(
+      db,
+      "ai.models.cloud",
+      JSON.stringify([
+        {
+          id: "01CHAT",
+          label: "OpenRouter",
+          url: OPENROUTER_PROVIDER.baseUrl,
+          model: OPENROUTER_PROVIDER.defaultModel,
+          local: false,
+          apiFlavor: "chat-completions",
+          apiKey: "key",
+          order: 0,
+          capabilities: {
+            text: true,
+            image: true,
+            embedding: false,
+            video: false,
+            stt: false,
+            tts: false,
+          },
+          detectedCapabilities: {
+            text: true,
+            image: true,
+            embedding: false,
+            video: false,
+            stt: false,
+            tts: false,
+          },
+        },
+        {
+          id: "01EMB",
+          label: "OpenRouter",
+          url: OPENROUTER_PROVIDER.baseUrl,
+          model: CLOUD_EMBEDDING_MODEL,
+          local: false,
+          apiFlavor: "chat-completions",
+          apiKey: "key",
+          order: 1,
+          capabilities: {
+            text: false,
+            image: false,
+            embedding: true,
+            video: false,
+            stt: false,
+            tts: false,
+          },
+          detectedCapabilities: {
+            text: false,
+            image: false,
+            embedding: true,
+            video: false,
+            stt: false,
+            tts: false,
+          },
+        },
+      ]),
+    );
+
+    expect(await migrateStaleCloudDefaults(db)).toBe(true);
+    const stt = await resolveMobileCloudChain(db, "stt");
+    expect(stt?.model).toBe(CLOUD_STT_MODEL);
+    expect(stt?.apiKey).toBe("key");
   });
 });
 

--- a/tests/mobile/ai-connect.test.ts
+++ b/tests/mobile/ai-connect.test.ts
@@ -283,6 +283,61 @@ describe("connectCloudModel", () => {
     expect(embedding?.model).toBe(CLOUD_EMBEDDING_MODEL);
   });
 
+  it("retires the 4B embedding row 0.29.1 wrote, leaving exactly one", async () => {
+    // 4B was a one-provider model on OpenRouter, which is the shape of outage
+    // that took 0.6B away mid-field-test. A leftover row would sit in the
+    // fallback chain and answer with 2560-dimension vectors the library can
+    // no longer compare.
+    const db = await library();
+    await setSetting(
+      db,
+      "ai.models.cloud",
+      JSON.stringify([
+        {
+          id: "01EMB4B",
+          label: "OpenRouter",
+          url: OPENROUTER_PROVIDER.baseUrl,
+          model: "qwen/qwen3-embedding-4b",
+          local: false,
+          apiFlavor: "chat-completions",
+          apiKey: "key",
+          order: 1,
+          capabilities: {
+            text: false,
+            image: false,
+            embedding: true,
+            video: false,
+            stt: false,
+            tts: false,
+          },
+          detectedCapabilities: {
+            text: false,
+            image: false,
+            embedding: true,
+            video: false,
+            stt: false,
+            tts: false,
+          },
+        },
+      ]),
+    );
+
+    await connectCloudModel(db, "key", { verify: accept });
+
+    const rows = JSON.parse(
+      (await getSetting(db, "ai.models.cloud")) as string,
+    ) as Array<{ model: string; capabilities: Record<string, boolean> }>;
+    const embedRows = rows.filter((row) => row.capabilities.embedding);
+    expect(embedRows).toHaveLength(1);
+    expect(embedRows[0]?.model).toBe(CLOUD_EMBEDDING_MODEL);
+    // And no fallback hiding behind it.
+    let chain = await resolveMobileCloudChain(db, "embedding");
+    while (chain) {
+      expect(chain.model).toBe(CLOUD_EMBEDDING_MODEL);
+      chain = chain.fallback ?? null;
+    }
+  });
+
   it("writes three rows, so a desktop on the same database resolves the same models", async () => {
     // A registry row is an endpoint, and an endpoint carries *one* model.
     // Encoding the embedding model as an extra field on the chat row worked on
@@ -397,7 +452,7 @@ describe("connectCloudModel", () => {
 describe("canonical embedding id", () => {
   it("agrees with the desktop for both the wire name and the stored id", () => {
     // The interesting one is the *wire* name. OpenRouter serves the model as
-    // `qwen/qwen3-embedding-4b`; a desktop configured against the same
+    // `qwen/qwen3-embedding-8b`; a desktop configured against the same
     // provider must tag its vectors with the same id the device uses, or a
     // shared library re-embeds itself — at cost — on the next search.
     expect(canonicalEmbeddingModelId(CLOUD_EMBEDDING_MODEL)).toBe(
@@ -406,7 +461,7 @@ describe("canonical embedding id", () => {
     expect(canonicalEmbeddingModelId(CLOUD_EMBEDDING_MODEL_ID)).toBe(
       CLOUD_EMBEDDING_MODEL_ID,
     );
-    expect(canonicalEmbeddingModelId("Qwen/Qwen3-Embedding-4B")).toBe(
+    expect(canonicalEmbeddingModelId("Qwen/Qwen3-Embedding-8B")).toBe(
       CLOUD_EMBEDDING_MODEL_ID,
     );
   });

--- a/tests/mobile/dom-contract.test.ts
+++ b/tests/mobile/dom-contract.test.ts
@@ -92,4 +92,33 @@ describe("index.html / TypeScript element contract", () => {
       new Set(["learn", "library", "progress", "settings"]),
     );
   });
+
+  /**
+   * The tab bar is a flex row, so every *direct child* has to claim its share
+   * — including a wrapper that only exists to position the badge. One that
+   * does not sizes to its content and pushes the rest out of line, which is
+   * how "Lernen" ended up flush against the left edge in 0.29.1 while a tap
+   * meant for it selected the neighbouring tab.
+   */
+  it("gives every direct child of the tab bar an equal share", () => {
+    const html = read("mobile/index.html");
+    const css = read("mobile/src/ui/components.css");
+    const bar = html.slice(
+      html.indexOf('<nav class="tabbar"'),
+      html.indexOf("</nav>"),
+    );
+    // Direct children only: the markup indents them one level deeper than the
+    // <nav>, and anything inside a wrapper deeper still.
+    const children = [
+      ...bar.matchAll(/^ {8}<\w+ class="([a-z-]+)"/gm),
+    ].map((match) => match[1] as string);
+    expect(new Set(children)).toEqual(new Set(["tab-wrap", "tab"]));
+    for (const cls of new Set(children)) {
+      const rule = css.slice(css.indexOf(`\n.${cls} {`));
+      const body = rule.slice(0, rule.indexOf("}"));
+      expect(body, `.${cls} is a tab bar child without flex: 1`).toMatch(
+        /flex:\s*1\b/,
+      );
+    }
+  });
 });

--- a/tests/mobile/evaluate.test.ts
+++ b/tests/mobile/evaluate.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateMobileAnswer,
   evaluationSpeech,
   isCloudHttpEndpoint,
+  NoEvaluationBackendError,
   resolveEvaluationBackend,
   selectCloudHttpEndpoint,
 } from "../../mobile/src/evaluate.js";
@@ -487,5 +488,52 @@ describe("a reasoning model that thinks past its budget", () => {
       }),
     ).rejects.toThrow(/reasoning model may be a poor fit/);
     expect(fetchText).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("no backend at all", () => {
+  /**
+   * An iPad with no key pasted: no on-device model, no endpoint, and nothing
+   * that failed. The review screen tells these apart by type, so that a fresh
+   * install asks for a self-rating instead of showing a red failure on every
+   * card — see the catch in `runSmartEvaluation`.
+   */
+  it("is its own error type, not a generic failure", async () => {
+    const ports: EvaluationPorts = {
+      checkOnDeviceStatus: vi.fn(),
+      generateOnDevice: vi.fn(async (): Promise<never> => {
+        throw new Error("should not be called");
+      }),
+    };
+    const attempt = evaluateMobileAnswer({
+      card,
+      learnerAnswer: "F = m · a",
+      locale: "de",
+      endpoint: null,
+      onDeviceAvailable: false,
+      ports,
+    });
+    await expect(attempt).rejects.toBeInstanceOf(NoEvaluationBackendError);
+    expect(ports.generateOnDevice).not.toHaveBeenCalled();
+  });
+
+  it("still reports a configured backend that failed", async () => {
+    // The distinction only earns its keep if a real failure keeps saying so.
+    const attempt = evaluateMobileAnswer({
+      card,
+      learnerAnswer: "F = m · a",
+      locale: "de",
+      endpoint: cloudEndpoint(),
+      onDeviceAvailable: false,
+      ports: {
+        checkOnDeviceStatus: vi.fn(),
+        generateOnDevice: vi.fn(),
+        fetchText: async (): Promise<never> => {
+          throw new Error("HTTP 401");
+        },
+      },
+    });
+    await expect(attempt).rejects.not.toBeInstanceOf(NoEvaluationBackendError);
+    await expect(attempt).rejects.toThrow(/401/);
   });
 });


### PR DESCRIPTION
Four independent fixes, all found by using 0.29.1 rather than by reading it.

## Cloud voice mode had no speech model

Connecting an OpenRouter key wrote a chat row and an embedding row. Speech-to-text had neither, so `resolveMobileCloudChain(db, "stt")` fell through to the chat endpoint and the device POSTed audio to a model that cannot transcribe it. `openai/gpt-transcribe` is now registered as its own row carrying only the `stt` flag, on the desktop connect path and the device one alike, and `migrateStaleCloudDefaults` adds it for anyone who connected before this — no reconnect needed.

The second recommended model moves from Gemini 2.5 Flash Lite to Gemma 4 31B: same input price ballpark as Luna, cheaper output, and multimodal enough for photo import.

*(Authored by Grok; committed here unchanged.)*

## The iPad tab bar was not evenly divided

"Lernen" sat flush against the left edge while the other three tabs split what was left — and a tap aimed at the first tab selected the second. The Learn button is wrapped in a span so its badge has a positioning context, and that wrapper, not the button, is what the flex row lays out. It had no `flex: 1`, so it sized to its content.

Found by tapping at 21 % of the screen width and landing on Inhalte.

## Self-rating was reported as a failure

Without an AI key, every revealed card showed a red line:

> Automatische Beurteilung nicht möglich (no evaluation backend available). Bitte selbst bewerten.

That is the normal state of a fresh install. Nothing failed, no key has been pasted yet, and rating yourself is how ZAM works without AI — the 0.29.0 notes say so in as many words. A learner without a key saw a red error, half of it an untranslated internal string, on every single card they ever opened.

`NoEvaluationBackendError` now separates "nothing is configured" from "something broke". The first asks for a self-rating in the ordinary way; the second keeps the red text and the reason, because that one is worth reading.

## Foundry Local was offered to machines that cannot run it

Foundry Local is Microsoft's, it installs through winget, and `installFoundryLocal` already throws on every other platform. The settings panel drew its section unconditionally anyway, so a Mac got a heading, an explanation, "not available on this computer" and a **Set up text model** button in the same breath — an installer for software that cannot be installed.

That panel exists to answer one question: which model is ZAM using. Three lines of Windows-only product noise sat directly in front of it.

The section now ships hidden and is revealed only when the status call reports Windows on ARM — today, a Snapdragon X. The bridge carries `os` and `snapdragonX` for the gate; both already existed on the system profile. A failed status call leaves the section hidden rather than guessing at the machine.

## A committed symlink that breaks fresh checkouts

`mobile/node_modules` went into the repository during the 0.29.0 release prep as a symlink to an absolute path on one machine — pointing, from that very path, at itself. Anyone who checks the repo out at `~/src/zam` gets a self-referential link where the mobile dependencies belong, and every `tsc` there fails with *too many levels of symbolic links*. CI never noticed because `npm ci` deletes `node_modules` before installing.

It slipped past both ignore files because they spell the rule `node_modules/`, and a trailing slash matches directories only, never a symlink. Dropping the slash covers both.

## The cloud embedding model moves to the 8B

Not for the price, though it is half: `qwen/qwen3-embedding-8b` is $0.010/M against the 4B's $0.020/M, and at roughly a tenth of a cent per thousand cards that difference is noise.

The reason is provider coverage. ZAM has been broken once already by a single-provider embedding model — OpenRouter dropped `qwen3-embedding-0.6b` on 2026-08-08 and every `/embeddings` call in the field test answered 404. The 4B that replaced it has exactly one provider listed (DeepInfra), so 0.29.1 renewed the same bet with a different name. The 8B has three: Nebius, DeepInfra and SiliconFlow, all at ~100 % uptime.

Semantic search is the one capability with no fallback. An evaluation can be self-rated and a photo can be typed in, but a library embedded against a model that disappears has to be embedded again.

Superseded sizes are deliberately **not** kept in the alias set: 0.6B is 1024 dimensions, 4B is 2560, 8B is 4096, so those vectors are not comparable and should read as stale rather than be folded onto the current id. The kernel already stores `dims` and treats a change as a reason to re-embed. Their wire names do stay in the connect-time drop lists, so a leftover row cannot sit in the fallback chain answering with the wrong width. Nothing is migrated — there are no users outside the field test.

`docs/okf/local-ai-runtimes.md` is updated through `zam_okf_upsert` for the Foundry visibility gate, and ADR 2026-08-08 §5 carries an amendment note recording both model moves.

## Verification

- `npm run test` — 1987 passed, 5 skipped
- `npm run lint`, root `tsc --noEmit`, `mobile/` `tsc --noEmit`, `desktop/` `tsc --noEmit` — all clean
- New regression tests: the tab bar's flex contract, `NoEvaluationBackendError` versus a real backend failure, the Foundry Local visibility gate, the 8B alias folding, and a 4B row being retired on connect
- Model facts checked against the live catalogues rather than assumed — OpenRouter's `/api/v1/embeddings/models` and per-model `endpoints` for price and providers, the Hugging Face configs for the dimensions, `ollama.com/library/qwen3-embedding` for the local tags
- Built for the iPad (A16) simulator and driven through a full session: three cards answered, revealed and rated, FSRS intervals saved, progress bars drawn, all four tabs reached by tapping their labels. Reinstalled clean afterwards to confirm the first run ends with a grey "compare and rate" line instead of the red error
