### PR TITLE
release: prepare 0.34.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.34.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "zam-app"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "block2",
  "objc2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zam-app"
-version = "0.33.0"
+version = "0.34.0"
 description = "ZAM Active-Recall Studio"
 authors = ["ZAM Contributors"]
 edition = "2021"

--- a/docs/release-notes-0.34.0.md
+++ b/docs/release-notes-0.34.0.md
@@ -1,0 +1,44 @@
+# ZAM 0.34.0 — Curriculum on every device
+
+The curriculum walk that used to exist only on Desktop now runs on Android and
+iPadOS too. A learner picks state, school type, grade, subject and track on
+whatever device they have, and ZAM answers the same way everywhere: where a
+reviewed learning cell covers that position, the cell is the offer; only a
+position no cell reaches falls back to a generic import.
+
+## Curriculum navigator on Mobile
+
+- **The same taxonomy as Desktop.** Region → school type → grade → subject →
+  optional track → topic, from the shared provider registry. Providers without
+  a track level skip that step instead of showing an empty screen.
+- **Cell precedence at the surface** (ADR 2026-08-14 Decision 10). The
+  completed position is resolved against bundled-cell curriculum scopes before
+  any generic import is offered. Reviewed cells install and enrol with no model
+  and no network.
+- **Grounded fallback import.** Where no cell covers the position, the official
+  source must pass the deterministic readiness check first; the native shell
+  then performs a bounded HTTPS fetch (https only, capped size, checked content
+  type) on both Android and iOS, and a connected cloud text model produces card
+  drafts. Every draft keeps `source_link`, provider and stable topic id, and
+  goes through the editable multi-draft confirmation before it becomes a card.
+
+## No more 228-cell wall
+
+- Desktop and Mobile now list **active learning paths** plus one guided
+  "choose curriculum" action, instead of rendering the whole bundled catalog.
+- Cell status is computed with a handful of bulk queries over atoms, practice
+  items and cards, replacing two to three IPC round trips per cell — the
+  difference between four pilot cells and 228.
+- Bavarian Realschule track aliases (`I` / `wpfg1`, `II-III` / `wpfg2-3`) are
+  normalized, so a manifest spelling and a published tile spelling resolve to
+  the same position.
+
+## Upgrades & compatibility
+
+- Existing cards, review logs and FSRS schedules are unchanged. No cell ids
+  moved and no `replaces` mapping was added.
+- `bundled-cells-list` keeps its contract: unscoped it is the plain catalogue,
+  scoped it returns the covering cells plus the `needsGenericImport` verdict.
+  It now reads status only for the cells it returns.
+- Mobile Rust: `reqwest` and `url` are built for iOS as well as Android, and
+  `vision_request` is available on both.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-mobile",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-mobile",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-barcode-scanner": "^2.4.5"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zam-mobile",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.34.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mobile/src-tauri/gen/apple/project.yml
+++ b/mobile/src-tauri/gen/apple/project.yml
@@ -70,8 +70,8 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         # Stamped from package.json by the release workflow; kept in step here
         # so a local build is not mislabelled either.
-        CFBundleShortVersionString: 0.33.0
-        CFBundleVersion: "0.33.0"
+        CFBundleShortVersionString: 0.34.0
+        CFBundleVersion: "0.34.0"
         # Two uses since the app became standalone (ADR 2026-08-08): scanning
         # a QR code to take over an existing library, and photographing a page
         # to turn it into cards. Neither is the first-run path any more, but

--- a/mobile/src-tauri/src/curriculum.rs
+++ b/mobile/src-tauri/src/curriculum.rs
@@ -34,7 +34,9 @@ pub async fn curriculum_source_request(
 
     let mut response = client
         .get(url)
-        .header(USER_AGENT, "ZAM-Mobile/0.33 curriculum source reader")
+        // No version here on purpose: this crate's version is deliberately not
+        // bumped per release, so a version in the UA would silently go stale.
+        .header(USER_AGENT, "ZAM-Mobile curriculum source reader")
         .send()
         .await
         .map_err(|e| format!("curriculum source request failed: {e}"))?;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zam-core",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zam-core",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zam-core",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "The Symbiotic Learning Kernel: Elevating Human Intelligence through AI Collaboration.",
   "type": "module",
   "engines": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "zam",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "The Symbiotic Learning Kernel — Elevating Human Intelligence with Active Recall & Spaced Repetition",
   "author": {
     "name": "ZAM Contributors",

--- a/src/cli/adapters/source-reader.ts
+++ b/src/cli/adapters/source-reader.ts
@@ -130,7 +130,7 @@ export async function readWebLink(url: string): Promise<string> {
         redirect: "manual",
         signal: controller.signal,
         headers: {
-          "User-Agent": "ZAM-Content-Studio/0.33.0",
+          "User-Agent": "ZAM-Content-Studio/0.34.0",
         },
       });
 


### PR DESCRIPTION
## What changed

Version bump to 0.34.0 across root, desktop and mobile packages and locks, the
`zam-app` crate and its lock, the iOS bundle versions, the content-studio user
agent, and `plugin.json`. Adds the hand-written `docs/release-notes-0.34.0.md`.

Also drops the version from the mobile curriculum user agent introduced in
#305: `mobile/src-tauri/Cargo.toml` is deliberately not bumped per release, so
a version there would silently go stale.

## Contents of 0.34.0

Everything from #305 — the cell-first curriculum navigator on Android and
iPadOS, bulk bundled-cell status queries, bounded native HTTPS source fetch on
both mobile platforms, and the active-paths lists that replace the 228-cell
wall on Desktop and Mobile.

## Validation

- `npm run format`, `npm run lint`, `npm run typecheck` clean
- `npm run test` — 249 files passed, 2 skipped; 2324 tests passed, 7 skipped
- `cargo metadata --locked` clean for `desktop/src-tauri`

🤖 Generated with [Claude Code](https://claude.com/claude-code)