### PR TITLE
docs: research central learning knowledge base architecture

### DIFF
--- a/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
+++ b/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
@@ -1,6 +1,6 @@
 # Hierarchical Domain Ontology and Composite Token Identity
 
-**Status:** Proposed (draft)
+**Status:** Accepted (2026-07-04)
 **Date:** 2026-07-04
 **Deciders:** Thomas (project owner)
 **Related:**
@@ -75,7 +75,7 @@ token's address, what is its identity, and what gives domains meaning?**
 | **D. Globally-unique short slugs** (drop the domain prefix, keep global uniqueness) | slug | Cross-domain collisions (`einfuehrung`, `grundlagen`) come back as counter suffixes — the ugliness returns at scale. Rejected as the end state; acceptable interim while C's uniqueness switch is pending. |
 | **E. Mandatory standard ontology** (Wikidata/Dewey/schema.org as the domain vocabulary) | — | Team and project knowledge has no home in any standard; curriculum content already follows LehrplanPLUS's own taxonomy. Rejected in favor of optional anchors (Decision 4). |
 
-## Decision (proposed)
+## Decision
 
 **1. Identity stays with `token_id` (ULID); `(domain, slug)` becomes the
 composite *address*.** Domains stop being part of what a token *is* and
@@ -97,7 +97,7 @@ constraining them:
 
 ```sql
 CREATE TABLE IF NOT EXISTS domain_meta (
-  path         TEXT PRIMARY KEY,   -- "schule/mathematik/realschule-9"
+  path         TEXT PRIMARY KEY,   -- "mathematik/realschule-9"
   label        TEXT,               -- localized display name, Unicode
   ontology_ref TEXT,               -- optional anchor, e.g. "wikidata:Q11348"
   notes        TEXT
@@ -109,17 +109,29 @@ Hierarchy is implicit in the path (no parent_id to keep consistent);
 domain. The doctor `domains` task maintains both (renames update tokens +
 meta in one transaction).
 
-**4. Ontology anchors are optional and additive.** For general-knowledge
-domains, `ontology_ref` links to a standard concept (Wikidata QID first —
-language-neutral ids, localized labels for free, and the future
-multi-learner tier can match "same concept, different learners" through
-them). Curriculum imports may anchor to their official taxonomy
-(`lehrplanplus:<topic_id>` style). Nothing requires an anchor; nothing
-breaks without one.
+**Path roots are subject areas — never life areas or teams.** `mathematik`,
+`ai`, `axon-ivy` are roots; "school", "work", `docuware-cops` are contexts
+(contexts ADR) and must not appear in paths. The team-scoping example from
+the titles ADR (`docuware-cops/ai`) therefore migrates into a context once
+contexts ship; the `/` mechanics it introduced are unchanged.
+
+**4. The ontology actively guides naming; the schema stays free.**
+Whenever a domain path is created or restructured (imports, token
+registration, doctor `domains`), the LLM-assisted flow **proposes
+standard-aligned path names** — Wikidata labels for general knowledge,
+the official curriculum taxonomy (LehrplanPLUS structure) for school
+content — and records the matching `ontology_ref` anchor (Wikidata QID,
+`lehrplanplus:<topic_id>`) alongside. Users can always override; team and
+project domains simply have no anchor. Anchors stay additive: nothing
+requires one, nothing breaks without one — but the *default pull* is
+toward standard names, which is what makes the graph converge instead of
+sprawl. (Language-neutral anchor ids also give localized labels for free
+and let the future multi-learner tier match "same concept, different
+learners".)
 
 **5. Addressing in CLI/bridge: qualified first, bare tolerated.** The
 canonical written form becomes `domain/path:slug` (e.g.
-`schule/mathematik:bruch-erweitern`; `:` separates path from slug since `/`
+`mathematik/bruchrechnung:erweitern-kuerzen`; `:` separates path from slug since `/`
 belongs to the path). All commands accept: a qualified address, a bare slug
 (resolved iff globally unambiguous, error with candidates otherwise), or a
 ULID. Bridge outputs gain the qualified `address` field additively.
@@ -142,7 +154,9 @@ no absorption.
 
 - **Existing 253+ tokens:** untouched by default. Doctor tasks do the work
   incrementally and with confirmation: `domains` (restructure flat domains
-  into paths, e.g. `axon-ivy` → `docuware-cops/axon-ivy`), `identity`
+  into subject paths, e.g. `rag` → `ai/rag` — team membership like
+  `docuware-cops` moves to the *context* attribute, never into the path),
+  `identity`
   (shorten legacy slugs, updating nothing but the slug since references are
   id-based after Phase A).
 - **Re-embeds:** domain moves change `embeddingContentForToken` output →
@@ -175,6 +189,10 @@ no absorption.
 - **Phase B — path domains + `domain_meta`:** `/`-path support end-to-end
   (list/filter/graph grouping exist since the titles ADR), `domain_meta`
   table, doctor `domains` task, imports emit path domains.
+  **Priority decision:** B including a first doctor-`domains`
+  restructuring pass over the live base runs as early as possible — the
+  graph-legibility pain is the driving complaint. Prerequisite: the doctor
+  scaffolding from the titles ADR exists first.
 - **Phase C — short slugs for new tokens:** title-derived generation,
   qualified addressing accepted everywhere, doctor `identity` task for the
   backlog.
@@ -196,7 +214,7 @@ no absorption.
 ## Consequences
 
 - New tokens immediately get dignified addresses:
-  `schule/mathematik:bruch-erweitern` instead of a 60-char mangled
+  `mathematik/bruchrechnung:erweitern-kuerzen` instead of a 60-char mangled
   question — and the graph gains a real hierarchy to fold.
 - Taxonomy work becomes *safe, routine maintenance* (doctor + id-based
   references) instead of a breaking event — which is what makes the

--- a/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
+++ b/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
@@ -1,0 +1,58 @@
+# Hierarchical Domain Ontology and Composite Token Identity
+
+**Status:** Seed note — deliberately NOT drafted yet. This file collects the
+raw material so a **fresh session with full context budget** can think it
+through from first principles. It is intentionally kept out of the ADR index
+until a real draft exists.
+**Date:** 2026-07-04 (note)
+**Origin:** Thomas, during the titles/domains review — "Es scheint mir, das
+Thema ist groß genug für einen eigenen ADR."
+**Related:**
+[2026-07-04-human-friendly-titles-and-prefixed-domains.md](2026-07-04-human-friendly-titles-and-prefixed-domains.md)
+(Open Questions 1 + 4) · knowledge-contexts ADR (drafted separately) ·
+[2026-07-04-multi-learner-shared-knowledge.md](2026-07-04-multi-learner-shared-knowledge.md)
+
+---
+
+## The idea, in the owner's words (condensed)
+
+Use **domain + slug as the identifier**. Then the slug can be short and the
+domain long and precise. Domains would be hierarchical — ideally aligned
+with **standard ontology titles** for general knowledge. That could give a
+much better Knowledge Graph ("es wird aktuell schon unübersichtlich"),
+different filtering, and other benefits that come from hierarchy.
+
+## What a fresh session should think about (unordered, no decisions here)
+
+- **Composite identity `(domain, slug)`** — what actually breaks?
+  Prerequisites and cards reference `token_id` (ULIDs) and are untouched;
+  but `agent_skills.token_slugs`, bridge payloads, dedup-by-slug during
+  imports, `generateTokenSlug`'s domain prefixing and 60-char budget, and
+  the "slug is immutable" rule all assume globally-unique bare slugs.
+  Would slugs become unique only *within* a domain? Can a token move
+  domains without changing identity?
+- **Ontology choice for general knowledge**: Wikidata QIDs? schema.org?
+  Dewey-like taxonomies? German school subjects (LehrplanPLUS structure) vs.
+  international standards? Or: free-form hierarchy with *optional* ontology
+  anchors instead of a mandated vocabulary? Language-neutral IDs with
+  localized labels would fit the per-area-language decision.
+- **Relationship to what already shipped/decided**: the `/` separator
+  (titles ADR Decision 4) is forward-compatible on purpose; contexts
+  (work/school/private) may be the topmost level OR an orthogonal attribute
+  — the knowledge-contexts ADR takes the orthogonal-attribute position as
+  an interim; this ADR may confirm or subsume it.
+- **Graph UX**: hierarchy enables level-of-detail (collapse subtrees),
+  breadcrumb filtering, coloring by top level. What does "unübersichtlich"
+  concretely need first?
+- **Migration**: 253+ live tokens with flat domains and long domain-prefixed
+  slugs; a rename/re-domain pass is a natural `zam doctor domains` job; slug
+  shortening however touches identity — needs the composite-identity answer
+  first.
+- **Embeddings/search**: domain is part of `embeddingContentForToken` —
+  richer hierarchical domains change semantic weight; re-embed implications.
+- **Multi-learner**: shared libraries need stable cross-machine references —
+  composite identity vs. ULIDs as the sync anchor.
+
+## Explicitly NOT to do in this note
+
+No decisions, no options table, no schema sketches. Fresh eyes first.

--- a/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
+++ b/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
@@ -1,8 +1,16 @@
 # Hierarchical Domain Ontology and Composite Token Identity
 
-**Status:** Accepted (2026-07-04)
+**Status:** Draft (reverted from Accepted, 2026-08-14)
 **Date:** 2026-07-04
 **Deciders:** Thomas (project owner)
+
+> Reopened. This ADR answered how a personal or team graph stays
+> addressable when slugs grow long. The central learning-path work
+> asks a harder identity question — how two curricula and two
+> publishers recognize the same pedagogical atom — and that join key
+> is not settled. See
+> [central-learning-path-identity.md](../concepts/central-learning-path-identity.md).
+> Treat the decisions below as a candidate, not as a constraint.
 **Related:**
 [2026-07-04-human-friendly-titles-and-prefixed-domains.md](2026-07-04-human-friendly-titles-and-prefixed-domains.md)
 (Decision 4 `/` separator, Open Question 1) ·

--- a/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
+++ b/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md
@@ -1,58 +1,212 @@
 # Hierarchical Domain Ontology and Composite Token Identity
 
-**Status:** Seed note — deliberately NOT drafted yet. This file collects the
-raw material so a **fresh session with full context budget** can think it
-through from first principles. It is intentionally kept out of the ADR index
-until a real draft exists.
-**Date:** 2026-07-04 (note)
-**Origin:** Thomas, during the titles/domains review — "Es scheint mir, das
-Thema ist groß genug für einen eigenen ADR."
+**Status:** Proposed (draft)
+**Date:** 2026-07-04
+**Deciders:** Thomas (project owner)
 **Related:**
 [2026-07-04-human-friendly-titles-and-prefixed-domains.md](2026-07-04-human-friendly-titles-and-prefixed-domains.md)
-(Open Questions 1 + 4) · knowledge-contexts ADR (drafted separately) ·
-[2026-07-04-multi-learner-shared-knowledge.md](2026-07-04-multi-learner-shared-knowledge.md)
+(Decision 4 `/` separator, Open Question 1) ·
+[2026-07-04-knowledge-contexts.md](2026-07-04-knowledge-contexts.md) ·
+[2026-07-04-multi-learner-shared-knowledge.md](2026-07-04-multi-learner-shared-knowledge.md) ·
+[2026-07-03-rag-semantic-token-search.md](2026-07-03-rag-semantic-token-search.md)
 
 ---
 
-## The idea, in the owner's words (condensed)
+## Context
 
-Use **domain + slug as the identifier**. Then the slug can be short and the
-domain long and precise. Domains would be hierarchical — ideally aligned
-with **standard ontology titles** for general knowledge. That could give a
-much better Knowledge Graph ("es wird aktuell schon unübersichtlich"),
-different filtering, and other benefits that come from hierarchy.
+The owner's observation that seeded this ADR: use **domain + slug as the
+identifier** — then slugs can be short and domains long and precise;
+hierarchical domains, ideally aligned with standard ontology names for
+general knowledge, would make the growing Knowledge Graph legible again
+("es wird aktuell schon unübersichtlich").
 
-## What a fresh session should think about (unordered, no decisions here)
+Today the weight sits at the wrong end:
 
-- **Composite identity `(domain, slug)`** — what actually breaks?
-  Prerequisites and cards reference `token_id` (ULIDs) and are untouched;
-  but `agent_skills.token_slugs`, bridge payloads, dedup-by-slug during
-  imports, `generateTokenSlug`'s domain prefixing and 60-char budget, and
-  the "slug is immutable" rule all assume globally-unique bare slugs.
-  Would slugs become unique only *within* a domain? Can a token move
-  domains without changing identity?
-- **Ontology choice for general knowledge**: Wikidata QIDs? schema.org?
-  Dewey-like taxonomies? German school subjects (LehrplanPLUS structure) vs.
-  international standards? Or: free-form hierarchy with *optional* ontology
-  anchors instead of a mandated vocabulary? Language-neutral IDs with
-  localized labels would fit the per-area-language decision.
-- **Relationship to what already shipped/decided**: the `/` separator
-  (titles ADR Decision 4) is forward-compatible on purpose; contexts
-  (work/school/private) may be the topmost level OR an orthogonal attribute
-  — the knowledge-contexts ADR takes the orthogonal-attribute position as
-  an interim; this ADR may confirm or subsume it.
-- **Graph UX**: hierarchy enables level-of-detail (collapse subtrees),
-  breadcrumb filtering, coloring by top level. What does "unübersichtlich"
-  concretely need first?
-- **Migration**: 253+ live tokens with flat domains and long domain-prefixed
-  slugs; a rename/re-domain pass is a natural `zam doctor domains` job; slug
-  shortening however touches identity — needs the composite-identity answer
-  first.
-- **Embeddings/search**: domain is part of `embeddingContentForToken` —
-  richer hierarchical domains change semantic weight; re-embed implications.
-- **Multi-learner**: shared libraries need stable cross-machine references —
-  composite identity vs. ULIDs as the sync anchor.
+- Slugs carry everything: `mathematik-realschule-9-iii-wie-weist-man-mit-
+  der-umkehru` — domain prefix + truncated question crammed into 60 ASCII
+  chars, globally unique via counter suffixes.
+- Domains carry almost nothing: flat labels (`axon-ivy`, `Deutsch`, `rag`),
+  22+ of them already, no structure, casing inconsistencies, doing triple
+  duty as subject, scope group, and implied context.
 
-## Explicitly NOT to do in this note
+What references what (the blast radius that shapes every option):
 
-No decisions, no options table, no schema sketches. Fresh eyes first.
+- `prerequisites`, `cards`, `review_logs`, `sessions`, `token_embeddings`
+  reference **`token_id` (ULID)** — untouched by any renaming.
+- `agent_skills.token_slugs` stores **bare slug strings** (JSON arrays).
+- Bridge/CLI address tokens by **bare slug** everywhere (`add-token`,
+  `suggest-foundations`, `token prereq --token/--requires`, …); the bridge
+  protocol is a stable contract.
+- Curriculum re-import dedupes by regenerated base slug (plus
+  `provider`/`topic_id` where present).
+- `slug` is declared immutable; `embeddingContentForToken` includes
+  `domain`, so domain moves change content hashes (and trigger re-embeds).
+
+The titles ADR already fixed the *display* layer (`title`) and chose `/` as
+the hierarchy separator for scoped domains, explicitly forward-compatible
+with this ADR. The contexts ADR proposes work/school/private as an
+orthogonal attribute. What remains is the structural question: **what is a
+token's address, what is its identity, and what gives domains meaning?**
+
+## Decision drivers
+
+1. **Short, human slugs** — the slug should name the atom
+   (`umkehrfunktion-nachweis`), not restate its classification.
+2. **A taxonomy that may live** — hierarchies get refactored (doctor task
+   `domains` exists precisely for that); reclassification must never break
+   references or learning history.
+3. **Legible graph at growing scale** — collapse/expand by hierarchy level,
+   filter by subtree, color by top segment.
+4. **Ontology as leverage, not bureaucracy** — standard anchors where they
+   help (general knowledge, cross-learner matching later), freedom where
+   reality is idiosyncratic (`docuware-cops/ai` fits no standard ontology).
+5. **Contract stability** — bridge consumers and agent skills must keep
+   working through the transition.
+6. **Small steps** — each phase shippable, each reversible short of the
+   final uniqueness switch.
+
+## Options considered
+
+| Option | Identity | Verdict |
+|--------|----------|---------|
+| **A. Status quo** — global domain-prefixed slugs | slug | The problem statement. Rejected. |
+| **B. Hard composite identity** — `(domain, slug)` IS the identity | domain+slug | Bakes classification into identity: every taxonomy refactor (the *point* of hierarchical domains) changes identities and breaks references. Rejected. |
+| **C. ULID identity + composite address** — `token_id` stays the identity; `(domain path, short slug)` becomes the human/API **address**; slug-storing references migrate to ids | ULID | Short slugs AND a living taxonomy; domain moves are metadata updates. Costs a reference migration and an addressing transition. **Chosen.** |
+| **D. Globally-unique short slugs** (drop the domain prefix, keep global uniqueness) | slug | Cross-domain collisions (`einfuehrung`, `grundlagen`) come back as counter suffixes — the ugliness returns at scale. Rejected as the end state; acceptable interim while C's uniqueness switch is pending. |
+| **E. Mandatory standard ontology** (Wikidata/Dewey/schema.org as the domain vocabulary) | — | Team and project knowledge has no home in any standard; curriculum content already follows LehrplanPLUS's own taxonomy. Rejected in favor of optional anchors (Decision 4). |
+
+## Decision (proposed)
+
+**1. Identity stays with `token_id` (ULID); `(domain, slug)` becomes the
+composite *address*.** Domains stop being part of what a token *is* and
+remain part of where it *lives*. Moving a token to a better place in the
+taxonomy is a metadata update: history, prerequisites, cards, embeddings
+(modulo re-embed), and skills all survive because they reference the id.
+
+**2. Slugs become short and domain-free — for new tokens first.**
+`generateTokenSlug` stops prefixing the domain and stops deriving from the
+question; it derives from the *title* (the human name, titles ADR
+Decision 1), target ≤ 30 chars. Existing slugs stay valid indefinitely;
+shortening the backlog is a `zam doctor identity` task run *after* Phase A
+(below), never a bulk rename before it.
+
+**3. Domains are `/`-separated paths with a metadata side-table.**
+`tokens.domain` remains the TEXT source of truth (join-free, `/` semantics
+from the titles ADR). A new `domain_meta` table enriches paths without
+constraining them:
+
+```sql
+CREATE TABLE IF NOT EXISTS domain_meta (
+  path         TEXT PRIMARY KEY,   -- "schule/mathematik/realschule-9"
+  label        TEXT,               -- localized display name, Unicode
+  ontology_ref TEXT,               -- optional anchor, e.g. "wikidata:Q11348"
+  notes        TEXT
+);
+```
+
+Hierarchy is implicit in the path (no parent_id to keep consistent);
+`domain_meta` rows are optional — an unlisted path is simply a plain
+domain. The doctor `domains` task maintains both (renames update tokens +
+meta in one transaction).
+
+**4. Ontology anchors are optional and additive.** For general-knowledge
+domains, `ontology_ref` links to a standard concept (Wikidata QID first —
+language-neutral ids, localized labels for free, and the future
+multi-learner tier can match "same concept, different learners" through
+them). Curriculum imports may anchor to their official taxonomy
+(`lehrplanplus:<topic_id>` style). Nothing requires an anchor; nothing
+breaks without one.
+
+**5. Addressing in CLI/bridge: qualified first, bare tolerated.** The
+canonical written form becomes `domain/path:slug` (e.g.
+`schule/mathematik:bruch-erweitern`; `:` separates path from slug since `/`
+belongs to the path). All commands accept: a qualified address, a bare slug
+(resolved iff globally unambiguous, error with candidates otherwise), or a
+ULID. Bridge outputs gain the qualified `address` field additively.
+
+**6. Reference migration before uniqueness change.**
+`agent_skills.token_slugs` migrates to `token_ids` (M-series migration
+translating existing arrays; the skill format keeps slugs only as display
+hints). Only after that — and after qualified addressing ships — does a
+final migration relax `UNIQUE(slug)` to `UNIQUE(domain, slug)`. Until then
+new short slugs remain globally unique (Option D as interim), so nothing
+depends on the switch date.
+
+**7. Contexts stay orthogonal.** This ADR deliberately does **not** absorb
+work/school/private into the domain hierarchy: context is *whose world*
+(with language and sharing attributes), the domain path is *which
+subject*. The contexts ADR's Open Question 1 is hereby answered:
+no absorption.
+
+## Migration & compatibility
+
+- **Existing 253+ tokens:** untouched by default. Doctor tasks do the work
+  incrementally and with confirmation: `domains` (restructure flat domains
+  into paths, e.g. `axon-ivy` → `docuware-cops/axon-ivy`), `identity`
+  (shorten legacy slugs, updating nothing but the slug since references are
+  id-based after Phase A).
+- **Re-embeds:** domain moves change `embeddingContentForToken` output →
+  affected tokens re-embed automatically via hash staleness; a large
+  restructuring pass should mention `zam token reembed` in its summary.
+- **Curriculum re-import:** keeps `provider`/`topic_id` matching (primary),
+  base-slug matching remains as fallback during the interim.
+- **Bridge consumers:** bare-slug addressing keeps working through the
+  whole transition; the qualified form is additive. The only breaking
+  change ever is the uniqueness relaxation (Phase D), gated on consumers
+  being qualified-address-clean.
+
+## Open questions
+
+1. **Anchor payoff validation** — before investing in Wikidata tooling,
+   validate one concrete use: cross-learner concept matching in the
+   multi-learner tier, or localized domain labels in the graph. If neither
+   lands, anchors stay a dormant column (cheap either way).
+2. **Path depth convention** — recommend ≤ 3 levels in docs; enforce
+   nothing. Revisit when real trees exist.
+3. **Bare-slug deprecation horizon** — whether bare slugs in *skill files
+   and scripts* should warn after Phase C, or stay silently supported.
+
+## Scope and delivery plan
+
+- **Phase 0 — this ADR** proposed for sign-off.
+- **Phase A — reference migration:** `agent_skills` slugs → token_ids
+  (M-series + verification); qualified `address` field added to bridge
+  outputs (additive).
+- **Phase B — path domains + `domain_meta`:** `/`-path support end-to-end
+  (list/filter/graph grouping exist since the titles ADR), `domain_meta`
+  table, doctor `domains` task, imports emit path domains.
+- **Phase C — short slugs for new tokens:** title-derived generation,
+  qualified addressing accepted everywhere, doctor `identity` task for the
+  backlog.
+- **Phase D — uniqueness switch:** `UNIQUE(domain, slug)` replaces global
+  slug uniqueness once A–C are verified in the field.
+- **Phase E — graph level-of-detail:** collapse/expand by path segment,
+  color by top level, breadcrumb filter (may run parallel to C/D; pure UI).
+
+## Out of scope
+
+- Contexts (own ADR; explicitly not absorbed here).
+- Multi-learner sync mechanics (own ADR; this ADR only ensures ULIDs remain
+  the sync anchor and anchors *could* aid concept matching).
+- Automatic ontology classification of existing content (doctor proposes,
+  humans confirm — no autonomous re-taxonomizing).
+- Renaming the `domain` column or introducing a separate `category` field
+  (rejected in the titles ADR; still rejected).
+
+## Consequences
+
+- New tokens immediately get dignified addresses:
+  `schule/mathematik:bruch-erweitern` instead of a 60-char mangled
+  question — and the graph gains a real hierarchy to fold.
+- Taxonomy work becomes *safe, routine maintenance* (doctor + id-based
+  references) instead of a breaking event — which is what makes the
+  owner's ontology ambition practical at all.
+- Two migrations carry real risk and are therefore isolated and gated:
+  agent-skills reference translation (Phase A) and the uniqueness switch
+  (Phase D); everything between is additive.
+- The address grammar (`path:slug`) is one more concept for agents/users —
+  mitigated by bare slugs continuing to work and by AGENTS.md documenting
+  the form once it ships.
+- `domain_meta` may accumulate stale rows when paths change outside the
+  doctor (direct SQL); accepted — it is advisory metadata, and the doctor
+  reconciles.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-06-30](2026-06-30-learning-content-studio.md) | Learning Content Studio | Implemented |
 | [2026-07-02](2026-07-02-lehrplanplus-import-wizard.md) | LehrplanPLUS Curriculum Import Wizard | Partially implemented |
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
+| [2026-07-04](2026-07-04-hierarchical-domain-ontology-and-token-identity.md) | Hierarchical Domain Ontology and Composite Token Identity | Proposed |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
 | [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
 | [2026-07-05](../plans/2026-07-05-titles-doctor-adaptation.md) | Human-friendly Titles + `zam doctor` adaptation plan (post Fable 5 review) | In progress |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,7 +8,7 @@ Naming: `YYYY-MM-DD-kebab-title.md`, using the **decision date**. If two decisio
 land on the same day, disambiguate with a chronological letter suffix
 (`YYYY-MM-DDa-…`, `YYYY-MM-DDb-…`). The filename date is canonical and never
 changes; git history records edits.
-Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`) → (`Deprecated` | `Superseded by a later ADR`).
+Status: `Draft` → `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`) → (`Deprecated` | `Superseded by a later ADR`).
 
 | Date | Title | Status |
 |------|-------|--------|
