### PR TITLE
fix: stop a transient label from killing the dashboard load

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -690,8 +690,11 @@ function initializeTranslations() {
     t("stats_period_month");
   document.getElementById("lbl-stats-activity-title")!.textContent =
     t("stats_activity_title");
-  document.getElementById("stats-loading-label")!.textContent =
-    t("stats_loading");
+  // Transient: `loadStatsView()` replaces the whole #stats-activity container,
+  // so this placeholder is gone as soon as the stats view has been opened
+  // once. Asserting it here took the entire dashboard load down with it.
+  const statsLoading = document.getElementById("stats-loading-label");
+  if (statsLoading) statsLoading.textContent = t("stats_loading");
   document.getElementById("lbl-dashboard-kicker")!.textContent =
     t("dashboard_kicker");
   document.getElementById("lbl-dashboard-title")!.textContent =
@@ -734,7 +737,12 @@ function initializeTranslations() {
   document.getElementById("btn-reveal-answer")!.textContent = t("btn_reveal_answer");
   document.getElementById("lbl-observer-title")!.textContent = t("observer_title");
   document.getElementById("observer-status")!.textContent = t("observer_idle");
-  document.getElementById("observer-window-initial")!.textContent = t("observer_select_initial");
+  // Transient in the same way: refreshing the observer window list empties
+  // #observer-window-select, so this placeholder option is gone after the
+  // first refresh on Windows.
+  const observerInitial = document.getElementById("observer-window-initial");
+  if (observerInitial)
+    observerInitial.textContent = t("observer_select_initial");
   document.getElementById("btn-observer-refresh")!.textContent = t("observer_refresh");
   document.getElementById("btn-observer-analyze")!.textContent = t("observer_analyze");
   document.getElementById("btn-observer-cancel")!.textContent = t("observer_cancel");
@@ -4076,6 +4084,9 @@ async function loadStatsView(): Promise<void> {
   container.innerHTML = "";
   const loading = document.createElement("p");
   loading.className = "stats-loading";
+  // Same id the markup ships with, so a language switch while the placeholder
+  // is on screen still translates it.
+  loading.id = "stats-loading-label";
   loading.textContent = t("stats_loading");
   container.appendChild(loading);
   summary.classList.add("hidden");

--- a/tests/desktop/transient-element-lookups.test.ts
+++ b/tests/desktop/transient-element-lookups.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the dashboard crash reported on 0.30.0:
+ *
+ *   null is not an object (evaluating
+ *   'document.getElementById("stats-loading-label").textContent = t("stats_loading")')
+ *
+ * `#stats-loading-label` ships in `index.html` inside `#stats-activity`, and
+ * `loadStatsView()` replaces that container's entire contents. Once the learner
+ * had opened the stats view, the element was gone — and the translation pass
+ * still asserted it with `!`. The exception escaped into `loadDashboard()`'s
+ * catch, so the overview showed "Deine Daten konnten nicht geladen werden".
+ *
+ * Same family as the 0.27.0 crash guarded by settings-label-nesting.test.ts:
+ * markup that some code destroys, looked up by other code as if it were
+ * permanent. The rule here: **an element inside a container the module clears
+ * wholesale may only be looked up optionally.**
+ */
+const mainTs = readFileSync(
+  join(process.cwd(), "desktop", "src", "main.ts"),
+  "utf8",
+);
+const indexHtml = readFileSync(
+  join(process.cwd(), "desktop", "index.html"),
+  "utf8",
+);
+
+/** Element ids whose contents `main.ts` replaces wholesale. */
+function clearedContainerIds(source: string): string[] {
+  // Per function body, because names like `container`, `select` and `summary`
+  // are re-bound in dozens of functions: matching a clear in one function
+  // against a binding in another reports elements that are never touched.
+  const cleared = new Set<string>();
+  for (const body of source.split(/\n(?=(?:async )?function\s)/)) {
+    const bindings = new Map<string, string>();
+    for (const match of body.matchAll(
+      /(?:const|let)\s+(\w+)\s*=\s*document\.getElementById\(\s*"([^"]+)"\s*\)/g,
+    )) {
+      bindings.set(match[1], match[2]);
+    }
+    for (const match of body.matchAll(
+      /(\w+)\s*\.\s*(?:innerHTML\s*=\s*""|replaceChildren\(\s*\))/g,
+    )) {
+      const id = bindings.get(match[1]);
+      if (id) cleared.add(id);
+    }
+  }
+  return [...cleared];
+}
+
+/** Ids of elements nested inside `containerId` in the shipped markup. */
+function nestedIds(html: string, containerId: string): string[] {
+  const start = html.indexOf(`id="${containerId}"`);
+  if (start === -1) return [];
+  const openEnd = html.indexOf(">", start);
+  if (openEnd === -1) return [];
+
+  const tagMatch = html.slice(0, start).match(/<(\w+)[^<>]*$/);
+  const tag = tagMatch?.[1];
+  if (!tag) return [];
+
+  // Walk same-named tags so a nested <div> cannot end the scan early.
+  const rest = html.slice(openEnd);
+  const scanner = new RegExp(`<${tag}\\b|</${tag}\\s*>`, "gi");
+  let depth = 1;
+  let end = rest.length;
+  for (const token of rest.matchAll(scanner)) {
+    depth += token[0].startsWith("</") ? -1 : 1;
+    if (depth === 0) {
+      end = token.index ?? rest.length;
+      break;
+    }
+  }
+
+  return [...rest.slice(0, end).matchAll(/id="([^"]+)"/g)].map(
+    (match) => match[1],
+  );
+}
+
+describe("elements inside cleared containers are looked up optionally", () => {
+  it("never asserts a transient element with a non-null assertion", () => {
+    const offenders: string[] = [];
+    for (const containerId of clearedContainerIds(mainTs)) {
+      for (const id of nestedIds(indexHtml, containerId)) {
+        const asserted = new RegExp(
+          `getElementById\\(\\s*"${id}"\\s*\\)\\s*!`,
+        ).test(mainTs);
+        if (asserted) offenders.push(`#${id} (inside #${containerId})`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("recognises the container the crash came from", () => {
+    // A guard that silently matched nothing would pass forever.
+    expect(clearedContainerIds(mainTs)).toContain("stats-activity");
+    expect(nestedIds(indexHtml, "stats-activity")).toContain(
+      "stats-loading-label",
+    );
+  });
+});


### PR DESCRIPTION
Field report on 0.30.0 — the overview page shows:

> ⚠ Deine Daten konnten nicht geladen werden: null is not an object (evaluating
> `document.getElementById("stats-loading-label").textContent = t("stats_loading")`)

## Cause

`#stats-loading-label` ships in `index.html` **inside** `#stats-activity`, and
`loadStatsView()` does `container.innerHTML = ""`. So after the learner has
opened the stats view once, the element no longer exists — while the
translation pass still asserted it with `!`. That exception escapes into
`loadDashboard()`'s catch, which is why one missing placeholder reports the
whole dashboard as unloadable.

Nothing in 0.30.0 introduced it; the element and the lookup have coexisted
since #275. It fires the first time a learner opens stats and the dashboard
re-translates.

## Fix

- the lookup is optional;
- `loadStatsView()` gives the recreated placeholder the same id, so a language
  switch while it is on screen still translates it.

## Guard

`tests/desktop/transient-element-lookups.test.ts` derives the rule rather than
pinning this one case: **for every container `main.ts` clears wholesale, no
element nested inside it in `index.html` may be looked up with a non-null
assertion.** Binding analysis is per function body, so the generic names this
file reuses (`container`, `select`, `summary`) cannot cross-match.

It immediately found a **second live instance of the same defect**:
`#observer-window-initial` is an `<option>` inside `#observer-window-select`,
which `refreshObserverWindows()` empties — so on Windows the dashboard breaks
the same way after the first observer refresh. Fixed here as well.

Same family as the 0.27.0 startup crash guarded by
`settings-label-nesting.test.ts`: markup that some code destroys, looked up by
other code as if it were permanent.

`npm run test` (2,075 passed) · desktop `tsc` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)