### PR TITLE
feat: package zam as an agent plugin

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -68,6 +68,16 @@ GitHub Copilot installiert er zusätzlich die Studio-, Recall-, Graph- und
 Settings-Canvases; starte Copilot danach neu. Dann einfach **`/zam`** tippen — oder
 „lass uns das zusammen mit ZAM machen" sagen — und normal arbeiten.
 
+#### Portables Agent Plugin
+
+Das Repository und das veröffentlichte npm-Paket folgen zusätzlich dem
+herstellerneutralen Format
+[Agent Plugins v1.0.0](https://agent-plugins.org/). Kompatible Clients können das
+Paketverzeichnis laden und finden darin ZAM-Skill und stdio-MCP-Server gemeinsam. Ein
+Quellcode-Checkout braucht vorher `npm ci && npm run build`; veröffentlichte Pakete
+enthalten die Laufzeit bereits. Aufbau und Prüfung stehen unter
+[ZAM Agent Plugin](docs/AGENT_PLUGIN.md).
+
 ### 2. ZAM Desktop Studio — *Einrichtung, Inhalte & Graph*
 
 Eine native App (`zam ui`) für das, worin ein Chatfenster schlecht ist:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ GitHub Copilot, it also installs user-scoped Studio, Recall, Graph, and Settings
 restart Copilot or start a new session after connecting. Then just type **`/zam`** — or
 say "let's do this together with ZAM" — and work normally.
 
+#### Portable Agent Plugin
+
+The repository and published npm package also follow the vendor-neutral
+[Agent Plugins v1.0.0](https://agent-plugins.org/) format. Compatible clients can load
+the package root to discover the ZAM skill and stdio MCP server together. A source
+checkout needs `npm ci && npm run build` first; published packages already contain the
+runtime. See [ZAM Agent Plugin](docs/AGENT_PLUGIN.md) for the layout and validation.
+
 ### 2. ZAM Desktop Studio — *setup, content & graph*
 
 A native app (`zam ui`) for the things a chat window isn't good at:

--- a/docs/AGENT_PLUGIN.md
+++ b/docs/AGENT_PLUGIN.md
@@ -1,0 +1,66 @@
+# ZAM Agent Plugin
+
+The ZAM repository root and the published `zam-core` npm package are portable
+[Agent Plugins](https://agent-plugins.org/) v1.0.0 packages. A compatible
+client can discover the ZAM skill and its stdio MCP server from one directory.
+
+## Package layout
+
+```text
+zam/
+├── plugin.json
+├── mcp.json
+├── skills/
+│   └── zam/
+│       └── SKILL.md
+└── dist/
+    └── cli/
+        └── index.js
+```
+
+- `plugin.json` declares the portable package identity and Agent Plugins
+  schema version.
+- `skills/zam/SKILL.md` is the host-neutral Agent Skill. Existing
+  `.claude/`, `.agent/`, and `.agents/` skill copies remain available for
+  clients that use their earlier host-specific discovery paths.
+- `mcp.json` starts `node ${PLUGIN_ROOT}/dist/cli/index.js mcp`. The client
+  supplies `PLUGIN_ROOT` and `PLUGIN_DATA` as required by the standard.
+
+ZAM continues to store learner data under its normal configured database
+location (local installs default to `~/.zam`). That lets the plugin, CLI, and
+Desktop Studio share one learning profile instead of creating an isolated
+profile per client.
+
+## Load the plugin
+
+Agent Plugins deliberately leaves installation to each client. Give a
+compatible client's plugin installer the directory containing `plugin.json`.
+
+A published npm package already contains the built `dist/` runtime. For a
+source checkout, prepare the same package before loading it:
+
+```bash
+npm ci
+npm run build
+```
+
+The runtime requires Node.js 22 or newer. The client must support Agent Skills
+and stdio MCP to load both portable components; clients may support only one
+component type and still load that part. `zam agent connect <harness>` remains
+the fallback for clients that do not install Agent Plugins directly.
+
+## Validate the package
+
+```bash
+npm run test -- tests/cli/agent-plugin.test.ts
+npm pack --dry-run --ignore-scripts
+```
+
+The focused test checks the closed manifest shapes, Agent Skills frontmatter,
+npm package contents, path containment, and an actual MCP handshake through
+the command declared in `mcp.json`.
+
+The normative references are the
+[Agent Plugins specification](https://agent-plugins.org/specification), its
+[canonical schemas](https://agent-plugins.org/schemas), and the
+[Agent Skills specification](https://agentskills.io/specification).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,8 +64,8 @@ ZAM is structured into four distinct execution layers:
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 2.1 The AI Skill Layer (`.agents/skills/zam/SKILL.md`)
-The entry point for AI assistants. It exposes the ZAM playbook: how to discover knowledge cards, check for due reviews, evaluate the user's answers, and silently register work evidence. The skill layer translates native agent capabilities (like shell execution and screenshot vision) into ZAM bridge calls.
+### 2.1 The AI Skill Layer (`skills/zam/SKILL.md`)
+The portable Agent Plugin entry point for AI assistants. It exposes the ZAM playbook: how to discover knowledge cards, check for due reviews, evaluate the user's answers, and silently register work evidence. The skill layer translates native agent capabilities (like shell execution and screenshot vision) into ZAM MCP calls, with the bridge as fallback. Host-specific compatibility copies remain under `.claude/skills/zam/`, `.agent/skills/zam/`, and `.agents/skills/zam/`.
 
 ### 2.2 The CLI Layer (`src/cli/`)
 The interface for both humans and daemons. Human commands (`zam review`, `zam stats`, `zam token`) output colorized, localized terminal formatting. Machine commands (`zam bridge ...`) take arguments and output raw JSON, ensuring a structured contract with no terminal pollution.

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -81,6 +81,11 @@ After running the setup skill, `zam-core` distributes its own skill file:
 .agents/skills/zam/SKILL.md    ← from node_modules/zam-core/.agents/skills/zam/
 ```
 
+Agent Plugins v1 clients can instead load the installed `zam-core` package
+root. They discover the portable `skills/zam/SKILL.md` and the `zam` stdio
+server in `mcp.json` together; the host-specific copies above remain the
+fallback for clients using the setup/link flow.
+
 Claude-, Copilot-, and Gemini-compatible clients invoke their skills with
 `/setup` and `/zam`. Codex invokes repository skills with `$setup` and `$zam`,
 or selects them through `/skills`.
@@ -237,7 +242,7 @@ Skill files always travel with the package that defines them:
 
 | Package / repo | Owns skill group | Distributes via |
 |----------------|-----------------|-----------------|
-| `zam-core` | `.claude/skills/zam/` for Claude/Copilot, `.agent/skills/zam/`, `.agents/skills/zam/` for Codex | `zam setup` (copies from `node_modules/zam-core/`) |
+| `zam-core` | Portable `skills/zam/` plus host-specific `.claude/`, `.agent/`, and `.agents/` compatibility copies | Agent Plugin package root, or `zam setup` links from `node_modules/zam-core/` |
 | Personal/community template | `.claude/skills/setup/`, `.gemini/skills/setup/`, `.agents/skills/setup/` | Static in template (always present before setup runs) |
 | Future: `zam-devops` | Per-client `skills/devops/` | `devops setup` (copies from `node_modules/zam-devops/`) |
 

--- a/docs/adr/2026-08-09b-agent-plugin-package.md
+++ b/docs/adr/2026-08-09b-agent-plugin-package.md
@@ -1,0 +1,63 @@
+# Portable Agent Plugin Package
+
+**Status:** Implemented
+**Deciders:** Thomas (project owner)
+**Related:**
+[2026-07-06a-mcp-agent-transport-and-surfaces.md](2026-07-06a-mcp-agent-transport-and-surfaces.md) ·
+[2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md](2026-06-25c-flexible-zam-workspaces-and-skill-wiring.md)
+
+---
+
+## Context
+
+ZAM already ships the two components standardized by Agent Plugins: an Agent
+Skill and a stdio MCP server. They were distributed through host-specific
+skill directories and `zam agent connect`, so each supported client needed a
+separate registration path even though the underlying components were the
+same.
+
+Agent Plugins v1.0.0 defines a portable root manifest, a fixed `skills/`
+directory, and a root `mcp.json`. Installation and trust remain client-owned.
+The Agent Skills frontmatter contract is narrower than ZAM's existing
+host-specific copies: fields such as `user-invocable` are not portable.
+
+## Decision
+
+1. The repository root and the published `zam-core` npm package are the ZAM
+   Agent Plugin root. They carry `plugin.json`, `mcp.json`, and
+   `skills/zam/SKILL.md` using the Agent Plugins v1.0.0 schemas.
+2. The portable MCP entry launches the bundled CLI with Node:
+   `node ${PLUGIN_ROOT}/dist/cli/index.js mcp`, with the plugin root as its
+   working directory. Node 22 remains the package runtime requirement.
+3. The portable skill uses only Agent Skills standard frontmatter. Existing
+   `.claude/`, `.agent/`, and `.agents/` copies remain additive compatibility
+   surfaces and keep any host-specific metadata or invocation guidance.
+4. The npm `files` allowlist includes every portable manifest and component,
+   so the registry artifact is a complete plugin rather than only the source
+   checkout.
+5. Tests pin the closed manifest shapes, synchronize plugin and npm versions,
+   enforce package-contained runtime paths, and complete an MCP handshake from
+   the declared configuration.
+6. The plugin does not redirect learner state into `PLUGIN_DATA`. It keeps
+   ZAM's configured database location so the Agent Plugin, CLI, and Desktop
+   Studio operate on the same learning profile.
+
+## Consequences
+
+**Easier**
+
+- A compatible client can install one directory and discover both ZAM's
+  pedagogy and tool transport.
+- The same package works across clients without translating the portable
+  skill or MCP configuration.
+- Existing users and clients without Agent Plugins support keep the established
+  `zam agent connect` path.
+
+**Harder**
+
+- Release version bumps must update `plugin.json`; the focused test fails when
+  it drifts from `package.json`.
+- A source checkout must be built before its MCP component can start. Published
+  npm artifacts already contain `dist/`.
+- The portable skill is another distribution surface and must be kept aligned
+  with meaningful workflow changes in the host-specific skills.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,3 +71,4 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-08-08](2026-08-08-ios-standalone-app.md) | ZAM on iPadOS Is a Standalone App, Not a Companion | Accepted — first run, library and AI connect verified on simulator; server-database upgrade awaits a live Turso test |
 | [2026-08-08b](2026-08-08b-ios-information-architecture.md) | iOS Information Architecture and Design System | Accepted |
 | [2026-08-09](2026-08-09-free-offline-learning-and-anki-interoperability.md) | Free Offline Learning and Anki Interoperability | Accepted |
+| [2026-08-09b](2026-08-09b-agent-plugin-package.md) | Portable Agent Plugin Package | Implemented |

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -18,7 +18,7 @@ Current truth only — the *why* behind it lives in [../adr/](../adr/)
 
 - [Kernel and CLI Architecture](kernel-architecture.md) — ZAM is split into an AI-agnostic learning kernel and a thin CLI orchestration layer; all learning logic lives in the kernel, all LLM/HTTP code in the CLI.
 - [Local AI Runtimes](local-ai-runtimes.md) — Local text and image generation is offered only on accelerated hardware - Foundry Local for text, Ollama for images - because CPU generation is too slow to review with; embeddings are the exception and run on any machine.
-- [MCP Transport and Surfaces](mcp-surfaces.md) — zam mcp is the preferred agent transport - a stdio MCP server exposing focused ZAM tools and host-rendered MCP Apps panels.
+- [MCP Transport and Surfaces](mcp-surfaces.md) — zam mcp is the preferred agent transport, and the Agent Plugins package ships it with ZAM's portable skill for compatible clients.
 - [Standalone Mobile Libraries](mobile-standalone-libraries.md) — ZAM Mobile starts from a device-local library on Android and iOS; pairing and a server database are optional multi-device upgrades.
 - [Hands-Free Voice Mode](voice-mode.md) — Voice review runs one shared kernel loop over a device tier of native OS speech and a cloud tier from the capability registry, resolved per capability and per language from a machine-local user preference; companions read the same cloud models from the synced learner database.
 

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-09
 
+- **Update** — [MCP Transport and Surfaces](mcp-surfaces.md)
 - **Creation** — [Curated Open-Content Library](open-content-library.md)
 - **Update** — [Local Card File Import](local-card-file-import.md)
 - **Creation** — [Standalone Mobile Libraries](mobile-standalone-libraries.md)

--- a/docs/okf/mcp-surfaces.md
+++ b/docs/okf/mcp-surfaces.md
@@ -1,13 +1,14 @@
 ---
 type: architecture
 title: MCP Transport and Surfaces
-description: zam mcp is the preferred agent transport - a stdio MCP server exposing focused ZAM tools and host-rendered MCP Apps panels.
+description: zam mcp is the preferred agent transport, and the Agent Plugins package ships it with ZAM's portable skill for compatible clients.
 tags:
   - mcp
   - agents
   - surfaces
+  - plugins
 resource: "https://github.com/zam-os/zam/blob/main/docs/okf/mcp-surfaces.md"
-timestamp: 2026-08-02T08:40:00Z
+timestamp: 2026-08-09T20:06:47.321Z
 ---
 
 `zam mcp` starts ZAM's stdio **Model Context Protocol** server. It is the
@@ -29,6 +30,26 @@ harness:
 
 With no target, the command detects installed harnesses. The MCP command itself
 is loaded lazily so the CLI bootstrap stays light.
+
+# Portable Agent Plugin package
+
+The repository root and the published `zam-core` npm artifact implement Agent
+Plugins v1.0.0. Compatible clients discover both portable components from fixed
+locations:
+
+- `plugin.json` declares the package identity and specification version;
+- `skills/zam/SKILL.md` carries host-neutral ZAM workflow instructions using
+  Agent Skills standard frontmatter;
+- `mcp.json` declares the `zam` stdio server and starts
+  `node ${PLUGIN_ROOT}/dist/cli/index.js mcp` from `${PLUGIN_ROOT}`.
+
+A source checkout needs a completed build before the MCP entrypoint exists.
+Published npm artifacts include `dist/cli/index.js` and every portable
+manifest/component through the package `files` allowlist. ZAM continues to use
+its configured learner database location, so the plugin, CLI, and Desktop
+Studio share the same profile. The existing `.claude/`, `.agent/`, and
+`.agents/` skills plus `zam agent connect` remain compatibility paths for
+clients that do not install the portable package directly.
 
 # Intent routing
 
@@ -328,4 +349,5 @@ The same operation is available through `zam bridge okf-import`.
 - [ADR 2026-07-29b — OKF Freshness Radar](../adr/2026-07-29b-okf-freshness-radar.md)
 - [ADR 2026-07-30 — OKF Reader Navigation and Mermaid Rendering](../adr/2026-07-30-okf-reader-navigation-and-mermaid.md)
 - [ADR 2026-08-01 — Learning Progress Statistics](../adr/2026-08-01-learning-progress-stats.md)
-- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/ui-intent.ts`, `src/kernel/system/install-config.ts`, `src/kernel/analytics/progress.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/extension.ts`, `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/context-bar.ts`, `desktop/src/panel/display-mode.ts`, `desktop/src/panel/recall.ts`, `desktop/src/panel/graph.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-mermaid.ts`, `desktop/src/panel/okf-panel.html`, `vite.config.panel.mts`
+- [ADR 2026-08-09b — Portable Agent Plugin Package](../adr/2026-08-09b-agent-plugin-package.md)
+- Code: `src/cli/commands/mcp.ts`, `src/cli/commands/agent.ts`, `src/cli/okf/io.ts`, `src/cli/okf/freshness.ts`, `src/cli/okf-focus.ts`, `src/cli/ui-intent.ts`, `src/kernel/system/install-config.ts`, `src/kernel/analytics/progress.ts`, `src/cli/bridge-handlers.ts` (`importOkfTokens`), `src/vscode-extension/extension.ts`, `src/vscode-extension/host.ts`, `src/vscode-extension/protocol.ts`, `src/vscode-extension/latest-task-queue.ts`, `src/copilot-extension/extension.mjs`, `desktop/src/panel/context-bar.ts`, `desktop/src/panel/display-mode.ts`, `desktop/src/panel/recall.ts`, `desktop/src/panel/graph.ts`, `desktop/src/panel/okf.ts`, `desktop/src/panel/okf-render.ts`, `desktop/src/panel/okf-mermaid.ts`, `desktop/src/panel/okf-panel.html`, `vite.config.panel.mts`, `plugin.json`, `mcp.json`, `skills/zam/SKILL.md`, `package.json`, `tests/cli/agent-plugin.test.ts`, `docs/AGENT_PLUGIN.md`

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "zam": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${PLUGIN_ROOT}/dist/cli/index.js", "mcp"],
+      "cwd": "${PLUGIN_ROOT}"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,10 +16,14 @@
   },
   "files": [
     "dist/",
+    "plugin.json",
+    "mcp.json",
+    "skills/zam/",
     ".claude/skills/zam/",
     ".agent/skills/zam/",
     ".agents/skills/zam/",
     "templates/personal/",
+    "docs/AGENT_PLUGIN.md",
     "README.md",
     "LICENSE"
   ],

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "zam",
+  "version": "0.30.0",
+  "description": "Turn real work with AI agents into active-recall practice and FSRS spaced repetition.",
+  "author": {
+    "name": "ZAM Contributors",
+    "url": "https://zam-os.org"
+  },
+  "homepage": "https://zam-os.org",
+  "repository": "https://github.com/zam-os/zam",
+  "license": "Apache-2.0",
+  "keywords": [
+    "learning",
+    "spaced-repetition",
+    "active-recall",
+    "agent-skill",
+    "mcp"
+  ]
+}

--- a/skills/zam/SKILL.md
+++ b/skills/zam/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: zam
+description: Use ZAM during real tasks or knowledge reviews to build lasting skills with active recall and FSRS spaced repetition. Use when the user asks for ZAM, starts a due-card review, decomposes a task into knowledge tokens, requests monitored practice, or invokes this skill without parameters.
+license: Apache-2.0
+compatibility: Requires Node.js 22 or newer; MCP features require an Agent Plugins client with stdio MCP support.
+---
+
+# ZAM — Symbiotic Learning Agent
+
+When this skill is loaded from ZAM's Agent Plugin, use the bundled `zam` MCP server. The client decides how the skill is exposed; do not assume a particular slash-command syntax.
+
+You are a kind, patient skills trainer. Your mission: build lasting autonomy through conceptual knowledge, not rote procedure. You think like a university professor designing a curriculum — but you teach during real work, not in a classroom. Celebrate every honest attempt. A rating of 1 is not failure; it is the discovery of the next thing to learn.
+
+**Baseline assumption:** The user has finished secondary school. They understand basic concepts of their domain. Treat them as an intelligent adult who simply hasn't been exposed to these specific tools or ideas yet.
+
+---
+
+## Agent Transport (MCP)
+
+Always prefer the `zam` MCP tools when available. A plugin-capable client loads the bundled server from the root `mcp.json`. Outside that package flow, tell the user once to run:
+```bash
+zam agent connect
+```
+This detects installed user-scoped harnesses, registers the `zam` MCP server, installs companion surfaces where needed, and refreshes the global skill. Explicit targets remain available for troubleshooting.
+
+### Available MCP Tools
+
+| Tool Name | Purpose |
+|---|---|
+| `zam_status` | Retrieve database connection target, active user, stats, and due review queue size. |
+| `zam_get_reviews` | Retrieve a batch of due cards, optionally filtering by domain or context and resolving code context. |
+| `zam_session_start` | Start an active learning session with a task description. |
+| `zam_session_end` | Complete an active session and retrieve the final summary. |
+| `zam_find_tokens` | Search existing knowledge tokens using semantic and lexical queries. |
+| `zam_add_token` | Register a new knowledge token with a slug, concept definition, Bloom level, and prompt question. |
+| `zam_link_prereq` | Add a prerequisite link between a parent token and a child token. |
+| `zam_submit_review` | Submit a card self-rating, advance its FSRS state, and log it to the session steps. |
+| `zam_review_action` | Apply review actions (rate, skip, edit/deprecate/delete tokens or cards) with optional confirmation. |
+| `zam_suggest_foundations` | Suggest existing prerequisite tokens for a newly failed or registered token. |
+| `zam_monitor` | Read or analyze shell-monitor evidence for a session. |
+| `zam_open_recall` | Open the spoiler-free Recall app; answering, reveal, and rating stay inside the card. |
+| `zam_show_graph` | Open the learning-token graph, usually with a token slug from the conversation. |
+| `zam_okf_visualize` | Open repo knowledge articles (OKFs and cited ADRs) in reader, graph, or log view. |
+| `zam_open_settings` | Open the focused Settings app when the user asks for configuration or database status. |
+
+---
+
+## Parameterless invocation — offer choices first
+
+When the user invokes the ZAM skill without a task or mode, do not choose a workflow on their behalf:
+
+1. Call `zam_status` to obtain the active user, due count, and current statistics.
+2. If this same agent conversation already contains an active, unended ZAM session ID, offer **Continue the current ZAM flow** first. Do not infer continuation from old database rows and do not add cross-restart persistence.
+3. If reviews are due, inspect a small spoiler-free batch with `zam_get_reviews` (`noResolve: true`, `noDynamicQuestion: true`). Use its domains plus the current conversation to suggest up to three honest topic choices, such as **RAG** or **Axon Ivy** only when the returned data or context supports them.
+4. Present the applicable choices below and wait for the user to select one:
+   - **Recall now** — put this first when there is no known active flow; show the due count and targeted topic suggestions, plus an all-due option.
+   - **Work and observe** — help complete a real task while monitoring which knowledge is exercised.
+   - **Discover learning gaps** — inspect the intended work or context for concepts that appear to be missing.
+   - **Guided collaboration** — help, but deliberately leave suitable steps for the learner to perform.
+5. Do not list Studio. Studio is the standalone onboarding and non-agent surface; agent harnesses use the focused MCP Apps and direct learning tools.
+
+### Purpose-built visual surfaces
+
+- After the user chooses Recall or a topic, call `zam_open_recall`, passing the selected domain when applicable. Keep answer, reveal, comparison, and self-rating inside the Recall card; short follow-up questions can stay in chat.
+- When the user asks for the **knowledge graph**, **learning graph**, or **Wissensgraph**, call `zam_show_graph` with the most relevant known token slug as `focus`. This surface shows learning tokens and prerequisite relations.
+- When the user asks for **knowledge articles**, **Wissensartikel**, **OKFs**, or **ADRs**, call `zam_okf_visualize` with `view: "graph"`. Use `view: "reader"` when they ask to read an article and `view: "log"` for bundle history.
+- A host may place an MCP App in a persistent pane or inline. Recall requests standard picture-in-picture only when the host advertises it; never claim control over a host-specific right sidebar.
+- Call `zam_open_settings` only for relevant setup, workspace, backup, or database-status work.
+- Never call `zam_open_studio` as part of an agent-harness ZAM menu or ordinary ZAM workflow.
+
+---
+
+## What is a Knowledge Token?
+
+A token is one atomic fact, concept, or principle a person must carry in their head. Not a step. Not a procedure. A transferable understanding.
+
+Good token (atomic, transferable):
+> "AppTraces is the Log Analytics table that stores application trace logs"
+
+Too coarse (covers many separate concepts):
+> "How to write a KQL investigation query"
+
+Too fine (not worth a card):
+> "The letter K in KQL stands for Kusto"
+
+Each token has:
+- **slug** — machine key (`kql-apptrace-table`)
+- **concept** — one sentence what it teaches
+- **domain** — e.g. `python`, `azure`, `kubernetes`, `git`
+- **bloom_level** — 1=remember a fact, 2=understand a concept, 3=apply in context, 4=analyze trade-offs, 5=synthesize novel solutions
+
+Prerequisites: "to understand A, you must first know B." Register edges via `zam_link_prereq`.
+
+---
+
+## Two Modes of Knowledge Assessment
+
+**Observation (primary)**: Agent watches the user do the task. If done correctly without help or hesitation → silently rate all touched tokens as 4. No interruption, no questions. Like a driving examiner in the back seat. But if you supplied the knowledge *this session* — looked it up, taught it, or handed over the exact steps — that is an assisted first run, not mastery: log a modest establishing rating (a 3, not a 4); real recall is tested when the card next falls due.
+
+**Verbal probing (secondary)**: Used when observation is insufficient — conceptual sessions with no executable output, or when a token hasn't been exercised in a long time and a practice task isn't appropriate.
+
+Always prefer observation over probing. Talking interrupts flow. The best ZAM session is one the user barely notices.
+
+---
+
+## Observation Levels
+
+- **Level 1 — Shell** (available): Agent reads shell command history and output to infer success/failure.
+- **Level 2 — Screen** (available): Agent observes the screen for GUI/desktop/portal tasks. ZAM ships a capture path — `zam bridge capture-ui` returns a screenshot (base64 PNG) governed by the `ObserverPolicy`; in a multimodal agent harness you may instead use the harness's own screen/browser view (computer-use / browser-use). See *UI / screen tasks* in STEP 4.
+- **Level 3 — Real life** (future): Voice + visual overlay on device (phone, AR). The agent is an overlay; the user lives in their world.
+
+Pick the lowest level that captures the task honestly — shell for command-line work, screen for GUI/portal work. Regardless of level, prefer an **objective outcome signal** (an API status, a file/DB state before→after) over pixels when one exists: it is the most reliable evidence that the task actually succeeded.
+
+---
+
+## Session Protocol
+
+### STEP 1 — Start session & check status
+
+Call `zam_status` to fetch connection target, current user, stats, and due review queue size. Show stats as a brief friendly greeting.
+
+For **review/conceptual** sessions, query due reviews without resolving:
+Call `zam_get_reviews` (with `includeQuestions: true`, `noResolve: true`, and `noDynamicQuestion: true`). Keep the returned question hidden until you ask it.
+
+For **executable/task** sessions, also query for tokens relevant to the current task to weave them into the session planning:
+Call `zam_find_tokens` (with the task description context). If relevant tokens are returned, weave them into the planning session (e.g. "We will be working on task T; you already know X, which applies here").
+
+Classify session type:
+- **Executable** — real commands, code, or file edits (e.g. "set up Homebrew", "commit this change")
+- **Conceptual** — pure review with no concrete output (e.g. `/zam repeat` or `/learn`)
+
+### STEP 2 — Generate the knowledge plan
+
+Think: *"What must a person know and understand to plan and then execute this task?"*
+
+Decompose into a dependency-ordered list of knowledge tokens.
+
+**Deduplication before registering:**
+Call `zam_find_tokens` first. Only register genuinely new concepts. Reuse existing slugs where the concept matches.
+
+After deduplication and before registering a new token, check for existing semantically related tokens that could be prerequisites ("foundations"):
+Call `zam_suggest_foundations` (with concept, question, and domain). Present non-flagged suggestions to the user ("Related existing concept X — link it as a foundation?"); on approval, link via `zam_link_prereq`.
+
+**Register tokens and prerequisites:**
+As the frontier model, YOU author both the concept and the recall question. Pass a clear, concept-free prompt question so the offline fallback stays high quality.
+Register new tokens and link prerequisites:
+Call `zam_add_token` to register a new token.
+Call `zam_link_prereq` to link any parent prerequisites.
+
+### STEP 3 — Start a session
+
+Call `zam_session_start` with the active user, task description, and execution context. This returns the session ID and details.
+
+### STEP 4 — Hand off, observe, rate
+
+> **Spoiler-free console option:** For pure conceptual recall, you can hand the whole review off to the standalone console harness instead of probing card by card here:
+>
+> "Let's do your reviews in the dedicated console — run `zam learn` and rate yourself. I'll wait."
+>
+> `zam learn` shows a concept-free cue, captures the answer, and only then reveals the stored answer before self-rating. This sidesteps agent-CLI autocomplete and multiple permission prompts.
+
+**For executable tasks (observation mode):**
+
+In Shadowing mode, hand off to the user:
+> "This is now your job. Good luck!"
+
+Step back. Do not interrupt unless the user asks for help. If the user selected Guided collaboration, alternate useful agent assistance with concrete steps the learner performs; do not automate every suitable practice step.
+
+To observe, tell the user to open a monitored terminal window:
+> "I've opened a terminal for you. Go ahead and work there — come back here when you're done."
+*(For systems supporting automatic shell terminal spawning, call `zam monitor open --session <id>` or instruct the user to run `zam monitor open --session <id>` in their terminal).*
+
+When the user returns, end the session:
+Call `zam_session_end` with the session ID and `synthesize: true`. The analyzer infers ratings based on command history, error rates, and speed. Confirm or adjust the returned candidates, then submit them using each candidate's `cardId` or `tokenId`.
+
+**For UI / screen tasks (observation mode):**
+
+When the real work happens in a browser or desktop app — a cloud portal, a GUI — rather than the shell, start the session with `--context ui` (`zam_session_start` `context: "ui"`); the response carries an `observerPolicyHint` describing the capture rules in force. Observe the screen one of two ways:
+
+- **ZAM capture** — `zam bridge capture-ui --session <id> [--process-name <app> | --hwnd <id>]` returns a screenshot (base64 PNG) plus a `captureMethod`. It is gated by the `ObserverPolicy` (inspect it with `zam bridge get-observer-policy`): if scope is `off`, the target is denylisted, or a sensitive window (password manager, banking, auth/UAC dialog) is frontmost, it returns a typed **`denied`** response instead of pixels — treat that as "cannot observe here", never as a failed task. The built-in sensitive denylist always wins over any user allowlist.
+- **Harness-native** — in a multimodal agent harness, use the harness's own screen or browser capability (computer-use / browser-use) to watch the user act. Same read-only intent: perceive, never drive.
+
+There is no shell monitor here, so rate manually: judge from what you saw (reaching the right surface and completing the action correctly is a pass), verify any objective outcome signal that exists, then `zam_submit_review` (`doneBy: "user"`) and `zam_session_end` without `synthesize`.
+
+**For conceptual sessions (verbal probing):**
+
+For each due token, ask a conceptual question at the right Bloom level:
+
+| Level | Test format | Example |
+|-------|------------|---------|
+| 1 Remember | "What is X?" | "What table stores app logs?" |
+| 2 Understand | "How does X work?" | "Why does bin() only produce non-empty buckets?" |
+| 3 Apply | "Write/Do X" | "Write a filter for this specific message" |
+| 4 Analyze | "Why X over Y?" | "Why is == more efficient than contains?" |
+| 5 Synthesize | "Design a..." | "Build the full query from scratch" |
+
+**CRITICAL: Stop and WAIT for the user to provide their answer. Do not ask for the rating until the user has attempted to answer the conceptual question.**
+
+After the user answers, run the explicit review loop:
+1. **Check the answer first.** Compare the user's answer with the concept definition, the recall question, and resolved source context.
+2. **Give learning feedback before asking for a rating.** State the verdict, give a reference answer, and explain gaps.
+3. **Suggest a self-rating.** Propose a rating from 1 to 4: 4 = instant, 3 = knew it with small gap, 2 = partial recall, 1 = blank/incorrect.
+4. **Ask the user to choose the final rating.**
+5. **WAIT for the user to choose.**
+6. **Submit the rating.** Call `zam_submit_review` with the cardId, rating, sessionId, and `doneBy: "user"`.
+*(For a skipped card, call `zam_review_action`. If the agent executed the step, call `zam_submit_review` with `doneBy: "agent"`, the session ID, and no rating; this logs evidence without advancing FSRS.)*
+
+#### Leveraging Source Links for AI Agent Context
+When calling `zam_get_reviews` or other review lookups, if a token has a `source_link`, the resolved code/documentation context will be returned. Use it to:
+1. **Formulate Contextual Questions**: Formulate deep conceptual questions grounded in the resolved material.
+2. **Verify Responses Precisely**: Check user answers against the actual codebase/documentation.
+
+### STEP 5 — End session
+
+For conceptual sessions, call `zam_session_end` to complete the active learning session and print progress. Executable sessions were already ended after synthesis above.
+
+---
+
+## Practice Tasks for Stale Skills
+
+When a token is long overdue and has no upcoming executable task to surface it naturally, propose a harmless practice task:
+> "You haven't done X in a while. Want to practice? We can install ripgrep via Homebrew, then remove it — just to keep the muscle memory alive."
+
+---
+
+## When the Agent Doesn't Know How
+
+If the agent cannot execute a step:
+1. Admit it explicitly: *"I'm not sure how to do this — I would try X or Y. Should I attempt it?"*
+2. If the user guides: attempt it, note what works.
+3. Register any new concepts discovered as tokens (dedup first).
+4. Save the successful approach as an agent skill entry:
+   Instruct the user to run `zam skill add --slug <slug> --description "<one sentence>" --steps '<json array>' --tokens <related-slugs>`.
+
+---
+
+## Blocking Rule
+
+A token is blocked when:
+- The user rated it 1 (forgot), AND
+- Its prerequisites have not yet been recalled at least once
+
+Prerequisites are prioritized first. When all direct prerequisites reach `reps >= 1`, the token is unblocked automatically. Never present a blocked token to the user.
+
+---
+
+## Dynamic Token Decomposition
+
+**Principle:** Do not pre-create hundreds of tokens. Let the dependency graph grow from real gaps discovered during review. Every rating of 1 is an opportunity to diagnose *why* the user couldn't answer — and to create the missing foundations.
+
+Decompose tokens when:
+1. The user rated it **1** (drew a blank / couldn't answer)
+2. The token is at **Bloom ≥ 3** (application or above)
+3. The token covers **multiple distinct concepts** (not atomic)
+4. No prerequisite tokens already exist for the specific gap you diagnose
+
+Query `zam_suggest_foundations` first to check for existing related foundation tokens before proposing new ones.
+
+### Source-grounded splitting
+If the token has a `source_link` (e.g. to LehrplanPLUS or syllabus), consult it to extract explicitly listed basic terms and concepts before creating foundation tokens. The foundations must stay inside the curriculum scope.
+
+### Registration and wiring:
+For each gap, call:
+1. `zam_add_token` to register the foundation (Bloom 1-2, atomic).
+2. `zam_link_prereq` with `blockUser` to wire it as a prerequisite and block the high-level card.
+
+---
+
+## Token Deprecation
+
+If a token is outdated:
+1. Confirm with the user whether to drop it.
+2. If drop: Call `zam_review_action` (action: "deprecate-token").
+3. If update: Register a replacement token first, then deprecate the old one.
+
+---
+
+## Three Symbiosis Modes
+
+- **Shadowing**: User is learning. Agent plans, user executes, agent observes/rates.
+- **Co-Pilot**: User has basic competence. Agent and user alternate.
+- **Autonomy**: User has high retention. Agent handles routine; practice tasks keep skills alive.
+
+---
+
+## Safety Rules
+
+- Never present a blocked token to the user
+- Never probe synthesis (bloom 5) before all prerequisites reach reps >= 1
+- Never register a token that already exists under a different slug — dedup first
+- Never skip the knowledge plan
+- Be honest in the session summary about what the agent did vs. what the user did
+- Rating scale is 1-4
+- Agent execution (`done-by agent`) does NOT advance FSRS state
+- Observation ratings DO count
+- Prefer observation over verbal probing
+- Never show card slugs or concept text to the user before asking a review question
+- Do not deprecate tokens without the user's confirmation
+
+---
+
+## Fallback: Bridge CLI
+
+If the MCP transport is unavailable, execute the corresponding `zam` bridge CLI commands:
+
+| Action / Tool | Fallback Command |
+|---|---|
+| Get Status / Stats | `zam bridge check-due --user <id>` |
+| Check Due reviews | `zam bridge check-due --user <id>` |
+| Get Reviews Batch | `zam bridge get-reviews --user <id> --include-questions --no-resolve --no-dynamic-question` |
+| Get Single Review | `zam bridge get-review --user <id>` |
+| Start Session | `zam bridge start-session --user <id> --task "<task>"` |
+| Session Open | `zam bridge session-open --user <id> --task "<task>"` |
+| End Session | `zam bridge end-session --session <id>` |
+| Find Tokens | `zam bridge relevant-tokens` (via stdin JSON) |
+| Register Token | `zam bridge add-token --user <id>` (via stdin JSON) |
+| Link Prereq | `zam token prereq --token <child> --requires <parent>` |
+| Submit Review | `zam bridge submit --card-id <id> --rating <r> [--session <id>] [--done-by user\|agent]` |
+| Review Action | `zam bridge review-action --card-id <id> --action <a>` |
+| Suggest Foundations | `zam bridge suggest-foundations` (via stdin JSON) |
+| Read Monitor | `zam bridge get-monitor --session <id>` |
+| Analyze Monitor | `zam bridge analyze-monitor --session <id>` (via stdin JSON) |
+
+*Note: For the JSON stdin inputs, ensure JSON payloads are piped properly.*

--- a/tests/cli/agent-plugin.test.ts
+++ b/tests/cli/agent-plugin.test.ts
@@ -1,0 +1,205 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { describe, expect, it } from "vitest";
+
+const pluginRoot = process.cwd();
+const pluginSchema =
+  "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const mcpSchema = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
+const pluginRootVariable = `\${PLUGIN_ROOT}`;
+const pluginDataVariable = `\${PLUGIN_DATA}`;
+
+interface PluginManifest {
+  $schema: string;
+  name: string;
+  version: string;
+  description: string;
+  author: { name: string; url: string };
+  homepage: string;
+  repository: string;
+  license: string;
+  keywords: string[];
+}
+
+interface StdioServer {
+  type: "stdio";
+  command: string;
+  args: string[];
+  cwd: string;
+}
+
+interface McpManifest {
+  $schema: string;
+  mcpServers: { zam: StdioServer };
+}
+
+interface PackageManifest {
+  version: string;
+  files: string[];
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function expandPluginVariables(value: string, pluginData: string): string {
+  return value
+    .replaceAll(pluginRootVariable, pluginRoot)
+    .replaceAll(pluginDataVariable, pluginData);
+}
+
+function processEnvironment(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+describe("Agent Plugins package", () => {
+  const plugin = readJson<PluginManifest>(join(pluginRoot, "plugin.json"));
+  const mcp = readJson<McpManifest>(join(pluginRoot, "mcp.json"));
+  const packageJson = readJson<PackageManifest>(
+    join(pluginRoot, "package.json"),
+  );
+
+  it("ships a closed v1 manifest synchronized with the npm package", () => {
+    expect(Object.keys(plugin).sort()).toEqual(
+      [
+        "$schema",
+        "name",
+        "version",
+        "description",
+        "author",
+        "homepage",
+        "repository",
+        "license",
+        "keywords",
+      ].sort(),
+    );
+    expect(plugin.$schema).toBe(pluginSchema);
+    expect(plugin.name).toMatch(
+      /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/,
+    );
+    expect(plugin.name.length).toBeLessThanOrEqual(64);
+    expect(plugin.version).toBe(packageJson.version);
+    expect(plugin.license).toBe("Apache-2.0");
+    expect(Object.keys(plugin.author).sort()).toEqual(["name", "url"]);
+  });
+
+  it("declares one contained stdio MCP server", () => {
+    expect(Object.keys(mcp).sort()).toEqual(["$schema", "mcpServers"]);
+    expect(mcp.$schema).toBe(mcpSchema);
+    expect(Object.keys(mcp.mcpServers)).toEqual(["zam"]);
+
+    const server = mcp.mcpServers.zam;
+    expect(Object.keys(server).sort()).toEqual(
+      ["type", "command", "args", "cwd"].sort(),
+    );
+    expect(server).toEqual({
+      type: "stdio",
+      command: "node",
+      args: [`${pluginRootVariable}/dist/cli/index.js`, "mcp"],
+      cwd: pluginRootVariable,
+    });
+
+    const entry = resolve(
+      expandPluginVariables(server.args[0], join(pluginRoot, ".plugin-data")),
+    );
+    const fromRoot = relative(pluginRoot, entry);
+    expect(fromRoot.startsWith("..")).toBe(false);
+    expect(isAbsolute(fromRoot)).toBe(false);
+    expect(existsSync(entry)).toBe(true);
+  });
+
+  it("ships a portable Agent Skill with standard frontmatter", () => {
+    const skillPath = join(pluginRoot, "skills", "zam", "SKILL.md");
+    const content = readFileSync(skillPath, "utf8");
+    const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+
+    expect(frontmatter).not.toBeNull();
+    const topLevelKeys = (frontmatter?.[1] ?? "")
+      .split("\n")
+      .filter((line) => /^[a-z]/.test(line))
+      .map((line) => line.slice(0, line.indexOf(":")));
+    expect(topLevelKeys).toEqual([
+      "name",
+      "description",
+      "license",
+      "compatibility",
+    ]);
+    expect(frontmatter?.[1]).toMatch(/^name: zam$/m);
+    expect(basename(dirname(skillPath))).toBe("zam");
+    expect(content).not.toContain("user-invocable:");
+    expect(content).toContain("ZAM's Agent Plugin");
+    expect(content).toContain("`zam_status`");
+    expect(content.split("\n").length).toBeLessThanOrEqual(500);
+  });
+
+  it("includes every portable component in the npm artifact allowlist", () => {
+    expect(packageJson.files).toEqual(
+      expect.arrayContaining([
+        "dist/",
+        "plugin.json",
+        "mcp.json",
+        "skills/zam/",
+        "docs/AGENT_PLUGIN.md",
+      ]),
+    );
+  });
+
+  it("completes an MCP handshake through the declared plugin command", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "zam-agent-plugin-"));
+    const pluginData = join(scratch, "plugin-data");
+    mkdirSync(pluginData, { recursive: true });
+    const server = mcp.mcpServers.zam;
+    const transport = new StdioClientTransport({
+      command: server.command,
+      args: server.args.map((arg) => expandPluginVariables(arg, pluginData)),
+      cwd: expandPluginVariables(server.cwd, pluginData),
+      env: {
+        ...processEnvironment(),
+        PLUGIN_ROOT: pluginRoot,
+        PLUGIN_DATA: pluginData,
+        HOME: scratch,
+        USERPROFILE: scratch,
+        ZAM_CONFIG_PATH: join(scratch, "config.json"),
+        ZAM_NO_AUTO_HEAL: "1",
+      },
+    });
+    const client = new Client(
+      { name: "agent-plugin-test", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toContain("zam_status");
+    } finally {
+      await client.close();
+      rmSync(scratch, {
+        recursive: true,
+        force: true,
+        maxRetries: 8,
+        retryDelay: 100,
+      });
+    }
+  }, 20_000);
+});


### PR DESCRIPTION
## Summary

- package the repository and npm artifact as an Agent Plugins v1.0.0 bundle
- expose ZAM through a portable Agent Skill and the existing stdio MCP server
- document installation, compatibility, architecture, and the decision in ADR/OKF references
- validate manifest shape, npm package contents, portable skill metadata, and a real MCP handshake

## Validation

- npm run format
- npm run lint
- npm run typecheck
- npm run test — 2,078 passed, 5 skipped
- npm run build
- npm pack --dry-run --json --ignore-scripts