@@ -35,7 +35,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-06-30](2026-06-30-learning-content-studio.md) | Learning Content Studio | Implemented |
 | [2026-07-02](2026-07-02-lehrplanplus-import-wizard.md) | LehrplanPLUS Curriculum Import Wizard | Partially implemented |
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
-| [2026-07-04](2026-07-04-hierarchical-domain-ontology-and-token-identity.md) | Hierarchical Domain Ontology and Composite Token Identity | Accepted |
+| [2026-07-04](2026-07-04-hierarchical-domain-ontology-and-token-identity.md) | Hierarchical Domain Ontology and Composite Token Identity | Draft |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
 | [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
 | [2026-07-04](2026-07-04-multi-learner-shared-knowledge.md) | Closed-Group Learning Library: Curation, Privacy and Deployment | Accepted — Phase E scope and ordering amended by 2026-07-26b |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,7 +35,7 @@ Status: `Proposed` → `Accepted` → `Implemented` (or `Partially implemented`)
 | [2026-06-30](2026-06-30-learning-content-studio.md) | Learning Content Studio | Implemented |
 | [2026-07-02](2026-07-02-lehrplanplus-import-wizard.md) | LehrplanPLUS Curriculum Import Wizard | Partially implemented |
 | [2026-07-03](2026-07-03-rag-semantic-token-search.md) | RAG / Semantic Token Search on a Self-Hosted, No-License-Cost Store | Partially implemented |
-| [2026-07-04](2026-07-04-hierarchical-domain-ontology-and-token-identity.md) | Hierarchical Domain Ontology and Composite Token Identity | Proposed |
+| [2026-07-04](2026-07-04-hierarchical-domain-ontology-and-token-identity.md) | Hierarchical Domain Ontology and Composite Token Identity | Accepted |
 | [2026-07-04](2026-07-04-human-friendly-titles-and-prefixed-domains.md) | Human-friendly Titles and Prefixed Domains for the Knowledge Graph | Implemented |
 | [2026-07-04](2026-07-04-knowledge-contexts.md) | Knowledge Contexts: Work, School, Private | Implemented |
 | [2026-07-05](../plans/2026-07-05-titles-doctor-adaptation.md) | Human-friendly Titles + `zam doctor` adaptation plan (post Fable 5 review) | In progress |

--- a/docs/concepts/central-learning-path-architecture-review.md
+++ b/docs/concepts/central-learning-path-architecture-review.md
@@ -1,0 +1,254 @@
+# Review: Draft-Architektur der zentralen Wissensbasis
+
+**Status:** Review  
+**Datum:** 2026-08-14  
+**Reviewer:** Grok 4.6  
+**Gegenstand:** [central-learning-path-architecture.md](central-learning-path-architecture.md)  
+**Mitgelesen:** [central-learning-path-research.md](central-learning-path-research.md), laufender Kernel, Content-Service-ADRs  
+**Ausarbeitungen, auf die hier nur verwiesen wird:** [central-learning-path-identity.md](central-learning-path-identity.md) (Frage 0), [central-learning-path-refinement.md](central-learning-path-refinement.md) (Reduktion, Overlay-Abschluss, FSRS)
+
+Dieses Dokument ist kein zweiter Architektur-Entwurf. Es ist die Meinung zu den Themen, die der Draft setzt: was trägt, was schief sitzt, was ich weglassen oder verschieben würde.
+
+---
+
+## Gesamteindruck
+
+Der Draft trifft die Produktgestalt. Eine offene, versionsgeführte Wissensbasis, Curricula als Overlays, statische Kacheln, Lehrer als Qualitätsgate, Lernen vollständig auf dem Gerät — das ist die richtige Architektur für ZAM, und sie beantwortet die offene Hosting-Frage aus ADR 2026-07-26b besser als ein Datenbank-Endpoint.
+
+Was ihn als Bauplan noch unsicher macht: Er packt zu viel in den Knoten (Alter, Lehrplan, Interaktionen, Medien, Identität), stellt eine Klassen-Schicht neben ein anonymes CDN, und vermischt Gedächtnismodell mit Kompetenzmodell. Die Vision ist größer als der erste lieferbare Schnitt. Das ist erlaubt — solange der Phasenplan das nicht verschleiert.
+
+Urteil in einem Satz: **Verteilung und Curation-Haltung übernehmen, Datenmodell und Schicht 2 zerlegen, Scanner und Knowledge Tracing nach hinten.**
+
+---
+
+## 1. Vision: Bildungs-DAG von der Kindheit bis zur Hochschulreife
+
+**Gefällt mir.** Das Ziel ist konkret und größer als „LehrplanPLUS-Karten hosten“. Ein gerichteter Abhängigkeitsgraph über Fächer- und Jahrgangsgrenzen ist genau der Grund, warum ZAM Tokens und Prerequisites hat und nicht nur einen Kartenstapel.
+
+**Verbessern.** „Den gesamten Lernpfad“ als erster Liefergegenstand ist nicht baubar und nicht nötig. Der Graph wird glaubwürdig, wenn *eine* Zelle stimmt (eine Schulart, ein Fach, ein Jahr) und ein zweites Overlay dieselben Atome wiederverwendet. Ohne diese Wiederverwendung ist es keine universelle Basis, sondern ein gepacktes Curriculum.
+
+Die vier Ausstattungsmerkmale am Knoten (Alter, Overlay, Medien, zwei Interaktionsstufen) sind Produktwünsche, keine Knotendefinition. Ein Atom braucht eine Identität, eine abrufbare Aussage und Hard-Kanten. Alles andere hängt daran oder liegt daneben.
+
+---
+
+## 2. Das Paradigma „Google Maps für das Wissen“
+
+**Gefällt mir sehr — für die Verteilung.** Vorkompilierte, unveränderliche Artefakte, CDN, Routing auf dem Gerät: das ist das Kosten- und Datenschutzmodell, das einen Sponsor und eine Schule gleichzeitig ertragen. OpenStreetMap ist die ehrlichere Analogie als Google Maps (offene Daten, lokale Renderer, kein Nutzerprofil auf der Karte).
+
+**Verbessern.** Die Metapher trägt nicht für das Wissensmodell. Eine Karte ist isomorph zur Geographie. Ein Bildungsgraph ist eine kuratierte Reduktion; es gibt nicht *die* Karte des Wissens. Wer die Metapher wörtlich nimmt, erwartet eine eindeutige Geometrie, globale transitiv reduzierte Kanten und Zoomstufen, die dasselbe Objekt nur grober zeigen. Reduktionsstufen sind aber *andere Objekte*, kein LOD.
+
+SQLite-WASM als Review-Engine würde ich nicht festschreiben. Der Desktop- und Mobile-Kernel spricht schon natives SQLite. WASM ist ein Browser-Sonderfall, kein Architekturzwang.
+
+„Nahezu 0 €“ ist als Richtung richtig und als Zahl zu glatt. Der teure Teil ist Curation, nicht Bandbreite. Die Tabelle in Abschnitt 7 vergleicht Infrastrukturkosten und verschweigt Lehrerzeit. Das verzerrt die Entscheidung nicht — Curation will ZAM bewusst einmal zahlen — aber der Draft sollte das sagen.
+
+---
+
+## 3. Drei-Schichten-Topologie
+
+### Zentraler Knowledge-Layer
+
+**Gefällt mir.** Read-only, anonym, keine Karten, keine Logs: das ist die strukturelle Grenze, die ADR 2026-07-26b gezogen hat, und der Draft hält sie auf dieser Schicht ein. Git als Revisionsgeschichte, Signatur auf dem Artefakt, statischer Download — konsistent.
+
+**Verbessern.** In dieselbe Schicht wandern Dinge, die nicht kanonisch sind: typisches Mindestalter, YouTube-URLs als First-Class, „Knowledge Tracing“-Andeutungen im Client-Text daneben. Der Layer sollte nur enthalten, was alle Lerner derselben Fassung teilen und was offline wahr bleibt, wenn ein Video verschwindet.
+
+### Klassen- und Schul-Layer
+
+**Gefällt mir nicht in dieser Topologie.** Sobald ein zentraler oder „halboffener“ Dienst speichert, welches Thema die Klasse diese Woche macht, gibt es Identität, Minderjährige und einen Auftragsverarbeitungsvertrag. Genau das macht den Content-Service strukturell unmöglich. „Optional / Sync“ weicht das nur sprachlich auf.
+
+Klassenfortschritt ist ein Assignment, höchstens ein Schul-Workspace. Für den Feldtest reicht ein *lokaler* Cursor, gesetzt durch Scanner oder durch „wir sind bei Kapitel X“. Nichts davon gehört zwischen CDN und Gerät als eigene Netzschicht.
+
+Aggregierte Hausaufgabenempfehlungen der Lehrkraft sind dasselbe Problem plus Pädagogik: Aggregation über Schüler ist in ADR 2026-07-04 bewusst nicht gebaut.
+
+### Lerner-Edge
+
+**Gefällt mir.** FSRS, Notizen, gewählter Bildungspfad, Scans — alles lokal. Das ist der richtige Ort.
+
+**Verbessern.** FSRS-5 ist falsch; der Kernel ist FSRS-6. Der „Knowledge Tracing Vektor pro Knoten“ verdoppelt die Karte. Stabilität, `reps`, `blocked`, `state` *sind* der lokale Kompetenz-Proxy. Ein zweiter Score lädt dazu ein, FSRS-Updates aus Graph-Evidenz zu erfinden. Das würde ich aus der Architektur streichen, nicht als Zukunftsfeld offen halten.
+
+---
+
+## 4. Token-Schema
+
+Das Beispiel-JSON ist das nützlichste Stück des Drafts, weil man daran sieht, was in den Knoten gestopft wurde. Stück für Stück:
+
+### Identität und Verweise
+
+ULID als `id` ist in Ordnung als Zeile. Prerequisites, die auf Slugs zeigen (`"token_id": "physik-optik-…"`), sind es nicht. Slugs sind Sprache, Taxonomie und Tippfehler. Kanten müssen auf einen stabilen Knotenschlüssel zeigen.
+
+`wikidata_id` am Token ist der richtige Impuls und in dieser Form zu grob: ein Q für qualitative und quantitative Fassung. Das ist Frage 0; der Arbeitsvorschlag ist der PAID, nicht das Q allein.
+
+`domain: "schule/physik/optik"` stört mich nicht mehr als Korpus- oder Navigationspfad. Als Identität des Atoms taugt der Pfad nicht.
+
+### Alter und Piaget-Stufe
+
+**Gefällt mir als Hinweis, nicht als Gate.** „Typischerweise ab 14, weil Sinus“ ist kuratierbar und für Eltern lesbar.
+
+**Verbessern.** `developmental_stage: "formal_operational"` macht aus einer umstrittenen Stufentheorie ein Schemafeld. Alter und Stufe gehören an die Overlay-Mitgliedschaft oder bleiben ein unverbindlicher Kommentar. Dieselbe Entität hat mehrere Reduktionen; die formale Fassung ist „später“, die qualitative darf früher sein. Ein `typical_age_min` am *einen* Snellius-Knoten erzwingt die falsche Einheit.
+
+### Hard- und Soft-Kanten
+
+**Gefällt mir sehr.** Das ist die wichtigste Modell-Erweiterung gegenüber dem heutigen Kernel, und das Beispiel (Sinus hard, Huygens soft) ist didaktisch richtig. Soft darf nie blocken. Hard braucht eine `rationale` — die sollte die CI nicht schlucken, sondern im Review sichtbar bleiben.
+
+**Verbessern.** Die dritte Sorte fehlt: Curricular-hard („der Lehrplan verlangt das zuvor“) ist nicht dasselbe wie definitions-hard. Und transitives Streichen globaler Kanten ist falsch, sobald Overlays Zwischenknoten auslassen. Der Compiler muss den Overlay-Abschluss materialisieren; das Schema des Universalgraphen darf redundante Hard-Kanten behalten.
+
+### `curricula[]` am Token
+
+**Gefällt mir als Demonstration, nicht als Speicherform.** n:m-Mitgliedschaft ist richtig. Realschule Bayern 9 und Gymnasium BW 8 können dasselbe Atom verlangen.
+
+**Verbessern.** Wenn jedes Atom seine Overlays in sich trägt, wird das Atom bei jedem neuen Bundesland angefasst und jedes Curriculum-Tile muss den ganzen Tokenkörper ziehen. Mitgliedschaft gehört ins Overlay-Tile; das Atom kennt seinen PAID, nicht die Schulpolitik.
+
+### Medien
+
+**Gefällt mir:** PhET, kurze Videofenster, SVG mit Alt-Text. Dual Coding ist hier ehrlich operationalisiert, nicht als Poster-Satz.
+
+**Verbessern:** YouTube als First-Class-URI im Token. Links sterben, Videos werden privat, Lizenz ist ungeklärt. Lernen darf nicht brechen, wenn der Clip weg ist. Externe Medien sind ein Manifest mit Haltbarkeitscheck, nicht Teil der Atom-Identität. Der Kernel hat bereits lokale, content-addressed Bilder und Audio — das ist die zuverlässige Sorte. Externes darf fehlen.
+
+### Zwei Interaktionsstufen
+
+**Gefällt mir als UX.** Für Schüler ist Tippen auf „zum Lot hin“ die richtige erste Geste. Die Taucher-Aufgabe ist eine echte Prüfungsfrage, keine Umformulierung der Definition. Cognitive Load: Extraneous Load runter, Retrieval häufig — das ist richtig gedacht.
+
+**Verbessern.** Im Schema werden die Checks zur zweiten Wahrheitsquelle neben `question` / `concept`. Dann driftet die Formulierung, und der Kernel-Prompter (Bloom 1–5) konkurriert mit einem eingebetteten Mini-LMS. Tier 1/2 sind *Darstellungen* desselben Atoms. Sie dürfen im Tile mitreisen, wenn eine Lehrkraft sie geprüft hat. Review muss ohne sie funktionieren. Freigabe über `S > 21 Tage` würde ich nicht bauen; das ist ein zweiter Scheduler.
+
+Die Tier-2-Frage im Beispiel prüft Totalreflexion, nicht Snellius. Das ist kein Schönheitsfehler: sie hängt ein zweites Atom in die Prüfung. Entweder gehört sie an `wd:Q165738/…`, oder sie ist bewusst ein Transfer über zwei Knoten — dann darf sie nicht im Snellius-Token wohnen, als wäre sie seine Synthese.
+
+### Curation-Block
+
+**Gefällt mir:** `verified_by`, Zeitpunkt, Signatur.
+
+**Fehlt das Lasttragende:** cosmetic vs. material, `content_version`. Eine Signatur ohne Änderungssemantik sagt „jemand hat zugestimmt“, nicht „was passiert mit den Karten der Leute, die die alte Aussage gelernt haben“. Das hat ZAM schon entschieden und der Draft lässt es liegen.
+
+JSON-LD als Austauschformat ist optional und hier Marketing. Ein JSON-Schema über dem Kernel-Modell reicht. JSON-LD lohnt, wenn jemand den Graphen wirklich als Linked Data konsumieren soll — das ist kein Jahr-1-Ziel.
+
+---
+
+## 5. Knowledge Vector Tiles
+
+**Gefällt mir am meisten an diesem Draft.** Drei Sorten (Overlay, Domain, Media), Content-Hash in der URL, langes Cache, `index.json` zum Nachziehen: das ist eine Architektur, die man bauen kann, ohne einen Anwendungsserver.
+
+**Verbessern, konkret:**
+
+- Overlay-Tiles sind das eigentliche Lehrplan-Objekt. Sie müssen die Mitgliedermenge *und* den kompilierten Hard-DAG \(E_S\) enthalten, nicht nur Flags und eine Reihenfolge.
+- Domain-Tiles sollten kein SQLite-Besonderheitsformat plus Embeddings sein. Embeddings sprengen die 1–3-MB-Schätzung (1000 × 1536 × 4 B ≈ 6 MB roh) und binden das Tile an ein Embedding-Modell. Vektoren gehören in ein optionales viertes Tile mit `embedding_model_id`.
+- JSON-LD neben `.sqlite` neben `.json` ist drei Stacks. Ein kompiliertes Format wählen, das der bestehende Client schon spricht — oder bewusst ein schmales Austausch-JSON, das der Client in die lokale SQLite *importiert*. Range-Requests gegen eine Remote-SQLite würde ich nicht als v1 festnageln.
+- 15 MB beim Profil-Setup ist für WLAN in Ordnung, für schulisches Mobilfunk und für „erstes Fach zuerst“ zu grob. Overlay + ein Domain-Root zuerst; der Rest nachziehen.
+- Merkle-Trees (im Research-Briefing) sind für Jahres-Curricula Überbau. Hash-URL plus Index reicht.
+
+Die Google-Maps-Kachelmetapher verführt zu räumlicher Nachbarschaft. Wissensnachbarschaft ist der DAG, nicht `(x, y)`. Partition nach Domain-Wurzel und Overlay ist richtig; Partition nach „Zoomstufe“ wäre falsch.
+
+---
+
+## 6. Curation-Pipeline
+
+**Gefällt mir die Haltung.** „AI generiert Entwürfe — Lehrkräfte prüfen — Millionen profitieren“ ist dasselbe Prinzip wie ADR 2026-07-25, und es ist das einzige, das Schulmaterial tragen kann. Git für den Text, CI vor dem Tile, Signatur auf dem Artefakt: vernünftige Mechanik.
+
+**Verbessern.** Der Draft legt Review *und* Release in Studio plus PR, als wäre das neu. ZAM hat die Trennung schon: Git beantwortet „ist der Text richtig?“, das Studio beantwortet „was geschieht mit den Karten?“. Merging darf niemandes Queue erreichen. Das fehlt im Diagramm zwischen „Freigegeben“ und „Build“.
+
+CI prüft Zyklen, Bloom/Alter, tote Links. Es fehlt der Overlay-Abschluss: jeder exam-relevante Knoten erreichbar, keine Hard-Kante ins Leere, Reduktionsstufen desselben Ankers monoton im Overlay. Tote YouTube-Links sind Hygiene; ein zyklischer oder gelochter Hard-DAG ist ein Publish-Blocker.
+
+„Jedes Pflicht-Token hat einen `topic_code`“ ist als Erdung gut und als 1:1-Zwang falsch. Ein Atom hat oft mehrere Codes, ein Code oft mehrere Atome. Erdung ist n:m über `sources` / Overlay-Mitglieder.
+
+Spoiler-Freiheit von Titel und Frage: ja, das ist bestehendes ZAM-Handwerk und gehört in die Qualitätskriterien. Gut, dass es hier steht.
+
+---
+
+## 7. Schulheft-Scanner
+
+**Gefällt mir als Produktidee am meisten nach den Kacheln.** Das ist die Brücke, die Lernsoftware sonst nie baut: nicht der Lehrplan im Menü, sondern die Seite, die heute im Heft steht. Lokal, mit Bestätigung, Lücken im Graphen sichtbar — das ist studio-first und kindgerecht.
+
+**Verbessern.**
+
+- Er ist ein Client-Feature, das den Graphen *konsumiert*, kein Bestandteil der zentralen Wissensbasis. Im Phasenplan steht er eine Nummer zu früh und in der Topologie eine Schicht zu zentral.
+- Der Sequenzdiagramm-Schritt „setzt Klassen-Fortschrittsanker“ darf nur lokal schreiben. Sonst ist der Scanner der Einfallsweg für die Klassen-Schicht, die ich oben ablehne.
+- „Aktiviert abhängige FSRS-Karten für heute“ muss präzise heißen: Karten für gematchte Atome *anlegen* (Attach), nicht fremde Stabilität schreiben und nicht den ganzen Teilbaum als gelernt markieren. Ungelernte Hard-Prereqs rot markieren: ja. Als gelernt überspringen: nein.
+- v1 braucht kein VLM und keinen dichten Vektorindex über den Weltgraphen. Eine Jahrgangszelle hat ein paar hundert Atome. On-Device-OCR plus lexikalischer/leichter semantischer Match gegen Titel und Konzept der geladenen Zelle reicht, plus die Bestätigungsfrage, die schon im Draft steht. Die Bestätigung ist der eigentliche Qualitätsgate, nicht der Score 0.94.
+
+---
+
+## 8. Kosten- und Performance-Modell
+
+**Gefällt mir die Richtung der Tabelle.** Der qualitative Unterschied stimmt: kein Cluster, keine personenbezogenen Serverdaten, Offline ist der Normalfall.
+
+**Verbessern.** Die Euro-Zahlen und „< 5 ms“ sind Rhetorik. Sie schaden nicht, solange niemand darauf eine Finanzierung rechnet, ohne Curation, Signierung, Link-Checks und die seltene Neu-Kompilation einzupreisen. DSGVO ist „trivial“ nur für Schicht 1. Schicht 2 macht sie wieder schwer — ein weiterer Grund, Schicht 2 nicht zu bauen.
+
+---
+
+## 9. Phasenplan
+
+**Gefällt mir, dass es einen gibt.** Schema → echte Curricula → Studio → Scanner ist eine lesbare Geschichte.
+
+**Verbessern, Reihenfolge.** Der Plan überspringt die zwei Entscheidungen, ohne die Tiles nur ZIP-Dateien sind:
+
+0. Veröffentlichte Identität (PAID oder bewusst temporäre IDs für *eine* Zelle).
+1. Hard/Soft und Overlay-Abschluss als Compiler-Vertrag.
+2. Eine echte Zelle kompilieren und anfassen (nicht 15 Manifeste auf einmal).
+3. Menschliches Release mit Änderungssemantik.
+4. Scanner gegen die eine geladene Zelle.
+
+Phase 2 „15 Curriculum-Manifeste in KVT“ vor einer funktionierenden Zelle erzeugt 15 merkwürdige Graphen. Phase 3 „Curation Workspace“ existiert in Stücken schon (Studio, editorial states). Neu ist das Publish → Tile, nicht ein drittes Editorfenster. Phase 4 Scanner erst, wenn Attach an ein Overlay lokal langweilig zuverlässig ist.
+
+Lizenz von LehrplanPLUS-Ableitungen bleibt der Blocker vor einem öffentlichen CDN. Internes Tile an Feldtest-Geräte: ja. Welt-CDN: nicht in Phase 2 verstecken.
+
+---
+
+## 10. Was die Forschungsarbeit der Architektur zumutet
+
+Nur soweit es den Bauplan verbiegt.
+
+**Übernehmen.** Cognitive Load als Argument für schnelle Checks. Dual Coding als Argument für Medien-*Referenzen*. Overlay über einem gemeinsamen Netz statt 16 Inseln. DAG, den man auf Zyklen prüft.
+
+**Nicht übernehmen, jedenfalls nicht in v1.**
+
+- Die Accessibility-Formel (Sigmoid über Alter und Mastery) als Freigaberegel. Unkalibriert, vermischt Einheiten, ersetzt eine lexikographische Politik, die der Blocker fast schon hat.
+- FSRS-Stabilität entlang von Kanten propagieren. Kategoriefehler; ausführlich in der Verfeinerung.
+- Piaget-Stufen als Token-Enum.
+- Transitive Reduktion auf dem Universalgraphen.
+- DKT/neuronales Tracing im Client. Verletzt die Kernel-Grenze und löst kein Feldtest-Problem.
+
+1EdTech CASE taucht im Research-Vergleich auf und dann nie wieder. Für den Zentralgraphen ist CASE eher ein *Import-/Export-Adapter* für fremde Kompetenzrahmen, nicht das interne Modell. Das würde ich so festhalten, damit niemand das Token-Schema in CASE umschreibt.
+
+---
+
+## 11. Passung zum laufenden Kernel
+
+Der Draft tut so, als entwürfe er das Lernsystem. Er entwirft die **Verteilungsschicht** über einem System, das schon Tokens, Karten, Hard-Prereqs, Blocking, FSRS-6, Overlays als `provider`/`topic_id`, Editorial States, `content_version`, lokale Medien und Assignments hat.
+
+Was ich deshalb gut finde: nichts davon muss weg, damit KVT Sinn ergibt. Der Builder ist ein Compiler.
+
+Was ich deshalb streichen würde, statt es neu zu erfinden: zweiter Mastery-Vektor, FSRS-5, JSON-LD als Wahrheit, Klassen-Sync, WASM als Pflichtpfad, Interaktionsobjekte als Kernschema.
+
+Was der Kernel noch nicht hat und der Draft zu Recht andeutet: Soft-Kanten, veröffentlichten Join-Schlüssel, kompilierten Overlay-DAG, Medien-Manifest getrennt vom Atom.
+
+---
+
+## 12. Themen, gewichtet
+
+Was ich behalten würde, auch wenn der Rest umgeschrieben wird:
+
+1. Statische, anonyme Kacheln als Hosting-Form.
+2. Curricula als Overlays über geteilten Atomen.
+3. Lehrer prüft, KI entwirft.
+4. Hard- und Soft-Kanten.
+5. Lernen und Scans nur auf dem Gerät.
+6. Schulheft als *lokaler* Anker an den Unterricht.
+
+Was ich vor dem ersten Builder festziehen würde:
+
+1. PAID als veröffentlichter Schlüssel, ULID als Zeile.
+2. Reduktionsstufen als eigene Atome.
+3. Overlay-Abschluss statt globaler Kantenkürzung.
+4. Keine Klassen-Schicht auf oder neben dem CDN.
+5. Keine FSRS-Writes aus Graph-Evidenz.
+
+Was ich gerne im Dokument stehen lasse und nicht bauen würde, bevor eine Zelle lebt:
+
+1. Scanner.
+2. YouTube-First-Class.
+3. Tier-1-Objekte im Kernschema.
+4. Signatur-Infrastruktur (erst Hash und menschliches Release).
+5. Weltweites CDN.
+
+---
+
+## 13. Ton des Drafts, kurz
+
+Der Text ist werblich, wo er architektonisch sein könnte (Kostenzeile, „Google Maps“, „100 % DSGVO“). Für eine erste Vision ist das in Ordnung. Für den nächsten Stand würde ich pro Abschnitt eine Entscheidung, eine Nicht-Entscheidung und ein Gegenbeispiel verlangen. Das Snellius-JSON ist der richtige Stil — anfassbar, deshalb kritisierbar. Davon mehr, von den Tabellen mit erfundenen Euro weniger.

--- a/docs/concepts/central-learning-path-architecture.md
+++ b/docs/concepts/central-learning-path-architecture.md
@@ -1,0 +1,305 @@
+# Draft-Architektur: Zentrale Wissensbasis als weltweiter Bildungs-Graph („Google Maps für das Lernen“)
+
+**Status:** Draft / Proposal  
+**Datum:** 2026-08-14  
+**Autoren:** ZAM Core & Agent Research Team  
+**Bezug zu bestehenden ADRs:**
+- [ADR 2026-07-26b: Central Curriculum Content Service: Content Only, Pulled Forward](../adr/2026-07-26b-central-curriculum-content-service.md)
+- [ADR 2026-07-25: Shared Curated Learning Content — Review Once, Serve Many](../adr/2026-07-25-shared-curated-learning-content.md)
+- [ADR 2026-07-04: Closed-Group Learning Library: Curation, Privacy and Deployment](../adr/2026-07-04-multi-learner-shared-knowledge.md)
+- [ADR 2026-07-02: LehrplanPLUS Curriculum Import Wizard](../adr/2026-07-02-lehrplanplus-import-wizard.md)
+
+---
+
+## 1. Executive Summary & Leitprinzipien
+
+### 1.1 Die Vision
+Ziel dieses Systems ist der Aufbau einer **offenen, zentralen, versionsgeführten Wissensbasis**, die den gesamten Lernpfad eines heranwachsenden Menschen von der frühen Kindheit bis zum Schulabschluss (und darüber hinaus) als **gerichteten Abhängigkeitsgraphen (Prerequisite-DAG)** abbildet.
+
+Jeder Knoten (Knowledge Token) repräsentiert eine atomare Lerneinheit, versehen mit:
+1. **Didaktischen Alterstags** (Entwicklungsstufe / typisches Mindestalter für das Verstehen),
+2. **Curricularen Overlays** (z. B. *Realschule Bayern – 9. Klasse – naturwissenschaftlicher Zweig*),
+3. **Multimodalen Erklärungsressourcen** (kuratierte YouTube-Videoanker mit Timestamps, interaktive HTML5/PhET-Simulationen, Audio-Erklärungen, Bilddiagramme),
+4. **2-Stufen-Interaktionsmustern** (Tier 1: Schnelle, reibungslose Micro-Checks für den sofortigen Abrufeffekt; Tier 2: Vertiefende Synthese und Prüfungsaufgaben für spätere Meisterungsprüfungen).
+
+### 1.2 Das Paradigma: „Google Maps für das Wissen“
+Kartendienste wie Google Maps oder OpenStreetMap skalieren für Milliarden Menschen bei minimalen Kosten, weil sie:
+- Daten nicht pro Nutzer dynamisch auf zentralen Servern berechnen,
+- sondern **vorberechnete, unveränderliche Vektorkacheln (Vector Tiles)** über globale CDNs ausliefern,
+- während Rendering, Routing und Routenverfolgung **vollständig auf dem Endgerät (Edge/Client)** stattfinden.
+
+Die zentrale ZAM-Wissensbasis adaptiert genau dieses Prinzip als **Knowledge Vector Tiles (KVT)**:
+- **Zentraler Betreiber:** Pflegt und verteilt statische, kompilierte Graph-Kacheln über CDNs.
+- **Client (ZAM App):** Lädt den benötigten Sub-Graphen für den gewählten Bildungspfad herunter und führt Graph-Traversierung, FSRS-Scheduling und Knowledge Tracing lokal in einer In-Memory- oder SQLite-WASM-Engine aus.
+- **Kosten:** Nahezu **0 € Serverkosten** im laufenden Betrieb, 100% DSGVO-konform, vollständige Offline-Fähigkeit.
+
+---
+
+## 2. System-Topologie & Datentrennung
+
+Die Architektur erzwingt eine strikte physische und logische Trennung der Datenklassen gemäß [ADR 2026-07-26b](../adr/2026-07-26b-central-curriculum-content-service.md):
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│                      1. ZENTRALER KNOWLEDGE-LAYER (Öffentlich, Read-Only, CDN)            │
+├──────────────────────────────────────────────────────────────────────────────────────────┤
+│ • Canonical Tokens (Titel, Konzept, Frage, Bloom-Level, Typisches Mindestalter)          │
+│ • Prerequisite-Kanten (Strikte Abhängigkeiten & weiche Empfehlungen)                     │
+│ • Lehrplan-Taxonomien (LehrplanPLUS Bayern, KMK, etc. mit Prüfungsrelevanz-Flags)        │
+│ • Multimodale Ressourcen (YouTube Timestamps, PhET, GeoGebra, Audio, Bilder)             │
+│ • Lehrer-/Experten-Signaturen & Revisionsgeschichte (Git-basiert)                        │
+└────────────────────────────────────────────┬─────────────────────────────────────────────┘
+                                             │ Statischer Kachel-Download (HTTP Range / GET)
+                                             ▼
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│                     2. KLASSEN- & SCHUL-LAYER (Optional / Halboffen / Sync)              │
+├──────────────────────────────────────────────────────────────────────────────────────────┤
+│ • Klassen-Fortschrittszeiger (Aktuelles Thema der Woche im Schuljahr)                    │
+│ • Aggregierte Hausaufgaben- & Stoff-Empfehlungen der Lehrkraft                           │
+└────────────────────────────────────────────┬─────────────────────────────────────────────┘
+                                             │
+                                             ▼
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│                     3. LERNER-EDGE (100% Lokal, Privat, DSGVO-sicher)                    │
+├──────────────────────────────────────────────────────────────────────────────────────────┤
+│ • FSRS-5 Lernkarten (Stabilität, Schwierigkeit, Abrufhistorie, Reps, Lapses)             │
+│ • Knowledge Tracing Vektor (Individueller Mastery-Score pro Graph-Knoten)                │
+│ • Gescannte Schulhefte & Arbeitsblätter (Lokale Vision-OCR & Embedding-Matching)         │
+│ • Persönliche Eselsbrücken, Freitext-Notizen & Sprachaufnahmen                           │
+│ • Gewählter Bildungspfad (z. B. "Realschule Bayern, 9. Klasse, Zweig I")                 │
+└──────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Datenmodell & Schema-Spezifikation
+
+### 3.1 Kanonisches Knowledge-Token Schema (JSON-LD / JSON-Schema v1)
+
+```json
+{
+  "$schema": "https://zam.app/schemas/v1/knowledge-token.json",
+  "id": "01K3X9A7R4B8C1D2E3F4G5H6J7",
+  "slug": "physik-optik-brechungsgesetz-snellius",
+  "title": "Snelliussches Brechungsgesetz",
+  "wikidata_id": "Q202814",
+  "concept": "Beim Übergang von Licht zwischen zwei Medien mit Brechungsindizes n1 und n2 gilt das Brechungsgesetz: n1 * sin(alpha) = n2 * sin(beta).",
+  "domain": "schule/physik/optik",
+  "bloom_level": 3,
+  "age_recommendation": {
+    "typical_age_min": 14.0,
+    "developmental_stage": "formal_operational",
+    "rationale": "Erfordert Verständnis von Winkelfunktionen (Sinus) und proportionalen Verhältnissen."
+  },
+  "prerequisites": [
+    {
+      "token_id": "physik-optik-lichtausbreitung-strahlengang",
+      "type": "hard",
+      "rationale": "Ohne das Konzept des Lichtstrahls und des Einfallswinkels ist die Brechung nicht definierbar."
+    },
+    {
+      "token_id": "mathematik-geometrie-sinus-funktion",
+      "type": "hard",
+      "rationale": "Mathematische Berechnung der Winkelverhältnisse."
+    },
+    {
+      "token_id": "physik-wellenlehre-phasengeschwindigkeit",
+      "type": "soft",
+      "rationale": "Erklärt die physikalische Ursache der Brechung über Wellenfronten (Huygens-Prinzip)."
+    }
+  ],
+  "curricula": [
+    {
+      "provider": "lehrplanplus-bayern",
+      "country": "DE",
+      "region": "BY",
+      "school_type": "realschule",
+      "grade": 9,
+      "track": "naturwissenschaftlich",
+      "subject": "physik",
+      "topic_code": "PH9-LB2",
+      "topic_title": "Optik und Lichtbrechung",
+      "exam_relevant": true
+    },
+    {
+      "provider": "bildungsplan-bw",
+      "country": "DE",
+      "region": "BW",
+      "school_type": "gymnasium",
+      "grade": 8,
+      "subject": "physik",
+      "exam_relevant": true
+    }
+  ],
+  "learning_media": [
+    {
+      "id": "media-yt-01",
+      "type": "video",
+      "provider": "youtube",
+      "uri": "https://www.youtube.com/watch?v=sample-video-id",
+      "start_sec": 42,
+      "end_sec": 165,
+      "language": "de",
+      "title": "Brechung von Licht anschaulich im Experiment",
+      "author": "Lehrer Schmidt / SimpleClub"
+    },
+    {
+      "id": "media-sim-01",
+      "type": "interactive_simulation",
+      "provider": "phet",
+      "uri": "https://phet.colorado.edu/sims/html/bending-light/latest/bending-light_all.html",
+      "title": "Lichtbrechung interaktives Labor (PhET)",
+      "embedded_allowed": true
+    },
+    {
+      "id": "media-img-01",
+      "type": "infographic",
+      "uri": "assets/diagrams/optik-snellius-strahlengang.svg",
+      "alt_text": "Darstellung des Einfallswinkels alpha und Brechungswinkels beta zum Lot."
+    }
+  ],
+  "interactions": {
+    "tier1_fast_checks": [
+      {
+        "id": "fc-01",
+        "type": "binary_choice",
+        "prompt": "Wird ein Lichtstrahl beim Übergang von Luft in Glas zum Lot hin oder vom Lot weg gebrochen?",
+        "options": ["Zum Lot hin", "Vom Lot weg"],
+        "correct_index": 0,
+        "explanation": "Glas ist optisch dichter als Luft (n2 > n1), daher verkleinert sich der Winkel zum Lot."
+      },
+      {
+        "id": "fc-02",
+        "type": "cloze_tap",
+        "prompt": "Vervollständige die Formel: n1 * [gap1] = n2 * [gap2]",
+        "gaps": [
+          { "id": "gap1", "correct": "sin(α)", "distractors": ["cos(α)", "tan(α)", "α²"] },
+          { "id": "gap2", "correct": "sin(β)", "distractors": ["cos(β)", "tan(β)", "1/β"] }
+        ]
+      }
+    ],
+    "tier2_synthesis": {
+      "prompt": "Ein Taucher leuchtet mit einer Taschenlampe unter Wasser schräg nach oben an die Wasseroberfläche. Erkläre, was ab einem bestimmten Winkel passiert und wie man dieses Phänomen nennt.",
+      "expected_key_concepts": [
+        "Totalreflexion",
+        "Grenzwinkel",
+        "Übergang von optisch dichter zu optisch dünner",
+        "Keine Brechung mehr ins Freie"
+      ],
+      "sample_solution": "Ab dem Grenzwinkel der Totalreflexion wird das Licht vollständig an der Grenzfläche reflektiert und tritt nicht mehr in die Luft über."
+    }
+  },
+  "curation": {
+    "published_version": 1,
+    "verified_by": "fachschaft-physik-bayern",
+    "verified_at": "2026-08-14T12:00:00Z",
+    "signature": "ed25519:3b9f...a8c1"
+  }
+}
+```
+
+---
+
+## 4. Knowledge Vector Tiles (KVT): Skalierung & Verteilung
+
+### 4.1 Partitionierungsstrategie
+Der globale Graph wird nicht als monolithische Datenbank ausgeliefert, sondern in **Kacheln (Tiles)** zerschnitten:
+
+1. **Curriculum-Kacheln (`/tiles/curricula/{country}-{region}/{school-type}-{grade}-{subject}.jsonld`)**:
+   - Enthält die Zuordnungen, Reihenfolgen und Prüfungsrelevanz-Flags für ein konkretes Fach und Schuljahr (z. B. `de-by/realschule-9-physik.jsonld`, ~120 KB).
+2. **Topologische Domain-Kacheln (`/tiles/domains/{domain-root}.sqlite`)**:
+   - Enthält den universellen Wissensgraphen eines Großbereichs (z. B. `mathematik.sqlite`, `physik.sqlite`, jeweils ~1–3 MB).
+   - Enthält alle Knoten, Relationen, Einbettungsvektoren und Tier-1-Checks.
+3. **Media-Manifest-Kacheln (`/tiles/media/{domain-root}.json`)**:
+   - URLs, Timecodes und Metadaten zu externen Videos und Simulationen.
+
+### 4.2 Verteilungs- und Caching-Modell
+- **Hosting:** Statische Dateien auf Objektspeicher (z. B. Cloudflare R2, AWS S3, BunnyCDN, GitHub Pages).
+- **Caching:** `Cache-Control: public, max-age=31536000, immutable` mit Content-Hash-Versionierung in URLs (`/v2026.08/tiles/...`).
+- **Client-Download:** 
+  - Beim Einrichten eines Schülerprofils (z. B. Realschule Bayern 9. Klasse) lädt der ZAM-Client im Hintergrund 5–10 Kacheln (Gesamtvolumen: ~15 MB).
+  - Bei Änderungen wird über einen leichten Index (`index.json` mit Hash-Tabelle) differentiell synchronisiert.
+
+---
+
+## 5. Curation- & Audit-Pipeline für Lehrkräfte
+
+Damit Inhalte nicht durch halluzinierende LLMs verunreinigt werden, gilt das ZAM-Prinzip: **„AI generiert Entwürfe – Lehrkräfte prüfen und signieren – Millionen Lerner profitieren.“**
+
+```mermaid
+flowchart TD
+    A[Offizielle Lehrplan-Texte / Schulbücher] --> B[ZAM Ingestion Pipeline (Draft Generator)]
+    B --> C[Draft Token Pool in ZAM Studio]
+    C --> D{Lehrer-/Fachschafts-Review}
+    D -->|Korrektur nötig| C
+    D -->|Freigegeben| E[Git Pull Request / Curation Repo]
+    E --> F[CI/CD Validierung]
+    F --> F1[1. Zyklenfreiheit des DAG prüfen]
+    F --> F2[2. Bloom- & Alters-Konsistenz prüfen]
+    F --> F3[3. Medien-Links auf Erreichbarkeit testen]
+    F --> G[Build: Knowledge Vector Tiles kompilieren]
+    G --> H[Signierung mit Ed25519-Schlüssel]
+    H --> I[Deployment auf globales CDN]
+```
+
+### Qualitätskriterien für Freigaben:
+1. **Atomizität:** 1 Konzept, 1 Kernfrage, 1 prägnante Antwort.
+2. **Strikte Erdung:** Jedes Pflicht-Token verweist auf eine offizielle Lehrplan-Fundstelle (`topic_code`).
+3. **Spoiler-Freiheit:** Titel und Fragen dürfen die Antwort nicht vorwegnehmen.
+4. **Altersgerechte Formulierung:** Sprachniveau und kognitiver Anspruch passen zum Zielalter.
+
+---
+
+## 6. Schulheft-Scanner & Synchronisation mit dem Unterricht
+
+Ein Kernproblem traditioneller Lernsoftware ist die Entkopplung vom realen Schulunterricht. Die Lehrkraft folgt ihrem eigenen Zeitplan. Der Schulheft-Scanner schließt diese Lücke:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Learner as Schüler / Eltern
+    participant App as ZAM Mobile App (iPad / Android)
+    participant Vision as On-Device Vision / OCR
+    participant LocalDB as Lokale SQLite DB & Vector Index
+
+    Learner->>App: Fotografiert Seite aus Schulheft / Arbeitsblatt
+    App->>Vision: Führt lokale OCR & Strukturanalyse durch
+    Vision-->>App: Extrahierter Text, Formeln, Überschriften
+    App->>LocalDB: Semantische Vektorsuche im aktuellen Curriculum-Subgraphen
+    LocalDB-->>App: Bester Match: "Snelliussches Brechungsgesetz" (Score: 0.94)
+    App->>Learner: "Habt ihr heute Lichtbrechung (Snellius) durchgenommen?"
+    Learner->>App: Bestätigt ("Ja!")
+    App->>LocalDB: 1. Setzt Klassen-Fortschrittsanker auf dieses Token<br/>2. Aktiviert abhängige FSRS-Karten für den heutigen Tag<br/>3. Prüft ungelernte Prerequisites und markiert Lücken rot
+```
+
+### Vorteile:
+- **Null manueller Konfigurationsaufwand:** Kein mühsames Suchen nach Themen in Menüs.
+- **Transparenz über Wissenslücken:** Versteht ein Kind das neue Thema nicht, zeigt der Graph sofort: *„Achtung: Das Fundament 'Sinus-Funktion' aus der Mathematik ist noch ungefestigt!“*
+- **100% lokal:** Das Foto des Schulhefts verlässt das Gerät des Schülers nicht.
+
+---
+
+## 7. Kosten-, Skalierungs- & Performance-Modell
+
+| Metrik | Traditionelles SaaS (Dynamischer Server / DB) | ZAM KVT Architektur (Statische Kacheln & Edge) |
+| :--- | :--- | :--- |
+| **Server-Infrastruktur** | Cluster aus PostgreSQL, App-Servern, Redis, API-Gateways | Statischer Objektspeicher (Cloudflare R2 / S3) + CDN |
+| **Kosten bei 10.000 Nutzern** | ~200 – 500 € / Monat | < 1 € / Monat |
+| **Kosten bei 1.000.000 Nutzern** | ~15.000 – 40.000 € / Monat | ~20 – 50 € / Monat (reine CDN-Bandbreite) |
+| **Latenz beim Lernen** | 100 – 400 ms (Netzwerk-Roundtrips zu Datenbanken) | **< 5 ms** (Lokale SQLite In-Memory Abfrage auf dem Gerät) |
+| **Offline-Fähigkeit** | Nein oder fehleranfälliges 2-Wege-Sync | **Ja, 100% offline funktionsfähig** |
+| **DSGVO / Datenschutz** | Extrem komplex (Minderjährigendaten auf Servern, AVVs) | **Trivial (Keinerlei personenbezogene Daten auf Servern)** |
+
+---
+
+## 8. Nächste Umsetzungsschritte (Phasenplan)
+
+1. **Phase 1: Token-Schema & KVT-Builder:**
+   - Formalisierung des JSON-Schema v1 für multimodale Knowledge-Tokens.
+   - CLI-Befehl `zam curriculum compile-tiles` zur Erzeugung statischer Kacheln.
+2. **Phase 2: LehrplanPLUS-Bayern-Extraktion in den zentralen Graphen:**
+   - Konvertierung der bestehenden 15 Curriculum-Manifeste in kanonische KVT-Bundles.
+3. **Phase 3: ZAM Studio Curation Workspace:**
+   - Web-/Desktop-Oberfläche für Lehrkräfte zum Prüfen, Editieren und Signieren von Tokens.
+4. **Phase 4: Mobile Schulheft-Scanner Prototyp:**
+   - Integration von On-Device Apple Vision / Google ML Kit Text Recognition mit lokalem Embedding-Match.

--- a/docs/concepts/central-learning-path-architecture.md
+++ b/docs/concepts/central-learning-path-architecture.md
@@ -3,6 +3,7 @@
 **Status:** Draft / Proposal  
 **Datum:** 2026-08-14  
 **Autoren:** ZAM Core & Agent Research Team  
+**Gegenlesen:** [central-learning-path-refinement.md](central-learning-path-refinement.md) · [central-learning-path-identity.md](central-learning-path-identity.md) · **Review:** [central-learning-path-architecture-review.md](central-learning-path-architecture-review.md).  
 **Bezug zu bestehenden ADRs:**
 - [ADR 2026-07-26b: Central Curriculum Content Service: Content Only, Pulled Forward](../adr/2026-07-26b-central-curriculum-content-service.md)
 - [ADR 2026-07-25: Shared Curated Learning Content — Review Once, Serve Many](../adr/2026-07-25-shared-curated-learning-content.md)

--- a/docs/concepts/central-learning-path-codex-research-review.md
+++ b/docs/concepts/central-learning-path-codex-research-review.md
@@ -1,0 +1,699 @@
+# Forschungsvertiefung und Review: Identität, Ontologie-Mapping und Graphkompilation
+
+**Status:** Review — Zustimmung zur Architektur zurückgestellt
+
+**Datum:** 2026-08-14
+
+**Reviewer:** OpenAI Codex
+
+**Primärer Forschungsauftrag:** Forschungs-Briefing 1 aus
+[central-learning-path-research.md](central-learning-path-research.md):
+Ontologie-Mapping und Entitäts-Disambiguierung
+
+**Mitgeprüft:** Identität, didaktische Reduktion, Overlay-Abschluss, FSRS-Grenze,
+Kachelverteilung, Provenienz und Lizenzgrenze
+
+---
+
+## 0. Ergebnis vorweg
+
+Die Produktvision trägt: kuratierte Lerninhalte einmal prüfen, Curricula als
+Overlays über geteilten Lernzielen modellieren, unveränderliche öffentliche
+Artefakte anonym verteilen und Lernzustand ausschließlich beim Lerner halten.
+Auch Groks Korrekturen — kein Alters-Gate, keine FSRS-Stabilitätspropagierung,
+keine Klassenkonten im Content-CDN, kein globales transitives Pruning — gehen
+überwiegend in die richtige Richtung.
+
+**Für eine Zustimmung zur vorliegenden Architektur reicht das noch nicht.**
+Fünf Punkte sind vor einem ADR-Entscheid blockierend:
+
+1. Der vorgeschlagene PAID `(scheme, entity, reduction)` ist ein nützlicher
+   Matching-Fingerprint, aber kein sicherer veröffentlichter
+   Identitätsschlüssel. Er erzeugt nachweisbar falsche Gleichheiten.
+2. Zwischen sprachneutralem Lernziel und persönlicher FSRS-Karte fehlt die
+   **konkrete Übungsrepräsentation**: Frage, erwartete Antwort, Sprache,
+   Modalität und Testformat. Ohne diese Schicht wird Gedächtniszustand zwischen
+   nicht austauschbaren Abrufaufgaben übertragen.
+3. Groks Overlay-Abschluss überspringt ausgeblendete Hard-Prerequisites. Das
+   bewahrt Erreichbarkeit, aber nicht die Bedeutung von „notwendiger
+   Voraussetzung“. Zudem ist die angegebene mathematische Definition nicht die
+   Cover-Relation des projizierten DAGs.
+4. Der Tile-Entwurf definiert weder referenzielle Integrität über
+   Domain-Grenzen noch einen atomaren, rollback-sicheren Release-Snapshot.
+   Einzelne Hash-URLs und eine Ed25519-Signatur lösen das nicht vollständig.
+5. Die Beispiele wurden nicht gegen ihre behaupteten Primärquellen geprüft:
+   drei Wikidata-IDs und das zentrale Lehrplanbeispiel sind falsch. Solange
+   solche Fehler den menschlichen Review passieren, ist die geplante
+   Curation-Pipeline noch kein belastbares Qualitätsgate.
+
+Meine Empfehlung ist daher keine Verwerfung der Vision, sondern ein engerer
+nächster Schnitt: **opaque, namespaced Atom-ID + typisierte Alignments +
+separate Übungsitems + prerequisite-geschlossener Overlay-Compiler + ein
+signiertes Release-Manifest**, zunächst an zwei kleinen, überlappenden
+Curriculum-Zellen.
+
+---
+
+## 1. Geprüfte Grundlage
+
+Vollständig gelesen wurden alle auf diesem Branch neu angelegten oder
+geänderten Dokumente:
+
+- [Draft-Architektur](central-learning-path-architecture.md)
+- [Forschungsarbeit](central-learning-path-research.md)
+- [PAID-Identitätsvorschlag](central-learning-path-identity.md)
+- [Grok-Verfeinerung](central-learning-path-refinement.md)
+- [Grok-Architekturreview](central-learning-path-architecture-review.md)
+- [Draft-ADR zu Domain-Ontologie und lokaler Adresse](../adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md)
+- die Statusänderung im [ADR-Index](../adr/README.md)
+
+Für die behaupteten Invarianten wurden außerdem die maßgeblichen lokalen
+Entscheidungen und der Ist-Code herangezogen:
+
+- [LehrplanPLUS-Import](../adr/2026-07-02-lehrplanplus-import-wizard.md)
+- [Human-friendly Titles und Domain-Pfade](../adr/2026-07-04-human-friendly-titles-and-prefixed-domains.md)
+- [Knowledge Contexts](../adr/2026-07-04-knowledge-contexts.md)
+- [Closed-Group Library](../adr/2026-07-04-multi-learner-shared-knowledge.md)
+- [Review Once, Serve Many](../adr/2026-07-25-shared-curated-learning-content.md)
+- [Central Curriculum Content Service](../adr/2026-07-26b-central-curriculum-content-service.md)
+- Kernel-Schema, Prerequisite-Blocker und FSRS-6-Implementierung
+
+Der Kernel-Befund bestätigt Grok: ZAM verwendet FSRS-6; Karten und Kanten
+referenzieren ULIDs; `content_version`, Editorial State und die
+cosmetic/material-Semantik existieren bereits; Prerequisites haben heute eine
+reine AND-/Hard-Semantik.
+
+---
+
+## 2. Erdungsprüfung: Die derzeitigen Beispiele sind nicht publizierbar
+
+Die falschen Beispiele sind kein redaktioneller Nebenschaden. Sie treffen
+genau den vorgeschlagenen globalen Join-Schlüssel und zeigen damit, wie ein
+falscher Anker Lernzustand zwischen fremden Atomen zusammenführen würde.
+
+| Behauptung im Branch | Primärquellenbefund | Konsequenz |
+|---|---|---|
+| `Q202814` = Snelliussches Brechungsgesetz | Snell's law ist [Wikidata Q208391](https://www.wikidata.org/wiki/Q208391). | Sämtliche `wd:Q202814/...`-PAIDs im Entwurf sind sachlich falsch. |
+| `Q165738` = Totalreflexion | Total internal reflection ist [Wikidata Q234943](https://www.wikidata.org/wiki/Q234943). | Die beispielhafte Trennung Snellius/Totalreflexion verwendet den falschen Join. |
+| `Q11379` = Satz des Pythagoras | `Q11379` ist [Energie](https://www.wikidata.org/wiki/Q11379); der Satz des Pythagoras ist [Q11518](https://www.wikidata.org/wiki/Q11518). | Selbst das Leitbeispiel der Reduktionsstufen würde Pythagoras mit Energie clustern. |
+| Realschule Bayern 9 Physik verlangt qualitatives und formales Snellius | LehrplanPLUS verortet Brechung/Totalreflexion in [Realschule Physik 7 (I)](https://www.lehrplanplus.bayern.de/fachlehrplan/lernbereich/65643) beziehungsweise [Physik 8 (II/III)](https://www.lehrplanplus.bayern.de/fachlehrplan/realschule/8/physik/wpfg2-3), dort qualitativ und zeichnerisch. [Physik 9 (II/III)](https://www.lehrplanplus.bayern.de/fachlehrplan/realschule/9/physik/wpfg2-3) behandelt andere Gebiete. | Overlay, Alter, Prüfungsflag und `/formula` im Snellius-JSON sind nicht geerdet. |
+| CASE v1.0 (2020) ist der aktuelle Vergleichspunkt | Der aktuelle öffentliche Standard ist [CASE 1.1](https://standards.1edtech.org/case/). | Das Literaturkapitel muss auf CASE 1.1, seine IDs, URI- und Alignment-Semantik aktualisiert werden. |
+
+Der reale Lehrplansatz macht außerdem die Modellierungslücke sichtbar. Er
+verbindet unter anderem Ursache der Brechung, Zeichnungen, optische Hebung,
+Totalreflexion und Dispersion. Das ist weder ein einzelnes Welt-Entity noch ein
+einzelnes pädagogisches Atom. Im Gymnasium 8 wird beim selben
+Totalreflexions-Anker dagegen die Erklärung technischer Anwendungen verlangt
+([LehrplanPLUS Gymnasium 8](https://www.lehrplanplus.bayern.de/fachlehrplan/lernbereich/215729)).
+Beide Ziele wären nach `Q234943 + qualitative` identisch, obwohl sie nicht
+gegenseitig substituierbar sind.
+
+**Erforderliches Gate für jeden `wd:`-Anker:** Der Compiler löst die Q-ID gegen
+einen versionierten Wikidata-Snapshot oder die offizielle API auf, normalisiert
+Redirects, speichert Label, Beschreibung und geprüfte Revision und verlangt
+eine kuratorische Typ-/Scope-Bestätigung. Eine syntaktisch gültige Q-ID ist
+keine semantische Validierung.
+
+---
+
+## 3. Forschungs-Briefing 1: Was Entity-Linking leisten kann — und was nicht
+
+### 3.1 Identität und Gleichheit sind zwei verschiedene Verträge
+
+Ein stabiler Identifier beantwortet:
+
+> Welche überarbeitete Fassung erklärt derselbe Herausgeber weiterhin zum
+> selben Objekt?
+
+Ein Crosswalk beantwortet dagegen:
+
+> In welcher Beziehung stehen zwei von möglicherweise verschiedenen
+> Herausgebern definierte Objekte?
+
+PAID versucht beide Fragen mit einem semantisch lesbaren Tupel zu beantworten.
+Das ist attraktiv, aber zu stark. Ein kleiner Satz von Merkmalen kann globale
+pädagogische Gleichheit nicht sicher entscheiden.
+
+CASE 1.1 verwendet deshalb stabile, herausgeberseitige GUIDs und resolvierbare
+URIs für Items. Änderungen am Item lassen dessen Identifier stabil, während
+Beziehungen zwischen Frameworks als eigene `CFAssociation`-Objekte modelliert
+werden. Das kontrollierte Vokabular enthält unter anderem `exactMatchOf`,
+`replacedBy`, `isTranslationOf`, `isPartOf`, `precedes` und `hasSkillLevel`
+([CASE 1.1 Implementation Guide](https://www.imsglobal.org/spec/CASE/v1p1/impl)).
+
+SKOS trennt aus demselben Grund `exactMatch`, `closeMatch`, `broadMatch`,
+`narrowMatch` und `relatedMatch`. Besonders wichtig: `closeMatch` ist bewusst
+nicht transitiv, damit Alignment-Fehler nicht über mehrere Begriffssysteme
+verkettet werden; auch SKOS verlangt zusätzlich Provenienzmanagement
+([W3C SKOS Reference](https://www.w3.org/TR/skos-reference/#mapping)).
+
+**Folgerung für ZAM:** Opaque Identität plus explizite, versionierte und
+provenienztragende Mappings ist die sicherere Grundform. Semantische Merkmale
+sind Matching-Evidenz, nicht der Primärschlüssel.
+
+### 3.2 Es fehlen nicht vier, sondern fünf Objektklassen
+
+Der PAID-Entwurf trennt Welt-Entität, pädagogisches Atom,
+Overlay-Mitgliedschaft und Lernzustand. Zwischen Atom und Lernzustand fehlt
+noch ein Objekt:
+
+| # | Objekt | Beispiel | Stabilität / Verantwortung |
+|---|---|---|---|
+| 1 | **Welt-Entität** | Totalreflexion, Q234943 | externer Anker; keine Lernaufgabe |
+| 2 | **Kompetenz-/Lernziel-Atom** | Ursache der Totalreflexion qualitativ erklären | sprachübergreifend nur nach kuratierter Äquivalenz |
+| 3 | **Übungsitem / Repräsentation** | deutsche Freitextfrage; englischer Cloze; Diagramm-Aufgabe | konkrete Frage, Antwortmenge, Sprache, Format, Schwierigkeitsprofil |
+| 4 | **Overlay-Mitgliedschaft** | Gymnasium BY 8 verlangt Ziel 2 als prüfungsnah | Lehrplan-, Zeit- und Policy-Metadaten |
+| 5 | **Lernzustand** | FSRS-Zustand für Übungsitem 3 | ausschließlich lokal und beobachtungsbasiert |
+
+Der heutige ZAM-`token` ist näher an **3** als an **2**: Er enthält eine
+konkrete Frage, ein Konzept als Referenzantwort und einen Bloom-Level; die
+Karte plant den Abruf genau dieses Items. Der zentrale Draft macht den Token
+dagegen sprachneutral und erklärt Frage, Sprache, Tier-1/Tier-2 und Medien zu
+austauschbaren Darstellungen. Beides gleichzeitig geht nicht ohne eine weitere
+Schicht.
+
+Das ist auch gedächtnispsychologisch relevant. Abruf hängt von den verfügbaren
+Abrufhinweisen ab (klassisch: [Tulving & Thomson, Encoding Specificity](https://doi.org/10.1037/h0020071));
+Transfer von Retrieval Practice über deutlich andere Testformate ist keine
+kostenlose Identitätseigenschaft
+([Tran et al., Testing Effect and Far Transfer](https://pmc.ncbi.nlm.nih.gov/articles/PMC5183614/)).
+Ein bestandener Zwei-Optionen-Check darf daher weder eine freie Erklärung noch
+dieselbe Kompetenz in einer neuen Sprache still als FSRS-reviewed markieren.
+
+Das verlangt **keinen zweiten Mastery-Vektor**. Zunächst genügt:
+
+- FSRS bleibt pro konkret gezeigtem Übungsitem.
+- Atomweite Evidenz darf später aus Item-Logs abgeleitet werden, schreibt aber
+  niemals rückwirkend Stabilität auf ungezeigte Items.
+- Ein Overlay verlangt Lernziel-Atome; der Client wählt dafür kuratierte
+  Übungsitems in Sprache und Format des Lerners.
+
+### 3.3 Warum der gegenwärtige PAID als Schlüssel scheitert
+
+#### A. Der `lp:`-Raum kollidiert innerhalb eines einzigen Lernbereichs
+
+`lp:lehrplanplus-bayern:PH9-LB2/qualitative` ist höchstens einmal eindeutig.
+Ein Lernbereich enthält aber regelmäßig mehrere Kompetenzen und mehrere Atome
+derselben Reduktionsstufe. Schon Brechung, optische Hebung, Totalreflexion und
+Dispersion erzeugen mehrere qualitative Lernziele. `aspect` müsste zwingend
+und global kontrolliert werden; damit ist es nicht mehr der optionale
+Ausnahmefall des Vorschlags.
+
+#### B. Gleicher Welt-Anker plus gleiche Reduktion bedeutet nicht gleiche Kompetenz
+
+„Totalreflexion kausal erklären“, „eine technische Anwendung erläutern“ und
+„den Grenzwinkel experimentell bestimmen“ können denselben Q-Anker tragen.
+Selbst wenn die grobe Stufe jeweils `qualitative` oder `formula` heißt, sind
+Handlung, Bedingungen und erwartete Evidenz verschieden.
+
+#### C. Viele Lernziele sind kompositional
+
+Eine Kompetenz kann gleichzeitig Brechung, Lichtgeschwindigkeit, Diagramm,
+Mediumwechsel und Alltagsphänomen verbinden. Ein erzwungener „kanonischer“
+Q-Anker verliert Bedeutung; mehrere Anker mit Rollen sind die ehrlichere
+Darstellung.
+
+#### D. Mehrere Herausgeber dürfen mehrere gültige Darstellungen publizieren
+
+Der PAID-Entwurf bezeichnet zwei Zeilen mit demselben PAID und verschiedenem
+Inhalt als Curation-Fehler. Für einen weltweiten, mehrsprachigen Graphen ist das
+der Normalfall: deutsche und englische Fragen, alternative Erklärungen und
+unterschiedliche, aber gültige Übungsformate teilen ein Lernziel. Sie müssen
+nicht dedupliziert und verworfen, sondern als getrennte Repräsentationen
+versioniert werden.
+
+#### E. Ein Alias ist zu stark für ein Alignment
+
+`lp:` nach `wd:` zu „promovieren“ und den alten String als Alias zu behalten
+behauptet exakte Identität. Reale Crosswalks sind häufig nur `close`, `broad`,
+`narrow` oder `related`. Eine untypisierte Alias-Tabelle kann diese Unsicherheit
+nicht ausdrücken und macht späteren Fehlern transitive Wirkung.
+
+### 3.4 Empfohlenes Identitäts- und Alignment-Modell
+
+#### Öffentliche ID
+
+Jeder Publisher mintet eine global namespaced, opaque ID. Für ZAM bietet sich
+wegen der bestehenden Invariante eine ULID in einer URI an:
+
+```text
+https://knowledge.zam.app/atoms/01K...
+urn:zam:atom:01K...
+```
+
+Das erfordert **keinen schreibbaren Lernerdienst**. IDs werden im
+Git-/Curation-Prozess vergeben; das CDN bleibt anonym und read-only. Externe
+Publisher behalten ihre eigenen URIs. Wenn die zentrale ZAM-Curation zwei
+Objekte nach Review zusammenführt, bleiben alle früheren IDs als typisierte
+Mappings oder echte Redirects erhalten.
+
+Der Name PAID kann bleiben, sollte dann aber die opaque öffentliche Atom-ID
+bezeichnen. Das derzeitige Tupel wird zu einem `pedagogical_profile` oder
+`matching_fingerprint` herabgestuft.
+
+#### Minimale logische Tabellen
+
+```text
+learning_atoms
+  id, status, created_by, created_at, superseded_by
+
+atom_profiles
+  atom_id, process, representation_level, expected_evidence, constraints_json
+
+atom_anchors
+  atom_id, scheme, external_id, role, relation,
+  reviewed_revision, label_snapshot, asserted_by
+
+atom_alignments
+  source_atom_id, target_atom_id,
+  relation(exact|close|broad|narrow|related|translation|supersedes),
+  asserted_by, evidence, confidence, review_state, mapping_version
+
+practice_items
+  id, atom_id, publisher, locale, question, answer_spec,
+  interaction_type, bloom_level, content_version
+
+overlay_memberships
+  overlay_id, atom_id, source_item_uri, relation,
+  grade, typical_age_hint, exam_relevant, sequence
+
+cards
+  practice_item_id, user_id, ...FSRS
+```
+
+Das ist ein konzeptionelles Zielmodell, keine Aufforderung, diese Tabellen
+jetzt komplett in den Kernel zu migrieren. Der erste Builder kann die Schichten
+in Artefakt-JSON ausdrücken und beim Import weiterhin ZAM-Tokens
+materialisieren. Lasttragend ist die **Trennung der Verträge**, nicht sofort
+die Zahl der Tabellen.
+
+#### Zulässiger automatischer Transfer
+
+- Gleiche opaque ID, gleiche Item-Repräsentation und kompatible
+  `content_version`: bestehende Karte darf weiterlaufen.
+- Kuratiertes `exact` zwischen Lernziel-Atomen: Overlay-Coverage darf
+  wiederverwendet werden; verschiedene Übungsitems werden dadurch nicht als
+  bereits reviewed markiert.
+- `translation`: gemeinsames Lernziel, aber sprachspezifisches Übungsitem;
+  kein stiller FSRS-Transfer.
+- `close`, `broad`, `narrow`, `related`: nur Such-, Vorschlags- oder
+  Navigationssignal; niemals Dedup oder Lernzustandstransfer.
+
+### 3.5 Mapping-Pipeline für Briefing 1
+
+Die Forschungsfrage ist breiter als klassisches Entity Linking. Die Pipeline
+muss zunächst eine Kompetenz **dekomponieren**, dann Welt-Anker finden und
+schließlich ein bestehendes Lernziel oder eine Alignment-Relation bestimmen.
+
+1. **Quellobjekt stabilisieren.** Provider, Dokumentversion, Abschnitt,
+   offizielle Item-URI und exakter Text werden gespeichert. Wo verfügbar wird
+   CASE 1.1 importiert; CASE ist Adapter und Provenienzformat, nicht das interne
+   Token-Schema.
+2. **Kompetenzsatz dekomponieren.** Kandidaten enthalten Handlung
+   (`beschreiben`, `erklären`, `berechnen`, `messen`), Wissensobjekte,
+   Repräsentation, Bedingungen und erwartete Evidenz. Ein Satz darf null, ein
+   oder mehrere Atome ergeben.
+3. **Kandidaten hybrid abrufen.** BM25/lexikalische Suche und ein
+   multilingualer Bi-Encoder liefern gemeinsam Top-k aus (a) bereits
+   kuratierten ZAM-Atomen und (b) einem versionierten Wikidata-Kandidatenindex.
+4. **Kontextuell reranken.** Ein Cross-Encoder oder ein strikt
+   kandidatgebundenes LLM sieht Kompetenzsatz, Nachbarsätze, Entity-Beschreibung
+   und Typen. Es darf nur vorhandene Kandidaten wählen oder `NIL` ausgeben.
+5. **Relation klassifizieren.** Nicht nur `gleich/ungleich`, sondern
+   `exact/close/broad/narrow/related/none`; Ankerrollen werden separat
+   festgelegt.
+6. **Kuratorisch bestätigen.** UI zeigt Quelltext, Zerlegung, Kandidaten,
+   Beschreibungen, bestehende Atome und die Folgen eines `exact`-Joins. Kein
+   autonomes Publish.
+7. **Provenienz publizieren.** Modell-/Indexversion, Kandidatenliste,
+   Entscheidung, Reviewer und Quellrevision bleiben nachvollziehbar.
+
+Die Retrieval-/Rerank-Aufteilung ist durch BLINK gut belegt
+([Wu et al., EMNLP 2020](https://aclanthology.org/2020.emnlp-main.519/)). Für
+sprachübergreifende Kandidaten zeigt mGENRE den Nutzen mehrsprachiger
+Entity-Namen ([De Cao et al., TACL 2022](https://aclanthology.org/2022.tacl-1.16/)).
+Für ZAM besonders wichtig ist explizites `NIL`: Forschung zu „Learn to Not
+Link“ zeigt, dass Nicht-Verknüpfbarkeit ein eigener, oft vernachlässigter
+Fehlermodus ist
+([Zhu et al., Findings ACL 2023](https://aclanthology.org/2023.findings-acl.690/)).
+
+Diese Arbeiten validieren **nicht** PAID und auch nicht die automatische
+pädagogische Gleichheit. Sie begründen nur Kandidatengenerierung,
+Disambiguierung und Ablehnung als sinnvolle technische Bausteine.
+
+### 3.6 Verifikationsprotokoll statt Modellwette
+
+Vor einer Schemaentscheidung wird ein kleiner Goldstandard erstellt:
+
+- mindestens zwei überlappende Curriculum-Zellen, damit Wiederverwendung
+  wirklich vorkommt; beispielsweise Realschule BY Optik und Gymnasium BY
+  Optik, danach ein zweiter Provider/Bundesland;
+- zwei Fachlehrkräfte annotieren unabhängig Zerlegung, Ankerrollen und
+  Alignment-Relation; Konflikte werden adjudiziert;
+- Train/Dev/Test werden nach Curriculum und Quellabschnitt getrennt, damit
+  beinahe identische Nachbarsätze nicht in beide Seiten leaken;
+- alle `NIL`-Fälle und alle falsch positiven `exact`-Joins werden gesondert
+  ausgewertet.
+
+Zu messen sind getrennt:
+
+| Stufe | Metriken |
+|---|---|
+| Dekomposition | Atom-Set Precision/Recall/F1, Über-/Unterzerlegung |
+| Entity-Kandidaten | Recall@k, MRR, Precision@1 nur auf linkbaren Fällen |
+| `NIL` | False-Link-Rate, Precision/Recall der Ablehnung |
+| Profil | Macro-F1 und Confusion Matrix für Handlung/Repräsentation |
+| Atom-Alignment | Macro-F1 je Relation; vor allem Precision von `exact` |
+| Ende-zu-Ende | Anteil vollständig korrekter Zerlegungen und Alignments; Risk-Coverage-Kurve bei Abstention |
+| Human Review | Zeit pro Item, Korrekturquote, Inter-Annotator-Agreement |
+
+BM25, Dense Retrieval und Hybrid-Retrieval werden mit **demselben**
+Kandidatenkorpus verglichen; ein Cross-Encoder kommt erst als zweite Stufe.
+Hosted und offene Embedding-Modelle dürfen Teil des Benchmarks sein, aber jede
+Messung pinnt Modell, Snapshot und Prompt. Ein einzelner Wert wie
+Precision@1 verschleiert sonst, ob das System das falsche Q wählte, eine
+Kompetenz nicht zerlegte oder zwei nahe Lernziele fälschlich als exakt
+zusammenführte.
+
+Für automatisch vorgeschlagene `exact`-Joins ist ein vorab festgelegtes,
+extrem precision-orientiertes Gate nötig; Publish bleibt auch oberhalb des
+Gates menschlich bestätigt. Der Schaden eines verpassten Joins ist eine
+doppelte Karte. Der Schaden eines falschen Joins ist still übertragener,
+falscher Lernzustand. Diese Fehler sind nicht symmetrisch.
+
+---
+
+## 4. Review der übrigen Architektur
+
+### 4.1 Overlay-Abschluss: richtige Sorge, falsche Reparatur
+
+Grok zeigt korrekt, dass eine globale transitive Reduktion den Blick eines
+Overlays nicht berücksichtigen kann. Die vorgeschlagene Projektion
+
+```text
+A -> B -> C, Overlay enthält nur A und C  =>  A -> C
+```
+
+ist für eine **Hard**-Semantik jedoch nicht korrekt. Wenn `B` wirklich
+notwendig für `C` ist, macht die neue Kante `A -> C` aus der Beherrschung von
+`A` eine hinreichende Freigabe und verliert genau die notwendige Kompetenz
+`B`. Erreichbarkeit bleibt erhalten; Voraussetzungserfüllung nicht.
+
+Die robustere Kompilation unterscheidet:
+
+- `S_target`: explizit vom Curriculum verlangte Lernziel-Atome;
+- `S_support`: die transitive Hülle aller universellen Hard-Prerequisites;
+- `S_effective = S_target ∪ S_support`;
+- universelle definitional/operatorische Hard-Kanten;
+- overlay-spezifische Reihenfolge- oder Policy-Kanten, separat provenanziert.
+
+Support-Knoten dürfen in der UI zunächst eingeklappt sein. Sie dürfen aber
+nicht aus dem Blocking-Graphen verschwinden. Wenn ein Curriculum sie nur als
+Vorwissen voraussetzt, ist gerade das ein Grund, sie als Support zu laden.
+
+Auch die Formel in der Verfeinerung ist nicht die transitive Reduktion der
+projizierten Erreichbarkeitsrelation. Für die Cover-Kante gilt bei einem DAG:
+
+\[
+(u,v) \in E_{cover}
+\iff
+u \leadsto v
+\land
+\nexists w \in S_{effective}\setminus\{u,v\}: u\leadsto w\land w\leadsto v.
+\]
+
+„Kein `w` liegt auf **jedem** Pfad“ ist zu schwach: Bei zwei parallelen
+Zwischenpfaden liegt kein einzelnes `w` auf jedem Pfad, obwohl die direkte
+Kante transitiv redundant ist.
+
+Empfohlener Compiler-Vertrag:
+
+1. Hülle der universellen Hard-Prerequisites bilden.
+2. Overlay-spezifische Kanten hinzufügen und ihre Provenienz behalten.
+3. Auf Hard-Kanten Zyklen und fehlende Ziele prüfen.
+4. Optional eine reduzierte **operative** Sicht erzeugen; den kuratierten
+   Quellgraphen und Kantenrationalen nie wegwerfen.
+5. Target- und Support-Mitgliedschaft im Tile unterscheiden.
+
+Für v1 darf Hard weiterhin reine Konjunktion bedeuten. Dann muss das aber als
+Grenze dokumentiert werden. Alternative Voraussetzungen wie `(A und B) oder
+C` benötigen später Requirement-Gruppen/Hyperkanten; eine binäre Kante kann
+sie nicht korrekt ausdrücken.
+
+### 4.2 Hard, Soft und curricular: `kind` allein genügt langfristig nicht
+
+Groks additive `kind = hard|soft`-Spalte ist als erste Kernel-Erweiterung
+vernünftig. Der Universalgraph braucht zusätzlich mindestens Herkunft und
+Geltungsbereich:
+
+- **universal-definitional / operatorisch:** gilt in jedem Overlay;
+- **curricular:** gilt nur in einem benannten Overlay oder einer Version;
+- **soft:** erklärt, analogisiert oder empfiehlt; blockt nie;
+- `rationale`, `source`, `reviewed_by`, `content_version` der Kante.
+
+Eine curriculare Reihenfolge als universelle Hard-Kante würde andere
+Lehrpfade unnötig sperren. Eine universelle mathematische Voraussetzung als
+overlay-relativ zu behandeln würde sie dagegen zu leicht umgehen.
+
+### 4.3 FSRS-Grenze: Groks Verbot ist richtig, seine Ersatzheuristik noch Forschung
+
+Volle Zustimmung zu:
+
+- keine Stabilitäts- oder Schwierigkeitswrites auf ungezeigte Karten;
+- ein Erfolg auf `B` ist kein beobachteter Abruf von `A`;
+- Graph-Evidenz darf Reihenfolge/Vorschläge beeinflussen, nicht FSRS-Historie
+  erfinden;
+- kein DKT/LLM im Kernel.
+
+Noch nicht entscheidungsreif sind dagegen:
+
+- „Frontier zuerst“ als allgemeine Review-Reihenfolge;
+- Vorfahren nach Erfolg am Frontier innerhalb der Session regelmäßig nach
+  hinten zu schieben;
+- Tier-2-Freigabe nach drei erfolgreichen Reviews oder einem anderen festen
+  `reps`-Wert.
+
+Diese Regeln können sinnvoll sein, müssen aber gegen die heutige Queue in
+einem A/B- oder Replay-Test messen: Retention, Sessionlänge, Lapses in
+Vorfahren und subjektive Belastung. Wegen Cue- und Formatabhängigkeit ist ein
+bestandener Nachfolger nur schwache Evidenz für ungezeigte Vorfahren.
+
+### 4.4 KVT: Artefaktverteilung ja, festes Format und „Kachel“ später
+
+Statische, inhaltsadressierte Pakete sind die stärkste Architekturentscheidung
+des Gemini-Drafts. Vor einem Formatentscheid fehlen aber vier Verträge:
+
+#### Referenzielle Integrität über Pakete
+
+Domain-Partitionen schneiden fächerübergreifende Hard-Kanten. Benötigt werden
+ein globaler `atom_id -> tile`-Index, explizite Tile-Abhängigkeiten und CI, die
+keine dangling edge im Release zulässt. Alternativ enthält ein Overlay alle
+notwendigen kleinen Atom-Stubs und lädt Körper nach Bedarf.
+
+#### Atomarer Release-Snapshot
+
+Ein signiertes Top-Level-Manifest muss Schema-Version, Release-Sequenz,
+Overlay-/Domain-/Media-Hashes, Abhängigkeiten, Dateigrößen und Mindestclient
+enthalten. Der Client lädt in Staging, prüft alle Hashes und importiert erst
+dann transaktional. Sonst kann er Overlay N mit Domain N-1 kombinieren.
+
+#### Rollback, Freeze und Schlüsselrotation
+
+Eine Ed25519-Signatur beweist nur, dass ein Schlüssel ein Artefakt signiert
+hat. Sie verhindert weder Mix-and-match noch Rollback oder endloses Festhalten
+an einer alten Version und definiert keine Schlüsselrotation. Die Architektur
+sollte mindestens die Bedrohungen und Metadatenrollen von
+[The Update Framework](https://theupdateframework.github.io/specification/v1.0.26/)
+übernehmen; ob dafür TUF selbst eingesetzt wird, ist eine spätere
+Implementierungsentscheidung.
+
+#### Benchmark vor Formatbindung
+
+JSON(+zstd), SQLite-Importpaket und gegebenenfalls ein binäres Format werden
+erst gegen die echte Pilotzelle verglichen: komprimierte Größe, Parse-/Import-
+Zeit, Peak Memory, partielle Aktualisierung, native iOS/Android/Desktop-Pfade
+und Browserpfad. Remote SQLite Range Requests, DuckDB-WASM und Merkle-Bäume
+sind keine v1-Anforderungen.
+
+„Knowledge Vector Tile“ kann als Produktmetapher bleiben. Technisch sind es
+zunächst **versionierte Graph-Pakete**, nicht räumliche Vektorkacheln.
+
+### 4.5 Versionen und Provenienz brauchen vier Ebenen
+
+Der Branch verwendet „Version“ derzeit für mehrere Dinge:
+
+1. Atom-Identität / fachliche Kontinuität,
+2. sprach- und publisherspezifische Übungsitem-Revision,
+3. Overlay-Version / Schuljahr,
+4. kompletter Artefakt-Release.
+
+`content_version` löst Ebene 2 innerhalb des heutigen Kernels. Sie kann nicht
+gleichzeitig konkurrierende Publisher-Fassungen, Overlay-Saisons und einen
+atomaren Tile-Release nummerieren. Diese vier Versionen müssen im nächsten
+Schema-Beispiel getrennt sichtbar sein.
+
+Ebenso authentifiziert eine Publisher-Signatur nur Herkunft und
+Unverändertheit, nicht didaktische Richtigkeit. Benötigt werden ein
+Publisher-/Key-Trust-Store, Rollen, Rotation/Widerruf und die Frage, welchen
+Publishern ein Gerät standardmäßig vertraut. `verified_by` als freier String
+reicht nicht.
+
+### 4.6 Curation muss für Lehrkräfte Studio-first bleiben
+
+Git als unveränderliche Review-Historie und Studio als material/cosmetic-
+Release-Gate passen zu den bestehenden ADRs. Die Benutzerreise darf daraus
+aber nicht „Lehrkraft bedient Git und Ed25519“ machen. Studio kann Branch,
+Diff, Reviewanfrage, Identitätskandidaten und Publish im Hintergrund
+orchestrieren. Eine klare Aktion pro Schritt bleibt auch für Curatoren ein
+Produktprinzip.
+
+Für ein `exact`-Alignment muss die Oberfläche die Konsequenz explizit zeigen:
+gemeinsame Overlay-Coverage, aber **kein** automatischer FSRS-Write auf andere
+Übungsitems.
+
+### 4.7 Lizenz: präziser als „offen“ oder „Blocker“
+
+Die aktuelle LehrplanPLUS-Seite stellt klar, dass die **Texte der Lehrpläne**
+nicht urheberrechtlich geschützt sind und nimmt Originaltexte der Lehrpläne
+von der dortigen kommerziellen Beschränkung aus. Für weitere Inhalte,
+Servicematerialien, Bilder und KI-abgeleitete Ergebnisse gelten andere
+Bedingungen
+([LehrplanPLUS-Nutzungsbedingungen](https://www.lehrplanplus.bayern.de/seite/impressum)).
+
+Damit ist „LehrplanPLUS-Lizenz“ nicht pauschal ein Blocker, aber auch keine
+Blankovollmacht. Der Ingest muss Quelltypen unterscheiden:
+
+- amtlicher Original-Lehrplantext,
+- zusätzliche ISB-Serviceinhalte,
+- Inhalte Dritter,
+- neu kuratierte ZAM-Fragen und -Antworten,
+- externe Medienlinks und lokale Medienbytes.
+
+Vor öffentlichem oder gesponsertem Release braucht jede Klasse eine explizite
+Lizenz-/Attributionsregel und eine kurze juristische Prüfung. Der Compiler
+blockt unbekannte oder inkompatible Lizenzen statt sie als bloße
+`source_link`-Metadaten mitzuschleppen.
+
+### 4.8 Kosten, Datenschutz und Medien nicht absolut formulieren
+
+- Eine Million Erstinstallationen à 15 MB sind ungefähr 15 TB Transfer. Die
+  Kosten können bei einem geeigneten Sponsor niedrig sein, sind aber keine
+  formatunabhängige Eigenschaft. Euro-Zahlen gehören in einen messbaren
+  Betriebsplan, nicht in die Architekturentscheidung.
+- „Keine personenbezogenen Daten im Content-Service“ ist eine starke,
+  strukturelle Aussage. „100 % DSGVO“ oder „DSGVO trivial“ ist es nicht: Der
+  Client verarbeitet Minderjährigendaten, und externe Medienaufrufe können
+  Metadaten an Dritte senden.
+- YouTube/PhET/GeoGebra bleiben optionale Ressourcen. Kernfrage und
+  Referenzantwort müssen offline vollständig funktionieren. Medien brauchen
+  Lizenz, Integritäts-/Linkstatus und Fallback, aber keine Identitätswirkung.
+
+---
+
+## 5. Bewertung der bisherigen Beiträge
+
+### 5.1 Was Gemini richtig gesetzt hat
+
+- Die zentrale Bibliothek ist Content-Infrastruktur, kein Lerner-Backend.
+- Curricula sind Overlays, nicht Kopien des Weltgraphen.
+- Curation ist „AI proposes, human disposes“.
+- Statische Artefakte sind die plausible Antwort auf anonyme, globale
+  Verteilung.
+- Scanner und lokaler Unterrichtsanker sind starke Produktideen.
+- Das Beispiel-JSON macht die offenen Entscheidungen konkret genug, um sie zu
+  falsifizieren — das ist trotz seiner Fehler wertvoll.
+
+### 5.2 Was Grok wesentlich verbessert hat
+
+- didaktische Reduktionsstufen statt Piaget-Enum und Alters-Gate;
+- Hard/Soft-Trennung und Soft-Kanten ohne Blocking;
+- kein FSRS-Write aus Graph-Evidenz;
+- keine zentrale Klassen-/Schul-Schicht neben dem anonymen CDN;
+- Overlay-Mitgliedschaft aus dem Tokenkörper heraus;
+- Embeddings als optionales, modellversioniertes Paket;
+- eine echte Zelle vor fünfzehn Manifesten und Scanner später.
+
+### 5.3 Wo dieses Review Grok widerspricht oder nachschärft
+
+- PAID ist nicht entscheidungsreif und sollte nicht „vor dem ersten Builder
+  festgezogen“ werden; zunächst opaque IDs und Alignment-Evidenz.
+- Der Overlay-Abschluss darf notwendige Zwischenknoten nicht umgehen und seine
+  Formel ist zu korrigieren.
+- „Die Karte ist der Kompetenz-Proxy“ gilt nur für ein konkretes Übungsitem,
+  nicht automatisch für ein sprachneutrales Lernziel mit Tier-1-, Tier-2- und
+  Sprachvarianten.
+- Frontier-first ist eine prüfbare Scheduler-Hypothese, keine bereits
+  abgesicherte Ersatzregel.
+- `hard|soft` braucht bei Curricula Scope und Provenienz; curricular-hard und
+  universal-hard dürfen nicht in derselben unqualifizierten Kante
+  verschwimmen.
+
+---
+
+## 6. Konsensmatrix
+
+### Jetzt zustimmungsfähig
+
+- anonyme, read-only, statische Content-Verteilung;
+- keine Karten, Logs, Assignments oder Klassenzeiger im Content-Service;
+- Curriculum-Overlays als eigene n:m-Schicht;
+- ULID als lokale Zeilen-/FK-Identität;
+- lokale Domain-/Slug-Adresse getrennt von öffentlichem Join;
+- menschliches Publish-Gate und material/cosmetic-Versionierung;
+- FSRS nur aus beobachteten Reviews;
+- Soft-Kanten blocken nie;
+- Alter als Overlay-Hinweis, nicht als Freigabe-Gate;
+- erste kleine Zelle, danach zweite überlappende Zelle.
+
+### In der vorliegenden Form abzulehnen
+
+- `(scheme, entity, reduction)` als automatisch joinbarer Primärschlüssel;
+- ein kanonischer Q-Anker pro Atom;
+- Alias-Promotion ohne Alignment-Typ und Provenienz;
+- eine Tokenzeile als zugleich sprachneutrales Atom und konkrete FSRS-Aufgabe;
+- globales transitives Pruning;
+- Overlay-Projektion, die Hard-Zwischenknoten überspringt;
+- FSRS-Stabilitätspropagierung oder automatisches Review ungezeigter Karten;
+- Piaget-Stufe im Kernschema und unkalibrierte Accessibility-Formel;
+- Klassen-/Schul-Sync im anonymen Content-Service;
+- festes SQLite-WASM/JSON-LD/KVT-Format ohne Pilotbenchmark;
+- absolute Kosten- und Datenschutzversprechen.
+
+### Vor dem nächsten ADR zu entscheiden
+
+1. Wird der öffentliche Atomschlüssel opaque und namespaced? **Empfehlung: ja.**
+2. Werden Alignments typisiert und provenanziert statt als Aliase behandelt?
+   **Empfehlung: ja.**
+3. Trennt das Modell Lernziel-Atom und Übungsitem? **Empfehlung: ja, spätestens
+   vor Mehrsprachigkeit oder Tier 1/2.**
+4. Bildet der Overlay-Compiler die universelle Prerequisite-Hülle und markiert
+   Target vs. Support? **Empfehlung: ja.**
+5. Bleiben curriculare Kanten overlay-scoped? **Empfehlung: ja.**
+6. Definiert ein Top-Level-Release-Manifest atomare Tile-Snapshots, Trust und
+   Rollback? **Empfehlung: ja.**
+7. Welche zwei Zellen und welche Goldannotation falsifizieren das Modell vor
+   Migrationen? **Empfehlung: Realschule/Gymnasium Optik als Überlappung;
+   danach ein zweiter Provider.**
+
+---
+
+## 7. Empfohlener nächster Arbeitsstand für Opus und Gemini
+
+Der nächste gemeinsame Entwurf sollte nicht alle Visionsteile umschreiben,
+sondern fünf kleine Artefakte liefern:
+
+1. ein korrigiertes, primärquellengeprüftes Beispiel mit echten Q-IDs und
+   echtem Lehrplanabschnitt;
+2. ein Fünf-Objekte-Schema (Entity, Lernziel, Übungsitem, Overlay, Karte) mit
+   opaque ID und typisierten Alignments;
+3. einen Overlay-Compiler-Vertrag mit Target-/Support-Hülle und korrekter
+   Cover-Relation;
+4. ein Release-Manifest-Beispiel mit Tile-Hashes, Abhängigkeiten, Version und
+   Trust-Metadaten;
+5. ein Experimentprotokoll für zwei überlappende Zellen mit Goldannotation,
+   `NIL`, Relationstypen und Ende-zu-Ende-Metriken.
+
+Erst wenn diese fünf Artefakte dieselben Gegenbeispiele ohne Sonderregeln
+tragen, ist eine Architekturzustimmung verantwortbar. Bis dahin ist mein
+Urteil: **Vision bejahen, PAID und Overlay-Abschluss nicht akzeptieren,
+Builder noch nicht auf ein dauerhaftes Schema festlegen.**

--- a/docs/concepts/central-learning-path-identity.md
+++ b/docs/concepts/central-learning-path-identity.md
@@ -1,0 +1,288 @@
+# Frage 0: Die veröffentlichte Identität eines pädagogischen Atoms
+
+**Status:** Working proposal  
+**Datum:** 2026-08-14  
+**Gehört zu:** [central-learning-path-research.md](central-learning-path-research.md), [central-learning-path-architecture.md](central-learning-path-architecture.md), [central-learning-path-refinement.md](central-learning-path-refinement.md)  
+**Gegenentwurf (offen):** [ADR 2026-07-04 Hierarchical Domain Ontology](../adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md) — Draft, nicht bindend.
+
+---
+
+## 1. Die Frage
+
+Woran erkennen zwei Curricula, zwei Herausgeber und zwei Geräte **dasselbe lernbare Atom** — und woran erkennen sie, dass zwei Fassungen *nicht* dasselbe Atom sind?
+
+Das ist nicht die Frage, die der Ontology-Entwurf stellt. Der fragt: wie bleibt ein *lokaler* Graph adressierbar, wenn Slugs zu lang und Domains zu flach werden. Antwortkandidat dort: ULID als Zeile, `(domain, slug)` als Adresse, Wikidata als stummer Anker.
+
+Der Zentralgraph fragt härter. Ohne einen veröffentlichten Join-Schlüssel gibt es keinen universellen Bildungsgraphen, nur eine ZAM-Bibliothek mit internen IDs. Entity-Linking, Overlay-Projektion, Umzug eines Lerners zwischen Lehrplänen und jedes zweite Herausgeber-Tile hängen an dieser einen Entscheidung.
+
+---
+
+## 2. Vier Dinge, die nicht dieselbe ID tragen dürfen
+
+| # | Ding | Beispiel | Lebt wo |
+|---|---|---|---|
+| 1 | **Welt-Entität** | Satz des Pythagoras, Wikidata Q11379 | Crosswalk, nicht lernbar |
+| 2 | **Pädagogisches Atom** | Pythagoras als Flächenumlegung; Pythagoras als \(a^2+b^2=c^2\) | Zentralgraph, Tile, Overlay-Mitglied |
+| 3 | **Overlay-Mitgliedschaft** | „Realschule Bayern 9 Mathematik verlangt Atom X, exam-relevant“ | Curriculum-Tile |
+| 4 | **Lernzustand** | Stabilität, Schwierigkeit, `blocked`, `reps` | Nur Gerät / Karte |
+
+Frage 0 betrifft ausschließlich **2**. 1 ist der Anker *in* 2. 3 zeigt auf 2. 4 zeigt auf die lokale Zeile, die 2 materialisiert.
+
+Geminis drei Schichten sind genau diese Trennung, sobald Schicht 1 und Schicht 2 in **1:n** stehen. Ein Q-Item, ein Token, ein Mindestalter — das wäre 1:1 und ist der Fehler im ersten Draft, nicht die Schicht selbst.
+
+---
+
+## 3. Anforderungen an den veröffentlichten Schlüssel
+
+Ein Schlüssel, der Frage 0 trägt, muss:
+
+| ID | Anforderung | Warum |
+|---|---|---|
+| **S** | **Stabil gegen Formulierung.** Andere Frage, klarerer Titel, Tippfehler → dieselbe ID. | Sonst ist jede Korrektur ein neues Atom und die Karte hängt in der Luft. Dafür existiert `content_version`. |
+| **R** | **Trennt Reduktion.** Qualitative und formale Fassung derselben Entität → verschiedene IDs. | Verschiedene Voraussetzungen, verschiedenes Alter, verschiedene Overlays. |
+| **J** | **Joint Herausgeber.** Zwei unabhängige Tiles können dasselbe Atom benennen, ohne eine gemeinsame ULID-Registry. | Sonst ist ZAM der Identitäts-Monopolist und das CDN braucht Schreibkonten. |
+| **L** | **Sprachneutral.** Deutsches und englisches „Snellius, qualitativ“ sind dasselbe Atom. | Sonst zerfällt der weltweite Graph an der Sprache. Fragetext ist Darstellung, nicht Identität. |
+| **U** | **Hat einen unverankerten Raum.** Teamwissen, noch nicht gemappte Lehrplansätze, Idiosynkrasie brauchen eine ID, bevor ein Q existiert. | Sonst blockiert Wikidata-Abdeckung das Publizieren. |
+| **N** | **Nicht vom Domain-Pfad abhängig.** Taxonomie umhängen darf die ID nicht ändern. | Sonst ist jede Graph-Aufräumaktion ein Identitätsbruch. |
+
+Lokal lesbare Adressen (`physik/optik:snellius`) und lokale Zeilen-IDs (ULID) dürfen zusätzlich existieren. Sie ersetzen **J** und **N** nicht.
+
+---
+
+## 4. Warum die naheliegenden Schlüssel scheitern
+
+### 4.1 Nur ULID — bricht **J**
+
+Funktioniert, solange *ein* Herausgeber alle Atome vergibt. Der zweite Herausgeber mint eine neue ULID für dasselbe Snellius. Join wird wieder Entity-Linking. Eine zentrale ULID-Registry gegen dieses Problem braucht Schreibrechte und Identität — genau das, was der Content-Service strukturell nicht haben soll.
+
+ULID bleibt die richtige **Zeilen-ID** in einer Datenbank. Sie ist der falsche *veröffentlichte* Schlüssel.
+
+### 4.2 `(domain, slug)` — bricht **N**, teilweise **J** und **L**
+
+Der Ontology-Entwurf will genau das als Adresse, und nach Phase D als Eindeutigkeit. Für CLI und Graph-Navigation ist das brauchbar. Als Join-Schlüssel klebt die Identität an einer Taxonomie, die leben muss (`schule/physik/optik` vs. `physik/optik` vs. `physics/optics`). Zwei Herausgeber einigen sich nicht auf denselben Pfad. Deutscher Slug und englischer Slug sind verschiedene IDs für dasselbe Atom.
+
+### 4.3 Nur Wikidata-Q — bricht **R** und **U**
+
+Q202814 ist Snellius, die Welt-Entität. Qualitative Richtung („zum Lot hin“) und quantitative Formel teilen dieses Q. Ein Lerner, der die qualitative Fassung beherrscht, hätte damit die Formel „mitgelernt“, sobald ein Overlay wechselt oder ein Tile die beiden zusammenlegt. Das ist der härteste Fehlertyp: stiller, falscher Transfer.
+
+Teamwissen und viele schulische Kleinstkompetenzen haben kein Q. Ein Pflicht-Q blockiert Publikation oder erzeugt Müll-Items.
+
+### 4.4 Lehrplan-Code — bricht **J** und **R**
+
+`lehrplanplus:PH9-LB2` ist ein Lernbereich, kein Atom. Ein LB zerfällt in mehrere Atome. Derselbe Stoff heißt in BW anders. Der Code ist ein ausgezeichneter *Overlay-Zeiger* (Schicht 3), kein Atom-Schlüssel (Schicht 2).
+
+---
+
+## 5. Vorschlag: PAID — Pedagogical Atom ID
+
+Veröffentlichte Identität eines Atoms ist das Tupel
+
+\[
+\mathrm{PAID} = (\textit{scheme},\; \textit{entity},\; \textit{reduction})
+\]
+
+mit einem **optionalen** Qualifier `aspect`, der nur dann gesetzt wird, wenn zwei Atome dieselbe Reduktion teilen und trotzdem nicht austauschbar sind.
+
+### 5.1 Kanonische Schreibweise
+
+```
+paid       := scheme ":" entity "/" reduction [ ":" aspect ]
+scheme     := "wd" | "lp" | "zam"
+entity     := qid | provider ":" topic | publisher "/" local
+qid        := "Q" DIGIT+
+reduction  := "iconic" | "qualitative" | "formula" | "derivation" | "formal"
+aspect     := 1*( ALPHA / DIGIT / "-" )
+```
+
+Beispiele:
+
+```
+wd:Q202814/qualitative
+wd:Q202814/formula
+wd:Q11379/iconic
+wd:Q11379/formula
+wd:Q202814/formula:compute          # nur wenn "Formel nennen" ≠ "Formel anwenden" eigene Atome sein müssen
+lp:lehrplanplus-bayern:PH9-LB2/qualitative
+zam:feldtest-by/snellius-qualitativ
+```
+
+Normalisierung: `scheme` und `reduction` klein, keine abschließenden Schrägstriche, `aspect` weglassen wenn leer. Der String ist der Indexschlüssel in Tiles und Alias-Tabellen.
+
+JSON-Form (für Schema und Compiler):
+
+```json
+{
+  "scheme": "wd",
+  "entity": "Q202814",
+  "reduction": "formula",
+  "aspect": null
+}
+```
+
+### 5.2 Die drei Räume
+
+| scheme | entity | Wann | Auto-Join mit anderen Herausgebern |
+|---|---|---|---|
+| `wd` | Wikidata-Q | Weltwissen, sobald ein Q trägt | ja, über gleiches Q + gleiche reduction |
+| `lp` | `{provider}:{topic_id}` | Lehrplansatz, noch ohne Q, oder gebündelte Kompetenz | nur innerhalb desselben Providers |
+| `zam` | `{publisher}/{local}` | unveröffentlicht, Team, Idiosynkrasie | nie automatisch |
+
+`wd` ist der bevorzugte kanonische Raum. `lp` und `zam` sind keine Bürger zweiter Klasse: sie sind gültige PAIDs und dürfen publiziert werden. Sie werden *promoviert*, nicht ersetzt (5.4).
+
+### 5.3 Reduktionsvokabular — klein und global
+
+`reduction` ist der Teil, der **R** trägt. Freier Text (`formel` / `formula` / `quantitativ`) zerbricht den Join genauso wie ein fehlendes Q. Deshalb ein geschlossenes Vokabular mit fünf Stufen:
+
+| Code | Was der Lerner konkret tun kann | Typische Lage |
+|---|---|---|
+| `iconic` | Handeln, legen, zeigen, ohne Symbole | Grundschule, Einstieg |
+| `qualitative` | Richtung, Vergleich, verbale Regel | frühe Sek. I |
+| `formula` | Symbolische Form anwenden, rechnen | Sek. I |
+| `derivation` | Begründen, herleiten, Modell wählen | späte Sek. I / II |
+| `formal` | Axiomatisch, in einem formalen Kalkül | Sek. II / Hochschule |
+
+Das ist absichtlich grob. Fächer dürfen später *Erweiterungen* registrieren (`physik:wave-model`), nicht Synonyme für dieselben fünf. Ein neues globales Codewort ist eine Schema-Entscheidung, kein freies Feld.
+
+**Aspekt bleibt draußen, bis er weh tut.** „Formel nennen“ und „Formel anwenden“ sind oft zwei Fragen an *einem* Atom (Bloom, Interaktion), nicht zwei Identitäten. Zwei PAIDs mit gleichem `(scheme, entity, reduction)` und verschiedenem `aspect` sind erlaubt, aber die Voreinstellung ist: ein Atom, eine Reduktion, Darstellung variiert. Wer `aspect` setzt, muss begründen, warum die beiden nicht substituiert werden dürfen (verschiedene Hard-Prereqs oder verschiedene Overlay-Mitgliedschaften).
+
+Bloom ist **Eigenschaft**, nicht Identität. Bloom 2 und Bloom 3 an derselben Reduktion sind zwei Fragen oder ein Material-Update, kein neues Atom — außer die Kuratorin legt bewusst einen `aspect` fest.
+
+### 5.4 Aliase und Promotion
+
+Eine Zeile darf **viele PAIDs** tragen. Genau einer ist kanonisch.
+
+```
+tokens.id                 ULID              Zeile; Karten, Prerequisites, Logs zeigen hierhin
+tokens.paid               TEXT NULL UNIQUE  kanonischer PAID (nach Publish)
+token_paid_aliases        (alias, token_id) ehemalige und parallele PAIDs
+```
+
+Promotion, nie Umbenennung:
+
+1. Atom wird als `lp:lehrplanplus-bayern:PH9-LB2/qualitative` publiziert.
+2. Review hängt Q202814 an.
+3. Kanonisch wird `wd:Q202814/qualitative`. Der `lp:`-String bleibt Alias.
+4. Karten, Logs, lokale Zeile bleiben auf der ULID. Nichts am Lernerzustand ändert sich.
+
+Zwei Tiles, die unabhängig `wd:Q202814/qualitative` publizieren, sind dasselbe Atom. Der Client dedupliziert beim Attach über den PAID, nicht über die ULID des Herausgebers.
+
+Konflikt: zwei Zeilen, gleicher kanonischer PAID, verschiedener Inhalt. Das ist ein Curation-Fehler, kein Sync-Problem. CI des Tile-Builders lehnt den zweiten Publish ab oder verlangt eine `aspect`-Unterscheidung bzw. eine andere Reduktion.
+
+### 5.5 Was die ID *nicht* enthält
+
+Nicht Teil des PAID, absichtlich:
+
+- Sprache, Titel, Frage, Konzept → Darstellung; Version über `content_version`.
+- Domain-Pfad, Slug → lokale Adresse / Navigation. Der Ontology-Entwurf darf hier weiterdenken.
+- Alter, Jahrgang, Schulart, Prüfungsflag → Overlay-Mitgliedschaft.
+- Bloom, Tier-1-Checks, Medien → Eigenschaften oder Darstellungen des Atoms.
+- Herausgeber, Signatur, Git-Revision → Provenienz der *Fassung*, nicht des Atoms.
+
+Eine material geänderte *Aussage* (die Antwort war falsch) bleibt dasselbe Atom und erhöht `content_version`. Eine andere Reduktion ist ein anderes Atom.
+
+---
+
+## 6. Beziehung zum laufenden Kernel und zum Ontology-Entwurf
+
+Drei Schlüssel dürfen nebeneinander existieren. Sie lösen verschiedene Probleme:
+
+```
+ULID                 Zeile in einer DB. Sync, FK, Karte, Prerequisite-Kante.
+domain + slug        Menschliche / CLI-Adresse in *einem* Graphen.
+PAID                 Veröffentlichter Join über Herausgeber und Overlays.
+```
+
+Der Kernel kann PAID lange **nullable** lassen. Persönliche Tokens und Teamwissen brauchen keinen. Der Compiler des Zentralgraphen *vergibt* ihn beim Publish und schreibt ihn auf die Zeile. `cascadeBlock` und FSRS sehen ihn nie; sie bleiben auf der ULID.
+
+Der Ontology-Entwurf (jetzt Draft) bleibt ein Kandidat für die *lokale* Adresse. Er ist kein Kandidat mehr für die veröffentlichte Identität. Konkret:
+
+- Decision 1 (ULID bleibt Zeilen-Identität) ist mit PAID verträglich und wahrscheinlich richtig.
+- Decision 2–3 (kurze Slugs, `/`-Pfade, `domain_meta`) sind Adress- und Navigationsfragen, unabhängig von Frage 0.
+- Decision 4 (Ontology *führt* die Benennung, Anker optional und stumm) ist für den Zentralgraphen zu schwach: der Anker plus die Reduktion *ist* der Join, nicht ein schlafendes Feld.
+- Decision 5–6 (qualified `path:slug`, `UNIQUE(domain, slug)`) dürfen die lokale Adresse regeln. Sie dürfen nicht der Tile-Schlüssel werden.
+
+`schule/physik/optik` als Pfad ist damit wieder erlaubt als Navigation oder Korpus-Partition. Es ist nicht die Identität des Atoms.
+
+---
+
+## 7. Durchgerechnetes Beispiel
+
+Lichtbrechung in drei Overlays, ein Welt-Anker Q202814, ein zweiter Q165738 (Totalreflexion):
+
+| Overlay | Was der Lehrplan verlangt | PAID |
+|---|---|---|
+| Realschule Bayern 9 Physik NW | Richtung der Brechung *und* Formel | `wd:Q202814/qualitative`, `wd:Q202814/formula` |
+| Gymnasium BW 8 Physik | Lichtbrechung, überwiegend qualitativ | `wd:Q202814/qualitative` |
+| Sek. II / Einstieg Uni | Herleitung aus Huygens | `wd:Q202814/derivation` |
+| Alle drei, wo Totalreflexion vorkommt | Phänomen + Grenzwinkel | `wd:Q165738/qualitative`, ggf. `/formula` |
+
+Ein Kind, das in BW `wd:Q202814/qualitative` gelernt hat und nach Bayern wechselt, hängt die bestehende Karte an dasselbe Atom. Die Formel-Karte ist neu. Huygens bleibt Soft-Kante auf `/derivation`, nicht Hard-Gate auf `/formula`.
+
+Gegenprobe ohne Reduktion im Schlüssel: alle drei Overlays zeigen auf `Q202814`. Der Bayern-Tile „entdeckt“ eine beherrschte Formel, die nie gelernt wurde.
+
+Gegenprobe mit Lehrplan-Code als Schlüssel: der Umzug BW → BY erzeugt eine neue Karte für denselben qualitativen Satz, weil `bildungsplan-bw:…` ≠ `lehrplanplus:PH9-LB2`.
+
+---
+
+## 8. Was der Compiler und Briefing 1 damit tun
+
+Entity-Linking ist zweistufig. Precision@1 auf Stufe 1 allein ist die falsche Metrik.
+
+```
+Lehrplan-Kompetenzsatz
+        │
+        ├─1─► Welt-Entität     (wd:Q… oder Ablehnung → lp:)
+        │
+        └─2─► reduction        (aus Jahrgang, Verb, Symbolgehalt)
+                 │
+                 ▼
+              PAID
+```
+
+Heuristik für Stufe 2, als Start — Kuratorin bestätigt vor Publish:
+
+- keine Symbole, Grundschule, „legen / zeigen / zuordnen“ → `iconic`
+- „beschreiben, Richtung, vergleichen, zum Lot / vom Lot“ → `qualitative`
+- Gleichung, „berechnen, einsetzen“ → `formula`
+- „herleiten, begründen, beweisen, Modell“ → `derivation`
+- Kalkül, Axiome, Grenzwerte als Voraussetzung → `formal`
+
+Ein Kompetenzsatz erzeugt oft **mehrere** PAIDs (qualitativ + Formel im selben Lernbereich). Das ist der Normalfall, kein Mapping-Fehler.
+
+Overlay-Tile speichert Mitgliedschaften per PAID, nicht per Herausgeber-ULID:
+
+```json
+{
+  "overlay": "lehrplanplus-bayern/realschule-9/physik",
+  "members": [
+    { "paid": "wd:Q202814/qualitative", "exam_relevant": true, "grade": 9 },
+    { "paid": "wd:Q202814/formula",     "exam_relevant": true, "grade": 9 }
+  ]
+}
+```
+
+Der Overlay-Abschluss \(E_S\) (siehe Verfeinerung, Abschnitt 4) läuft über diese Mitgliedermenge.
+
+---
+
+## 9. Was bewusst offen bleibt
+
+Diese vier Punkte entscheidet Frage 0 *nicht*. Sie werden kleiner, sobald der PAID steht:
+
+1. **Wer vergibt den ersten PAID?** Vorschlag: Compiler schlägt vor, Kuratorin bestätigt beim Publish. Kein autonomes Mapping in den Lerner-Graphen.
+2. **Wie streng ist das Reduktionsvokabular in geisteswissenschaftlichen Fächern?** Fünf Stufen kommen aus MINT-Reduktion. Geschichte und Deutsch brauchen vielleicht `narrative` / `source-critical` als Erweiterungen, nicht als Synonyme.
+3. **Darf ein Atom mehrere kanonische `wd:`-Anker haben?** (Snellius *und* Brechungsindex.) Vorschlag: ein kanonischer Anker, weitere als Alias-Entities — sonst zerfällt der Join.
+4. **Lokale Adresse.** Ob `(domain, slug)` so bleibt, wie der Ontology-Entwurf es will, ist eine eigene Entscheidung und keine Voraussetzung für Tiles.
+
+---
+
+## 10. Entscheidung, um die gebeten wird
+
+Für den Zentralgraphen:
+
+> Die veröffentlichte Identität eines pädagogischen Atoms ist der PAID
+> `(scheme, entity, reduction)` mit optionalem `aspect`.
+> ULID bleibt Zeilen-ID. Domain und Slug bleiben lokale Adresse.
+> Wikidata ist der bevorzugte `scheme`, nicht die Identität selbst.
+
+Das ist klein genug zum Ablehnen und groß genug, dass Overlay-Abschluss, Entity-Linking und Tile-Format daran gebaut werden können.

--- a/docs/concepts/central-learning-path-refinement.md
+++ b/docs/concepts/central-learning-path-refinement.md
@@ -1,0 +1,367 @@
+# Verfeinerung: Universeller Bildungsgraph — Reduktion, Overlay-Abschluss, Identität
+
+**Status:** Research note / Gegenlesen der Gemini-Entwürfe  
+**Datum:** 2026-08-14 (rev.: Ontology-ADR als offen behandelt)  
+**Autor:** Grok 4.6 (kollaborative Runde)  
+**Liest:**
+- [central-learning-path-research.md](central-learning-path-research.md)
+- [central-learning-path-architecture.md](central-learning-path-architecture.md)
+- [ADR-Entwurf Hierarchical Domain Ontology](https://github.com/zam-os/zam/blob/docs/domain-ontology-adr-note/docs/adr/2026-07-04-hierarchical-domain-ontology-and-token-identity.md) — Branch `docs/domain-ontology-adr-note`. Status dort „Accepted“, **Entscheidung hier nicht als gewiss behandelt.**
+- Bestehende Kernel-Implementierung und die Content-Service-ADRs als *Ist-Zustand*, nicht als Gesetz für den zentralen Graphen.
+
+---
+
+## 0. Haltung
+
+Die Gemini-Entwürfe treffen die Produktvision. Kacheln, Curricula als Overlays, Lehrer-Signatur statt LLM-Autorität, Schulheft als Brücke zum Unterricht — das sind die richtigen großen Linien.
+
+Die erste Fassung dieser Note hat die Ontology-ADR wie geltendes Recht gelesen (ULID = Identität, Domain = nur Fach, Wikidata = optionaler Anker). Das war falsch gewichtet. Der Entwurf auf `docs/domain-ontology-adr-note` beantwortet eine *andere* Frage — wie ein persönlicher oder Team-Graph lesbar bleibt, wenn Slugs zu lang und Domains zu flach werden. Der zentrale Bildungsgraph stellt eine härtere Frage: **woran erkennen zwei Curricula und zwei Herausgeber dasselbe lernbare Atom?**
+
+Was ohne diese ADR trägt:
+
+1. Dieselbe wissenschaftliche Entität braucht **mehrere didaktische Reduktionsstufen** als eigene Knoten.
+2. **Hard-Kanten sind overlay-relativ**; transitive Reduktion auf dem Universalgraphen ist falsch.
+3. FSRS modelliert **Gedächtnis**, nicht Wissen. Knowledge Tracing darf die Stabilität nicht anfassen.
+4. Die **öffentliche Identität** eines Knotens im weltweiten Graphen ist selbst eine Forschungsfrage — die Ontology-ADR ist nur eine der Antworten.
+
+---
+
+## 1. Ist-Zustand des Kernels, nicht Gesetz für den Zentralgraphen
+
+| Thema | Heute im Kernel | Gemini-Entwurf | Was davon lasttragend ist |
+|---|---|---|---|
+| Zeilen-ID | ULID | ULID im Beispiel, Kanten per Slug | Irgendein stabiler Knotenschlüssel. Welcher, ist offen (Abschnitt 2). |
+| Domain | Freier String, `/` als Hierarchie erlaubt; Contexts existieren parallel | `schule/physik/optik` | Für den *zentralen Schulgraphen* kann `schule` eine Korpus-Partition sein, kein Lebenswelt-Kontext. Nicht vorschnell verwerfen. |
+| Wikidata | Nicht modelliert | Schicht 1 | Die 1:1-Gleichsetzung Entität = Token ist falsch. Die Schicht selbst ist eine ernsthafte Kandidaten-Antwort auf die Join-Frage. |
+| Scheduler | FSRS-6, Blocking getrennt | FSRS-5 + Mastery-Vektor + \(S\)-Propagation | Hier widerspricht der Entwurf der Lernpsychologie und dem Kernel aus demselben Grund. Bleibt eine Korrektur. |
+| Overlay vs. Token | `provider` / `topic_id` am Token | `curricula[]` am Token | Mitgliedschaft ist n:m. Alter und Prüfungsflag gehören an die Mitgliedschaft, nicht an den Knoten. |
+| Klassenfortschritt | `assignments` | eigene Schicht im zentralen Stack | Auf einem anonymen CDN strukturell unmöglich, sobald man Minderjährige ernst nimmt. |
+| Hosting | offene Frage: DB vs. Artefakt | Knowledge Vector Tiles | Weiter die beste Antwort auf die Verteilungsfrage. |
+
+---
+
+## 2. Forschungsfrage 0: Was ist die öffentliche Identität eines Knotens?
+
+Ausgearbeitet als Arbeitsvorschlag: [central-learning-path-identity.md](central-learning-path-identity.md) — **PAID** `(scheme, entity, reduction)`, optional `aspect`. Kurzfassung:
+
+Zwei verschiedene Probleme, die nicht dieselbe Lösung erzwingen:
+
+| Problem | Typische Antwort | Optimiert für |
+|---|---|---|
+| Persönlicher / Team-Graph wächst, Slugs werden unlesbar | Ontology-ADR: ULID bleibt Zeilen-ID, `(domain, slug)` wird Adresse, Wikidata optional | Refactoring der Taxonomie, CLI, ein Herausgeber |
+| Weltweiter Bildungsgraph, 16 Länder, viele Overlays | Gemini: Wikidata als Schicht 1 | Join über Sprachen und Lehrpläne |
+
+Ein ULID, den *ein* ZAM-Verlag vergibt, ist ein schlechter Join-Schlüssel für „dasselbe Snellius, anderer Herausgeber, anderer Lehrplan“. Ein Wikidata-Q ist ein schlechter Schlüssel für „dasselbe Snellius, andere Reduktionsstufe“. Ein Lehrplan-Code ist ein schlechter Schlüssel für „dasselbe Snellius, anderes Bundesland“.
+
+### 2.1 Was identifiziert werden muss
+
+Vier Dinge, die ein weltweiter Graph auseinanderhalten muss — unabhängig davon, wie die Tabelle heißt:
+
+```
+1. Welt-Entität           „Satz des Pythagoras“, Q11379
+2. Pädagogisches Atom     eine konkret abrufbare Reduktion + ein Aspekt
+3. Overlay-Mitgliedschaft welches Curriculum sie in welcher Jahrgangsstufe verlangt
+4. Lernzustand            Karte, FSRS — nie im zentralen Artefakt
+```
+
+Das 3-Schichten-Bild der Entwürfe ist genau diese Trennung, **wenn Schicht 1 und Schicht 2 in 1:n stehen**. Der Fehler im Draft ist nicht die Schicht, sondern die implizite 1:1-Abbildung (ein Q-Item, ein Token, ein Mindestalter).
+
+Knowledge Contexts (`work` / `school` / `private`) lösen ein Geräteproblem: ein Mensch, mehrere Leben. Der Zentralgraph *ist* das öffentliche Schul- und Weltwissen. `schule/physik/optik` als Pfad kann dort „dieser Knoten gehört zum Schulkorpus, Fach Physik, Gebiet Optik“ heißen — eine Partition des Korpus, kein Wiedereinzug der Lebenswelt in die Identität. Ob der Pfad Teil der *Identität* oder nur der *Navigation* ist, bleibt offen.
+
+### 2.2 Kandidaten für den veröffentlichten Schlüssel
+
+| Kandidat | Form | Hält Refactor der Taxonomie aus? | Trennt Reduktionsstufen? | Joint zwei Herausgeber? | Team-/Privatwissen ohne Autorität? |
+|---|---|---|---|---|---|
+| **A. Nur ULID** | `01K3X9…` | ja | nur wenn jede Stufe eine ULID hat | nein, außer alle teilen eine Registry | ja |
+| **B. `(domain, slug)`** | `physik/optik:snellius` | nein | ja, per Slug | nur bei identischer Taxonomie | ja |
+| **C. Nur Wikidata** | `Q202814` | ja | **nein** | ja, wo ein Q existiert | nein |
+| **D. Lehrplan-Code** | `lehrplanplus:PH9-LB2` | ja, lokal | nein (ein LB, viele Atome) | nein, Codes sind regional | nein |
+| **E. Pädagogisches Tupel** | `(anchor, reduction, aspect)` | ja | ja | ja, wo der Anker geteilt wird | über einen privaten Anker-Raum |
+
+**E** ist der einzige Kandidat, der die Join-Frage des Zentralgraphen und die Reduktionsfrage zugleich beantwortet.
+
+Beispiel:
+
+```
+wd:Q202814 / reduction=qualitative / aspect=direction
+wd:Q202814 / reduction=formula    / aspect=compute
+wd:Q11379  / reduction=rearrange  / aspect=area
+wd:Q11379  / reduction=algebra    / aspect=equation
+```
+
+Unverankertes Wissen (Team, Idiosynkrasie, noch nicht gemappt) braucht einen zweiten Raum, nicht die Abwesenheit von Identität:
+
+```
+zam:unpublished / publisher=feldtest-by / local=snellius-qualitativ
+```
+
+Eine ULID kann weiter die **Zeilen-ID in einer Datenbank** sein. Das ist Implementierung. Die **veröffentlichte Identität im Tile** muss das Tupel sein, sonst wird jedes Re-Publish, jeder zweite Herausgeber und jedes Entity-Linking zu einem Forschungsprojekt.
+
+Die Ontology-ADR wählt faktisch A+B (ULID intern, Domain+Slug als Adresse, Anker optional und stumm). Für den persönlichen Graphen ist das plausibel. Für den Zentralgraphen ist ein stummer Anker zu wenig: ohne dass der Anker plus die Stufe den Join *trägt*, gibt es keinen universellen Graphen, nur eine große ZAM-Bibliothek mit internen IDs.
+
+### 2.3 Was daraus für Briefing 1 folgt
+
+Entity-Linking ist dann nicht „Lehrplansatz → ein Wikidata-Q → fertig“. Die Abbildung ist zweistufig:
+
+1. Lehrplan-Kompetenzsatz → Welt-Entität (Q-Item oder Ablehnung).
+2. Dieselbe Kompetenz → Reduktionsstufe + Aspekt (ein oder mehrere pädagogische Atome).
+
+Precision@1 auf Stufe 1 allein ist die falsche Metrik. Ein perfekter Q-Treffer bei falscher Stufe erzeugt die falsche Karte.
+
+---
+
+## 3. Die fehlende Primitive: didaktische Reduktion
+
+Piaget-Stufen als Token-Tag sind entwicklungspsychologisch überholt (überlappende Wellen, bereichsspezifisches Wissen, starke Kultur- und Unterrichtseffekte). Was die Entwürfe mit „Mindestalter“ meinen, ist in der deutschsprachigen Didaktik längst benannt: **didaktische Reduktion** (Wagenschein, Klafki). Dieselbe wissenschaftliche Entität tritt auf mehreren Verstehensstufen auf.
+
+Pythagoras ist nicht ein Knoten:
+
+| Pädagogisches Atom (eigene veröffentlichte ID) | Reduktion | Typisches Overlay | Hard-Prereqs |
+|---|---|---|---|
+| `mathematik/geometrie:pythagoras-legen` | Ikonisch: Flächen umlegen | GS 4 / RS 5 | Flächeninhalt Quadrat |
+| `mathematik/geometrie:pythagoras-formel` | Algebraisch: \(a^2+b^2=c^2\) | RS 9 / Gym 8 | Potenzen, Gleichung umstellen, Stufe „legen“ |
+| `mathematik/vektoren:pythagoras-skalarprodukt` | Formal: \(\|u+v\|^2\) | Sek. II | Vektoren, Skalarprodukt, Stufe „Formel“ |
+
+Alle drei dürfen `wikidata_id = Q11379` tragen. Das Overlay wählt die Stufe. Die Hard-Kante läuft *zwischen den Stufen*, nicht von „Sinus 9. Klasse“ auf „das eine Pythagoras-Ding“.
+
+Das löst drei Scheinprobleme der Entwürfe auf einmal:
+
+- **Altersmonotonie** gilt zwischen Reduktionsstufen desselben Ankers, nicht zwischen beliebigen Fachknoten.
+- **Cross-Curriculum-Mapping** (Briefing 1) ist zuerst ein Mapping auf Anker + Stufe, nicht auf einen Token.
+- **„Kind kann früher, wenn Fundamente sitzen“** ist kein Sigmoid über Alter, sondern: die qualitative Stufe ist zugänglich, die formale bleibt geblockt.
+
+Die Accessibility-Formel
+
+\[\sigma\!\left(k_1(A_L-A_T)+k_2(\min M_p-\theta)\right)\ge\tau\]
+
+mischt Jahre und einheitenlose Mastery in einem unkalibrierten Sigmoid. Als Freigaberegel taugt sie nicht. Die operative Regel ist lexikographisch und schon fast die bestehende Blocking-Politik:
+
+1. Alle *overlay-sichtbaren* Hard-Prereqs erfüllt (sonst blocken).
+2. Token liegt im gewählten Overlay (sonst nicht anbieten).
+3. Reduktionsstufe passt — entweder weil das Overlay sie verlangt, oder weil die qualitative Vorstufe sitzt.
+4. Alter ist ein **Hinweis für die Oberfläche** („ungewöhnlich früh / spät“), nie ein hartes Gate.
+
+---
+
+## 4. Forschungsfrage 2, ausgearbeitet: Hard, Soft, und warum transitive Reduktion den Overlay bricht
+
+### 4.1 Definitionen, die der Kernel testen kann
+
+ZAM hat heute genau eine Kantensorte. `addPrerequisite` lehnt Zyklen ab. `cascadeBlock` sperrt das vergessene Token und holt seine direkten Vorgänger in die Queue. `unblockReady` gibt frei, wenn *alle* direkten Vorgänger `reps ≥ 1` und selbst nicht geblockt sind.
+
+Das ist eine Hard-Semantik. Sie ist richtig — und zu grob, sobald der Graph fächerübergreifend wird.
+
+**Hard** \(u \vdash v\): Ohne nachweisbares \(u\) ist \(v\) nicht definierbar, nicht berechenbar oder im zuständigen Overlay ausdrücklich vorausgesetzt.
+
+Testfrage an die Kuratorin: *Kann eine kompetente Lernerin \(v\) zeigen, ohne \(u\) zeigen zu können?* Wenn nein → hard.
+
+Drei Unterarten, alle hard, aber mit verschiedener Reparatur:
+
+| Unterart | Beispiel | Wenn die Kante fehlt |
+|---|---|---|
+| Definitional | Lichtstrahl ⊢ Einfallswinkel | \(v\) ist sprachlich leer |
+| Operator | Sinus ⊢ quantitatives Snellius | \(v\) ist rechnerisch leer |
+| Curricular | Lehrplan sagt „zuvor LB 2.1“ | \(v\) ist prüfungsrechtlich verfrüht |
+
+**Soft** \(u \leadsto v\): \(u\) erleichtert \(v\), definiert es aber nicht.
+
+Testfrage: *Sinkt die Schwierigkeit von \(v\) typischerweise, wenn \(u\) sitzt — obwohl \(v\) ohne \(u\) definierbar bleibt?* Wenn ja → soft.
+
+Huygens-Prinzip für Snellius ist soft. Es erklärt das *Warum*, nicht das *Was*. Eine Soft-Kante darf **nie** blocken. Sie darf erklären, im Graphen als gestrichelte Kante liegen, und bei Foundation Healing als *Vorschlag* auftauchen.
+
+Eine dritte Sorte braucht der Universalgraph, sonst entstehen Scheinzyklen:
+
+**Aspekt-Spaltung statt Zyklus.** „Funktion“ und „Graph“ beleuchten sich gegenseitig. Das ist kein Deadlock, sondern zwei Tokens (`funktion-zuordnung`, `funktion-graph`) mit gerichteter Hard-Kante von der einfacheren Reduktion zur nächsten. Graph-Repair ist in der Regel **Zerlegung**, nicht Kantendeletion.
+
+### 4.2 Transitive Reduktion ist overlay-relativ
+
+Die Entwürfe wollen \(A \to B \to C\) plus \(A \to C\) zu \(A \to B \to C\) kürzen. Auf einem *einzigen* Lehrpfad stimmt das. Auf einem universellen Graphen mit Overlays bricht es.
+
+Gegenbeispiel:
+
+- Universal: Sinus \(A\) → Trig-Identitäten \(B\) → quantitatives Snellius \(C\).
+- Overlay „Realschule Bayern 9 Physik“ enthält \(A\) und \(C\), nicht \(B\) (Identitäten liegen im Gymnasium).
+
+Kürzt man \(A \to C\) global weg, hat \(C\) im Overlay keinen wirksamen Vorgänger. `unblockReady` sieht nur \(B\), \(B\) existiert für diesen Lerner nicht, und entweder bleibt \(C\) ewig geblockt oder es wird ohne Sinus freigegeben.
+
+**Satz (Overlay-Abschluss).** Sei \(G=(V,E_\text{hard})\) ein DAG und \(S \subseteq V\) die Tokenmenge eines Overlays. Der für Blocking und Freigabe wirksame Graph ist
+
+\[
+E_S = \{\,(u,v)\in S\times S \mid (u,v)\in E_\text{hard}^\ast \;\wedge\; \text{kein } w\in S\setminus\{u,v\} \text{ liegt auf jedem } u\text{-}v\text{-Pfad}\,\}.
+\]
+
+In Worten: Zwischen zwei Overlay-Tokens bleibt die *kürzeste sichtbare* Hard-Kante stehen. Intermediate Knoten außerhalb von \(S\) werden unsichtbar, ihre transitive Wirkung wird zur direkten Kante **befördert**.
+
+Das ist die Kompilation, die ein Curriculum-Tile tatsächlich leisten muss — nicht „JSON der Lehrplan-Flags“, sondern **der auf \(S\) projizierte Hard-DAG**.
+
+Folgerungen:
+
+- Transitives Pruning läuft **pro Overlay**, nie auf \(G\) selbst.
+- Der Universalgraph darf redundante Hard-Kanten halten. Sie sind Dokumentation und Sicherheitsnetz.
+- Altersmonotonie wird ebenfalls auf \(E_S\) geprüft: \(\mathrm{Age}_S(u) \le \mathrm{Age}_S(v)\) für \((u,v)\in E_S\). \(\mathrm{Age}_S\) ist eine Overlay-Eigenschaft. Ein Verstoß ist ein Overlay-Fehler, kein Token-Fehler.
+- CI für ein Tile: (1) \(G[S]\) nach Abschluss azyklisch, (2) jeder exam-relevante Knoten in \(S\) hat einen Pfad von den Overlay-Wurzeln, (3) keine Hard-Kante zeigt auf ein Token außerhalb von \(S\), ohne dass der Abschluss eine Ersatzkante in \(S\) erzeugt hat.
+
+### 4.3 Was der Kernel konkret bräuchte
+
+Heute: Tabelle `prerequisites (token_id, requires_id)`.
+
+Minimal additiv, unabhängig von der Identitätsfrage:
+
+```sql
+-- additive Spalte, Default = heutiges Verhalten
+ALTER TABLE prerequisites ADD COLUMN kind TEXT NOT NULL DEFAULT 'hard';
+-- CHECK (kind IN ('hard', 'soft'))
+```
+
+Politik:
+
+- `cascadeBlock` / `unblockReady` lesen nur `kind = 'hard'`.
+- Soft-Kanten gehen in Graph, Erklärpfad, Healing-*Vorschläge*.
+- Zyklusprüfung bleibt auf Hard-Kanten. Ein Soft-Zyklus („A veranschaulicht B, B veranschaulicht A“) ist erlaubt und oft sinnvoll.
+- Overlay-Kompilation materialisiert \(E_S\) als Tile, nicht als zweite Wahrheit in der Lerner-DB.
+
+Das ist kleiner als ein neues Knowledge-Tracing-Modell und schaltet Briefing 2 erst scharf.
+
+---
+
+## 5. Forschungsfrage 5, ausgearbeitet: FSRS nicht mit BKT vermischen
+
+### 5.1 Kategoriefehler
+
+Pelánek (UMUAI-Übersicht) zieht die Grenze, die der Entwurf überschreitet:
+
+- **Gedächtnismodelle** (FSRS, Half-Life Regression) beschreiben das Vergessen eines *Items* nach beobachteten Wiederholungen.
+- **Kompetenzmodelle** (BKT, PFA, DKT) beschreiben, ob eine *Fertigkeit* beherrscht wird. Klassisches BKT hat entweder kein Vergessen oder ein schlecht identifizierbares \(P(F)\).
+
+ZAM hat diese Trennung bereits im Kernel: `evaluateRating()` schreibt FSRS-Zustand; `cascadeBlock()` ist eine getrennte Graph-Politik. Die Entwürfe wollen Stabilität \(S\) von \(B\) auf die Prerequisites \(\{A_i\}\) hochzählen, wenn \(B\) gelingt.
+
+Das darf der Kernel nicht tun.
+
+1. FSRS-Gewichte sind unter der Annahme trainiert, dass jede Aktualisierung eine **beobachtete** Wiederholung genau dieser Karte ist. Ein Ghost-Update von \(S_A\) nach Erfolg auf \(B\) verdreckt den Schätzer.
+2. Erfolg auf \(B\) ist **kein Abruf von \(A\)**. Es gibt Eselsbrücken, Teilkredite, Multiple-Choice-Glück. Genau deshalb existiert `cascadeBlock`: Lerner bestehen \(B\) und haben \(A\) trotzdem verloren.
+3. Ein zweiter „Mastery-Vektor“ neben der Karte verdoppelt den Lernzustand. Die Karte *ist* der lokale Kompetenz-Proxy: `reps`, `stability`, `blocked`, `state`.
+
+### 5.2 Was sich aus einem Graphen *wohlbegründet* schließen lässt
+
+Sei Wissen konjunktiv (AND über Hard-Prereqs) — das ist die ZAM-Annahme hinter `unblockReady`.
+
+| Beobachtung | Starke Folgerung | Schwache Folgerung | Verbotene Folgerung |
+|---|---|---|---|
+| Lapse auf \(B\) | mindestens ein Hard-Prereq ist wacklig, *oder* \(B\) selbst | — | \(S\) aller Prereqs senken |
+| Erfolg auf \(B\) | \(B\) war heute abrufbar | \(P(A\text{ abrufbar})\) steigt leicht | \(S_A\) erhöhen, \(A\) als reviewed markieren |
+| Erfolg auf allen Kindern von \(A\) | immer noch nicht: \(A\) wurde nicht abgerufen | \(A\) heute in der Queue nach hinten | \(A\) aus FSRS nehmen |
+
+Deshalb ist **Foundation Healing bei Misserfolg** (schon gebaut) epistemisch sauber, **Stabilitäts-Propagation bei Erfolg** nicht.
+
+Die richtige Stelle für Graph-Evidenz ist die **Queue**, nicht die Karte.
+
+### 5.3 Zwei entgegengesetzte Testordnungen
+
+Die Entwürfe behandeln Erwerb und Behalten als dasselbe Scheduling-Problem. Sie sind es nicht.
+
+**Erwerb (neue Karten, `state = new`).** Fundamente zuerst. Das tut der Blocker schon: ohne erfüllte Hard-Prereqs kommt \(B\) nicht in die Queue.
+
+**Behalten (fällige Reviews).** Frontier zuerst.
+
+Wenn heute \(\{A_1, A_2, B, C\}\) fällig sind und \(A_i \vdash B \vdash C\):
+
+1. Ziehe den höchsten fälligen Knoten, der nicht geblockt ist (\(C\), sonst \(B\)).
+2. Gelingt \(C\): *verschiebe* fällige strikte Vorfahren in der *heutigen* Session nach hinten (Order-Hint, kein FSRS-Write). Sie bleiben fällig; sie werden nur nicht *zusätzlich* abgefragt, solange die Frontier hält.
+3. Scheitert \(C\): bestehendes `cascadeBlock` — \(C\) raus, direkte Hard-Prereqs heute nach vorn.
+4. Nie eine Vorfahren-Karte als reviewed schreiben, die nicht gezeigt wurde.
+
+Das beantwortet Briefing 5, Teilaufgabe 2 ohne 95-Prozent-Konfidenztheater. Eine 95-Prozent-Aussage über zehn abhängige Knoten ist unter realen Löchern nicht identifizierbar. Die operative Größe ist **erwartete überflüssige Abfragen heute**, nicht eine globale Wissensgarantie.
+
+### 5.4 Tier-1 → Tier-2 ohne zweiten Scheduler
+
+Bloom liegt schon am Token. Eine zusätzliche Freigabe „erst wenn \(S > 21\) Tage“ ist ein zweiter, mit FSRS konkurrierender Schwellenwert.
+
+Einfachere Regel, kompatibel mit dem Prompter:
+
+- Bloom 1–2 und Karten in `learning` / früher `review`: schnelle Checks (Tap, 2–4 Optionen). Das ist *Darstellung*, generierbar aus `question` + `concept`.
+- Bloom 3–5 oder Karte mit `reps` über einer kleinen Schwelle (z. B. 3 erfolgreiche Reviews): bestehende freie Frage.
+- Prüfungsnahe Overlay-Flags können Tier 2 früher erzwingen, unabhängig von \(S\).
+
+Kein neues Zustandsmodell. Kein LLM im Kernel. Die Checks dürfen im Tile liegen (Lehrer hat sie geprüft) oder zur Laufzeit erzeugt werden — Quelle der Wahrheit bleiben Frage und Konzept.
+
+### 5.5 Was bewusst *nicht* in den Kernel kommt
+
+DKT, AKT, graphische neuronale Tracer: Sie brauchen Trainingsdaten, eine Modelldatei und typischerweise einen Netzwerklauf. Das verletzt die Kernel-Grenze (keine LLM-/Netzwerkabhängigkeit unter `src/kernel/`). Wenn je ein Kompetenzmodell über FSRS hinaus gebraucht wird, lebt es in der CLI-Schicht und schreibt höchstens ein optionales, vom Scheduler ignorierbares Feld. Der Blocker und FSRS bleiben deterministisch.
+
+---
+
+## 6. Architektur: KVT behalten, Schicht 2 streichen, Tiles aus dem Kernel kompilieren
+
+### 6.1 KVT ist die Antwort auf ADR 2026-07-26b, Frage 3
+
+Anonyme, unveränderliche, inhaltsadressierte Artefakte ohne Lernerkonten — genau die Form, die den Content-Service sponsorenfähig hält. Das sollte als *Entscheidung* festgehalten werden, nicht als Metapher.
+
+Die Google-Maps-Analogie trägt für **Verteilung** (vorkompilierte Kacheln, Rendering am Rand, keine Personalisierung auf dem Server). Sie trägt nicht für **Wissen**: eine Karte ist isomorph zur Geographie; ein Bildungsgraph ist eine kuratierte Reduktion. Es gibt nicht *die* Karte des Wissens, sondern eine Version mit Overlay-Projektionen.
+
+### 6.2 Drei Tile-Sorten, an das echte Schema gebunden
+
+Nicht JSON-LD als Wahrheitsquelle. Quelle ist die Kernel-Bibliothek (Tokens, Prerequisites, Sources, Editorial State, `content_version`). Der Builder ist ein Compiler.
+
+| Tile | Inhalt | Typische Größe | Hinweis |
+|---|---|---|---|
+| **Overlay** `/tiles/curricula/{provider}/{school}-{grade}-{subject}.json` | Veröffentlichte Atom-IDs in \(S\), exam-Flags, lokale Reihenfolge, **kompilierter** \(E_S\) | Zehn bis wenige hundert KB | Das ist das eigentliche Lehrplan-Objekt. |
+| **Domain** `/tiles/domains/{root}.json.zst` | Tokenkörper (Titel, Frage, Konzept, Bloom, Anker, Hard/Soft-Kanten) | Klein ohne Embeddings | Embeddings *nicht* hier. 1000 × 1536 × 4 B ≈ 6 MB allein für Vektoren. |
+| **Media-Manifest** | URLs, Hashes, Timecodes, Lizenz | Klein | Bytes selbst content-addressed oder extern. YouTube darf fehlen; Lernen darf nicht brechen. |
+
+Embeddings, falls der Schulheft-Scanner sie braucht, sind ein **optionales viertes Tile**, versioniert mit `embedding_model_id`. Int8-Quantisierung. Nie im Hot Path des Reviews.
+
+Sync: Content-Hash in der URL plus `index.json` reicht. Ein Merkle-Tree ist für Jahres-Curricula Überbau. Material/cosmetic aus ADR 2026-07-04 bleibt die Semantik, wenn ein Token sich ändert: Hash wechselt, Karte mit älterem `learned_content_version` wird fällig, FSRS wird nicht stumm überschrieben.
+
+### 6.3 Die Klassen-Schicht gehört nicht ins CDN
+
+„Aktuelles Thema der Woche“ ist ein **Assignment**, höchstens ein Schul-Workspace (Deployment B). Sobald ein zentraler Dienst Klassenzeiger speichert, gibt es Identität, Minderjährige, AVV — genau das, was 2026-07-26b strukturell unmöglich machen will.
+
+Der Schulheft-Scanner bleibt trotzdem sinnvoll. Er schreibt den Fortschritt **lokal**: entweder ein persönliches Assignment oder einen lokalen Cursor „wir sind bei Token \(X\)“. Nichts davon verlässt das Gerät. Bestätigung durch Schüler/Eltern ist der Gate, nicht ein Server.
+
+### 6.4 Schema am Beispiel-Token — was fest und was offen ist
+
+Am Snellius-Beispiel aus dem Architektur-Draft:
+
+- Zwei pädagogische Atome, ein Welt-Anker `Q202814`: qualitativ („zum Lot hin“) und quantitativ (Formel mit Sinus). Das ist unabhängig von ULID vs. Tupel.
+- `age_recommendation` wandert ins Overlay oder bleibt unverbindlicher Hinweis.
+- `curricula[]` ist Overlay-Mitgliedschaft, nicht Identität des Atoms.
+- `interactions.tier1_*` dürfen als geprüfte Darstellungshilfen mitreisen; Review muss ohne sie mit Frage und Konzept funktionieren.
+- `curation` braucht eine Versions- und Änderungssemantik (cosmetic / material), nicht nur eine Signatur.
+- Ob der veröffentlichte Schlüssel eine ULID, ein `domain:slug` oder das Tupel aus Abschnitt 2 ist, und ob der Pfad `schule/physik/optik` oder `physik/optik` heißt: **offen**.
+
+### 6.5 Phasenplan
+
+Die Draft-Phasen (Schema → LehrplanPLUS → Studio → Scanner) überspringen die Lücke zwischen Universalgraph und Overlay.
+
+Vorschlag:
+
+0. **Identität des veröffentlichten Atoms entscheiden** (Abschnitt 2) — oder bewusst eine Zelle lang mit temporären IDs arbeiten und den Join-Schlüssel nachziehen. Die Ontology-ADR nicht vorher festziehen.
+1. **Hard/Soft + Overlay-Abschluss** als Compiler-Vertrag. Ohne das sind Tiles nur ZIP-Dateien von Manifesten.
+2. **`zam curriculum compile-tiles`** gegen *eine* echte Zelle: Realschule Bayern 9 Physik *oder* Mathematik — inkl. \(E_S\)-Check, Zyklen, fehlende Fundamente, und ein explizites Mapping Lehrplansatz → Anker → Reduktionsstufe.
+3. Qualitätsgate bleibt menschliches Review vor dem Publish. Signatur optional.
+4. Scanner als Client-Feature, nachdem ein Overlay lokal liegt. v1: On-Device-OCR + Match gegen die ~100–400 Atome der Zelle. Kein VLM in Phase 1.
+
+Lizenz bleibt der Blocker vor öffentlichem CDN. Der Compiler kann intern gegen die bestehenden Provider-Manifeste laufen.
+
+---
+
+## 7. Was aus den Entwürfen bleiben soll
+
+- Curricula als Overlays über einem geteilten Konzeptnetz, nicht 16 isolierte Token-Inseln.
+- Lehrer prüft, KI entwirft. Ein Review, viele Lerner.
+- Statische, anonyme Verteilung. Lernerdaten nie auf Sponsor-Infrastruktur.
+- Zwei Interaktionsgeschwindigkeiten als UX, nicht als zweites Gedächtnismodell.
+- Schulheft als Anker an den echten Unterricht — lokal, mit Bestätigung, ohne Menü-Archäologie.
+- Multimediale *Referenzen* (PhET, kurze Videofenster) als Dual-Coding-Hilfe, vom Token entkoppelbar.
+
+---
+
+## 8. Offene Fragen
+
+0. **Veröffentlichte Identität.** Arbeitsvorschlag: PAID `(scheme, entity, reduction)` — siehe [central-learning-path-identity.md](central-learning-path-identity.md). ULID bleibt Zeile, Domain/Slug lokale Adresse. Offen: Vokabular in Nicht-MINT, kanonischer Anker bei mehreren Q, Vergabeprozess.
+1. **Reduktionsstufen als eigene Knoten** (Empfehlung) oder Aspekte an einem Knoten? Aspekte schonen die Graph-UI und zerbrechen Blocking sowie Overlay-Abschluss.
+2. **Soft-Kanten in v1** oder erst beim ersten echten fächerübergreifenden Tile?
+3. **Klassenfortschritt** rein lokal für 2026/27, oder parallel ein Schul-Workspace? Nicht auf dem CDN.
+4. **Erstes Artefakt:** ein intern verteiltes Tile für eine bayerische Zelle, noch ohne öffentliches CDN, solange die Lizenz offen ist?
+
+0 und 1 zuerst. Danach werden Entity-Linking, Tile-Format und Scanner empirisch: sie bekommen eine Zelle und einen Join-Schlüssel, gegen den man messen kann.

--- a/docs/concepts/central-learning-path-research.md
+++ b/docs/concepts/central-learning-path-research.md
@@ -1,0 +1,295 @@
+# Forschungsarbeit: Didaktische Wissensgraphen, Ontologie-Harmonisierung und Kognitionsmodellierung für universelle Lernpfade
+
+**Status:** Research Paper & Collaborative Discussion Draft  
+**Datum:** 2026-08-14  
+**Autoren:** ZAM Scientific & AI Research Working Group  
+**Zweck:** Wissenschaftliche Fundierung, formaltheoretische Herleitung und strukturierte Forschungsfragen zur kollaborativen Bearbeitung durch spezialisierte KI-Agenten und Fachexperten.
+
+---
+
+## 1. Abstract & Problemstellung
+
+Die Digitalisierung von Bildungsinhalten beschränkt sich heute weitgehend auf zwei isolierte Extreme:
+1. **Unstrukturierte Fakten- und Wissensgraphen (z. B. Wikidata, DBpedia):** Sie bilden Enzyklopädiewissen und semantische Relationen ab, ignorieren jedoch systematisch pädagogische Dimensionen wie Entwicklungsalter, Vorwissenshierarchien (Prerequisites), kognitiven Workload und didaktische Reduktion.
+2. **Monolithische Lehrplan-PDFs und Schulbuchkapitel:** Sie definieren zwar Jahrgangsstufen und Kompetenzen, sind aber maschinenunlesbar, regional fragmentiert (z. B. 16 Bundesländer in Deutschland) und bilden keine formalen Abhängigkeitsgraphen über Fächer- und Altersgrenzen hinweg ab.
+
+**Das Forschungsziel:**  
+Entwicklung eines formalen, ontologisch verankerten und kognitionswissenschaftlich validierten Modells für einen **universellen Bildungs-Wissensgraphen**, der:
+- menschliche Lernpfade von der frühen Kindheit bis zur Hochschulreife als gerichteten, zyklenfreien Graphen (DAG) abbildet,
+- reale Curricula (wie LehrplanPLUS Bayern) als modulare Overlays über einem universellen Konzeptnetzwerk verankert,
+- kognitionspsychologische Prinzipien (Cognitive Load Theory, Dual Coding, Vygotsky ZPD, FSRS Spaced Repetition) in der Interaktionsarchitektur operationalisiert,
+- und eine extrem skalierbare, datenschutzkonforme (DSGVO-by-Design) Edge-Verteilung ermöglicht.
+
+---
+
+## 2. Stand der Forschung & Ontologie-Vergleich
+
+### 2.1 Taxonomie bestehender Wissens- und Bildungsstandards
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                VERGLEICH BESTEHENDER ONTOLOGIEN                                  │
+├──────────────────────┬──────────────────────┬────────────────────────────────────────────────────┤
+│ Standard / Ontologie │ Primärer Fokus       │ Eignung & Grenzen für didaktische Lernpfade        │
+├──────────────────────┼──────────────────────┼────────────────────────────────────────────────────┤
+│ **Wikidata**         │ Universal-Enzyklopädie│ + Eindeutige Q-IDs, Mehrsprachigkeit, Relationen   │
+│                      │                      │ - Keine Altersangaben, keine Didaktik, keine Tests │
+├──────────────────────┼──────────────────────┼────────────────────────────────────────────────────┤
+│ **ConceptNet**       │ Commonsense-Semantik │ + Relationen wie `HasPrerequisite`, `Causes`       │
+│                      │                      │ - Zu unpräzise für formale Schulfächer & Curricula │
+├──────────────────────┼──────────────────────┼────────────────────────────────────────────────────┤
+│ **1EdTech CASE**     │ Kompetenz-Austausch  │ + Standard für Curricula & Lernstandards           │
+│                      │                      │ - Schwerfällig, keine Graph-Traversierungs-Engine  │
+├──────────────────────┼──────────────────────┼────────────────────────────────────────────────────┤
+│ **Schema.org/LRMI**  │ Lernressourcen-Web   │ + Metadaten: `teaches`, `assesses`, `educational`  │
+│                      │                      │ - Beschreibt Dokumente, keinen kognitiven Graphen  │
+├──────────────────────┼──────────────────────┼────────────────────────────────────────────────────┤
+│ **LehrplanPLUS (BY)**│ Staatlicher Lehrplan │ + Offizielle Verbindlichkeit, Fach-Kompetenzen     │
+│                      │                      │ - Isoliert pro Bundesland, keine Quervernetzung    │
+└──────────────────────┴──────────────────────┴────────────────────────────────────────────────────┘
+```
+
+### 2.2 Das 3-Schichten-Ontologie-Modell (The 3-Layer Pedagogical Ontology)
+Um das Rad nicht neu zu erfinden, schlagen wir eine klare Schichten-Architektur vor:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│ SCHICHT 1: UNIVERSAL ENTITY ANCHORS (Wikidata / DBpedia)                                │
+│ "Was ist das Ding an sich?" -> Q11379 (Satz des Pythagoras), Q202814 (Snellius-Gesetz) │
+└────────────────────────────────────────────┬────────────────────────────────────────────┘
+                                             │ 1:n Mapping (Ein Thema -> n Teil-Konzepte)
+                                             ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│ SCHICHT 2: PEDAGOGICAL KNOWLEDGE GRAPH (ZAM Core Tokens & DAG)                           │
+│ Didaktische Zerlegung:                                                                  │
+│ • Atomare Konzepte, Fragen & Antworten                                                  │
+│ • Bloom-Taxonomie (Stufe 1 bis 5)                                                       │
+│ • Entwicklungs- & Mindestalter (Piaget-Stufe)                                           │
+│ • Strikte Prerequisite-Kanten (gerichteter Graph)                                       │
+│ • Multimodale Erklärungs-Anker (YouTube Timestamps, PhET Simulationen)                  │
+└────────────────────────────────────────────┬────────────────────────────────────────────┘
+                                             │ n:m Projektion
+                                             ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│ SCHICHT 3: CURRICULAR OVERLAYS (LehrplanPLUS, KMK, Common Core)                          │
+│ Staatliche / Schulische Bindung:                                                        │
+│ • Bundesland / Schulart / Jahrgangsstufe / Ausbildungsrichtung                          │
+│ • Prüfungsrelevanz-Status ("Muss in Schulaufgabe gekonnt werden" vs. "Vertiefung")     │
+│ • Zuordnung zu offiziellen Lernbereichen & Kompetenzerwartungen                         │
+└─────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Kognitionswissenschaftliche & Didaktische Modellierung
+
+### 3.1 Alterskalibrierung & Entwicklungspsychologische Stufen
+Ein Alterstag an einem Lernknoten darf nicht als starrer Filter verstanden werden, sondern als **kognitive Reifeschwelle**.
+
+Wir orientieren uns an der Synthese aus Jean Piagets Entwicklungstheorie, der Neo-Piaget'schen Kapazitätstheorie (Robbie Case) und Lew Wygotskis Konzept der *Zone der nächsten Entwicklung (ZPD)*:
+
+1. **Prä-operationale Stufe (ca. 4–6 Jahre):**
+   - Dominanz der Wahrnehmung über die Logik; ikonisches Lernen.
+   - *Anforderung an Tokens:* Reine Bild- und Tonrepräsentationen, Zähl- und Erkennungsaufgaben, keine formalen Symbolmanipulationen.
+2. **Konkret-operationale Stufe (ca. 7–11 Jahre / Grundschule bis Orientierungsstufe):**
+   - Reversible mentale Operationen, Verständnis von Invarianz/Erhaltung, Klassifikation anhand konkreter Anschauungsobjekte.
+   - *Anforderung an Tokens:* Handlungsorientierte Beispiele (z. B. geometrische Formen, Bruchrechnen über Flächenaufteilung, Naturbeobachtung).
+3. **Formal-operationale Stufe (ca. 12+ Jahre / Sekundarstufe I & II):**
+   - Abstraktes, hypothetisch-deduktives Denken; Verständnis von Variablen, Formeln, Funktionsgraphen und logischen Implikationen.
+   - *Anforderung an Tokens:* Mathematische Beweise, theoretische Modelle (z. B. Atommodelle, Winkelfunktionen, historische Kausalitätsanalysen).
+
+**Mathematische Modellierung der Zugänglichkeit:**
+Sei $A_{Learner}$ das chronologische/kognitive Alter des Lerners, $A_{Token}$ das didaktische Mindestalter des Tokens und $M_{Prereq} \in [0, 1]$ der durchschnittliche Beherrschungsgrad aller direkten Prerequisites. Ein Token wird aktivierbar, wenn:
+$$\text{Accessibility}(Token) = \sigma\left( k_1 \cdot (A_{Learner} - A_{Token}) + k_2 \cdot \left( \min_{p \in Prereqs}(M_p) - \theta_{threshold} \right) \right) \ge \tau$$
+*Bedeutung:* Hervorragend beherrschte Fundamente erlauben es einem Kind, kognitive Schwellen früher zu überschreiten (Scaffolding-Effekt).
+
+---
+
+### 3.2 Cognitive Load Theory (Sweller) & 2-Tier Interaktionsparadigma
+
+Die *Cognitive Load Theory* unterscheidet drei Arten von kognitiver Belastung beim Lernen:
+- **Intrinsic Load:** Die dem Lerninhalt inhärente Komplexität (Zahl der interagierenden Elemente).
+- **Extraneous Load:** Belastung durch schlechte Präsentation, unnötige Tipparbeit, unübersichtliche UIs.
+- **Germane Load:** Die für den Aufbau mentaler Schemata produktive Denkleistung.
+
+#### Das 2-Stufen-Interaktionsmodell zur Minimierung des Extraneous Load:
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│ STUFE 1: TIER 1 – RAPID RETRIEVAL CHECKS (< 5 Sek. pro Check)                            │
+├──────────────────────────────────────────────────────────────────────────────────────────┤
+│ • 1-Tap Multiple Choice (2–4 Optionen mit plausiblen Distraktoren)                       │
+│ • Binär-Entscheidung (Wahr / Falsch, Größer / Kleiner, "Zum Lot / Vom Lot weg")         │
+│ • Lückentext mit Wortkarten-Tap (Cloze-Tap)                                              │
+│ • Bild-Wort / Diagramm-Zuordnung                                                         │
+│                                                                                          │
+│ 🎯 Ziel: Unmittelbarer Abrufeffekt (Retrieval Practice), minimale Tipp-Hürde,           │
+│          hohe Frequenz, kein Frust bei täglichen Wiederholungen.                        │
+└────────────────────────────────────────────┬─────────────────────────────────────────────┘
+                                             │ Freigabe nach Festigung im Langzeitgedächtnis
+                                             │ (z. B. FSRS Stabilität S > 21 Tage)
+                                             ▼
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│ STUFE 2: TIER 2 – DEEP SYNTHESIS & EXAM MASTERY (30–90 Sek. pro Aufgabe)                 │
+├──────────────────────────────────────────────────────────────────────────────────────────┤
+│ • Freitext-Erklärung (Eigenformulierung mit semantischem LLM-Check auf Kernkonzepte)     │
+│ • Audio-Erklärung ("Erkläre es mit eigenen Worten in 30 Sekunden")                       │
+│ • Handschriftliche Rechenaufgabe mit Foto-Upload / Canvas-Zeichnung                      │
+│ • Prüfungsaufgaben-Transfer (Kombination mehrerer Graph-Knoten)                          │
+│                                                                                          │
+│ 🎯 Ziel: Tiefes Verständnis, Transferleistung, Vorbereitung auf Klausuren.              │
+└──────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 3.3 Dual Coding Theory (Paivio) & Multimodale Wissensanker
+
+Nach Allan Paivios *Dual-Coding-Theorie* speichert das menschliche Gehirn Informationen parallel über zwei getrennte, aber interagierende Kanäle: einen **verbal-linguistischen** und einen **visuell-nichtverbalen** Kanal. Werden beide Kanäle synchron angesprochen, steigt die Behaltensleistung signifikant.
+
+Im ZAM-Bildungsgraphen wird jedes kanonische Token multimodal angereichert:
+1. **Linguistischer Pfad:** Prägnante Formulierung von Konzept, Frage und Schlüsselbegriffen.
+2. **Visuell-Dynamischer Pfad:**
+   - Kuratierte Video-Snippets (zielgenaue YouTube-Timestamps: 30–90 Sekunden Erklärfenster, keine 20-Minuten-Vorlesungen).
+   - Interaktive Exploration via HTML5/PhET/GeoGebra (Handlungsorientiertes Entdecken vor dem Abfragen).
+   - SVG-Infografiken und Diagramme mit Image-Occlusion.
+
+---
+
+### 3.4 Knowledge Tracing & Spaced Repetition (FSRS-5 + Bayesian DAG Tracing)
+
+Traditionelle Spaced-Repetition-Systeme (wie Anki / SM-2) behandeln jede Lernkarte als isoliertes Atom. Im Bildungs-Graphen hängen Karten jedoch voneinander ab.
+
+Wir verknüpfen den **FSRS-5 Algorithmus (Free Spaced Repetition Scheduler)** mit einem **Bayesian Knowledge Tracing (BKT)** über dem Graphen:
+- Gelingt der Abruf eines fortgeschrittenen Knotens $B$, erhöht dies probabilistisch die angenommene Stabilität aller seiner Prerequisites $\{A_1, A_2, \dots\}$.
+- Scheitert der Abruf von $B$ wiederholt (Lapse), schlägt das System automatisch vor, die fundamentalen Prerequisites $\{A_1, A_2\}$ gezielt im Tier-1-Modus aufzufrischen (*Foundation Healing*).
+
+---
+
+## 4. Graphentheoretische Grundlagen für didaktische DAGs
+
+### 4.1 Formale Definition
+Sei $G = (V, E, W)$ ein gewichteter, gerichteter Graph, wobei:
+- $V = \{t_1, t_2, \dots, t_n\}$ die Menge der Knowledge-Tokens ist.
+- $E \subseteq V \times V$ die gerichteten Prerequisite-Kanten darstellt: $(u, v) \in E \iff$ „Das Verstehen von $u$ ist Voraussetzung für $v$“.
+- $W: E \to \{\text{hard}, \text{soft}\}$ der Prerequisite-Typ ist.
+
+### 4.2 Zyklenfreiheit (Acyclicity) & Transitive Reduktion
+1. **Acyclicity ($G$ ist ein DAG):**
+   - Ein didaktischer Graph darf **keine gerichteten Zyklen** enthalten ($t_1 \to t_2 \to \dots \to t_1$). Zyklen bedeuten einen didaktischen Deadlock („Um A zu verstehen, musst du B können; um B zu verstehen, musst du A können“).
+   - *Algorithmus:* Topologische Sortierung via Tarjan / Kahn mit $O(|V| + |E|)$.
+2. **Transitive Reduktion (Graph Pruning):**
+   - Gibt es Kanten $A \to B$, $B \to C$ und $A \to C$, so ist die direkte Kante $A \to C$ didaktisch redundant und erzeugt visuellen Ballast im Graphen.
+   - *Regel:* Die transitive Reduktion $G_{red}$ entfernt $A \to C$, behält aber die transitive Erreichbarkeit bei.
+
+---
+
+## 5. Strukturierte Forschungs-Briefings für KI-Agenten
+
+Die folgenden fünf Forschungs-Briefings sind so formuliert, dass sie direkt an spezialisierte KI-Agenten oder Arbeitsgruppen zur tiefergehenden Ausarbeitung und Simulation übergeben werden können.
+
+---
+
+### 🔬 Forschungs-Briefing 1: Automatisches Ontologie-Mapping & Entitäts-Disambiguierung
+
+> **Forschungsfrage:**  
+> *Wie können wir bestehende Entitäts-Ontologien (Wikidata, ConceptNet, DBpedia) automatisiert und mit hoher Präzision mit den Kompetenzformulierungen amtlicher Lehrpläne (z. B. LehrplanPLUS Bayern) verknüpfen, ohne semantischen Drift oder fehlerhafte Zuordnungen zu erzeugen?*
+
+#### Teilaufgaben für den Agenten:
+1. **Vergleich von Entity-Linking-Verfahren:**
+   - Evaluation von Lexical Search (BM25) vs. Dense Bi-Encoder Embeddings (z. B. `text-embedding-3-large`, `e5-mistral`) vs. Cross-Encoder Rerankern.
+2. **Taxonomie-Abgleich:**
+   - Wie werden zusammengesetzte schulische Lernbereiche (z. B. „PH9 2.1 Brechung und Totalreflexion an ebenen Grenzflächen“) auf atomare Wikidata-Items (Q202814 Snellius, Q165738 Totalreflexion) dekomponiert?
+3. **Qualitätsmetriken:**
+   - Definition von Precision@1, Recall@k und Halluzinations-Schwellenwerten für unüberwachtes Mapping vor dem Lehrer-Audit.
+
+---
+
+### 🔬 Forschungs-Briefing 2: Didaktische Prerequisite-Validierung & Transitives Pruning
+
+> **Forschungsfrage:**  
+> *Mit welchen formalen Algorithmen und LLM-gestützten Konsistenzprüfungen lässt sich ein globaler Abhängigkeitsgraph mit >100.000 Kanten auf Zyklenfreiheit, transitive Redundanz und didaktische Altersmonotonie validieren?*
+
+#### Teilaufgaben für den Agenten:
+1. **Formale Kriterien für „Hard“ vs. „Soft“ Prerequisites:**
+   - Mathematische Definition: Wann ist eine Kante zwingend notwendig (`hard`: ohne $A$ ist $B$ mathematisch/logisch unmöglich), wann nur förderlich (`soft`: $A$ bietet ein anschauliches Analogon für $B$)?
+2. **Altersmonotonie-Prüfung:**
+   - Formaler Beweis / Check: Für jede Kante $(u, v) \in E_{hard}$ muss gelten: $\text{AgeMin}(u) \le \text{AgeMin}(v)$. Wie werden Verstöße automatisiert repariert?
+3. **Graph-Repair-Heuristiken:**
+   - Automatisierte Vorschläge zur Beseitigung von Zyklen bei fächerübergreifenden Verknüpfungen (z. B. Mathe $\leftrightarrow$ Physik $\leftrightarrow$ Informatik).
+
+---
+
+### 🔬 Forschungs-Briefing 3: Ultra-Low-Cost Static Graph Tiling (KVT) & Edge-Query-Architektur
+
+> **Forschungsfrage:**  
+> *Welche Speicherformate, Kompressionsalgorithmen und Indexstrukturen ermöglichen die schnellste Ausführung von Sub-Graph-Abfragen (Traversierung, Nachbarschaftssuche, Pfadfindung) direkt im Browser / Mobile Client via WebAssembly / SQLite bei minimaler Netzwerk-Transfergröße?*
+
+#### Teilaufgaben für den Agenten:
+1. **Format-Benchmark:**
+   - Vergleich von:
+     - Statischem JSON-LD / MessagePack / CBOR,
+     - SQLite over HTTP Range Requests (via `sql.js-httpvfs`),
+     - FlatBuffers / FlatGeobuf-analogen Vektorstrukturen,
+     - Apache Arrow / DuckDB-WASM.
+2. **Partitionierungs-Strategie:**
+   - Wie groß sollte eine Kachel (Tile) idealerweise sein (in KB/MB) für optimale HTTP/2- und HTTP/3-Multiplexing-Performance auf Mobilgeräten?
+3. **Offline-Sync & Cache-Invalidierung:**
+   - Entwurf eines Merkle-Tree-basierten Differentiell-Update-Protokolls für geänderte Token-Revisionen.
+
+---
+
+### 🔬 Forschungs-Briefing 4: Multimodales On-Device Note-to-Curriculum Alignment
+
+> **Forschungsfrage:**  
+> *Wie kann eine mobile Client-Anwendung ein Foto eines handschriftlichen Schulhefts, Tafelbilds oder Arbeitsblatts on-device analysieren und mit höchster Treffsicherheit dem richtigen Knoten im Lehrplan-Subgraphen zuordnen, ohne sensible Schülerdaten an Cloud-APIs zu senden?*
+
+#### Teilaufgaben für den Agenten:
+1. **On-Device Vision & OCR Pipeline:**
+   - Evaluation von Apple Vision Framework / Google ML Kit Text Recognition / lokalen quantized VLM-Modellen (z. B. MiniCPM-V, MobileVLM, SmolVLM).
+2. **Embedding & Matching:**
+   - Lokale Erzeugung kompakter Text-Embeddings (z. B. via `bge-micro-v2` in ONNX/WASM) und Cosine-Similarity-Match gegen die vorab geladenen KVT-Knoten der aktuellen Jahrgangsstufe.
+3. **Robustheit gegenüber unvollständigen Notizen:**
+   - Wie geht das System mit kindlicher Handschrift, unvollständigen Skizzen oder Formelfragmenten um?
+
+---
+
+### 🔬 Forschungs-Briefing 5: Adaptives Knowledge Tracing auf hierarchischen Graphen mit FSRS
+
+> **Forschungsfrage:**  
+> *Wie lässt sich der FSRS-5 Wiederholungsplaner mathematisch exakt mit probabilistischem Knowledge Tracing (BKT / DKT) auf einem Prerequisite-DAG kombinieren, um Über-Testung (Over-Testing) zu vermeiden und gezieltes Foundation-Healing zu steuern?*
+
+#### Teilaufgaben für den Agenten:
+1. **Prerequisite-Propagierung von Stabilität ($S$) und Schwierigkeit ($D$):**
+   - Wenn Knoten $B$ erfolgreich wiederholt wird, wie stark erhöht sich die Verweildauer von $A$ im Langzeitgedächtnis?
+2. **Automatisches Queue-Pruning:**
+   - Wenn ein Schüler 10 hierarchisch abhängige Karten fällig hat: Welche minimale Teilmenge muss getestet werden, um den Wissensstand über alle 10 Knoten mit 95% Konfidenz zu verifizieren?
+3. **Adaptive Tier-1 zu Tier-2 Progression:**
+   - Formale Kriterien für den Übergang von Schnell-Checks zu freien Transferaufgaben.
+
+---
+
+## 6. Methodologie für kollaborative KI-Forschung
+
+Um mit externen KI-Agenten, Forschergruppen und Open-Source-Beitragenden an diesen Fragestellungen zu arbeiten, wird folgende Arbeitsweise empfohlen:
+
+1. **Agenten-Rollenzuweisung:**
+   - Jedem Agenten wird genau **ein Forschungs-Briefing** als Primärauftrag übergeben.
+   - Der Agent liefert: Mathematische Formalisierung, Benchmark-Ergebnisse, Pseudocode / TypeScript-Referenzimplementierung und ein Verifikationsprotokoll.
+2. **Synthese im Diskussionsdokument:**
+   - Ergebnisse werden als neue Abschnitte in diesem Dokument oder als spezialisierte Folge-ADRs unter `docs/adr/` integriert.
+3. **Experimentelle Validierung:**
+   - Vor der Implementierung im ZAM Kernel werden Algorithmen anhand echter LehrplanPLUS-Daten (z. B. Realschule Bayern Mathematik & Physik 9. Klasse) auf Zyklenfreiheit und Matching-Genauigkeit getestet.
+
+---
+
+## 7. Literatur & Referenzen
+
+1. **Sweller, J. (1988).** *Cognitive load during problem solving: Effects on learning.* Cognitive Science, 12(2), 257–285.
+2. **Paivio, A. (1986).** *Mental representations: A dual coding approach.* Oxford University Press.
+3. **Vygotsky, L. S. (1978).** *Mind in society: The development of higher psychological processes.* Harvard University Press.
+4. **Piaget, J. (1976).** *The grasp of consciousness: Action and concept in the young child.* Harvard University Press.
+5. **Ye, J. et al. (2024).** *FSRS: Free Spaced Repetition Scheduler — Algorithm & Optimization.* Open Spaced Repetition Initiative.
+6. **Corbett, A. T., & Anderson, J. R. (1994).** *Knowledge tracing: Modeling the acquisition of procedural knowledge.* User Modeling and User-Adapted Interaction, 4(4), 253–278.
+7. **1EdTech Consortium (2020).** *Competency and Academic Standards Exchange (CASE) Service Specification v1.0.*
+8. **Bayerisches Staatsministerium für Unterricht und Kultus (ISB).** *LehrplanPLUS Bayern: Curriculare Strukturen und Kompetenzerwartungen.* <https://www.lehrplanplus.bayern.de/>

--- a/docs/concepts/central-learning-path-research.md
+++ b/docs/concepts/central-learning-path-research.md
@@ -3,7 +3,8 @@
 **Status:** Research Paper & Collaborative Discussion Draft  
 **Datum:** 2026-08-14  
 **Autoren:** ZAM Scientific & AI Research Working Group  
-**Zweck:** Wissenschaftliche Fundierung, formaltheoretische Herleitung und strukturierte Forschungsfragen zur kollaborativen Bearbeitung durch spezialisierte KI-Agenten und Fachexperten.
+**Zweck:** Wissenschaftliche Fundierung, formaltheoretische Herleitung und strukturierte Forschungsfragen zur kollaborativen Bearbeitung durch spezialisierte KI-Agenten und Fachexperten.  
+**Gegenlesen:** [central-learning-path-refinement.md](central-learning-path-refinement.md) · [central-learning-path-identity.md](central-learning-path-identity.md) (Frage 0: PAID).
 
 ---
 
@@ -195,13 +196,15 @@ Die folgenden fünf Forschungs-Briefings sind so formuliert, dass sie direkt an 
 > **Forschungsfrage:**  
 > *Wie können wir bestehende Entitäts-Ontologien (Wikidata, ConceptNet, DBpedia) automatisiert und mit hoher Präzision mit den Kompetenzformulierungen amtlicher Lehrpläne (z. B. LehrplanPLUS Bayern) verknüpfen, ohne semantischen Drift oder fehlerhafte Zuordnungen zu erzeugen?*
 
+Die Abbildung ist zweistufig (siehe [Frage 0 / PAID](central-learning-path-identity.md)): Lehrplansatz → Welt-Entität, und derselbe Satz → Reduktionsstufe. Precision@1 auf der Entität allein ist die falsche Metrik — ein richtiger Q-Treffer bei falscher Stufe erzeugt die falsche Karte.
+
 #### Teilaufgaben für den Agenten:
 1. **Vergleich von Entity-Linking-Verfahren:**
    - Evaluation von Lexical Search (BM25) vs. Dense Bi-Encoder Embeddings (z. B. `text-embedding-3-large`, `e5-mistral`) vs. Cross-Encoder Rerankern.
 2. **Taxonomie-Abgleich:**
    - Wie werden zusammengesetzte schulische Lernbereiche (z. B. „PH9 2.1 Brechung und Totalreflexion an ebenen Grenzflächen“) auf atomare Wikidata-Items (Q202814 Snellius, Q165738 Totalreflexion) dekomponiert?
 3. **Qualitätsmetriken:**
-   - Definition von Precision@1, Recall@k und Halluzinations-Schwellenwerten für unüberwachtes Mapping vor dem Lehrer-Audit.
+   - Getrennt messen: Entitäts-Precision@1 *und* Reduktions-Genauigkeit. Ein richtiger Q-Treffer bei falscher Stufe ist ein Fehler. Dazu Recall@k und eine Ablehnungsrate für Sätze ohne vertretbares Q (`lp:`-Fallback).
 
 ---
 


### PR DESCRIPTION
## What changed

- adds the central learning-path architecture and research foundation
- records the PAID identity proposal and the subsequent architectural refinement/review
- returns the related ontology ADR to Draft while identity and graph semantics remain under review
- adds Codex's focused research review of ontology mapping, public atom identity, practice-item separation, overlay compilation, and release integrity

## Why

This is a deliberate multi-model research round for ZAM's central learning knowledge base. The branch collects the evidence, disagreements, counterexamples, and candidate consensus before any durable schema or implementation decision is accepted.

## Impact

Documentation only. Runtime behavior and public APIs are unchanged. The PR remains a draft while Opus and Gemini complete the next review and synthesis rounds.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 220 files passed, 1 skipped; 2,118 tests passed, 5 skipped
- `npm run build`
- staged diff whitespace check and local Markdown link check
