### PR TITLE
release: prepare 0.29.2

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.29.1",
+  "version": "0.29.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.29.1"
+version = "0.29.2"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.29.2.md
+++ b/docs/release-notes-0.29.2.md
@@ -1,0 +1,60 @@
+# ZAM 0.29.2 — Speech that transcribes, search that stays, and a quieter first card
+
+Four fixes found by using 0.29.1 rather than by reading it: on an iPad in the
+simulator, and in the desktop settings panel.
+
+## Voice mode has a speech model again
+
+Connecting an OpenRouter key registered a chat model and an embedding model.
+Speech-to-text got neither, so the device sent your recording to a chat model
+that cannot transcribe audio. Cloud voice mode now has its own entry
+(`openai/gpt-transcribe`), and a device connected before this release picks it
+up on its own — there is nothing to reconnect.
+
+## Semantic search no longer hangs on one supplier
+
+The embedding model behind cloud semantic search moves to
+**`qwen/qwen3-embedding-8b`**. The reason is not the price, though it is half:
+it is that the previous model was offered by a single supplier, and that is
+exactly what broke search two releases ago when the model before it was
+withdrawn overnight. The new one is served by three.
+
+Search is the one feature with nothing to fall back on. You can grade yourself
+when the AI is away and you can type a card instead of photographing it, but a
+library measured against a model that disappears has to be measured again from
+scratch.
+
+Because of that, this release re-reads your cards once in the background the
+first time semantic search runs. Nothing is lost and nothing is asked of you;
+searching by wording works throughout.
+
+## The first card no longer looks like something went wrong
+
+Without an AI key, every card you revealed showed a red failure line — half of
+it in English, on an app that had done nothing wrong. Not having a key is the
+normal state of a fresh install: you grade yourself, and that is how ZAM works
+without AI. The line is now the ordinary grey prompt to compare your answer and
+rate it honestly. A key that is set up and then actually fails still says so, in
+red, with the reason.
+
+## Tab bar
+
+On iPad the four tabs were not evenly spaced — Learn sat hard against the left
+edge, and a tap aimed at it could select Library instead. They now divide the
+bar in four.
+
+## Desktop settings only offer what your computer can run
+
+The AI models panel showed a Foundry Local section on every machine, including
+Macs — a heading, an explanation, "not available on this computer", and a Set-up
+button, all at once, for Windows software that cannot be installed there. That
+section now appears only on the Windows-on-ARM machines it is for.
+
+## Notes
+
+- Local EmbeddingGemma on the desktop is unchanged; this release only moves the
+  cloud model.
+- The second recommended chat model is now Gemma 4 31B, which is multimodal and
+  cheaper on output than the Gemini Flash Lite tier it replaces.
+- A `node_modules` symlink had been committed by mistake and broke fresh clones
+  of the repository. It is gone. This affects contributors, not learners.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-mobile",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-mobile",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-barcode-scanner": "^2.4.5"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zam-mobile",
   "private": true,
-  "version": "0.29.1",
+  "version": "0.29.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -70,8 +70,8 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         # Stamped from package.json by the release workflow; kept in step here
         # so a local build is not mislabelled either.
-        CFBundleShortVersionString: 0.29.1
-        CFBundleVersion: "0.29.1"
+        CFBundleShortVersionString: 0.29.2
+        CFBundleVersion: "0.29.2"
         # Two uses since the app became standalone (ADR 2026-08-08): scanning
         # a QR code to take over an existing library, and photographing a page
         # to turn it into cards. Neither is the first-run path any more, but

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.29.1",
+          "User-Agent": "ZAM-Content-Studio/0.29.2",
         },
       });
 


### PR DESCRIPTION
Version bump only, plus the release notes.

Bumps root, `desktop/`, `mobile/`, the `zam-app` crate (and its `Cargo.lock`), the iOS `CFBundleShortVersionString`/`CFBundleVersion` placeholders, and the hardcoded content-studio User-Agent — the full set from the release checklist, so no field is left behind at 0.29.1.

Contents of the release are the four fixes merged in #286: a dedicated cloud speech-to-text model, the embedding model moving to `qwen/qwen3-embedding-8b` for provider coverage, the iPad tab bar dividing evenly, self-rating no longer presented as a failure, and the Foundry Local settings section appearing only on Windows on ARM.

`npm run test` — 1987 passed, 5 skipped. `npm run lint` clean. `cargo metadata --locked` verifies the refreshed lock.