### PR TITLE
test: give provisioning room on the slowest CI runner

### DIFF
--- a/tests/kernel/provision.test.ts
+++ b/tests/kernel/provision.test.ts
@@ -60,7 +60,19 @@ async function describeSchema(db: Database): Promise<Record<string, string[]>> {
   return shape;
 }
 
-describe("applySchemaAndMigrations", () => {
+/**
+ * Provisioning runs the whole schema plus every migration through the mobile
+ * IPC stub, one statement at a time against a real file. That is milliseconds
+ * on a developer machine (12–26 ms as of M022) and seconds on the
+ * `windows-arm64` CI runner, where each SQLite write is orders of magnitude
+ * slower — it timed out at the 5 s default twice on 2026-08-09/10, in code
+ * neither change touched.
+ *
+ * The number protects the slowest supported runner, not the code: raising it
+ * hides nothing, because a provisioning path that genuinely regressed would
+ * blow past this too. If it starts failing again, measure before raising.
+ */
+describe("applySchemaAndMigrations", { timeout: 30_000 }, () => {
   it("produces the same schema as openDatabase, over IPC only", async () => {
     const stub = createTauriInvokeStub(join(tempDir(), "mobile.db"));
     const mobile = createTauriDatabase(stub.invoke);


### PR DESCRIPTION
`tests/kernel/provision.test.ts` timed out at vitest's 5 s default on
**windows-arm64** twice within a day — on #293 and on #295 — in code neither
branch touches. Both times a re-run passed, which is the signature of a
marginal test rather than a flaky one.

## Why it is marginal there

Those tests run the entire schema plus every migration through the mobile IPC
stub, one statement at a time, against a real file:

| | |
| :--- | :--- |
| locally | **12–26 ms** per test |
| windows-arm64 | **> 5 000 ms** |

Each SQLite write on that runner is orders of magnitude slower, and M020–M022
in 0.30.0 pushed the statement count past what 5 s covers there.

## The change

30 s on the describe block, with a comment recording the measurement, naming
the runner, and saying to measure before raising it again. It hides nothing: a
provisioning path that genuinely regressed would blow past 30 s as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)