### PR TITLE
release: 0.32.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.31.0"
+version = "0.32.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.32.0.md
+++ b/docs/release-notes-0.32.0.md
@@ -1,0 +1,100 @@
+# ZAM 0.32.0 — Pick a cell, say what you already know, and get an offer instead of a wall
+
+This release adds the first complete learning path built from a shared
+curriculum cell rather than from cards you made yourself. You choose a cell,
+ZAM builds the queue, and the parts that used to be decisions on paper — what
+to do about prerequisites you already know, what happens when the day's work
+runs out, what to do with knowledge just outside your curriculum — are things
+you can now actually do.
+
+## Choose a cell instead of building a deck
+
+Four bundled cells ship with this release: Optik for Realschule Bayern 7/8,
+Gymnasium 8, a Realschule extension, and the quantitative BOS variant. You pick
+one and get a queue.
+
+There is no file picker and no URL field, on purpose. These cells come from the
+repository and nothing else can be loaded yet — the trust, signature and
+provenance work that arbitrary content would need is not built, and shipping a
+door before its lock is how content nobody vouched for reaches a learner.
+
+Each cell's curriculum claims are resolved against the official LehrplanPLUS
+learning areas, and a test refuses to ship a cell whose bindings are not in its
+own source list. The Bavarian source pages named are 65643 (Physik 7, Zweig I),
+65854 (Physik 8, II/III) and 119285 (BOS Vorklasse).
+
+**Installing a cell enrols nobody.** Content and enrolment stay two steps
+underneath, so a shared library can hold every cell while your queue holds only
+what you chose.
+
+## "I already know that" defers a question — it does not delete it
+
+A cell brings its prerequisites. If four of them stand between you and the
+first real question, answering all four before starting is a wall.
+
+So you can say you already have one. The card is deferred, not removed: three
+weeks later it is asked for real, because a claim nobody ever checks is not
+knowledge, it is a note. Decline several and they come back spread out rather
+than all on the same day.
+
+Nothing about a self-assessment touches your scheduling state. You did not
+retrieve anything, so nothing is recorded as if you had — the card simply waits.
+Saying "I want to learn it" instead puts it straight back in the queue.
+
+## When the day's work is done, you decide whether to continue
+
+An empty queue now offers to keep going, and admits what the daily limit held
+back. It is an offer, not an automatic top-up: a limit that quietly ignores
+itself teaches you the number is decoration.
+
+What you get is the curriculum you have not reached yet — not the prerequisites
+you just set aside.
+
+## An offer at the edge of what you can do
+
+Once you genuinely hold the foundations of something adjacent to your
+curriculum, ZAM can offer it: what it rests on, what it opens, and nothing
+else. You can accept it or ignore it, and either way your due work is
+unchanged. It is never scheduled for you, never scored, and never counted.
+
+An atom is only offered when its foundations were actually retrieved.
+Enrolment alone does not count, and neither does saying you already know
+something.
+
+## One-tap checks, in an order you cannot memorise
+
+Tier-1 items are answered with a tap instead of typed. The options are
+reordered per card: every authored check stores the correct answer first, and
+shown that way you would learn the position instead of the physics — and the
+rating that followed would be evidence of nothing while scheduling ran on it.
+The order is fixed while you answer and different the next time the card comes
+round.
+
+## The curriculum wizard offers the reviewed cell first
+
+If you walk the curriculum import wizard to a position a cell already covers,
+it names that cell before its own topic list. A cell carries checked sources,
+the order things build on each other, and questions someone went through; a
+generic import carries the text of a curriculum page. Both remain available —
+the reviewed one is simply what gets named first.
+
+## Also in this release
+
+- The review log records which version of a question earned each rating, so a
+  later change to the knowledge base can tell an unchanged item from a revised
+  one instead of guessing.
+- A published practice item can declare what it replaces, and only that
+  declaration moves your card and history to a new id. Where a learner holds
+  both, ZAM refuses rather than merging two histories into one.
+- On mobile, a card's title no longer appears under the question before you
+  reveal the answer. For imported cards it was often the first sentence of the
+  answer.
+
+## Known limits
+
+- Curriculum import still exists only on the desktop. A phone or tablet can
+  select a bundled cell, but a position no cell covers yet needs the desktop.
+- The four cells are pilot content, not a public catalogue. Their identifiers
+  may change when the central knowledge base arrives; your review history is
+  what is designed to survive that, and it will not be transferred across an
+  uncertain match.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-mobile",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-mobile",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-barcode-scanner": "^2.4.5"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zam-mobile",
   "private": true,
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -70,8 +70,8 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         # Stamped from package.json by the release workflow; kept in step here
         # so a local build is not mislabelled either.
-        CFBundleShortVersionString: 0.31.0
-        CFBundleVersion: "0.31.0"
+        CFBundleShortVersionString: 0.32.0
+        CFBundleVersion: "0.32.0"
         # Two uses since the app became standalone (ADR 2026-08-08): scanning
         # a QR code to take over an existing library, and photographing a page
         # to turn it into cards. Neither is the first-run path any more, but

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "zam",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Turn real work with AI agents into active-recall practice and FSRS spaced repetition.",
   "author": {
     "name": "ZAM Contributors",

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.31.0",
+          "User-Agent": "ZAM-Content-Studio/0.32.0",
         },
       });
 


### PR DESCRIPTION
Version bump and release notes for 0.32.0.

Touches every version site the checklist names: root/desktop/mobile
`package.json` plus their lockfiles, the `zam-app` crate and
`Cargo.lock`, the iOS project's `CFBundleShortVersionString` and
`CFBundleVersion`, the content-reader User-Agent, and `plugin.json`
(asserted equal to the npm version by `tests/cli/agent-plugin.test.ts`).

Highlights are in [docs/release-notes-0.32.0.md](docs/release-notes-0.32.0.md):
the first learning path built from a shared curriculum cell rather than
from cards the learner made — cell selection, precondition
self-assessment that defers instead of deleting, keep-going on an empty
queue, the bonus offer, one-tap Tier-1 checks in an order that cannot be
memorised, and a curriculum wizard that names a covering cell first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)