### PR TITLE
release: prepare 0.31.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.30.0"
+version = "0.31.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.31.0.md
+++ b/docs/release-notes-0.31.0.md
@@ -1,0 +1,92 @@
+# ZAM 0.31.0 — The phone's own AI, an import that tells you where it is, and a dashboard that loads
+
+This release is mostly field report repair. Three things that looked broken on
+a real device in 0.30.0 — a dashboard that refused to load, an import that
+looked frozen, and a phone that never used the chip it has — are fixed here.
+
+## The dashboard loads again
+
+Opening the statistics view once and then returning to the overview reported
+your whole dashboard as unloadable:
+
+> ⚠ Your data could not be loaded: null is not an object
+
+One placeholder element is destroyed when the stats view renders, and the
+translation pass afterwards still insisted it was there. The single missing
+label took the entire page down with it. The lookup no longer insists, the
+recreated placeholder keeps its identity so a language switch mid-view still
+translates it, and a test now walks the whole desktop source looking for the
+same pattern anywhere else. It found one more; that one is fixed too.
+
+If you are on 0.30.0 and see this message, it is this bug and nothing is wrong
+with your data.
+
+## An import that finishes in seconds, and says where it is
+
+Importing a 440-card Anki package took about three minutes with nothing on
+screen. It was not hung — it was writing, one network round trip at a time,
+against a remote database where each statement costs ~50 ms. Eight statements
+per card became three: a card's row is written once instead of written and read
+back, slug uniqueness is resolved against a list loaded once rather than a
+query per card, and cards with no media skip the media path entirely.
+
+The import also reports itself now. Studio shows a live count while the file is
+being written, so a long import looks like work in progress instead of a frozen
+window. Agents and scripts get the same events as NDJSON on stderr — `zam
+bridge` keeps stdout pure JSON.
+
+## Android uses the chip in your phone
+
+A Pixel 9 has Gemini Nano on its NPU, and ZAM never used it. The plumbing was
+there and connected to nothing: availability was never checked, failures were
+swallowed, and the "prepare the model" call existed but was dead code. Every
+review quietly went to a paid cloud model.
+
+- **Settings has a "Local AI" section.** Per capability — reviews, card text,
+  image import, embeddings — you choose *on device only*, *device first*, or
+  *best quality*. Each row shows what this device can actually do right now.
+- **Reviews and voice prefer your device by default.** Card authoring and photo
+  import prefer a good cloud model by default, because learning content is
+  written once and reviewed for years — that is a judgement, and you can
+  overrule it per capability.
+- **A row that cannot work says so.** Embeddings and image import have no
+  on-device implementation on Android, so the settings row says "not possible
+  on this device" instead of offering a switch that changes nothing.
+- **You are told which model answered, and why.** When your device could not
+  take a review, the evaluation names the model that did and the reason —
+  *"used instead because: Gemini Nano is downloading"*. A cloud answer nobody
+  chose no longer looks like an ordinary result.
+- **"Prepare now"** downloads the on-device model deliberately, from settings,
+  instead of making your first review wait for it.
+- **On-device only means on-device only.** If the model is unavailable, the
+  review fails visibly with a reason rather than silently calling a paid
+  endpoint.
+
+Also fixed: a phone paired with a desktop whose shared database offers only
+local Ollama models used to show an empty model list. It now says what happened
+and which rule excluded them — a desktop's local endpoint is not reachable from
+your phone by construction.
+
+The reasoning, the per-capability defaults, and what was deliberately left out
+(on-device embeddings, syncing API keys through the database) are in
+ADR 2026-08-09c.
+
+## ZAM as an agent plugin
+
+The repository and the npm package are now an Agent Plugins v1.0.0 bundle, so a
+harness that speaks that format can install ZAM directly and reach it through
+the existing stdio MCP server and a portable Agent Skill. `zam agent connect
+<harness>` remains the path for everything else.
+
+## Notes
+
+- iPadOS has no per-capability choice: Apple's on-device API covers speech, and
+  the rest runs in the cloud. The settings rows say so rather than pretending.
+- Your preference is stored on the device, never in the shared database — a
+  phone and a desktop can disagree about which tier to prefer, which is the
+  point.
+- A preference left at its shipped default is not written down, so a learner
+  who never touched the control follows the judgement when it improves.
+- The provisioning test suite got a realistic timeout for the slowest supported
+  CI runner, where each SQLite write is orders of magnitude slower than on a
+  developer machine. No behaviour changed.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-mobile",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-mobile",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-barcode-scanner": "^2.4.5"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zam-mobile",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -70,8 +70,8 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         # Stamped from package.json by the release workflow; kept in step here
         # so a local build is not mislabelled either.
-        CFBundleShortVersionString: 0.30.0
-        CFBundleVersion: "0.30.0"
+        CFBundleShortVersionString: 0.31.0
+        CFBundleVersion: "0.31.0"
         # Two uses since the app became standalone (ADR 2026-08-08): scanning
         # a QR code to take over an existing library, and photographing a page
         # to turn it into cards. Neither is the first-run path any more, but

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "zam",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Turn real work with AI agents into active-recall practice and FSRS spaced repetition.",
   "author": {
     "name": "ZAM Contributors",

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.30.0",
+          "User-Agent": "ZAM-Content-Studio/0.31.0",
         },
       });
 


### PR DESCRIPTION
Version bumps and the hand-written release notes for **0.31.0**, which ships
what has accumulated on `main` since the 0.30.0 tag:

- #294 — the dashboard crash reported from the field on 0.30.0
- #296 — ZAM packaged as an Agent Plugins v1.0.0 bundle
- #297 — a realistic provisioning-test timeout for `windows-arm64`
- #293 — import round trips cut from eight per card to three, with progress
- #295 — on-device AI preference, ADR 2026-08-09c phases 1–4

Minor rather than patch: #295 and #296 are features.

## Bump list

Root, `desktop/` and `mobile/` `package.json` + lockfiles, the `zam-app` crate
and `Cargo.lock`, `mobile/src-tauri/gen/apple/project.yml`, and the Studio
User-Agent in `src/cli/adapters/source-reader.ts`.

New this release: **`plugin.json`**. It carries its own version since #296, and
`tests/cli/agent-plugin.test.ts` asserts it matches the npm package — so a bump
that skips it fails CI. `mobile/src-tauri/Cargo.toml` stays at 0.24.1 as
before; both `tauri.conf.json` files read the version from root
`package.json`.

`format` · `lint` · `typecheck` (root + mobile) · `test` — 2,118 passed ·
`build` · `cargo metadata --locked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)